### PR TITLE
Move Provenance and Constraint out of distribution.py

### DIFF
--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -34,7 +34,6 @@ from probpipe.distributions import (
     EmpiricalDistribution,
     ArrayEmpiricalDistribution,
     BroadcastDistribution,
-    Provenance,
     # Global settings
     BootstrapDistribution,
     JointBootstrapDistribution,
@@ -42,20 +41,6 @@ from probpipe.distributions import (
     RETURN_APPROX_DIST,
     set_default_num_evaluations,
     set_return_approx_dist,
-    # Constraints
-    Constraint,
-    real,
-    positive,
-    non_negative,
-    non_negative_integer,
-    boolean,
-    unit_interval,
-    simplex,
-    positive_definite,
-    sphere,
-    interval,
-    greater_than,
-    integer_interval,
     # Continuous
     Normal,
     Beta,
@@ -100,7 +85,22 @@ from probpipe.distributions import (
     LinearBasisFunction,
 )
 from probpipe.core.node import WorkflowFunction, Module, wf
-from probpipe.core.provenance import provenance_ancestors, provenance_dag
+from probpipe.core.provenance import Provenance, provenance_ancestors, provenance_dag
+from probpipe.core.constraints import (
+    Constraint,
+    real,
+    positive,
+    non_negative,
+    non_negative_integer,
+    boolean,
+    unit_interval,
+    simplex,
+    positive_definite,
+    sphere,
+    interval,
+    greater_than,
+    integer_interval,
+)
 from probpipe.modeling import Likelihood, GenerativeLikelihood, IterativeForecaster
 from probpipe.inference import (
     InferenceDiagnostics,

--- a/probpipe/converters/_probpipe.py
+++ b/probpipe/converters/_probpipe.py
@@ -26,10 +26,10 @@ DEFAULT_NUM_SAMPLES = 1024
 from ..core.distribution import (
     ArrayEmpiricalDistribution,
     Distribution,
-    Provenance,
     _auto_key,
-    _supports_compatible,
 )
+from ..core.provenance import Provenance
+from ..core.constraints import _supports_compatible
 from ._protocol import Converter
 from ._registry import ConversionInfo, ConversionMethod
 

--- a/probpipe/converters/_scipy.py
+++ b/probpipe/converters/_scipy.py
@@ -13,9 +13,9 @@ import jax.numpy as jnp
 from ..core.distribution import (
     ArrayDistribution,
     ArrayEmpiricalDistribution,
-    Provenance,
     _auto_key,
 )
+from ..core.provenance import Provenance
 from ._protocol import Converter
 from ._registry import ConversionInfo, ConversionMethod
 

--- a/probpipe/converters/_tfp.py
+++ b/probpipe/converters/_tfp.py
@@ -15,9 +15,9 @@ from ..custom_types import PRNGKey
 from ..core.distribution import (
     ArrayDistribution,
     ArrayEmpiricalDistribution,
-    Provenance,
     _auto_key,
 )
+from ..core.provenance import Provenance
 from ._protocol import Converter
 from ._registry import ConversionInfo, ConversionMethod
 

--- a/probpipe/core/constraints.py
+++ b/probpipe/core/constraints.py
@@ -1,0 +1,270 @@
+"""Support constraints for distributions (real, positive, simplex, ...)."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from ..custom_types import Array, ArrayLike
+
+__all__ = [
+    "Constraint",
+    "real",
+    "positive",
+    "non_negative",
+    "non_negative_integer",
+    "boolean",
+    "unit_interval",
+    "simplex",
+    "positive_definite",
+    "sphere",
+    "interval",
+    "greater_than",
+    "integer_interval",
+]
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+class Constraint:
+    """Describes the support of a distribution (the set of valid values)."""
+
+    def check(self, value: ArrayLike) -> Array:
+        """Return a boolean array indicating which elements satisfy the constraint."""
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return self.__class__.__name__
+
+    def __eq__(self, other: object) -> bool:
+        return type(self) is type(other) and self.__dict__ == other.__dict__
+
+    def __hash__(self) -> int:
+        return hash((type(self), tuple(sorted(self.__dict__.items()))))
+
+
+# ---------------------------------------------------------------------------
+# Concrete constraints
+# ---------------------------------------------------------------------------
+
+class _Real(Constraint):
+    """All real numbers."""
+    def check(self, value: ArrayLike) -> Array:
+        return jnp.isfinite(jnp.asarray(value))
+    def __repr__(self) -> str:
+        return "real"
+
+class _Positive(Constraint):
+    """Strictly positive reals (0, inf)."""
+    def check(self, value: ArrayLike) -> Array:
+        return jnp.asarray(value) > 0
+    def __repr__(self) -> str:
+        return "positive"
+
+class _NonNegative(Constraint):
+    """Non-negative reals [0, inf)."""
+    def check(self, value: ArrayLike) -> Array:
+        return jnp.asarray(value) >= 0
+    def __repr__(self) -> str:
+        return "non_negative"
+
+class _NonNegativeInteger(Constraint):
+    """Non-negative integers {0, 1, 2, ...}."""
+    def check(self, value: ArrayLike) -> Array:
+        v = jnp.asarray(value)
+        return (v >= 0) & (v == jnp.floor(v))
+    def __repr__(self) -> str:
+        return "non_negative_integer"
+
+class _Boolean(Constraint):
+    """Binary values {0, 1}."""
+    def check(self, value: ArrayLike) -> Array:
+        v = jnp.asarray(value)
+        return (v == 0) | (v == 1)
+    def __repr__(self) -> str:
+        return "boolean"
+
+class _UnitInterval(Constraint):
+    """Closed unit interval [0, 1]."""
+    def check(self, value: ArrayLike) -> Array:
+        v = jnp.asarray(value)
+        return (v >= 0) & (v <= 1)
+    def __repr__(self) -> str:
+        return "unit_interval"
+
+class _Simplex(Constraint):
+    """Probability simplex (non-negative, sums to 1 along last axis)."""
+    def check(self, value: ArrayLike) -> Array:
+        v = jnp.asarray(value)
+        return (jnp.all(v >= 0, axis=-1)) & (jnp.abs(jnp.sum(v, axis=-1) - 1.0) < 1e-5)
+    def __repr__(self) -> str:
+        return "simplex"
+
+class _PositiveDefinite(Constraint):
+    """Positive-definite matrices."""
+    def check(self, value: ArrayLike) -> Array:
+        v = jnp.asarray(value)
+        eigvals = jnp.linalg.eigvalsh(v)
+        return jnp.all(eigvals > 0, axis=-1)
+    def __repr__(self) -> str:
+        return "positive_definite"
+
+class _Sphere(Constraint):
+    """Unit sphere (vectors with unit L2 norm)."""
+    def check(self, value: ArrayLike) -> Array:
+        v = jnp.asarray(value)
+        return jnp.abs(jnp.linalg.norm(v, axis=-1) - 1.0) < 1e-5
+    def __repr__(self) -> str:
+        return "sphere"
+
+class _Interval(Constraint):
+    """Half-open or closed interval [low, high]."""
+    def __init__(self, low: float, high: float):
+        self.low = low
+        self.high = high
+    def check(self, value: ArrayLike) -> Array:
+        v = jnp.asarray(value)
+        return (v >= self.low) & (v <= self.high)
+    def __repr__(self) -> str:
+        return f"interval({self.low}, {self.high})"
+
+class _GreaterThan(Constraint):
+    """Values strictly greater than a lower bound."""
+    def __init__(self, lower_bound: float):
+        self.lower_bound = lower_bound
+    def check(self, value: ArrayLike) -> Array:
+        return jnp.asarray(value) > self.lower_bound
+    def __repr__(self) -> str:
+        return f"greater_than({self.lower_bound})"
+
+class _IntegerInterval(Constraint):
+    """Integer values in [low, high]."""
+    def __init__(self, low: int, high: int):
+        self.low = low
+        self.high = high
+    def check(self, value: ArrayLike) -> Array:
+        v = jnp.asarray(value)
+        return (v >= self.low) & (v <= self.high) & (v == jnp.floor(v))
+    def __repr__(self) -> str:
+        return f"integer_interval({self.low}, {self.high})"
+
+
+# ---------------------------------------------------------------------------
+# Singleton instances for common constraints
+# ---------------------------------------------------------------------------
+
+real = _Real()
+positive = _Positive()
+non_negative = _NonNegative()
+non_negative_integer = _NonNegativeInteger()
+boolean = _Boolean()
+unit_interval = _UnitInterval()
+simplex = _Simplex()
+positive_definite = _PositiveDefinite()
+sphere = _Sphere()
+
+
+# ---------------------------------------------------------------------------
+# Factory functions for parameterized constraints
+# ---------------------------------------------------------------------------
+
+def interval(low: float, high: float) -> _Interval:
+    return _Interval(low, high)
+
+def greater_than(lower_bound: float) -> _GreaterThan:
+    return _GreaterThan(lower_bound)
+
+def integer_interval(low: int, high: int) -> _IntegerInterval:
+    return _IntegerInterval(low, high)
+
+
+# ---------------------------------------------------------------------------
+# Constraint lattice (subset relationships)
+# ---------------------------------------------------------------------------
+
+# Immediate supersets in the constraint partial order.
+# Each constraint type maps to the types that are its direct (one-step)
+# supersets.  The transitive closure is computed once by ``_all_supersets``.
+_IMMEDIATE_SUPERSETS: dict[type, tuple[type, ...]] = {
+    _Boolean: (_NonNegativeInteger, _UnitInterval),
+    _UnitInterval: (_NonNegative,),
+    _Positive: (_NonNegative,),
+    _NonNegative: (_Real,),
+    _NonNegativeInteger: (_NonNegative,),
+    _Simplex: (_UnitInterval,),
+    _Sphere: (_Real,),
+    _PositiveDefinite: (_Real,),
+}
+
+_ALL_SUPERSETS: dict[type, set[type]] | None = None
+
+
+def _all_supersets() -> dict[type, set[type]]:
+    """Return the transitive closure of ``_IMMEDIATE_SUPERSETS``.
+
+    Computed once and cached at module level.
+    """
+    global _ALL_SUPERSETS
+    if _ALL_SUPERSETS is not None:
+        return _ALL_SUPERSETS
+
+    result: dict[type, set[type]] = {}
+
+    def _collect(t: type) -> set[type]:
+        if t in result:
+            return result[t]
+        immediate = _IMMEDIATE_SUPERSETS.get(t, ())
+        sups: set[type] = set(immediate)
+        for parent in immediate:
+            sups |= _collect(parent)
+        result[t] = sups
+        return sups
+
+    for t in _IMMEDIATE_SUPERSETS:
+        _collect(t)
+
+    _ALL_SUPERSETS = result
+    return result
+
+
+def _supports_compatible(source: Constraint, target: Constraint) -> bool:
+    """Check whether *source* support is a subset of *target* support.
+
+    Conservative: returns ``True`` when in doubt (e.g. for parameterized
+    constraints that can't be compared structurally).
+    """
+    # Identical constraints are always compatible
+    if source == target:
+        return True
+
+    supersets = _all_supersets()
+    source_type = type(source)
+    target_type = type(target)
+
+    # source ⊆ target?
+    if target_type in supersets.get(source_type, set()):
+        return True
+
+    # target ⊆ source means target is *narrower* — incompatible
+    if source_type in supersets.get(target_type, set()):
+        return False
+
+    # Parameterized constraints: interval/greater_than
+    if isinstance(source, _Interval) and isinstance(target, _Interval):
+        return source.low >= target.low and source.high <= target.high
+    if isinstance(source, _Interval) and isinstance(target, _Real):
+        return True
+    if isinstance(source, _GreaterThan) and isinstance(target, _GreaterThan):
+        return source.lower_bound >= target.lower_bound
+    if isinstance(source, _GreaterThan) and isinstance(target, _Real):
+        return True
+    if isinstance(source, (_Positive, _NonNegative)) and isinstance(target, _GreaterThan):
+        return True  # (0, inf) or [0, inf) ⊂ (lb, inf) when lb <= 0
+    if isinstance(source, _IntegerInterval) and isinstance(target, _IntegerInterval):
+        return source.low >= target.low and source.high <= target.high
+    if isinstance(source, _IntegerInterval) and isinstance(target, (_NonNegativeInteger, _Real)):
+        return True
+
+    # Conservative: allow when we can't determine
+    return True

--- a/probpipe/core/distribution.py
+++ b/probpipe/core/distribution.py
@@ -2,8 +2,6 @@
 Core distribution abstractions for ProbPipe.
 
 Provides:
-  - ``Provenance``                  – Lightweight lineage tracker.
-  - ``Constraint``                  – Support constraints (real, positive, simplex, …).
   - ``Distribution``                – Generic base class parameterized by value type T.
   - ``PyTreeArrayDistribution``     – Pytree-of-arrays layer with batch/event shape
                                       semantics, sampling, expectations, flatten/unflatten,
@@ -16,12 +14,15 @@ Provides:
   - ``BootstrapDistribution``       – MC error tracking via bootstrap resampling.
   - ``FlattenedView``               – Wraps any ``PyTreeArrayDistribution`` as a flat
                                       ``ArrayDistribution`` for algorithm interoperability.
+
+See also:
+  - :mod:`probpipe.core.provenance` for ``Provenance``.
+  - :mod:`probpipe.core.constraints` for ``Constraint`` and support singletons.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 from typing import Any, Callable, Generic, TypeVar
 
 from .._utils import prod
@@ -40,6 +41,23 @@ import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from ..custom_types import Array, ArrayLike, PRNGKey
+from .provenance import Provenance
+from .constraints import (
+    Constraint,
+    _supports_compatible,
+    real,
+    positive,
+    non_negative,
+    non_negative_integer,
+    boolean,
+    unit_interval,
+    simplex,
+    positive_definite,
+    sphere,
+    interval,
+    greater_than,
+    integer_interval,
+)
 
 # ---------------------------------------------------------------------------
 # Type variables
@@ -47,74 +65,6 @@ from ..custom_types import Array, ArrayLike, PRNGKey
 
 T = TypeVar('T')
 T_out = TypeVar('T_out')
-
-# ---------------------------------------------------------------------------
-# Provenance
-# ---------------------------------------------------------------------------
-
-@dataclass(frozen=True)
-class Provenance:
-    """Tracks how a distribution was created."""
-
-    operation: str
-    parents: tuple[Distribution, ...] = ()
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-    def __repr__(self) -> str:
-        parent_names = ", ".join(
-            p.name or type(p).__name__ for p in self.parents
-        )
-        return f"Provenance({self.operation!r}, parents=[{parent_names}])"
-
-    # -- Serialization -----------------------------------------------------
-
-    def to_dict(self, *, recurse: bool = True) -> dict[str, Any]:
-        """Serialize to a JSON-compatible dict.
-
-        Parameters
-        ----------
-        recurse : bool
-            If True, recursively serialize parent provenance chains.
-            If False, only include parent type/name references.
-        """
-        parent_dicts = []
-        for p in self.parents:
-            entry: dict[str, Any] = {
-                "type": type(p).__name__,
-                "name": p.name,
-            }
-            if recurse and p.source is not None:
-                entry["source"] = p.source.to_dict(recurse=True)
-            parent_dicts.append(entry)
-
-        # Filter metadata to JSON-serializable values
-        safe_metadata = {}
-        for k, v in self.metadata.items():
-            if isinstance(v, (str, int, float, bool, list, dict, type(None))):
-                safe_metadata[k] = v
-            else:
-                safe_metadata[k] = str(v)
-
-        return {
-            "operation": self.operation,
-            "parents": parent_dicts,
-            "metadata": safe_metadata,
-        }
-
-    @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Provenance:
-        """Reconstruct from a dict produced by :meth:`to_dict`.
-
-        Parent distributions are not available at deserialization time, so
-        ``parents`` will be an empty tuple.  The parent information is
-        preserved in the dict under ``"parents"`` for inspection.
-        """
-        return cls(
-            operation=d["operation"],
-            parents=(),
-            metadata={**d.get("metadata", {}), "_parents_info": d.get("parents", [])},
-        )
-
 
 # ---------------------------------------------------------------------------
 # Global defaults
@@ -416,238 +366,6 @@ class PyTreeArrayDistribution(Distribution[T]):
     def supports(self) -> T:
         """Per-leaf constraints. Default returns ``real`` for every leaf."""
         return jax.tree.map(lambda _: real, self.event_shapes)
-
-
-# ---------------------------------------------------------------------------
-# Constraints
-# ---------------------------------------------------------------------------
-
-class Constraint:
-    """Describes the support of a distribution (the set of valid values)."""
-
-    def check(self, value: ArrayLike) -> Array:
-        """Return a boolean array indicating which elements satisfy the constraint."""
-        raise NotImplementedError
-
-    def __repr__(self) -> str:
-        return self.__class__.__name__
-
-    def __eq__(self, other: object) -> bool:
-        return type(self) is type(other) and self.__dict__ == other.__dict__
-
-    def __hash__(self) -> int:
-        return hash((type(self), tuple(sorted(self.__dict__.items()))))
-
-
-class _Real(Constraint):
-    """All real numbers."""
-    def check(self, value: ArrayLike) -> Array:
-        return jnp.isfinite(jnp.asarray(value))
-    def __repr__(self) -> str:
-        return "real"
-
-class _Positive(Constraint):
-    """Strictly positive reals (0, inf)."""
-    def check(self, value: ArrayLike) -> Array:
-        return jnp.asarray(value) > 0
-    def __repr__(self) -> str:
-        return "positive"
-
-class _NonNegative(Constraint):
-    """Non-negative reals [0, inf)."""
-    def check(self, value: ArrayLike) -> Array:
-        return jnp.asarray(value) >= 0
-    def __repr__(self) -> str:
-        return "non_negative"
-
-class _NonNegativeInteger(Constraint):
-    """Non-negative integers {0, 1, 2, ...}."""
-    def check(self, value: ArrayLike) -> Array:
-        v = jnp.asarray(value)
-        return (v >= 0) & (v == jnp.floor(v))
-    def __repr__(self) -> str:
-        return "non_negative_integer"
-
-class _Boolean(Constraint):
-    """Binary values {0, 1}."""
-    def check(self, value: ArrayLike) -> Array:
-        v = jnp.asarray(value)
-        return (v == 0) | (v == 1)
-    def __repr__(self) -> str:
-        return "boolean"
-
-class _UnitInterval(Constraint):
-    """Closed unit interval [0, 1]."""
-    def check(self, value: ArrayLike) -> Array:
-        v = jnp.asarray(value)
-        return (v >= 0) & (v <= 1)
-    def __repr__(self) -> str:
-        return "unit_interval"
-
-class _Simplex(Constraint):
-    """Probability simplex (non-negative, sums to 1 along last axis)."""
-    def check(self, value: ArrayLike) -> Array:
-        v = jnp.asarray(value)
-        return (jnp.all(v >= 0, axis=-1)) & (jnp.abs(jnp.sum(v, axis=-1) - 1.0) < 1e-5)
-    def __repr__(self) -> str:
-        return "simplex"
-
-class _PositiveDefinite(Constraint):
-    """Positive-definite matrices."""
-    def check(self, value: ArrayLike) -> Array:
-        v = jnp.asarray(value)
-        eigvals = jnp.linalg.eigvalsh(v)
-        return jnp.all(eigvals > 0, axis=-1)
-    def __repr__(self) -> str:
-        return "positive_definite"
-
-class _Sphere(Constraint):
-    """Unit sphere (vectors with unit L2 norm)."""
-    def check(self, value: ArrayLike) -> Array:
-        v = jnp.asarray(value)
-        return jnp.abs(jnp.linalg.norm(v, axis=-1) - 1.0) < 1e-5
-    def __repr__(self) -> str:
-        return "sphere"
-
-class _Interval(Constraint):
-    """Half-open or closed interval [low, high]."""
-    def __init__(self, low: float, high: float):
-        self.low = low
-        self.high = high
-    def check(self, value: ArrayLike) -> Array:
-        v = jnp.asarray(value)
-        return (v >= self.low) & (v <= self.high)
-    def __repr__(self) -> str:
-        return f"interval({self.low}, {self.high})"
-
-class _GreaterThan(Constraint):
-    """Values strictly greater than a lower bound."""
-    def __init__(self, lower_bound: float):
-        self.lower_bound = lower_bound
-    def check(self, value: ArrayLike) -> Array:
-        return jnp.asarray(value) > self.lower_bound
-    def __repr__(self) -> str:
-        return f"greater_than({self.lower_bound})"
-
-class _IntegerInterval(Constraint):
-    """Integer values in [low, high]."""
-    def __init__(self, low: int, high: int):
-        self.low = low
-        self.high = high
-    def check(self, value: ArrayLike) -> Array:
-        v = jnp.asarray(value)
-        return (v >= self.low) & (v <= self.high) & (v == jnp.floor(v))
-    def __repr__(self) -> str:
-        return f"integer_interval({self.low}, {self.high})"
-
-
-# Singleton instances for common constraints
-real = _Real()
-positive = _Positive()
-non_negative = _NonNegative()
-non_negative_integer = _NonNegativeInteger()
-boolean = _Boolean()
-unit_interval = _UnitInterval()
-simplex = _Simplex()
-positive_definite = _PositiveDefinite()
-sphere = _Sphere()
-
-# Factory functions for parameterized constraints
-def interval(low: float, high: float) -> _Interval:
-    return _Interval(low, high)
-
-def greater_than(lower_bound: float) -> _GreaterThan:
-    return _GreaterThan(lower_bound)
-
-def integer_interval(low: int, high: int) -> _IntegerInterval:
-    return _IntegerInterval(low, high)
-
-
-# Immediate supersets in the constraint partial order.
-# Each constraint type maps to the types that are its direct (one-step)
-# supersets.  The transitive closure is computed once by ``_all_supersets``.
-_IMMEDIATE_SUPERSETS: dict[type, tuple[type, ...]] = {
-    _Boolean: (_NonNegativeInteger, _UnitInterval),
-    _UnitInterval: (_NonNegative,),
-    _Positive: (_NonNegative,),
-    _NonNegative: (_Real,),
-    _NonNegativeInteger: (_NonNegative,),
-    _Simplex: (_UnitInterval,),
-    _Sphere: (_Real,),
-    _PositiveDefinite: (_Real,),
-}
-
-_ALL_SUPERSETS: dict[type, set[type]] | None = None
-
-
-def _all_supersets() -> dict[type, set[type]]:
-    """Return the transitive closure of ``_IMMEDIATE_SUPERSETS``.
-
-    Computed once and cached at module level.
-    """
-    global _ALL_SUPERSETS
-    if _ALL_SUPERSETS is not None:
-        return _ALL_SUPERSETS
-
-    result: dict[type, set[type]] = {}
-
-    def _collect(t: type) -> set[type]:
-        if t in result:
-            return result[t]
-        immediate = _IMMEDIATE_SUPERSETS.get(t, ())
-        sups: set[type] = set(immediate)
-        for parent in immediate:
-            sups |= _collect(parent)
-        result[t] = sups
-        return sups
-
-    for t in _IMMEDIATE_SUPERSETS:
-        _collect(t)
-
-    _ALL_SUPERSETS = result
-    return result
-
-
-def _supports_compatible(source: Constraint, target: Constraint) -> bool:
-    """Check whether *source* support is a subset of *target* support.
-
-    Conservative: returns ``True`` when in doubt (e.g. for parameterized
-    constraints that can't be compared structurally).
-    """
-    # Identical constraints are always compatible
-    if source == target:
-        return True
-
-    supersets = _all_supersets()
-    source_type = type(source)
-    target_type = type(target)
-
-    # source ⊆ target?
-    if target_type in supersets.get(source_type, set()):
-        return True
-
-    # target ⊆ source means target is *narrower* — incompatible
-    if source_type in supersets.get(target_type, set()):
-        return False
-
-    # Parameterized constraints: interval/greater_than
-    if isinstance(source, _Interval) and isinstance(target, _Interval):
-        return source.low >= target.low and source.high <= target.high
-    if isinstance(source, _Interval) and isinstance(target, _Real):
-        return True
-    if isinstance(source, _GreaterThan) and isinstance(target, _GreaterThan):
-        return source.lower_bound >= target.lower_bound
-    if isinstance(source, _GreaterThan) and isinstance(target, _Real):
-        return True
-    if isinstance(source, (_Positive, _NonNegative)) and isinstance(target, _GreaterThan):
-        return True  # (0, inf) or [0, inf) ⊂ (lb, inf) when lb <= 0
-    if isinstance(source, _IntegerInterval) and isinstance(target, _IntegerInterval):
-        return source.low >= target.low and source.high <= target.high
-    if isinstance(source, _IntegerInterval) and isinstance(target, (_NonNegativeInteger, _Real)):
-        return True
-
-    # Conservative: allow when we can't determine
-    return True
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -26,9 +26,9 @@ from .distribution import (
     BroadcastDistribution,
     Distribution,
     EmpiricalDistribution,
-    Provenance,
     _make_marginal,
 )
+from .provenance import Provenance
 from .protocols import (
     SupportsConditioning,
     SupportsCovariance,

--- a/probpipe/core/provenance.py
+++ b/probpipe/core/provenance.py
@@ -1,14 +1,87 @@
-"""Provenance graph utilities for tracing distribution lineage."""
+"""Provenance tracking and graph utilities for distribution lineage."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .distribution import Distribution
 
-__all__ = ["provenance_ancestors", "provenance_dag"]
+__all__ = ["Provenance", "provenance_ancestors", "provenance_dag"]
 
+
+# ---------------------------------------------------------------------------
+# Provenance dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Provenance:
+    """Tracks how a distribution was created."""
+
+    operation: str
+    parents: tuple[Distribution, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __repr__(self) -> str:
+        parent_names = ", ".join(
+            p.name or type(p).__name__ for p in self.parents
+        )
+        return f"Provenance({self.operation!r}, parents=[{parent_names}])"
+
+    # -- Serialization -----------------------------------------------------
+
+    def to_dict(self, *, recurse: bool = True) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict.
+
+        Parameters
+        ----------
+        recurse : bool
+            If True, recursively serialize parent provenance chains.
+            If False, only include parent type/name references.
+        """
+        parent_dicts = []
+        for p in self.parents:
+            entry: dict[str, Any] = {
+                "type": type(p).__name__,
+                "name": p.name,
+            }
+            if recurse and p.source is not None:
+                entry["source"] = p.source.to_dict(recurse=True)
+            parent_dicts.append(entry)
+
+        # Filter metadata to JSON-serializable values
+        safe_metadata = {}
+        for k, v in self.metadata.items():
+            if isinstance(v, (str, int, float, bool, list, dict, type(None))):
+                safe_metadata[k] = v
+            else:
+                safe_metadata[k] = str(v)
+
+        return {
+            "operation": self.operation,
+            "parents": parent_dicts,
+            "metadata": safe_metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Provenance:
+        """Reconstruct from a dict produced by :meth:`to_dict`.
+
+        Parent distributions are not available at deserialization time, so
+        ``parents`` will be an empty tuple.  The parent information is
+        preserved in the dict under ``"parents"`` for inspection.
+        """
+        return cls(
+            operation=d["operation"],
+            parents=(),
+            metadata={**d.get("metadata", {}), "_parents_info": d.get("parents", [])},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Graph utilities
+# ---------------------------------------------------------------------------
 
 def provenance_ancestors(dist: Distribution) -> list[Distribution]:
     """Return all ancestor distributions reachable via provenance chains.

--- a/probpipe/distributions/__init__.py
+++ b/probpipe/distributions/__init__.py
@@ -1,5 +1,4 @@
 from ..core.distribution import (
-    Constraint,
     Distribution,
     PyTreeArrayDistribution,
     ArrayDistribution,
@@ -7,14 +6,16 @@ from ..core.distribution import (
     EmpiricalDistribution,
     ArrayEmpiricalDistribution,
     BroadcastDistribution,
-    Provenance,
     BootstrapDistribution,
     JointBootstrapDistribution,
     DEFAULT_NUM_EVALUATIONS,
     RETURN_APPROX_DIST,
     set_default_num_evaluations,
     set_return_approx_dist,
-    # constraint singletons & factories
+)
+from ..core.provenance import Provenance
+from ..core.constraints import (
+    Constraint,
     real,
     positive,
     non_negative,

--- a/probpipe/distributions/continuous.py
+++ b/probpipe/distributions/continuous.py
@@ -14,7 +14,9 @@ from ._tfp_base import TFPDistribution
 from ..core.distribution import (
     ArrayDistribution,
     EmpiricalDistribution,
-    Provenance,
+)
+from ..core.provenance import Provenance
+from ..core.constraints import (
     Constraint,
     real,
     positive,

--- a/probpipe/distributions/discrete.py
+++ b/probpipe/distributions/discrete.py
@@ -14,12 +14,14 @@ from ._tfp_base import TFPDistribution
 from ..core.distribution import (
     ArrayDistribution,
     EmpiricalDistribution,
-    Provenance,
+    _auto_key,
+)
+from ..core.provenance import Provenance
+from ..core.constraints import (
     Constraint,
     boolean,
     non_negative_integer,
     integer_interval,
-    _auto_key,
 )
 from ..custom_types import Array, ArrayLike, PRNGKey
 

--- a/probpipe/distributions/joint.py
+++ b/probpipe/distributions/joint.py
@@ -92,13 +92,12 @@ from ..core.distribution import (
     ArrayEmpiricalDistribution,
     PyTreeArrayDistribution,
     EmpiricalDistribution,
-    Provenance,
-    Constraint,
-    real,
     _auto_key,
     _vmap_sample,
     _mc_expectation,
 )
+from ..core.provenance import Provenance
+from ..core.constraints import Constraint, real
 from ..core.protocols import (
     SupportsConditioning,
     SupportsCovariance,

--- a/probpipe/distributions/multivariate.py
+++ b/probpipe/distributions/multivariate.py
@@ -8,7 +8,7 @@ import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from ._tfp_base import TFPDistribution
-from ..core.distribution import (
+from ..core.constraints import (
     Constraint,
     real,
     positive_definite,

--- a/probpipe/distributions/transformed.py
+++ b/probpipe/distributions/transformed.py
@@ -13,8 +13,10 @@ import tensorflow_probability.substrates.jax.distributions as tfd
 from ._tfp_base import TFPDistribution
 from ..core.distribution import (
     ArrayDistribution,
+)
+from ..core.provenance import Provenance
+from ..core.constraints import (
     Constraint,
-    Provenance,
     real,
     positive,
     unit_interval,

--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import jax.numpy as jnp
 
-from ..core.distribution import Provenance
+from ..core.provenance import Provenance
 from ..core.node import WorkflowFunction
 from ..custom_types import ArrayLike
 from ._diagnostics import InferenceDiagnostics, extract_arviz_diagnostics

--- a/probpipe/inference/_rwmh.py
+++ b/probpipe/inference/_rwmh.py
@@ -8,7 +8,7 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 
-from ..core.distribution import Provenance
+from ..core.provenance import Provenance
 from ..core.node import WorkflowFunction
 from ..core.protocols import SupportsLogProb, SupportsMean
 from ..custom_types import Array, ArrayLike, PRNGKey

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -7,7 +7,8 @@ from typing import Any, Callable
 
 import jax.numpy as jnp
 
-from ..core.distribution import Distribution, Provenance
+from ..core.distribution import Distribution
+from ..core.provenance import Provenance
 from ..custom_types import Array
 from ..inference._diagnostics import extract_arviz_diagnostics
 from ..inference._mcmc_distribution import MCMCApproximateDistribution

--- a/probpipe/modeling/_simple.py
+++ b/probpipe/modeling/_simple.py
@@ -8,7 +8,8 @@ import jax
 import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.mcmc as tfp_mcmc
 
-from ..core.distribution import Distribution, Provenance
+from ..core.distribution import Distribution
+from ..core.provenance import Provenance
 from ..core.protocols import (
     SupportsLogProb,
     SupportsMean,

--- a/probpipe/modeling/_stan.py
+++ b/probpipe/modeling/_stan.py
@@ -11,7 +11,8 @@ from typing import Any
 
 import jax.numpy as jnp
 
-from ..core.distribution import Distribution, Provenance
+from ..core.distribution import Distribution
+from ..core.provenance import Provenance
 from ..core.protocols import SupportsLogProb
 from ..custom_types import Array, ArrayLike
 from ..inference._diagnostics import InferenceDiagnostics, extract_arviz_diagnostics


### PR DESCRIPTION
## Summary

- Moves `Provenance` class from `core/distribution.py` to `core/provenance.py` (alongside existing `provenance_ancestors` and `provenance_dag` utilities)
- Extracts all constraint code (`Constraint` base class, 11 subclasses, 9 singletons, 3 factories, lattice logic) from `core/distribution.py` into new `core/constraints.py`
- Updates all 17 consumer files to import from canonical locations

Closes #79

## Test plan

- [x] All 1363 tests pass
- [x] `mkdocs build --strict` passes