### PR TITLE
Supporting code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -20,11 +23,20 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest pylint
+          pip install pytest pytest-cov pylint
 
       - name: Run pylint
         run: |
           pylint probpipe/core examples --fail-under=0.0
 
-      - name: Run tests
-        run: pytest -v
+      - name: Run tests with coverage
+        run: |
+          pytest -v --cov=probpipe/core --cov-report=term-missing --cov-report=xml --cov-report=html --cov-fail-under=0
+
+      - name: Upload coverage HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: htmlcov/
+

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
     extras_require={
         "dev": [
             "pytest",
+            "pytest-cov",
+            "pylint",
             "sphinx",
             "nbsphinx",
             "black",


### PR DESCRIPTION
Now the github actions deals with code coverage! For now I didn't set any threshold testing code coverage of our unit test (--cov-fail-under=0). But, we can pull it to a higher value if we want to escalate the unit test standards. (see the ci.yml file for details). Also, as a result of running codecov as a part of CI, a report is generated for checking out the result of the codecov test. There are two versions: a brief one (a terminal style report) and a more detailed one (an interactive HTML report). I thought the interactve report is pretty cool so I added the option of downloading the HTML report. 

You can see the both tests by clicking on the CI test in Github Actions -> test -> click on "Run tests with coverage" for displaying basic report; click on "Upload coverage HTML report" and use the link in "Artifact download URL" and paste it in your browser to downolad the detailed report. 