### PR TITLE
Add Codecov integration and README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
         run: |
           pytest -v --cov=probpipe --cov-report=term-missing --cov-report=xml --cov-report=html --cov-fail-under=0
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+
       - name: Upload coverage HTML report
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ProbPipe
 
+[![CI](https://github.com/TARPS-group/prob-pipe/actions/workflows/ci.yml/badge.svg)](https://github.com/TARPS-group/prob-pipe/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/TARPS-group/prob-pipe/branch/main/graph/badge.svg)](https://codecov.io/gh/TARPS-group/prob-pipe)
+
 ProbPipe is a Python framework for building probabilistic pipelines with automated uncertainty quantification. Its core organizing principle is **distributions in, distributions out**: every node in a pipeline can consume and emit probability distributions, enabling principled uncertainty propagation across the entire workflow.
 
 ## Philosophy


### PR DESCRIPTION
## Summary
- Add Codecov upload step to CI workflow (codecov-action v5)
- Add CI status and code coverage badges to top of README

## Notes
- Public repo so no Codecov token needed
- fail_ci_if_error: false so CI does not break if Codecov is temporarily unavailable
- Repo needs to be activated on codecov.io to start receiving reports