### PR TITLE
Remove license section from README, add author

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
-prob-pipe Authors
+ProbPipe Authors
 =================
 
 Jonathan Huggins <huggins@bu.edu>
 Yongho Lim <ylim2@bu.edu>
 Can Erozer <caner@bu.edu>
+Andrew Roberts <arober@bu.edu>

--- a/README.md
+++ b/README.md
@@ -154,6 +154,3 @@ provenance_ancestors(positive)  # [Normal(name='base', event_shape=())]
 | [05_autodiff](examples/05_autodiff.ipynb) | JAX autodiff: score functions, sensitivity analysis, MLE, variational inference |
 | [06_modular_forecasting](examples/06_modular_forecasting.ipynb) | Modular inference pipeline, swappable likelihoods, posterior predictive checks |
 
-## License
-
-MIT


### PR DESCRIPTION
## Summary
- Remove the License section from README (license is already in the LICENSE file)
- Add Andrew Roberts (arober@bu.edu) to AUTHORS