### PR TITLE
Use ProbPipe consistently in prose

### DIFF
--- a/docs/examples/01_distributions.ipynb
+++ b/docs/examples/01_distributions.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Distribution Basics\n",
     "\n",
-    "prob-pipe wraps [TensorFlow Probability (TFP)](https://www.tensorflow.org/probability) distributions with a unified API that follows TFP shape semantics (`sample_shape + batch_shape + event_shape`). On top of the standard TFP interface it adds:\n",
+    "ProbPipe wraps [TensorFlow Probability (TFP)](https://www.tensorflow.org/probability) distributions with a unified API that follows TFP shape semantics (`sample_shape + batch_shape + event_shape`). On top of the standard TFP interface it adds:\n",
     "\n",
     "- **Provenance tracking** -- every distribution records how it was created and from which parents.\n",
     "- **Support constraints** -- each distribution declares its support (e.g. `real`, `positive`, `unit_interval`) so that cross-family conversions can be validated automatically.\n",
@@ -249,10 +249,10 @@
     "fig, ax = plt.subplots(figsize=(5, 4))\n",
     "sc = ax.scatter(samples_d[:, 0], samples_d[:, 1], c=samples_d[:, 2],\n",
     "                alpha=0.5, s=10, cmap=\"viridis\")\n",
-    "ax.set_xlabel(\"x₀\")\n",
-    "ax.set_ylabel(\"x₁\")\n",
-    "ax.set_title(\"Dirichlet([2, 5, 1]) samples (color = x₂)\")\n",
-    "plt.colorbar(sc, label=\"x₂\")\n",
+    "ax.set_xlabel(\"x\u2080\")\n",
+    "ax.set_ylabel(\"x\u2081\")\n",
+    "ax.set_title(\"Dirichlet([2, 5, 1]) samples (color = x\u2082)\")\n",
+    "plt.colorbar(sc, label=\"x\u2082\")\n",
     "plt.show()"
    ]
   },
@@ -262,7 +262,7 @@
    "source": [
     "## Discrete Distributions\n",
     "\n",
-    "prob-pipe includes `Poisson`, `Bernoulli`, and `Categorical` (among others).  These follow the same `sample` / `log_prob` interface."
+    "ProbPipe includes `Poisson`, `Bernoulli`, and `Categorical` (among others).  These follow the same `sample` / `log_prob` interface."
    ]
   },
   {

--- a/docs/examples/02_transformations.ipynb
+++ b/docs/examples/02_transformations.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Bijectors and Transformed Distributions\n",
     "\n",
-    "prob-pipe's `TransformedDistribution` applies a TFP bijector to any base distribution, producing a new distribution with transformed support. This enables constrained parameterizations like log-normal, sigmoid-bounded, and more.\n",
+    "ProbPipe's `TransformedDistribution` applies a TFP bijector to any base distribution, producing a new distribution with transformed support. This enables constrained parameterizations like log-normal, sigmoid-bounded, and more.\n",
     "\n",
     "This notebook builds on concepts from [01_distributions.ipynb](01_distributions.ipynb)."
    ]
@@ -320,7 +320,7 @@
     "samples = mvn_exp.sample(key, (1000,))\n",
     "\n",
     "plt.scatter(samples[:, 0], samples[:, 1], alpha=0.3, s=5)\n",
-    "plt.title(\"Exp(MultivariateNormal) — correlated log-normal\")\n",
+    "plt.title(\"Exp(MultivariateNormal) \u2014 correlated log-normal\")\n",
     "plt.xlabel(\"x\\u2081\")\n",
     "plt.ylabel(\"x\\u2082\")\n",
     "plt.show()"
@@ -436,7 +436,7 @@
     "emp_samples = n.sample(key, (500,))\n",
     "emp = EmpiricalDistribution(emp_samples.reshape(-1, 1), name=\"normal_samples\")\n",
     "\n",
-    "# Apply Exp bijector — transforms real-valued samples to positive reals\n",
+    "# Apply Exp bijector \u2014 transforms real-valued samples to positive reals\n",
     "emp_exp = TransformedDistribution(emp, tfb.Exp())\n",
     "new_samples = emp_exp.sample(jax.random.PRNGKey(1), (1000,))\n",
     "\n",
@@ -496,7 +496,7 @@
    "source": [
     "## Provenance Tracking\n",
     "\n",
-    "Every `TransformedDistribution` automatically records how it was created — which base distribution and which bijector were used. This lets you trace the full lineage of any distribution."
+    "Every `TransformedDistribution` automatically records how it was created \u2014 which base distribution and which bijector were used. This lets you trace the full lineage of any distribution."
    ]
   },
   {
@@ -539,7 +539,7 @@
     "print(f\"shifted.source:  {shifted.source}\")\n",
     "print(f\"  bijector: {shifted.source.metadata['bijector']}, parent: {shifted.source.parents[0].name}\")\n",
     "\n",
-    "# Trace full ancestry: positive → shifted → prior\n",
+    "# Trace full ancestry: positive \u2192 shifted \u2192 prior\n",
     "ancestors = provenance_ancestors(positive)\n",
     "print(f\"\\nFull lineage of '{positive.name}': {[a.name for a in ancestors]}\")\n",
     "\n",
@@ -556,7 +556,7 @@
     "Key takeaways:\n",
     "\n",
     "- **`TransformedDistribution(base, bijector)`** creates a new distribution by applying a bijector to a base distribution.\n",
-    "- Works with any prob-pipe distribution as the base, including TFP-backed distributions and `EmpiricalDistribution`.\n",
+    "- Works with any ProbPipe distribution as the base, including TFP-backed distributions and `EmpiricalDistribution`.\n",
     "- **`log_prob`** includes automatic Jacobian correction via the change-of-variables formula.\n",
     "- **Support is derived automatically** for common bijectors (`Exp` $\\to$ positive, `Sigmoid` $\\to$ unit interval, etc.).\n",
     "- Bijectors can be **chained** via `tfb.Chain` for complex transformations."

--- a/probpipe/core/modeling.py
+++ b/probpipe/core/modeling.py
@@ -1,5 +1,5 @@
 """
-Modeling components for prob-pipe.
+Modeling components for ProbPipe.
 
 Provides abstract interfaces for likelihoods and posterior approximation,
 concrete MCMC samplers (TFP-backed NUTS/HMC with automatic fallback),

--- a/probpipe/custom_types.py
+++ b/probpipe/custom_types.py
@@ -1,7 +1,7 @@
 """
 Type aliases for the array backend.
 
-prob-pipe uses JAX as its primary array backend. These aliases provide a
+ProbPipe uses JAX as its primary array backend. These aliases provide a
 single place to change if the backend ever needs to swap.
 """
 

--- a/probpipe/distributions/distribution.py
+++ b/probpipe/distributions/distribution.py
@@ -1,5 +1,5 @@
 """
-Core distribution abstractions for prob-pipe.
+Core distribution abstractions for ProbPipe.
 
 Provides:
   - ``Distribution``          – Abstract base class following TFP shape semantics.
@@ -346,7 +346,7 @@ class Provenance:
 
 class Distribution(ABC):
     """
-    Abstract base for all prob-pipe distributions.
+    Abstract base for all ProbPipe distributions.
 
     Shape semantics follow TFP conventions:
 


### PR DESCRIPTION
## Summary
- Replace `prob-pipe` with `ProbPipe` in all prose references (docstrings, notebook markdown)
- Keep `prob-pipe` in URLs, file paths, and repo names (those are the actual identifiers)