### PR TITLE
Standardize array semantics & centralize weight handling

### DIFF
--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -24,6 +24,7 @@ _warnings.filterwarnings(
     category=DeprecationWarning,
 )
 
+from probpipe._weights import Weights
 from probpipe.core.distribution import (
     Distribution,
     PyTreeArrayDistribution,
@@ -132,6 +133,8 @@ from probpipe.converters import (
 )
 
 __all__ = [
+    # Weights
+    "Weights",
     # Base classes
     "Distribution",
     "PyTreeArrayDistribution",

--- a/probpipe/_utils.py
+++ b/probpipe/_utils.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
+
 import jax
+import jax.numpy as jnp
 
 from .custom_types import PRNGKey
 
@@ -25,6 +28,19 @@ def _auto_key() -> PRNGKey:
     key = jax.random.PRNGKey(_AUTO_KEY_COUNTER)
     _AUTO_KEY_COUNTER += 1
     return key
+
+
+def _is_numeric_array(x) -> bool:
+    """Return ``True`` if *x* is a JAX or numpy array with a numeric dtype.
+
+    Numpy object arrays (used for generic non-array samples in
+    ``EmpiricalDistribution``) return ``False``.
+    """
+    if isinstance(x, jnp.ndarray):
+        return True
+    if isinstance(x, np.ndarray):
+        return x.dtype != object
+    return False
 
 
 def prod(shape: tuple[int, ...]) -> int:

--- a/probpipe/_weights.py
+++ b/probpipe/_weights.py
@@ -1,12 +1,438 @@
-"""Centralized weight utilities for prob-pipe.
+"""Centralized weight utilities for ProbPipe.
 
-This module will provide:
-- Weight validation and normalization
-- A ``Weights`` class for encapsulating weight state
-- Weighted moment functions (mean, variance, covariance)
-- Weighted sampling utilities
-
-See PR description for the full design plan.
+Provides:
+  - ``Weights``               – Normalized probability weights (JAX-array-compatible).
+  - ``weighted_mean()``       – Weighted mean over leading axis.
+  - ``weighted_variance()``   – Weighted variance over leading axis.
+  - ``weighted_covariance()`` – Weighted covariance matrix.
+  - ``weighted_choice()``     – Draw weighted random indices.
+  - ``validate_and_normalize_log_weights()`` – Validate raw user input.
 """
 
-# TODO: Implementation coming after design review.
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from .custom_types import Array, ArrayLike, PRNGKey
+
+
+# ---------------------------------------------------------------------------
+# Pure utility functions (internal workhorses)
+# ---------------------------------------------------------------------------
+
+def validate_and_normalize_log_weights(
+    n: int,
+    weights: ArrayLike | None = None,
+    *,
+    log_weights: ArrayLike | None = None,
+) -> tuple[Array | None, bool]:
+    """Validate and convert user-supplied weights to log-unnormalized form.
+
+    Parameters
+    ----------
+    n : int
+        Expected number of weight entries.
+    weights : array-like, optional
+        Non-negative weights.  Mutually exclusive with *log_weights*.
+    log_weights : array-like, optional
+        Log-unnormalized weights.  Mutually exclusive with *weights*.
+
+    Returns
+    -------
+    log_w : Array or None
+        Log-unnormalized weights, or ``None`` when uniform.
+    is_uniform : bool
+        ``True`` when neither *weights* nor *log_weights* was provided.
+    """
+    if weights is not None and log_weights is not None:
+        raise ValueError("Provide either weights or log_weights, not both.")
+
+    if weights is not None:
+        weights = jnp.asarray(weights, dtype=jnp.float32)
+        if weights.shape != (n,):
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"number of items {n}."
+            )
+        if jnp.any(weights < 0):
+            raise ValueError("weights must be non-negative.")
+        total = jnp.sum(weights)
+        if total <= 0:
+            raise ValueError("weights must sum to a positive value.")
+        return jnp.log(weights), False
+
+    if log_weights is not None:
+        log_weights = jnp.asarray(log_weights, dtype=jnp.float32)
+        if log_weights.shape != (n,):
+            raise ValueError(
+                f"log_weights shape {log_weights.shape} does not match "
+                f"number of items {n}."
+            )
+        return log_weights, False
+
+    return None, True
+
+
+def normalize_weights(log_weights: Array) -> Array:
+    """Convert log-unnormalized weights to normalized probabilities.
+
+    Uses ``jax.nn.softmax`` for numerical stability.
+    """
+    return jax.nn.softmax(log_weights)
+
+
+def normalized_log_weights(log_weights: Array) -> Array:
+    """Normalize log-weights in log-space (subtract logsumexp)."""
+    return log_weights - jax.scipy.special.logsumexp(log_weights)
+
+
+def uniform_weights(n: int) -> Array:
+    """Return uniform weight vector of length *n*."""
+    return jnp.ones(n, dtype=jnp.float32) / n
+
+
+def weighted_mean(weights: Array | None, values: Array) -> Array:
+    """Weighted mean over the leading axis of *values*.
+
+    Parameters
+    ----------
+    weights : Array or None
+        Normalized weights of shape ``(n,)``.  ``None`` for uniform.
+    values : Array
+        Values of shape ``(n, ...)``.
+    """
+    if weights is None:
+        return jnp.mean(values, axis=0)
+    return jnp.einsum("n,n...->...", weights, values)
+
+
+def weighted_variance(
+    weights: Array | None,
+    values: Array,
+    mean: Array | None = None,
+) -> Array:
+    """Weighted variance over the leading axis of *values*.
+
+    Parameters
+    ----------
+    weights : Array or None
+        Normalized weights of shape ``(n,)``.  ``None`` for uniform.
+    values : Array
+        Values of shape ``(n, ...)``.
+    mean : Array, optional
+        Pre-computed weighted mean.  Computed if ``None``.
+    """
+    if mean is None:
+        mean = weighted_mean(weights, values)
+    diff = values - mean
+    return weighted_mean(weights, diff ** 2)
+
+
+def weighted_covariance(
+    weights: Array | None,
+    values: Array,
+    mean: Array | None = None,
+) -> Array:
+    """Weighted covariance matrix over the leading axis of *values*.
+
+    Parameters
+    ----------
+    weights : Array or None
+        Normalized weights of shape ``(n,)``.  ``None`` for uniform.
+    values : Array
+        Values of shape ``(n, ...)``.  Flattened to ``(n, d)`` internally.
+    mean : Array, optional
+        Pre-computed weighted mean.  Computed if ``None``.
+
+    Returns
+    -------
+    Array, shape ``(d, d)``
+        Weighted covariance matrix where ``d = prod(values.shape[1:])``.
+    """
+    n = values.shape[0]
+    flat = values.reshape(n, -1)
+    if mean is None:
+        mean = weighted_mean(weights, values)
+    diff = flat - mean.reshape(-1)
+    if weights is None:
+        return jnp.einsum("ni,nj->ij", diff, diff) / n
+    return jnp.einsum("ni,nj,n->ij", diff, diff, weights)
+
+
+def weighted_choice(
+    key: PRNGKey,
+    n: int,
+    *,
+    weights: Array | None = None,
+    shape: tuple[int, ...] = (),
+) -> Array:
+    """Draw random indices with optional weighting.
+
+    Parameters
+    ----------
+    key : PRNGKey
+        JAX PRNG key.
+    n : int
+        Number of items to choose from (indices ``0..n-1``).
+    weights : Array or None
+        Normalized weights of shape ``(n,)``.  ``None`` for uniform.
+    shape : tuple of int
+        Output shape of index array.
+
+    Returns
+    -------
+    Array
+        Integer index array of the given *shape*.
+    """
+    if not shape:
+        shape = (1,)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if weights is None:
+        indices = jax.random.randint(key, shape=shape, minval=0, maxval=n)
+    else:
+        indices = jax.random.choice(
+            key, n, shape=shape, p=weights, replace=True,
+        )
+
+    if squeeze:
+        return indices[0]
+    return indices
+
+
+# ---------------------------------------------------------------------------
+# Weights class
+# ---------------------------------------------------------------------------
+
+class Weights:
+    """Normalized probability weights over *n* items.
+
+    ``Weights`` stores log-unnormalized weights internally for numerical
+    stability and provides lazy-cached access to normalized weights and
+    log-weights.
+
+    It implements the JAX array protocol (``__jax_array__``), so a
+    ``Weights`` object can be passed directly to any JAX operation that
+    expects an array — it will automatically convert to its **normalized**
+    weight vector.
+
+    Parameters
+    ----------
+    n : int
+        Number of items.
+    weights : ArrayLike, optional
+        Non-negative weights (normalized internally).  Mutually exclusive
+        with *log_weights*.
+    log_weights : ArrayLike, optional
+        Log-unnormalized weights.  Preferred when weights span many orders
+        of magnitude (e.g. importance sampling).  Mutually exclusive with
+        *weights*.
+
+    Examples
+    --------
+    Create from raw weights or log-weights:
+
+    >>> w = Weights(3, weights=jnp.array([1.0, 2.0, 1.0]))
+    >>> w = Weights(3, log_weights=jnp.array([-1.0, 0.0, -1.0]))
+
+    Create uniform weights:
+
+    >>> w = Weights.uniform(5)
+
+    **Use as a JAX array** — returns normalized weights automatically:
+
+    >>> jnp.sum(w)                          # -> ~1.0
+    >>> jnp.einsum("n,n...->...", w, vals)  # weighted sum
+    >>> w * values                          # element-wise product
+
+    This means ``Weights`` can be passed anywhere a weight array is
+    expected, including ``jax.random.choice(..., p=w)``.
+
+    **Access different representations** explicitly when needed:
+
+    >>> w.normalized         # Array, shape (n,) — probabilities summing to 1
+    >>> w.log_normalized     # Array | None — log-probabilities (None if uniform)
+    >>> w.log_unnormalized   # Array | None — raw stored log-weights (None if uniform)
+    >>> w.is_uniform         # bool — True when all items are equally weighted
+
+    **Compute weighted statistics** directly:
+
+    >>> w.mean(samples)                 # weighted mean along leading axis
+    >>> w.variance(samples)             # weighted variance
+    >>> w.covariance(samples)           # weighted covariance matrix
+    >>> w.choice(key, shape=(10,))      # draw 10 weighted random indices
+
+    **JAX compatibility** — ``Weights`` is registered as a JAX pytree,
+    so it works transparently inside ``jax.jit``, ``jax.vmap``, and
+    ``jax.grad``.  The log-weights array is the traceable leaf;
+    ``is_uniform`` and ``n`` are static auxiliary data.  The
+    normalization cache is a Python-side optimization that is recomputed
+    inside traced contexts.
+    """
+
+    __slots__ = ("_n", "_log_weights", "_is_uniform", "_cache")
+
+    def __init__(
+        self,
+        n: int,
+        weights: ArrayLike | None = None,
+        *,
+        log_weights: ArrayLike | None = None,
+    ):
+        self._n = n
+        self._log_weights, self._is_uniform = validate_and_normalize_log_weights(
+            n, weights, log_weights=log_weights,
+        )
+        self._cache: Array | None = None
+
+    @staticmethod
+    def uniform(n: int) -> Weights:
+        """Create uniform weights over *n* items."""
+        w = object.__new__(Weights)
+        w._n = n
+        w._log_weights = None
+        w._is_uniform = True
+        w._cache = None
+        return w
+
+    # -- properties ---------------------------------------------------------
+
+    @property
+    def n(self) -> int:
+        """Number of items."""
+        return self._n
+
+    @property
+    def is_uniform(self) -> bool:
+        """``True`` when all items are equally weighted."""
+        return self._is_uniform
+
+    @property
+    def normalized(self) -> Array:
+        """Normalized weights, shape ``(n,)``.  Cached after first access."""
+        if self._is_uniform:
+            return uniform_weights(self._n)
+        if self._cache is None:
+            self._cache = normalize_weights(self._log_weights)
+        return self._cache
+
+    @property
+    def log_normalized(self) -> Array | None:
+        """Normalized log-weights, shape ``(n,)``.  ``None`` when uniform."""
+        if self._is_uniform:
+            return None
+        return normalized_log_weights(self._log_weights)
+
+    @property
+    def log_unnormalized(self) -> Array | None:
+        """Raw log-unnormalized weights as stored.  ``None`` when uniform."""
+        return self._log_weights
+
+    # -- JAX array protocol -------------------------------------------------
+
+    def __jax_array__(self) -> Array:
+        """Return normalized weights as a JAX array.
+
+        This allows ``Weights`` to be used directly in JAX operations
+        (``jnp.sum(w)``, ``jnp.einsum(..., w, ...)``, ``w * arr``, etc.).
+        """
+        return self.normalized
+
+    # -- array duck-typing --------------------------------------------------
+
+    @property
+    def shape(self) -> tuple[int]:
+        """Shape of the weight vector: ``(n,)``."""
+        return (self._n,)
+
+    @property
+    def dtype(self) -> jnp.dtype:
+        """Data type: always ``float32``."""
+        return jnp.float32
+
+    def __len__(self) -> int:
+        return self._n
+
+    # -- weighted operations ------------------------------------------------
+
+    def mean(self, values: Array) -> Array:
+        """Compute weighted mean: ``sum_i w_i * values[i]``."""
+        return weighted_mean(
+            None if self._is_uniform else self.normalized, values,
+        )
+
+    def variance(self, values: Array, mean: Array | None = None) -> Array:
+        """Compute weighted variance over the leading axis."""
+        return weighted_variance(
+            None if self._is_uniform else self.normalized, values, mean=mean,
+        )
+
+    def covariance(self, values: Array, mean: Array | None = None) -> Array:
+        """Compute weighted covariance matrix over the leading axis."""
+        return weighted_covariance(
+            None if self._is_uniform else self.normalized, values, mean=mean,
+        )
+
+    def choice(self, key: PRNGKey, *, shape: tuple[int, ...] = ()) -> Array:
+        """Draw weighted random indices from ``0..n-1``."""
+        return weighted_choice(
+            key, self._n,
+            weights=None if self._is_uniform else self.normalized,
+            shape=shape,
+        )
+
+    def subsample(self, indices: Array) -> Weights:
+        """Return a new ``Weights`` for a subset, re-normalized.
+
+        Parameters
+        ----------
+        indices : Array
+            Integer indices selecting a subset of items.
+
+        Returns
+        -------
+        Weights
+            New ``Weights`` over ``len(indices)`` items with weights
+            proportional to the original weights at *indices*.
+        """
+        if self._is_uniform:
+            return Weights.uniform(len(indices))
+        sub_log = self._log_weights[indices]
+        return Weights(len(indices), log_weights=sub_log)
+
+    # -- JAX pytree registration --------------------------------------------
+
+    def tree_flatten(self):
+        """Flatten for JAX pytree: leaves are the traceable arrays."""
+        children = (self._log_weights,)
+        aux = (self._n, self._is_uniform)
+        return children, aux
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        """Unflatten from JAX pytree."""
+        (log_weights,) = children
+        n, is_uniform = aux
+        w = object.__new__(cls)
+        w._n = n
+        w._log_weights = log_weights
+        w._is_uniform = is_uniform
+        w._cache = None
+        return w
+
+    # -- repr ---------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        if self._is_uniform:
+            return f"Weights(n={self._n}, uniform)"
+        return f"Weights(n={self._n})"
+
+
+jax.tree_util.register_pytree_node(
+    Weights,
+    lambda w: w.tree_flatten(),
+    lambda aux, children: Weights.tree_unflatten(aux, children),
+)

--- a/probpipe/core/_array_distributions.py
+++ b/probpipe/core/_array_distributions.py
@@ -28,6 +28,7 @@ import jax
 import jax.numpy as jnp
 
 from ..custom_types import Array, ArrayLike, PRNGKey
+from .._weights import Weights, weighted_mean, weighted_variance
 from .constraints import (
     Constraint,
     _supports_compatible,
@@ -431,10 +432,10 @@ class BootstrapDistribution(ArrayDistribution, SupportsSampling, SupportsMean, S
         self._n = self._evaluations.shape[0]
 
         if weights is not None:
-            w = jnp.asarray(weights, dtype=jnp.float32)
-            self._weights = w / jnp.sum(w)
+            # BootstrapDistribution accepts pre-normalized weights.
+            self._w = Weights(self._n, weights=weights)
         else:
-            self._weights = None
+            self._w = Weights.uniform(self._n)
 
         self._name = name
         self._approximate = True
@@ -457,32 +458,22 @@ class BootstrapDistribution(ArrayDistribution, SupportsSampling, SupportsMean, S
 
     def _mean(self) -> Array:
         """Point estimate: (weighted) mean of evaluations."""
-        if self._weights is None:
-            return jnp.mean(self._evaluations, axis=0)
-        return jnp.einsum("n,n...->...", self._weights, self._evaluations)
+        return self._w.mean(self._evaluations)
 
     def _variance(self) -> Array:
         """Variance of the sampling distribution (approx Var[f(X)] / n_eff)."""
         mu = self._mean()
-        diff = self._evaluations - mu
-        if self._weights is None:
-            sample_var = jnp.mean(diff ** 2, axis=0)
+        w_arr = None if self._w.is_uniform else self._w.normalized
+        sample_var = weighted_variance(w_arr, self._evaluations, mean=mu)
+        if self._w.is_uniform:
             return sample_var / self._n
-        # Weighted variance / effective sample size
-        sample_var = jnp.einsum("n,n...->...", self._weights, diff ** 2)
-        n_eff = 1.0 / jnp.sum(self._weights ** 2)
+        n_eff = 1.0 / jnp.sum(self._w.normalized ** 2)
         return sample_var / n_eff
 
     def _sample_one(self, key: PRNGKey) -> Array:
         """Draw a single bootstrap resample of the mean."""
-        if self._weights is None:
-            idx = jax.random.choice(key, self._n, shape=(self._n,), replace=True)
-            return jnp.mean(self._evaluations[idx], axis=0)
-        else:
-            idx = jax.random.choice(
-                key, self._n, shape=(self._n,), replace=True, p=self._weights
-            )
-            return jnp.mean(self._evaluations[idx], axis=0)
+        idx = self._w.choice(key, shape=(self._n,))
+        return jnp.mean(self._evaluations[idx], axis=0)
 
     def _sample(
         self,
@@ -494,16 +485,16 @@ class BootstrapDistribution(ArrayDistribution, SupportsSampling, SupportsMean, S
             return self._sample_one(key)
         total = prod(sample_shape)
         keys = jax.random.split(key, total)
+        w_arr = None if self._w.is_uniform else self._w.normalized
 
         def _one_resample(k):
-            if self._weights is None:
+            if w_arr is None:
                 idx = jax.random.choice(k, self._n, shape=(self._n,), replace=True)
-                return jnp.mean(self._evaluations[idx], axis=0)
             else:
                 idx = jax.random.choice(
-                    k, self._n, shape=(self._n,), replace=True, p=self._weights
+                    k, self._n, shape=(self._n,), replace=True, p=w_arr
                 )
-                return jnp.mean(self._evaluations[idx], axis=0)
+            return jnp.mean(self._evaluations[idx], axis=0)
 
         results = jax.vmap(_one_resample)(keys)
         return results.reshape(sample_shape + self.event_shape)

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -26,6 +26,7 @@ import jax
 import jax.numpy as jnp
 
 from ..custom_types import Array
+from .._weights import Weights, weighted_mean, weighted_choice
 from ._distribution_base import Distribution
 from ._empirical import (
     ArrayEmpiricalDistribution,
@@ -120,7 +121,7 @@ class _MixtureSampling:
     def _sample(self, key, sample_shape=()):
         n_draws = prod(sample_shape) if sample_shape else 1
         key1, key2 = jax.random.split(key)
-        indices = jax.random.choice(key1, self.n, shape=(n_draws,), p=self.weights)
+        indices = weighted_choice(key1, self.n, weights=self.weights, shape=(n_draws,))
         keys = jax.random.split(key2, n_draws)
 
         results = []
@@ -138,7 +139,7 @@ class _MixtureMean:
 
     def _mean(self):
         means = jnp.stack([c._mean() for c in self._components], axis=0)
-        return jnp.einsum("n,n...->...", self.weights, means)
+        return weighted_mean(self.weights, means)
 
 
 class _MixtureVariance:
@@ -147,11 +148,11 @@ class _MixtureVariance:
     def _variance(self):
         means = jnp.stack([c._mean() for c in self._components], axis=0)
         variances = jnp.stack([c._variance() for c in self._components], axis=0)
-        overall_mean = jnp.einsum("n,n...->...", self.weights, means)
+        overall_mean = weighted_mean(self.weights, means)
         # Law of total variance: E[Var(Y|X)] + Var(E[Y|X])
-        e_var = jnp.einsum("n,n...->...", self.weights, variances)
+        e_var = weighted_mean(self.weights, variances)
         diff = means - overall_mean
-        var_e = jnp.einsum("n,n...->...", self.weights, diff ** 2)
+        var_e = weighted_mean(self.weights, diff ** 2)
         return e_var + var_e
 
 
@@ -353,10 +354,14 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling, SupportsNamedC
         self._output_samples = output_samples
         self._output_distributions = output_distributions
 
+        # Determine n from first broadcast arg
+        first_key = list(broadcast_args)[0]
+        first_arr = input_samples[first_key]
+        n = first_arr.shape[0] if hasattr(first_arr, 'shape') else len(first_arr)
         if weights is not None:
-            weights = jnp.asarray(weights, dtype=jnp.float32)
-            weights = weights / jnp.sum(weights)
-        self._weights = weights
+            self._w = Weights(n, weights=weights)
+        else:
+            self._w = Weights.uniform(n)
         self._broadcast_args = list(broadcast_args)
         self._name = name
         self._approximate = True
@@ -367,16 +372,12 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling, SupportsNamedC
     @property
     def n(self) -> int:
         """Number of input–output pairs."""
-        first_key = self._broadcast_args[0]
-        arr = self._input_samples[first_key]
-        return arr.shape[0] if hasattr(arr, 'shape') else len(arr)
+        return self._w.n
 
     @property
     def weights(self) -> Array:
         """Normalised weights, shape ``(n,)``."""
-        if self._weights is None:
-            return jnp.ones(self.n, dtype=jnp.float32) / self.n
-        return self._weights
+        return self._w.normalized
 
     @property
     def input_samples(self) -> dict[str, Any]:
@@ -400,7 +401,8 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling, SupportsNamedC
             return self.marginalize()
         if key in self._input_samples:
             arr = self._input_samples[key]
-            return EmpiricalDistribution(arr, weights=self._weights)
+            w = None if self._w.is_uniform else self._w.normalized
+            return EmpiricalDistribution(arr, weights=w)
         raise KeyError(f"Unknown component {key!r}; available: {self.component_names}")
 
     # -- joint sampling -----------------------------------------------------
@@ -408,10 +410,7 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling, SupportsNamedC
     def _sample(self, key, sample_shape=()):
         """Resample paired input–output tuples."""
         n_draws = prod(sample_shape) if sample_shape else 1
-        if self._weights is None:
-            indices = jax.random.randint(key, shape=(n_draws,), minval=0, maxval=self.n)
-        else:
-            indices = jax.random.choice(key, self.n, shape=(n_draws,), p=self.weights, replace=True)
+        indices = self._w.choice(key, shape=(n_draws,))
 
         result = {}
         for arg_name in self._broadcast_args:
@@ -441,9 +440,10 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling, SupportsNamedC
         ``BroadcastDistribution``.
         """
         if self._marginal_cache is None:
+            w_arr = None if self._w.is_uniform else self._w.normalized
             self._marginal_cache = _make_marginal(
                 self._output_samples,
-                self._weights,
+                w_arr,
                 output_distributions=self._output_distributions,
             )
             if self.source is not None and isinstance(self._marginal_cache, Distribution):

--- a/probpipe/core/_empirical.py
+++ b/probpipe/core/_empirical.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import numpy as np
 
-from .._utils import prod
+from .._utils import prod, _is_numeric_array
 from .protocols import (
     SupportsCovariance,
     SupportsExpectation,
@@ -27,6 +27,7 @@ import jax
 import jax.numpy as jnp
 
 from ..custom_types import Array, ArrayLike, PRNGKey
+from .._weights import Weights, weighted_mean
 from .constraints import Constraint, real
 from . import _distribution_base as _base
 from .._utils import _auto_key
@@ -51,10 +52,15 @@ class EmpiricalDistribution[T](
 
     This is the generic base class.  It stores samples in a numpy object
     array, supporting arbitrary sample types ``T`` (arrays, pytrees,
-    distributions, callables, etc.).  Use :class:`ArrayEmpiricalDistribution`
-    when TFP-style shape semantics (``batch_shape``, ``event_shape``,
-    ``flatten_value``, ``support``, etc.) are required — it stores samples
-    as a stacked JAX array for efficient vectorised operations.
+    distributions, callables, etc.).
+
+    **Automatic array dispatch:** When *samples* is a numeric JAX or
+    numpy array, ``EmpiricalDistribution(samples, ...)`` automatically
+    returns an :class:`ArrayEmpiricalDistribution` instance, which
+    provides TFP-style shape semantics (``batch_shape``, ``event_shape``,
+    ``flatten_value``, ``support``, etc.) and exact weighted moments.
+    Pass a non-numeric sequence (e.g. a list of objects) to get the
+    generic base class.
 
     Parameters
     ----------
@@ -72,6 +78,11 @@ class EmpiricalDistribution[T](
     name : str, optional
         An optional name for provenance / JointDistribution integration.
     """
+
+    def __new__(cls, samples=None, *args, **kwargs):
+        if cls is EmpiricalDistribution and samples is not None and _is_numeric_array(samples):
+            return object.__new__(ArrayEmpiricalDistribution)
+        return object.__new__(cls)
 
     def __init__(
         self,
@@ -100,41 +111,11 @@ class EmpiricalDistribution[T](
         log_weights: ArrayLike | None = None,
         name: str | None = None,
     ) -> None:
-        """Validate and store weights, name, and flags.
-        """
-        if weights is not None and log_weights is not None:
-            raise ValueError(
-                "Provide either weights or log_weights, not both."
-            )
-
-        if weights is not None:
-            weights = jnp.asarray(weights, dtype=jnp.float32)
-            if weights.shape != (n,):
-                raise ValueError(
-                    f"weights shape {weights.shape} does not match "
-                    f"number of samples {n}."
-                )
-            if jnp.any(weights < 0):
-                raise ValueError("weights must be non-negative.")
-            total = jnp.sum(weights)
-            if total <= 0:
-                raise ValueError("weights must sum to a positive value.")
-            self._log_weights = jnp.log(weights)
-            self._is_uniform = False
-        elif log_weights is not None:
-            log_weights = jnp.asarray(log_weights, dtype=jnp.float32)
-            if log_weights.shape != (n,):
-                raise ValueError(
-                    f"log_weights shape {log_weights.shape} does not match "
-                    f"number of samples {n}."
-                )
-            self._log_weights = log_weights
-            self._is_uniform = False
+        """Validate and store weights, name, and flags."""
+        if weights is None and log_weights is None:
+            self._w = Weights.uniform(n)
         else:
-            self._log_weights = None
-            self._is_uniform = True
-
-        self._weights_cache: Array | None = None
+            self._w = Weights(n, weights, log_weights=log_weights)
         self._name = name
         self._approximate = True
 
@@ -156,32 +137,23 @@ class EmpiricalDistribution[T](
     @property
     def is_uniform(self) -> bool:
         """True when all samples have equal weight."""
-        return self._is_uniform
+        return self._w.is_uniform
 
     @property
     def weights(self) -> Array:
         """Normalised weights, shape ``(n,)``."""
-        if self._is_uniform:
-            return jnp.ones(self.n, dtype=jnp.float32) / self.n
-        if self._weights_cache is None:
-            self._weights_cache = jax.nn.softmax(self._log_weights)
-        return self._weights_cache
+        return self._w.normalized
 
     @property
     def log_weights(self) -> Array | None:
         """Normalised log-weights, shape ``(n,)``.  ``None`` when uniform."""
-        if self._is_uniform:
-            return None
-        return self._log_weights - jax.scipy.special.logsumexp(self._log_weights)
+        return self._w.log_normalized
 
     # -- sampling -----------------------------------------------------------
 
     def _sample_one(self, key: PRNGKey) -> T:
         """Draw a single sample (with replacement according to weights)."""
-        if self._is_uniform:
-            idx = jax.random.randint(key, shape=(), minval=0, maxval=self.n)
-        else:
-            idx = jax.random.choice(key, self.n, p=self.weights)
+        idx = self._w.choice(key)
         return self._samples[idx]
 
     def _sample(
@@ -200,12 +172,7 @@ class EmpiricalDistribution[T](
         if sample_shape == ():
             return self._sample_one(key)
         n_draws = prod(sample_shape)
-        if self._is_uniform:
-            indices = jax.random.randint(key, shape=(n_draws,), minval=0, maxval=self.n)
-        else:
-            indices = jax.random.choice(
-                key, self.n, shape=(n_draws,), p=self.weights, replace=True,
-            )
+        indices = self._w.choice(key, shape=(n_draws,))
         draws = self._samples[indices]
         return draws.reshape(sample_shape + draws.shape[1:])
 
@@ -241,26 +208,18 @@ class EmpiricalDistribution[T](
                 key = _auto_key()
             idx = jax.random.choice(key, self.n, shape=(num_evaluations,), replace=False)
             f_vals = self._eval_f(f, self._samples[idx])
+            sub_w = self._w.subsample(idx)
 
             rd = return_dist if return_dist is not None else _base.RETURN_APPROX_DIST
             if rd:
-                sub_w = None
-                if not self._is_uniform:
-                    sub_w = self.weights[idx]
-                    sub_w = sub_w / jnp.sum(sub_w)
-                return BootstrapDistribution(f_vals, weights=sub_w)
+                w_arr = None if sub_w.is_uniform else sub_w.normalized
+                return BootstrapDistribution(f_vals, weights=w_arr)
 
-            if self._is_uniform:
-                return jnp.mean(f_vals, axis=0)
-            sub_w = self.weights[idx]
-            sub_w = sub_w / jnp.sum(sub_w)
-            return jnp.einsum("n,n...->...", sub_w, f_vals)
+            return sub_w.mean(f_vals)
 
         # Exact: evaluate f on all support points
         f_vals = self._eval_f(f, self._samples)
-        if self._is_uniform:
-            return jnp.mean(f_vals, axis=0)
-        return jnp.einsum("n,n...->...", self.weights, f_vals)
+        return self._w.mean(f_vals)
 
 
 # ---------------------------------------------------------------------------
@@ -284,9 +243,25 @@ class ArrayEmpiricalDistribution(
     ``unflatten_value``, ``support``, etc.) via :class:`ArrayDistribution`,
     plus exact weighted moments (mean, variance, covariance).
 
-    Use this instead of :class:`EmpiricalDistribution` when the distribution
-    must interoperate with :class:`JointDistribution` components or other
-    code that requires :class:`ArrayDistribution` instances.
+    Parameters
+    ----------
+    samples : array-like
+        Sample array.  The leading axis (or axes, if *sample_shape* is
+        given) indexes the support points; trailing axes form the event
+        shape.
+    weights : array-like, shape ``(n,)``, optional
+        Non-negative weights (normalised internally).
+    log_weights : array-like, shape ``(n,)``, optional
+        Log-unnormalised weights.  Mutually exclusive with *weights*.
+    sample_shape : tuple of int, optional
+        Shape of the leading sample dimensions.  When ``None`` (default),
+        the first axis is the single sample axis (``n = samples.shape[0]``)
+        and ``event_shape = samples.shape[1:]``.  When provided,
+        ``n = prod(sample_shape)``, the leading dimensions must match
+        *sample_shape*, and ``event_shape = samples.shape[len(sample_shape):]``.
+        The samples array is reshaped internally to ``(n, *event_shape)``.
+    name : str, optional
+        Distribution name.
     """
 
     def __init__(
@@ -295,12 +270,25 @@ class ArrayEmpiricalDistribution(
         weights: ArrayLike | None = None,
         *,
         log_weights: ArrayLike | None = None,
+        sample_shape: tuple[int, ...] | None = None,
         name: str | None = None,
     ):
         # Store only the JAX array — bypass the generic base's storage.
         self._samples = jnp.asarray(samples, dtype=jnp.float32)
         if self._samples.ndim == 0:
             raise ValueError("samples must have at least 1 dimension (the sample axis).")
+
+        if sample_shape is not None:
+            n_sample_dims = len(sample_shape)
+            if self._samples.shape[:n_sample_dims] != sample_shape:
+                raise ValueError(
+                    f"Leading dimensions {self._samples.shape[:n_sample_dims]} "
+                    f"do not match sample_shape {sample_shape}."
+                )
+            n = prod(sample_shape)
+            event_shape = self._samples.shape[n_sample_dims:]
+            self._samples = self._samples.reshape(n, *event_shape)
+
         self._init_weights(
             self._samples.shape[0], weights, log_weights=log_weights, name=name,
         )
@@ -328,26 +316,14 @@ class ArrayEmpiricalDistribution(
     # -- moments ------------------------------------------------------------
 
     def _mean(self) -> Array:
-        if self._is_uniform:
-            return jnp.mean(self._samples, axis=0)
-        return jnp.einsum("n,n...->...", self.weights, self._samples)
+        return self._w.mean(self._samples)
 
     def _variance(self) -> Array:
-        mu = self._mean()
-        diff = self._samples - mu
-        if self._is_uniform:
-            return jnp.mean(diff**2, axis=0)
-        return jnp.einsum("n,n...->...", self.weights, diff**2)
+        return self._w.variance(self._samples)
 
     def _cov(self) -> Array:
         """Weighted sample covariance matrix, shape ``(d, d)``."""
-        mu = self._mean()
-        # Flatten to 2D: (n, d)
-        flat_samples = self._samples.reshape(self.n, -1)
-        diff = flat_samples - mu.reshape(-1)
-        if self._is_uniform:
-            return jnp.einsum("ni,nj->ij", diff, diff) / self.n
-        return jnp.einsum("ni,nj,n->ij", diff, diff, self.weights)
+        return self._w.covariance(self._samples)
 
 
 # ---------------------------------------------------------------------------
@@ -362,9 +338,13 @@ class BootstrapReplicateDistribution[T](
     """N-fold product of an empirical distribution (bootstrap resampling).
 
     This is the generic base class.  It stores observations in a numpy
-    object array, supporting arbitrary observation types ``T``.  Use
-    :class:`ArrayBootstrapReplicateDistribution` when TFP-style shape semantics
-    (``batch_shape``, ``event_shape``, ``support``, etc.) are required.
+    object array, supporting arbitrary observation types ``T``.
+
+    **Automatic array dispatch:** When *source* is a numeric JAX or
+    numpy array (or an ``EmpiricalDistribution`` backed by numeric
+    arrays), ``BootstrapReplicateDistribution(source, ...)``
+    automatically returns an :class:`ArrayBootstrapReplicateDistribution`
+    instance with TFP-style shape semantics.
 
     Each sample from this distribution is a bootstrapped dataset — ``n``
     observations drawn i.i.d. with replacement from the source data.
@@ -398,6 +378,14 @@ class BootstrapReplicateDistribution[T](
     _sampling_cost: str = "low"
     _preferred_orchestration: str | None = None
 
+    def __new__(cls, source=None, *args, **kwargs):
+        if cls is BootstrapReplicateDistribution and source is not None:
+            if _is_numeric_array(source):
+                return object.__new__(ArrayBootstrapReplicateDistribution)
+            if isinstance(source, EmpiricalDistribution) and _is_numeric_array(source.samples):
+                return object.__new__(ArrayBootstrapReplicateDistribution)
+        return object.__new__(cls)
+
     def __init__(
         self,
         source: EmpiricalDistribution | Sequence | ArrayLike,
@@ -407,8 +395,7 @@ class BootstrapReplicateDistribution[T](
     ):
         if isinstance(source, EmpiricalDistribution):
             self._data = source.samples
-            self._is_uniform = source.is_uniform
-            self._weights = None if source.is_uniform else source.weights
+            self._w = source._w
             default_n = source.n
         elif isinstance(source, (jnp.ndarray, np.ndarray)):
             self._data = source
@@ -416,15 +403,13 @@ class BootstrapReplicateDistribution[T](
                 raise ValueError("source must have at least 1 dimension (the observation axis).")
             if len(self._data) == 0:
                 raise ValueError("source must be a non-empty sequence.")
-            self._is_uniform = True
-            self._weights = None
+            self._w = Weights.uniform(len(self._data))
             default_n = len(self._data)
         else:
             self._data = np.asarray(source, dtype=object)
             if len(self._data) == 0:
                 raise ValueError("source must be a non-empty sequence.")
-            self._is_uniform = True
-            self._weights = None
+            self._w = Weights.uniform(len(self._data))
             default_n = len(self._data)
         self._init_bootstrap_state(default_n, n=n, name=name)
 
@@ -471,23 +456,16 @@ class BootstrapReplicateDistribution[T](
     @property
     def weights(self) -> Array:
         """Normalised weights, shape ``(source_n,)``."""
-        if self._is_uniform:
-            return jnp.ones(self._source_n, dtype=jnp.float32) / self._source_n
-        return self._weights
+        return self._w.normalized
 
     @property
     def is_uniform(self) -> bool:
         """True when all source observations have equal weight."""
-        return self._is_uniform
+        return self._w.is_uniform
 
     def _sample_one(self, key: PRNGKey) -> Any:
         """Draw a single bootstrapped dataset."""
-        if self._weights is None:
-            idx = jax.random.choice(key, self._source_n, shape=(self._n,), replace=True)
-        else:
-            idx = jax.random.choice(
-                key, self._source_n, shape=(self._n,), replace=True, p=self._weights,
-            )
+        idx = self._w.choice(key, shape=(self._n,))
         return self._data[idx]
 
     @property
@@ -583,18 +561,15 @@ class ArrayBootstrapReplicateDistribution(BootstrapReplicateDistribution[Array],
         # Coerce to JAX array, then let the generic base store it.
         if isinstance(source, EmpiricalDistribution):
             jax_data = jnp.asarray(list(source.samples), dtype=jnp.float32)
-            # Reconstruct via the array path so the base stores a JAX array.
             self._data = jax_data
-            self._is_uniform = source.is_uniform
-            self._weights = None if source.is_uniform else source.weights
+            self._w = source._w
             default_n = source.n
         else:
             jax_data = jnp.asarray(source, dtype=jnp.float32)
             if jax_data.ndim == 0:
                 raise ValueError("source must have at least 1 dimension (the observation axis).")
             self._data = jax_data
-            self._is_uniform = True
-            self._weights = None
+            self._w = Weights.uniform(jax_data.shape[0])
             default_n = jax_data.shape[0]
 
         self._event_shape_per_obs = self._data.shape[1:]

--- a/probpipe/distributions/joint.py
+++ b/probpipe/distributions/joint.py
@@ -86,6 +86,7 @@ import jax.numpy as jnp
 from .._utils import prod, _auto_key
 
 from ..custom_types import Array, ArrayLike, PRNGKey
+from .._weights import Weights, weighted_mean, weighted_variance
 from ..core.distribution import (
     ArrayDistribution,
     ArrayEmpiricalDistribution,
@@ -527,39 +528,20 @@ class JointEmpirical(JointDistribution, SupportsSampling, SupportsMean, Supports
         self._n = n
         self._name = name
 
-        # Handle weights (same logic as EmpiricalDistribution)
-        if weights is not None and log_weights is not None:
-            raise ValueError("Provide either weights or log_weights, not both.")
-
-        if weights is not None:
-            weights = jnp.asarray(weights, dtype=jnp.float32)
-            if weights.shape != (n,):
-                raise ValueError(f"weights shape {weights.shape} != ({n},)")
-            if jnp.any(weights < 0):
-                raise ValueError("weights must be non-negative.")
-            self._log_weights = jnp.log(weights)
-            self._is_uniform = False
-        elif log_weights is not None:
-            log_weights = jnp.asarray(log_weights, dtype=jnp.float32)
-            if log_weights.shape != (n,):
-                raise ValueError(f"log_weights shape {log_weights.shape} != ({n},)")
-            self._log_weights = log_weights
-            self._is_uniform = False
+        if weights is None and log_weights is None:
+            self._w = Weights.uniform(n)
         else:
-            self._log_weights = None
-            self._is_uniform = True
-
-        self._weights_cache: Array | None = None
+            self._w = Weights(n, weights, log_weights=log_weights)
 
         # Build _components as ArrayEmpiricalDistribution per component
         # (JointDistribution requires ArrayDistribution leaves for shape introspection)
         comp_dists: dict[str, ArrayEmpiricalDistribution] = {}
         for cname, arr in self._joint_samples.items():
-            if self._is_uniform:
+            if self._w.is_uniform:
                 comp_dists[cname] = ArrayEmpiricalDistribution(arr, name=cname)
             else:
                 comp_dists[cname] = ArrayEmpiricalDistribution(
-                    arr, log_weights=self._log_weights, name=cname
+                    arr, log_weights=self._w.log_unnormalized, name=cname
                 )
         self._components = comp_dists
 
@@ -570,16 +552,12 @@ class JointEmpirical(JointDistribution, SupportsSampling, SupportsMean, Supports
 
     @property
     def is_uniform(self) -> bool:
-        return self._is_uniform
+        return self._w.is_uniform
 
     @property
     def weights(self) -> Array:
         """Normalised weights, shape ``(n,)``."""
-        if self._is_uniform:
-            return jnp.ones(self._n, dtype=jnp.float32) / self._n
-        if self._weights_cache is None:
-            self._weights_cache = jax.nn.softmax(self._log_weights)
-        return self._weights_cache
+        return self._w.normalized
 
     def _sample_one(self, key: PRNGKey) -> dict[str, Array]:
         return self._sample_joint_rows(key, ())
@@ -596,12 +574,7 @@ class JointEmpirical(JointDistribution, SupportsSampling, SupportsMean, Supports
     ) -> dict[str, Array]:
         """Resample rows jointly, preserving correlation."""
         n_draws = prod(sample_shape)
-        if self._is_uniform:
-            indices = jax.random.randint(key, shape=(n_draws,), minval=0, maxval=self._n)
-        else:
-            indices = jax.random.choice(
-                key, self._n, shape=(n_draws,), p=self.weights, replace=True,
-            )
+        indices = self._w.choice(key, shape=(n_draws,))
         result = {}
         for cname, arr in self._joint_samples.items():
             drawn = arr[indices]
@@ -628,52 +601,30 @@ class JointEmpirical(JointDistribution, SupportsSampling, SupportsMean, Supports
         """Flat mean vector (for internal use by log_prob)."""
         parts = []
         for cname, arr in self._joint_samples.items():
-            if self._is_uniform:
-                m = jnp.mean(arr, axis=0)
-            else:
-                m = jnp.einsum("n,n...->...", self.weights, arr)
-            parts.append(m.reshape(-1))
+            parts.append(self._w.mean(arr).reshape(-1))
         return jnp.concatenate(parts)
 
     def _flat_variance(self) -> Array:
         """Flat variance vector (for internal use by log_prob)."""
-        mu_flat = self._flat_mean()
         parts = []
-        offset = 0
         for cname, arr in self._joint_samples.items():
-            flat_dim = prod(arr.shape[1:])
-            mu_comp = mu_flat[offset:offset + flat_dim]
             arr_flat = arr.reshape(self._n, -1)
-            diff = arr_flat - mu_comp
-            if self._is_uniform:
-                v = jnp.mean(diff**2, axis=0)
-            else:
-                v = jnp.einsum("n,nd->d", self.weights, diff**2)
-            parts.append(v)
-            offset += flat_dim
+            parts.append(self._w.variance(arr_flat))
         return jnp.concatenate(parts)
 
     def _mean(self) -> dict[str, Array]:
         """Per-component weighted means."""
-        result = {}
-        for cname, arr in self._joint_samples.items():
-            if self._is_uniform:
-                result[cname] = jnp.mean(arr, axis=0)
-            else:
-                result[cname] = jnp.einsum("n,n...->...", self.weights, arr)
-        return result
+        return {
+            cname: self._w.mean(arr)
+            for cname, arr in self._joint_samples.items()
+        }
 
     def _variance(self) -> dict[str, Array]:
         """Per-component weighted variances."""
-        means = self._mean()
-        result = {}
-        for cname, arr in self._joint_samples.items():
-            diff = arr - means[cname]
-            if self._is_uniform:
-                result[cname] = jnp.mean(diff**2, axis=0)
-            else:
-                result[cname] = jnp.einsum("n,n...->...", self.weights, diff**2)
-        return result
+        return {
+            cname: self._w.variance(arr)
+            for cname, arr in self._joint_samples.items()
+        }
 
     def _expectation(self, f, *, key=None, num_evaluations=None, return_dist=None):
         return _mc_expectation(self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist)
@@ -718,12 +669,12 @@ class JointEmpirical(JointDistribution, SupportsSampling, SupportsMean, Supports
                 "at least one must remain unconditioned."
             )
 
-        if self._is_uniform:
+        if self._w.is_uniform:
             result = JointEmpirical(**remaining_samples, name=self._name)
         else:
             result = JointEmpirical(
                 **remaining_samples,
-                log_weights=self._log_weights,
+                log_weights=self._w.log_unnormalized,
                 name=self._name,
             )
         result.with_source(Provenance(

--- a/tests/test_bootstrap_replicate.py
+++ b/tests/test_bootstrap_replicate.py
@@ -77,8 +77,16 @@ class TestProtocol:
         dist = BootstrapReplicateDistribution(jnp.ones((5, 2)))
         assert isinstance(dist, SupportsExpectation)
 
-    def test_generic_is_distribution_not_array(self):
+    def test_generic_numeric_dispatches_to_array(self):
+        # Factory dispatch: numeric arrays → ArrayBootstrapReplicateDistribution
         dist = BootstrapReplicateDistribution(jnp.ones((5, 2)))
+        assert isinstance(dist, Distribution)
+        assert isinstance(dist, ArrayDistribution)
+        assert isinstance(dist, ArrayBootstrapReplicateDistribution)
+
+    def test_generic_object_is_not_array(self):
+        # Non-numeric (object) source stays as base class
+        dist = BootstrapReplicateDistribution(["a", "b", "c"])
         assert isinstance(dist, Distribution)
         assert not isinstance(dist, ArrayDistribution)
 
@@ -210,19 +218,25 @@ class TestProperties:
         dist = BootstrapReplicateDistribution(jnp.ones((5, 2)))
         assert dist._approximate is True
 
-    def test_no_event_shape(self):
-        """Generic BootstrapReplicateDistribution has no event_shape."""
+    def test_numeric_has_event_shape(self):
+        """Numeric arrays dispatch to Array variant with event_shape."""
         dist = BootstrapReplicateDistribution(jnp.ones((5, 2)))
+        assert hasattr(dist, "event_shape")
+        assert dist.event_shape == (5, 2)
+
+    def test_generic_no_event_shape(self):
+        """Non-numeric BootstrapReplicateDistribution has no event_shape."""
+        dist = BootstrapReplicateDistribution(["a", "b", "c"])
         assert not hasattr(dist, "event_shape") or "event_shape" not in type(dist).__dict__
 
-    def test_no_dim(self):
-        """Generic BootstrapReplicateDistribution has no dim."""
-        dist = BootstrapReplicateDistribution(jnp.ones((5, 2)))
+    def test_generic_no_dim(self):
+        """Non-numeric BootstrapReplicateDistribution has no dim."""
+        dist = BootstrapReplicateDistribution(["a", "b", "c"])
         assert not hasattr(dist, "dim") or "dim" not in type(dist).__dict__
 
-    def test_no_dtype(self):
-        """Generic BootstrapReplicateDistribution has no dtype."""
-        dist = BootstrapReplicateDistribution(jnp.ones((5, 2)))
+    def test_generic_no_dtype(self):
+        """Non-numeric BootstrapReplicateDistribution has no dtype."""
+        dist = BootstrapReplicateDistribution(["a", "b", "c"])
         assert not hasattr(dist, "dtype") or "dtype" not in type(dist).__dict__
 
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -173,11 +173,18 @@ class TestSupportsMean:
         assert isinstance(normal, SupportsMean)
         assert isinstance(normal, SupportsVariance)
 
-    def test_empirical_generic_no_moments(self, empirical):
-        """Generic EmpiricalDistribution does not support moments."""
-        assert not isinstance(empirical, SupportsMean)
-        assert not isinstance(empirical, SupportsVariance)
-        assert not isinstance(empirical, SupportsCovariance)
+    def test_empirical_numeric_has_moments(self, empirical):
+        """Numeric EmpiricalDistribution dispatches to Array variant with moments."""
+        assert isinstance(empirical, SupportsMean)
+        assert isinstance(empirical, SupportsVariance)
+        assert isinstance(empirical, SupportsCovariance)
+
+    def test_empirical_generic_no_moments(self):
+        """Non-numeric EmpiricalDistribution does not support moments."""
+        dist = EmpiricalDistribution(["a", "b", "c"])
+        assert not isinstance(dist, SupportsMean)
+        assert not isinstance(dist, SupportsVariance)
+        assert not isinstance(dist, SupportsCovariance)
 
     def test_array_empirical(self):
         samples = jax.random.normal(jax.random.PRNGKey(0), (100, 2))

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,0 +1,428 @@
+"""Tests for probpipe._weights: Weights class and utility functions."""
+
+import pytest
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+
+from probpipe._weights import (
+    Weights,
+    validate_and_normalize_log_weights,
+    normalize_weights,
+    normalized_log_weights,
+    uniform_weights,
+    weighted_mean,
+    weighted_variance,
+    weighted_covariance,
+    weighted_choice,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_and_normalize_log_weights
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    def test_uniform(self):
+        log_w, is_uniform = validate_and_normalize_log_weights(5)
+        assert log_w is None
+        assert is_uniform is True
+
+    def test_from_weights(self):
+        log_w, is_uniform = validate_and_normalize_log_weights(
+            3, weights=jnp.array([1.0, 2.0, 1.0])
+        )
+        assert is_uniform is False
+        assert log_w.shape == (3,)
+
+    def test_from_log_weights(self):
+        log_w, is_uniform = validate_and_normalize_log_weights(
+            3, log_weights=jnp.array([-1.0, 0.0, -1.0])
+        )
+        assert is_uniform is False
+        npt.assert_allclose(log_w, jnp.array([-1.0, 0.0, -1.0]))
+
+    def test_mutual_exclusivity(self):
+        with pytest.raises(ValueError, match="either weights or log_weights"):
+            validate_and_normalize_log_weights(
+                3,
+                weights=jnp.ones(3),
+                log_weights=jnp.zeros(3),
+            )
+
+    def test_shape_mismatch(self):
+        with pytest.raises(ValueError, match="shape"):
+            validate_and_normalize_log_weights(3, weights=jnp.ones(5))
+
+    def test_negative_weights(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            validate_and_normalize_log_weights(
+                3, weights=jnp.array([1.0, -1.0, 1.0])
+            )
+
+    def test_zero_sum_weights(self):
+        with pytest.raises(ValueError, match="positive"):
+            validate_and_normalize_log_weights(
+                3, weights=jnp.zeros(3)
+            )
+
+    def test_log_weights_shape_mismatch(self):
+        with pytest.raises(ValueError, match="shape"):
+            validate_and_normalize_log_weights(
+                3, log_weights=jnp.zeros(5)
+            )
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+class TestUtilities:
+    def test_normalize_weights(self):
+        log_w = jnp.array([0.0, 1.0, 0.0])
+        w = normalize_weights(log_w)
+        npt.assert_allclose(jnp.sum(w), 1.0, atol=1e-6)
+        # Middle element should have highest weight
+        assert w[1] > w[0]
+        assert w[1] > w[2]
+
+    def test_normalized_log_weights(self):
+        log_w = jnp.array([0.0, 1.0, 0.0])
+        log_norm = normalized_log_weights(log_w)
+        npt.assert_allclose(jax.scipy.special.logsumexp(log_norm), 0.0, atol=1e-6)
+
+    def test_uniform_weights(self):
+        w = uniform_weights(4)
+        npt.assert_allclose(w, jnp.ones(4) / 4)
+
+
+class TestWeightedMean:
+    def test_uniform(self):
+        vals = jnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        result = weighted_mean(None, vals)
+        npt.assert_allclose(result, jnp.array([3.0, 4.0]))
+
+    def test_weighted(self):
+        vals = jnp.array([[1.0], [3.0]])
+        w = jnp.array([0.25, 0.75])
+        result = weighted_mean(w, vals)
+        npt.assert_allclose(result, jnp.array([2.5]))
+
+
+class TestWeightedVariance:
+    def test_uniform(self):
+        vals = jnp.array([[0.0], [2.0], [4.0]])
+        var = weighted_variance(None, vals)
+        # Mean = 2, variance = mean((0-2)^2, (2-2)^2, (4-2)^2) = (4+0+4)/3
+        npt.assert_allclose(var, jnp.array([8.0 / 3]), atol=1e-5)
+
+    def test_weighted(self):
+        vals = jnp.array([[0.0], [4.0]])
+        w = jnp.array([0.5, 0.5])
+        var = weighted_variance(w, vals)
+        # Mean = 2, variance = 0.5*(0-2)^2 + 0.5*(4-2)^2 = 4
+        npt.assert_allclose(var, jnp.array([4.0]))
+
+    def test_precomputed_mean(self):
+        vals = jnp.array([[0.0], [4.0]])
+        w = jnp.array([0.5, 0.5])
+        mu = jnp.array([2.0])
+        var = weighted_variance(w, vals, mean=mu)
+        npt.assert_allclose(var, jnp.array([4.0]))
+
+
+class TestWeightedCovariance:
+    def test_2d(self):
+        vals = jnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        cov = weighted_covariance(None, vals)
+        assert cov.shape == (2, 2)
+        # Diagonal should be variances
+        var = weighted_variance(None, vals)
+        npt.assert_allclose(jnp.diag(cov), var, atol=1e-5)
+
+
+class TestWeightedChoice:
+    def test_uniform(self):
+        key = jax.random.PRNGKey(42)
+        idx = weighted_choice(key, 10, shape=(100,))
+        assert idx.shape == (100,)
+        assert jnp.all(idx >= 0) and jnp.all(idx < 10)
+
+    def test_weighted_concentrates(self):
+        key = jax.random.PRNGKey(42)
+        # Almost all weight on index 2
+        w = jnp.array([0.001, 0.001, 0.998])
+        idx = weighted_choice(key, 3, weights=w, shape=(100,))
+        assert jnp.sum(idx == 2) > 90
+
+    def test_scalar_output(self):
+        key = jax.random.PRNGKey(42)
+        idx = weighted_choice(key, 10)
+        assert idx.shape == ()
+
+
+# ---------------------------------------------------------------------------
+# Weights class
+# ---------------------------------------------------------------------------
+
+class TestWeightsConstruction:
+    def test_uniform(self):
+        w = Weights.uniform(5)
+        assert w.n == 5
+        assert w.is_uniform is True
+        npt.assert_allclose(w.normalized, jnp.ones(5) / 5)
+
+    def test_from_weights(self):
+        w = Weights(3, weights=jnp.array([1.0, 2.0, 1.0]))
+        assert w.n == 3
+        assert w.is_uniform is False
+        npt.assert_allclose(jnp.sum(w.normalized), 1.0, atol=1e-6)
+
+    def test_from_log_weights(self):
+        w = Weights(3, log_weights=jnp.array([-1.0, 0.0, -1.0]))
+        assert w.n == 3
+        assert w.is_uniform is False
+        npt.assert_allclose(jnp.sum(w.normalized), 1.0, atol=1e-6)
+
+    def test_uniform_log_weights_none(self):
+        w = Weights.uniform(5)
+        assert w.log_normalized is None
+        assert w.log_unnormalized is None
+
+
+class TestWeightsProperties:
+    def test_normalized_cached(self):
+        w = Weights(3, weights=jnp.array([1.0, 2.0, 1.0]))
+        norm1 = w.normalized
+        norm2 = w.normalized
+        # Should be the exact same object (cached)
+        assert norm1 is norm2
+
+    def test_log_normalized(self):
+        w = Weights(3, log_weights=jnp.array([-1.0, 0.0, -1.0]))
+        log_n = w.log_normalized
+        npt.assert_allclose(
+            jax.scipy.special.logsumexp(log_n), 0.0, atol=1e-6
+        )
+
+    def test_log_unnormalized(self):
+        log_w = jnp.array([-1.0, 0.0, -1.0])
+        w = Weights(3, log_weights=log_w)
+        npt.assert_allclose(w.log_unnormalized, log_w)
+
+
+class TestWeightsJaxArrayProtocol:
+    def test_jax_array_returns_normalized(self):
+        w = Weights(3, weights=jnp.array([1.0, 2.0, 1.0]))
+        arr = w.__jax_array__()
+        npt.assert_allclose(arr, w.normalized)
+        npt.assert_allclose(jnp.sum(arr), 1.0, atol=1e-6)
+
+    def test_jnp_sum(self):
+        w = Weights(3, weights=jnp.array([1.0, 2.0, 1.0]))
+        npt.assert_allclose(jnp.sum(w), 1.0, atol=1e-6)
+
+    def test_einsum_works(self):
+        w = Weights(3, weights=jnp.array([1.0, 2.0, 1.0]))
+        vals = jnp.array([10.0, 20.0, 30.0])
+        result = jnp.einsum("n,n->", w, vals)
+        expected = jnp.einsum("n,n->", w.normalized, vals)
+        npt.assert_allclose(result, expected, atol=1e-5)
+
+
+class TestWeightsArrayDuckTyping:
+    def test_shape(self):
+        w = Weights(5, weights=jnp.ones(5))
+        assert w.shape == (5,)
+
+    def test_dtype(self):
+        w = Weights.uniform(5)
+        assert w.dtype == jnp.float32
+
+    def test_len(self):
+        w = Weights.uniform(7)
+        assert len(w) == 7
+
+
+class TestWeightsMethods:
+    def test_mean(self):
+        w = Weights(3, weights=jnp.array([1.0, 2.0, 1.0]))
+        vals = jnp.array([[1.0], [2.0], [3.0]])
+        result = w.mean(vals)
+        expected = weighted_mean(w.normalized, vals)
+        npt.assert_allclose(result, expected)
+
+    def test_variance(self):
+        w = Weights.uniform(3)
+        vals = jnp.array([[0.0], [2.0], [4.0]])
+        result = w.variance(vals)
+        expected = weighted_variance(None, vals)
+        npt.assert_allclose(result, expected)
+
+    def test_covariance(self):
+        w = Weights.uniform(3)
+        vals = jnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        result = w.covariance(vals)
+        expected = weighted_covariance(None, vals)
+        npt.assert_allclose(result, expected)
+
+    def test_choice(self):
+        w = Weights.uniform(10)
+        key = jax.random.PRNGKey(0)
+        idx = w.choice(key, shape=(50,))
+        assert idx.shape == (50,)
+        assert jnp.all(idx >= 0) and jnp.all(idx < 10)
+
+    def test_subsample_uniform(self):
+        w = Weights.uniform(10)
+        sub = w.subsample(jnp.array([0, 2, 4]))
+        assert sub.n == 3
+        assert sub.is_uniform is True
+
+    def test_subsample_weighted(self):
+        w = Weights(4, weights=jnp.array([1.0, 2.0, 3.0, 4.0]))
+        sub = w.subsample(jnp.array([1, 3]))
+        assert sub.n == 2
+        assert sub.is_uniform is False
+        npt.assert_allclose(jnp.sum(sub.normalized), 1.0, atol=1e-6)
+
+
+class TestWeightsPytree:
+    def test_tree_flatten_unflatten(self):
+        w = Weights(3, log_weights=jnp.array([-1.0, 0.0, -1.0]))
+        children, aux = w.tree_flatten()
+        w2 = Weights.tree_unflatten(aux, children)
+        assert w2.n == w.n
+        assert w2.is_uniform == w.is_uniform
+        npt.assert_allclose(w2.normalized, w.normalized)
+
+    def test_jax_tree_leaves(self):
+        w = Weights(3, log_weights=jnp.array([-1.0, 0.0, -1.0]))
+        leaves = jax.tree.leaves(w)
+        assert len(leaves) == 1
+        npt.assert_allclose(leaves[0], jnp.array([-1.0, 0.0, -1.0]))
+
+    def test_uniform_tree_leaves(self):
+        w = Weights.uniform(5)
+        leaves = jax.tree.leaves(w)
+        # Uniform weights have None log_weights, which JAX filters out
+        assert len(leaves) == 0
+
+    def test_jit_compatible(self):
+        w = Weights(3, weights=jnp.array([1.0, 2.0, 1.0]))
+        vals = jnp.array([10.0, 20.0, 30.0])
+
+        @jax.jit
+        def compute(weights, values):
+            return jnp.einsum("n,n->", weights, values)
+
+        result = compute(w, vals)
+        expected = jnp.einsum("n,n->", w.normalized, vals)
+        npt.assert_allclose(result, expected, atol=1e-5)
+
+
+class TestWeightsRepr:
+    def test_uniform_repr(self):
+        w = Weights.uniform(5)
+        assert "uniform" in repr(w)
+        assert "n=5" in repr(w)
+
+    def test_weighted_repr(self):
+        w = Weights(3, weights=jnp.ones(3))
+        assert "n=3" in repr(w)
+
+
+# ---------------------------------------------------------------------------
+# Factory dispatch tests
+# ---------------------------------------------------------------------------
+
+class TestFactoryDispatch:
+    def test_empirical_numeric_returns_array_variant(self):
+        from probpipe import EmpiricalDistribution, ArrayEmpiricalDistribution
+        dist = EmpiricalDistribution(jnp.array([1.0, 2.0, 3.0]))
+        assert isinstance(dist, ArrayEmpiricalDistribution)
+
+    def test_empirical_numpy_numeric_returns_array_variant(self):
+        from probpipe import EmpiricalDistribution, ArrayEmpiricalDistribution
+        dist = EmpiricalDistribution(np.array([1.0, 2.0, 3.0]))
+        assert isinstance(dist, ArrayEmpiricalDistribution)
+
+    def test_empirical_object_stays_generic(self):
+        from probpipe import EmpiricalDistribution, ArrayEmpiricalDistribution
+        dist = EmpiricalDistribution(["hello", "world"])
+        assert not isinstance(dist, ArrayEmpiricalDistribution)
+        assert isinstance(dist, EmpiricalDistribution)
+
+    def test_empirical_numpy_object_stays_generic(self):
+        from probpipe import EmpiricalDistribution, ArrayEmpiricalDistribution
+        dist = EmpiricalDistribution(np.array(["a", "b"], dtype=object))
+        assert not isinstance(dist, ArrayEmpiricalDistribution)
+
+    def test_bootstrap_numeric_returns_array_variant(self):
+        from probpipe import BootstrapReplicateDistribution, ArrayBootstrapReplicateDistribution
+        dist = BootstrapReplicateDistribution(jnp.ones((5, 2)))
+        assert isinstance(dist, ArrayBootstrapReplicateDistribution)
+
+    def test_bootstrap_from_empirical_returns_array_variant(self):
+        from probpipe import (
+            EmpiricalDistribution,
+            BootstrapReplicateDistribution,
+            ArrayBootstrapReplicateDistribution,
+        )
+        emp = EmpiricalDistribution(jnp.ones((5, 2)))
+        dist = BootstrapReplicateDistribution(emp)
+        assert isinstance(dist, ArrayBootstrapReplicateDistribution)
+
+    def test_bootstrap_object_stays_generic(self):
+        from probpipe import BootstrapReplicateDistribution, ArrayBootstrapReplicateDistribution
+        dist = BootstrapReplicateDistribution(["a", "b", "c"])
+        assert not isinstance(dist, ArrayBootstrapReplicateDistribution)
+
+    def test_subclass_not_redirected(self):
+        from probpipe import ArrayEmpiricalDistribution
+        dist = ArrayEmpiricalDistribution(jnp.array([1.0, 2.0, 3.0]))
+        assert type(dist) is ArrayEmpiricalDistribution
+
+
+# ---------------------------------------------------------------------------
+# sample_shape tests
+# ---------------------------------------------------------------------------
+
+class TestSampleShape:
+    def test_default_single_axis(self):
+        from probpipe import ArrayEmpiricalDistribution
+        samples = jnp.ones((100, 3))
+        dist = ArrayEmpiricalDistribution(samples)
+        assert dist.n == 100
+        assert dist.event_shape == (3,)
+
+    def test_explicit_1d_sample_shape(self):
+        from probpipe import ArrayEmpiricalDistribution
+        samples = jnp.ones((100, 3))
+        dist = ArrayEmpiricalDistribution(samples, sample_shape=(100,))
+        assert dist.n == 100
+        assert dist.event_shape == (3,)
+
+    def test_2d_sample_shape(self):
+        from probpipe import ArrayEmpiricalDistribution
+        samples = jnp.ones((10, 5, 3))
+        dist = ArrayEmpiricalDistribution(samples, sample_shape=(10, 5))
+        assert dist.n == 50
+        assert dist.event_shape == (3,)
+
+    def test_sample_shape_mismatch_raises(self):
+        from probpipe import ArrayEmpiricalDistribution
+        samples = jnp.ones((10, 3))
+        with pytest.raises(ValueError, match="do not match"):
+            ArrayEmpiricalDistribution(samples, sample_shape=(20,))
+
+    def test_moments_with_sample_shape(self):
+        from probpipe import ArrayEmpiricalDistribution, mean, variance
+        key = jax.random.PRNGKey(0)
+        samples = jax.random.normal(key, (10, 5, 2))
+        dist = ArrayEmpiricalDistribution(samples, sample_shape=(10, 5))
+        m = mean(dist)
+        v = variance(dist)
+        assert m.shape == (2,)
+        assert v.shape == (2,)


### PR DESCRIPTION
# Plan: Standardize Array Semantics & Centralize Weight Handling

**Issues:** #97 (array dispatch for EmpiricalDistribution/BootstrapReplicateDistribution) and #98 (centralize weight handling)

## Context

Weighted samples appear in many places across ProbPipe with heavily duplicated logic:
- **Weight validation/normalization** is copy-pasted in `EmpiricalDistribution._init_weights()`, `JointEmpirical.__init__()`, `BootstrapDistribution.__init__()`, and `BroadcastDistribution.__init__()`.
- **Weighted moments** (`jnp.einsum("n,n...->...", weights, values)` with uniform/non-uniform branching) appear 12+ times across `_empirical.py`, `_array_distributions.py`, `_broadcast_distributions.py`, and `joint.py`.
- **Weighted index sampling** (uniform vs weighted) is duplicated in 5+ locations.
- `EmpiricalDistribution[T]` wraps JAX arrays in slow numpy object arrays instead of dispatching to `ArrayEmpiricalDistribution`. Same issue for `BootstrapReplicateDistribution`.

This PR centralizes all weight logic into a `Weights` class (which acts as a specialized JAX array), removes duplication, adds automatic array dispatch, and generalizes `ArrayEmpiricalDistribution` to support multi-dimensional sample shapes.

## Decision: `Weights` class as a specialized JAX array

The `Weights` class encapsulates weight state (log_weights, is_uniform, normalization cache) and acts as a drop-in JAX array via `__jax_array__`. Distributions store a `Weights` instance instead of raw `_log_weights`/`_is_uniform`/`_weights_cache` attributes. Internal pure utility functions (`weighted_mean`, `weighted_variance`, etc.) handle the math; `Weights` methods delegate to them.

---

## Phase 1: Create `probpipe/_weights.py`

### `Weights` class

```python
class Weights:
    """Normalized probability weights over *n* items.

    ``Weights`` stores log-unnormalized weights internally and provides
    lazy-cached access to normalized weights and log-weights. It also
    implements the JAX array protocol (``__jax_array__``), so a
    ``Weights`` object can be passed directly to any JAX operation that
    expects an array — it will behave as its **normalized** weight vector.

    Parameters
    ----------
    n : int
        Number of items.
    weights : ArrayLike, optional
        Non-negative weights (normalized internally). Mutually exclusive
        with *log_weights*.
    log_weights : ArrayLike, optional
        Log-unnormalized weights. Preferred when weights span many orders
        of magnitude (e.g. importance sampling). Mutually exclusive with
        *weights*.

    Examples
    --------
    Create from raw weights or log-weights:

    >>> w = Weights(3, weights=jnp.array([1.0, 2.0, 1.0]))
    >>> w = Weights(3, log_weights=jnp.array([-1.0, 0.0, -1.0]))

    Create uniform weights:

    >>> w = Weights.uniform(5)

    Use as a JAX array (returns normalized weights automatically):

    >>> jnp.sum(w)                          # -> 1.0
    >>> jnp.einsum("n,n...->...", w, vals)  # weighted sum
    >>> w * values                          # element-wise product

    Access different representations explicitly:

    >>> w.normalized         # Array, shape (n,) — probabilities summing to 1
    >>> w.log_normalized     # Array | None — log-probabilities (None if uniform)
    >>> w.log_unnormalized   # Array | None — raw stored log-weights (None if uniform)
    >>> w.is_uniform         # bool

    Compute weighted statistics:

    >>> w.mean(samples)                 # weighted mean
    >>> w.variance(samples)             # weighted variance
    >>> w.covariance(samples)           # weighted covariance matrix
    >>> w.choice(key, shape=(10,))      # draw 10 weighted random indices

    JAX compatibility
    -----------------
    ``Weights`` is registered as a JAX pytree, so it works inside
    ``jax.jit``, ``jax.vmap``, and ``jax.grad``. The log-weights array
    is the traceable leaf; ``is_uniform`` and ``n`` are static auxiliary
    data. The normalization cache is a Python-side optimization and is
    recomputed inside traced contexts.
    """
```

Key implementation details:
- `__jax_array__` returns `self.normalized` (the softmax of log_weights).
- Array duck-typing: `shape -> (n,)`, `dtype -> jnp.float32`, `__len__ -> n`.
- `Weights.uniform(n)` static factory.
- JAX pytree registration via `jax.tree_util.register_pytree_class`.
- Methods: `mean(values)`, `variance(values)`, `covariance(values)`, `choice(key, shape=())`, `subsample(indices)`.

### Pure utility functions (internal)

These are the workhorses that `Weights` methods delegate to:

- `validate_and_normalize_log_weights(n, weights, log_weights) -> (Array|None, bool)` — validation + conversion.
- `weighted_mean(weights: Array|None, values: Array) -> Array`
- `weighted_variance(weights: Array|None, values: Array, mean=None) -> Array`
- `weighted_covariance(weights: Array|None, values: Array, mean=None) -> Array`
- `weighted_choice(key, n, weights=None, shape=()) -> Array`
- `normalize_weights(log_weights) -> Array` (softmax)
- `normalized_log_weights(log_weights) -> Array` (log-space normalization)
- `uniform_weights(n) -> Array`

---

## Phase 2: Refactor existing classes to use `Weights`

All changes are internal — public API (method signatures, properties) stays the same.

### `core/_empirical.py`
- `EmpiricalDistribution`: replace `_init_weights()` + `_log_weights`/`_is_uniform`/`_weights_cache` with `self._w = Weights(...)`.
- `weights`/`log_weights`/`is_uniform` properties delegate to `self._w`.
- `_sample_one`/`_sample`: use `self._w.choice()`.
- `_expectation`: use `weighted_mean()` for final reduction.
- `ArrayEmpiricalDistribution._mean/_variance/_cov`: use `self._w.mean()`, `self._w.variance()`, `self._w.covariance()`.
- `BootstrapReplicateDistribution`: store `self._w = Weights(...)`, delegate similarly.

### `core/_array_distributions.py`
- `BootstrapDistribution`: store `Weights`, use for `_mean/_variance/_sample`.

### `core/_broadcast_distributions.py`
- `_MixtureMean/_MixtureVariance/_MixtureSampling`: use `weighted_mean()`, `weighted_choice()`.
- `BroadcastDistribution`: store `Weights`, delegate.

### `distributions/joint.py`
- `JointEmpirical`: replace inline weight validation (lines 530-552) with `Weights`. Replace `_flat_mean/_flat_variance/_mean/_variance` with `weighted_mean()`/`weighted_variance()`. Replace `_sample_joint_rows` with `self._w.choice()`.

---

## Phase 3: Factory dispatch for array inputs

### `EmpiricalDistribution.__new__`
When `cls is EmpiricalDistribution` and `samples` is a numeric JAX/numpy array, return `ArrayEmpiricalDistribution` instance. Guard prevents redirect for subclasses.

### `BootstrapReplicateDistribution.__new__`
Same pattern for array/EmpiricalDistribution sources.

### `ArrayEmpiricalDistribution`: `sample_shape` parameter
Add optional `sample_shape` for multiple leading sample dimensions:
- `None` (default): first axis is the single sample axis (backward compatible).
- Explicit tuple: `event_shape = samples.shape[len(sample_shape):]`.

### Docstring updates
- Document factory dispatch on both classes.
- Document TFP shape semantics on `ArrayEmpiricalDistribution`, including `sample_shape`.

---

## Phase 4: Export updates

- Export `Weights` from `probpipe/__init__.py` as public API.
- Keep utility functions internal (`_weights.py`).
- Verify `core/distribution.py` facade re-exports correctly.

---

## Phase 5: Testing

### New: `tests/test_weights.py`
- `Weights` construction: from weights, from log_weights, uniform.
- Properties: `normalized`, `log_normalized`, `log_unnormalized`, `is_uniform`, `n`.
- `__jax_array__` protocol: `jnp.sum(w) ≈ 1.0`, `jnp.einsum` with `Weights`, arithmetic.
- Array duck-typing: `shape`, `dtype`, `len`.
- Methods: `mean`, `variance`, `covariance`, `choice`, `subsample`.
- JAX pytree: `jax.tree.leaves(w)`, roundtrip through `tree_flatten`/`tree_unflatten`.
- `jax.jit` compatibility.
- Validation edge cases: mutual exclusivity, shape mismatch, negative weights.

### New: factory dispatch tests
- `EmpiricalDistribution(jnp.array([1,2,3]))` returns `ArrayEmpiricalDistribution`.
- `EmpiricalDistribution([obj1, obj2])` returns base `EmpiricalDistribution`.
- `BootstrapReplicateDistribution(jnp.array(...))` returns `ArrayBootstrapReplicateDistribution`.
- Subclasses not redirected.

### New: `sample_shape` tests
- Multi-dimensional sample shapes, verify `event_shape`, `n`, moments.

### Regression
Run full suite: `python -m pytest tests/ -x -q`

---

## Key Files

| File | Action |
|------|--------|
| `probpipe/_weights.py` | **Create** — `Weights` class + utility functions |
| `probpipe/core/_empirical.py` | Refactor weights + add `__new__` factory + `sample_shape` |
| `probpipe/core/_array_distributions.py` | Refactor BootstrapDistribution |
| `probpipe/core/_broadcast_distributions.py` | Refactor mixture mixins + BroadcastDistribution |
| `probpipe/distributions/joint.py` | Refactor JointEmpirical |
| `probpipe/_utils.py` | Add `_is_numeric_array` helper |
| `probpipe/__init__.py` | Export `Weights` |
| `tests/test_weights.py` | **Create** — unit tests |
| `tests/test_distributions.py` | Add factory dispatch + sample_shape tests |