### PR TITLE
Add review-pr Claude Code skill

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,92 @@
+# Claude Code Skills
+
+This directory contains project-level [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills)
+(slash commands) available to all ProbPipe contributors. Skills are invoked
+from the Claude Code CLI or IDE extension.
+
+## Available Skills
+
+### `/review-pr [number]`
+
+Performs a structured review of a ProbPipe pull request.
+
+**When to use:** Before merging a PR, or when reviewing someone else's PR for
+issues and consistency with ProbPipe conventions.
+
+**What it checks:**
+- ProbPipe philosophy and convention adherence (read from `STYLE_GUIDE.md` and
+  `CONTRIBUTING.md` at review time, so it stays current as conventions evolve)
+- Documentation completeness and staleness — including whether the PR should
+  have updated `STYLE_GUIDE.md` or `CONTRIBUTING.md`
+- Test coverage gaps
+- Duplicate or redundant code (checks against existing abstractions in the
+  codebase)
+- AI artifact comments (thinking-aloud comments, unnecessary narration)
+- General concerns (edge cases, backward compatibility, performance)
+- Code quality (simplification, dead code, JAX idioms)
+
+**Usage:**
+```
+/review-pr          # reviews the PR for the current branch
+/review-pr 103      # reviews PR #103
+```
+
+**Behavior:** Claude analyzes the PR and presents a structured report organized
+by severity (critical, recommended, minor) with concrete suggestions including
+file paths and line numbers. No changes are made until the user approves
+specific suggestions.
+
+This skill can also be triggered automatically when asking Claude to review a
+PR in general conversation.
+
+---
+
+### `/audit-tests [file-or-pattern]`
+
+Audits the ProbPipe test suite for quality, correctness, and completeness.
+
+**When to use:** Periodically to check test suite health, after a major
+refactor, or to audit specific test files before a release.
+
+**What it checks:**
+- **Test gaps** — missing coverage for public APIs, edge cases, error paths,
+  protocol compliance
+- **Stale tests** — tests referencing renamed/removed APIs or outdated behavior
+- **Duplicate tests** — redundant tests (vs legitimate parametrization, which
+  is intentional)
+- **Misleading tests** — tests that don't actually test what their name claims,
+  or use trivially-true assertions
+- **Sham tests** — tests that mock away the thing being tested, inflate
+  coverage without validating behavior, or use trivial inputs designed to pass
+- **Mathematical correctness** — validates that tests use independent baselines
+  (analytical formulas, scipy, numerical approximations) rather than
+  self-referential checks; flags inappropriate tolerances
+- **Style and conventions** — checks against `STYLE_GUIDE.md` testing
+  conventions and existing suite patterns
+
+**Usage:**
+```
+/audit-tests                          # audits the entire test suite
+/audit-tests tests/test_continuous.py # audits a specific file
+/audit-tests tests/test_joint*        # audits by pattern
+```
+
+**Behavior:** Claude reads both the test files and the source code they
+exercise, then presents a structured report organized by severity (critical,
+gaps, recommended, minor). No changes are made until the user approves specific
+suggestions.
+
+This skill must be explicitly invoked — it will not auto-trigger.
+
+## Adding New Skills
+
+To add a new skill, create a directory under `.claude/skills/` with a
+`SKILL.md` file:
+
+```
+.claude/skills/<skill-name>/SKILL.md
+```
+
+See the [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code/skills)
+for the skill file format. Commit the skill to version control so all
+contributors have access.

--- a/.claude/skills/audit-tests/SKILL.md
+++ b/.claude/skills/audit-tests/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: audit-tests
+description: Audit the ProbPipe test suite for gaps, stale tests, duplicates, style issues, weak assertions, and mathematical correctness.
+disable-model-invocation: true
+allowed-tools: Read Grep Glob Bash(pytest *) Bash(git *) Agent
+argument-hint: [test-file-or-pattern]
+---
+
+# ProbPipe Test Suite Audit
+
+Audit the test suite for quality, correctness, and completeness.
+
+**Scope:** If `$ARGUMENTS` is provided, audit only the specified files or
+patterns (e.g., `tests/test_continuous.py`, `tests/test_joint*`). Otherwise,
+audit the entire `tests/` directory.
+
+## Instructions
+
+You are performing a read-only audit. **Do not edit any files.** Your job is to
+analyze the tests and present a structured report of findings with concrete
+suggestions. The user will decide which suggestions to act on before any changes
+are made.
+
+## Step 1: Gather context
+
+### 1a. Read project conventions
+
+Read the testing conventions section of `STYLE_GUIDE.md` and the architecture
+overview in `CONTRIBUTING.md`. These define the expected test structure, naming,
+fixture patterns, and project abstractions that tests should exercise.
+
+### 1b. Understand what is being tested
+
+Read the source files that the tests under audit are exercising. You need to
+understand the actual behavior in order to judge whether tests are correct,
+complete, and non-stale. For a full audit, scan `probpipe/__init__.py` for the
+public API surface, then read source files as needed per test file.
+
+### 1c. Read the tests
+
+Read every test file in scope. Also read:
+
+- `tests/conftest.py` — shared fixtures
+- `pyproject.toml` — pytest configuration, markers, xdist settings
+
+## Step 2: Run the audit checklist
+
+Work through **every** category below for each test file in scope. Note specific
+findings with file paths, line numbers, and the test function/class name. If a
+category has no issues for a file, say so briefly.
+
+### 2.1 Test gaps
+
+Identify source code that lacks test coverage:
+
+- Public classes, functions, or methods with no corresponding tests
+- Code paths exercised only in the "happy path" — missing tests for edge cases
+  (empty inputs, zero-length arrays, boundary values, single-element collections,
+  degenerate parameters)
+- Error paths: are `TypeError`, `ValueError`, and other expected exceptions
+  tested? Do tests verify that the correct exception type and message are raised?
+- Protocol compliance: if a class implements protocols (`SupportsSampling`,
+  `SupportsLogProb`, etc.), is each protocol method tested?
+- New abstractions or registries: are registration, dispatch, priority ordering,
+  and fallback behavior all tested?
+
+### 2.2 Stale tests
+
+Identify tests that have become outdated:
+
+- Tests that reference APIs, parameters, classes, or behaviors that no longer
+  exist or have been renamed
+- Tests whose assertions pass but no longer validate the intended behavior
+  because the implementation changed (e.g., testing a default value that was
+  changed, or asserting a shape that is no longer the expected shape)
+- Tests that import from private modules that have been restructured
+- Fixtures that create objects with outdated constructor signatures
+
+### 2.3 Duplicate and redundant tests
+
+- Tests that assert the exact same behavior as another test (possibly in a
+  different file)
+- Test files that overlap significantly in what they cover — could they be
+  consolidated?
+- Parametrized tests that redundantly test the same code path with different
+  values when a single representative value would suffice (distinguish this from
+  legitimate parametrization across distribution families, which is intentional)
+
+### 2.4 Tests that don't test what they claim
+
+- Tests whose name or docstring describes one behavior but whose assertions
+  verify something different or something trivially true
+- Tests that assert only that code runs without error but don't verify
+  correctness of the output (e.g., calling `sample()` but never checking the
+  result beyond its existence)
+- Tests that use `assert True`, `assert result is not None`, or similarly weak
+  assertions where a meaningful value check is possible
+- Tests with overly loose tolerances (e.g., `atol=1.0`) that would pass even
+  with incorrect results
+
+### 2.5 Sham tests
+
+Flag tests that appear to have been added to make the test suite pass or inflate
+coverage rather than to validate real behavior:
+
+- Tests that mock away the very thing they should be testing
+- Tests that only verify mock call counts without checking actual behavior
+- Tests that assert implementation details (e.g., internal method calls) rather
+  than observable behavior
+- Tests that construct trivial inputs specifically designed to make assertions
+  pass, when realistic inputs would fail
+- Tests in `test_coverage_gaps.py` or similar that merely touch code paths
+  without meaningful assertions
+
+### 2.6 Mathematical correctness
+
+For tests of mathematical operations (distributions, inference, linear algebra,
+expectations, etc.), check:
+
+- **Independent baselines** — Does the test validate results against an
+  independent calculation? Valid baselines include:
+  - Analytical formulas (e.g., known mean/variance for standard distributions)
+  - A different numerical library (e.g., scipy.stats, numpy, TFP directly)
+  - A numerical approximation (e.g., finite-difference gradient check, Monte
+    Carlo estimate with enough samples for a tight tolerance)
+  - Known identities or invariants (e.g., `log_prob` consistency with `prob`,
+    KL divergence non-negativity, law of total expectation)
+
+  The baseline should **not** use the same code path as the implementation being
+  tested. For example, testing `mean(Normal(0, 1))` by checking it equals
+  `Normal(0, 1).loc` just verifies passthrough, not correctness.
+
+- **Tolerance appropriateness** — Are `atol`/`rtol` values tight enough to
+  catch bugs but loose enough for floating-point and Monte Carlo noise? Flag
+  both overly loose (masks bugs) and overly tight (flaky) tolerances.
+
+- **Shape and broadcasting** — Do tests verify output shapes, especially for
+  batched operations, broadcasting, and multi-dimensional inputs?
+
+- **Edge cases specific to math** — Degenerate parameters (zero variance, unit
+  matrices), extreme values (very large/small), numerical stability (log-space
+  operations, underflow/overflow).
+
+### 2.7 Style and convention compliance
+
+Check tests against the conventions in `STYLE_GUIDE.md` section 8 and patterns
+established in the existing suite:
+
+- **Structure** — Are tests organized in `Test*` classes? Are related tests
+  grouped logically?
+- **Fixtures** — Are fixtures used appropriately? Parametrized fixtures for
+  distribution families? Shared fixtures in conftest.py vs local fixtures?
+- **Naming** — Do test names clearly describe the behavior being tested?
+  `test_<method>_<scenario>` pattern?
+- **Imports** — Importing from `probpipe` (public API), not from private modules?
+- **Optional dependencies** — Using `pytest.importorskip()` or pytest markers
+  for optional backends?
+- **Assertions** — Using `np.testing.assert_allclose` for numerical comparisons
+  (not bare `assert` with manual tolerance)?
+
+## Step 3: Present findings
+
+Organize your findings into a structured report with this format:
+
+```
+## Test Audit: <scope description>
+
+### Summary
+<1-2 sentence overall assessment of test suite health>
+
+### Findings
+
+#### Critical (tests that are wrong, misleading, or mask bugs)
+- ...
+
+#### Gaps (missing tests that should exist)
+- ...
+
+#### Recommended (improvements to existing tests)
+- ...
+
+#### Minor (style, naming, cleanup)
+- ...
+
+### Suggested Changes
+<Numbered list of concrete, actionable changes. For each:
+ - The file and test function/class
+ - What is wrong or missing
+ - What the fix or new test should look like (brief description, not full code)
+Group related changes together.>
+```
+
+**Do not make any changes.** Present the report and wait for the user to decide
+which suggestions to implement. Once the user approves specific items, then
+proceed with edits.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -7,7 +7,8 @@ argument-hint: [pr-number]
 
 # ProbPipe PR Review
 
-Review pull request **$ARGUMENTS** (if no number given, detect the PR for the current branch using `gh pr view`).
+Review pull request **$ARGUMENTS** (if no number given, detect the PR for the
+current branch using `gh pr view`).
 
 ## Instructions
 
@@ -18,7 +19,18 @@ are made.
 
 ## Step 1: Gather context
 
-Fetch the PR metadata and diff:
+### 1a. Read project conventions (do this first)
+
+Read the following files in full. These are the **authoritative source of truth**
+for all naming, style, architecture, and API conventions. Every check you perform
+in Step 2 must be grounded in what these documents say — do not rely on your own
+prior knowledge of ProbPipe conventions, as they may have changed.
+
+- `STYLE_GUIDE.md` — naming, imports, types, protocols, testing, module layout
+- `CONTRIBUTING.md` — architecture overview, design principles, package
+  structure, dependency graph, registry patterns, PR workflow
+
+### 1b. Fetch the PR
 
 ```
 gh pr view $ARGUMENTS --json title,body,baseRefName,headRefName,files
@@ -29,18 +41,44 @@ Identify which files were added, modified, or deleted. Read the full contents of
 every modified and newly added file so you have complete context (not just the
 diff hunks).
 
-Also read these project references — they define the conventions you are checking
-against:
+### 1c. Understand existing abstractions
 
-- `STYLE_GUIDE.md`
-- `CONTRIBUTING.md`
+Before checking for redundant code, familiarize yourself with the abstractions
+already available in the codebase. Scan these areas for classes, utilities, and
+patterns that the PR's code should be using rather than reimplementing:
+
+- `probpipe/__init__.py` — the public API surface
+- `probpipe/core/` — base classes, protocols, ops, registries
+- Any utility modules (`_weights.py`, `_utils.py`, `_array_utils.py`, etc.)
 
 ## Step 2: Run the review checklist
 
 Work through **every** category below. For each, note specific findings with
 file paths and line numbers. If a category has no issues, say so briefly.
 
-### 2.1 Documentation
+### 2.1 ProbPipe philosophy and conventions
+
+Check that the PR adheres to every convention documented in `STYLE_GUIDE.md` and
+`CONTRIBUTING.md`. These include (but are not limited to) — always defer to what
+the docs actually say over this summary:
+
+- **Design principles** — immutability, ops-not-methods, protocol-based dispatch,
+  private method convention, etc. (see CONTRIBUTING.md "Design principles")
+- **Naming** — protocols, ops, implementation functions, classes, modules,
+  reserved parameter names, the `.n` property convention (see STYLE_GUIDE.md)
+- **Imports** — `from __future__ import annotations`, relative internals, import
+  order, optional dependency patterns, `TYPE_CHECKING` guards
+- **Type annotations** — modern Python 3.12+ syntax, project type aliases
+- **Subpackage dependency graph** — no illegal cross-imports (see STYLE_GUIDE.md
+  section 6 and CONTRIBUTING.md)
+- **Registry patterns** — if the PR adds or modifies registry-dispatched
+  behavior, check it follows the documented registry conventions (converter
+  registry, inference method registry, etc.)
+- **Docstrings** — NumPy-style, module docstrings, section separators
+- **`__all__` exports** — updated in `__init__.py` when new public symbols are
+  added
+
+### 2.2 Documentation
 
 - Are new or modified public classes, functions, and modules documented with
   NumPy-style docstrings (`Parameters`, `Returns`, `Raises`)?
@@ -51,60 +89,31 @@ file paths and line numbers. If a category has no issues, say so briefly.
 - If the PR adds user-facing features, are the relevant docs pages in `docs/`
   updated?
 
-### 2.2 Test coverage
+### 2.3 Test coverage
 
 - Does every new public function/class/method have corresponding tests?
 - Are there edge cases that lack test coverage (empty inputs, boundary values,
   error paths)?
 - Have any existing tests become stale — testing behavior that no longer matches
   the implementation?
-- Do tests follow project conventions: `Test*` classes, pytest fixtures,
-  parametrized distribution families, `pytest.importorskip` for optional deps?
-- Is `__all__` updated in `__init__.py` files when new public symbols are added?
+- Do tests follow project conventions (see STYLE_GUIDE.md section 8)?
 
-### 2.3 ProbPipe philosophy
+### 2.4 Duplicate and redundant code
 
-Check that the PR adheres to the core design principles:
+Using the abstractions you identified in Step 1c, check whether the PR
+reimplements logic that already exists. Common patterns to watch for:
 
-- **Immutability** — Distribution parameters are fixed at construction. No
-  mutation of distribution state after `__init__`.
-- **Ops, not methods** — Public operations (`sample`, `mean`, `log_prob`,
-  `condition_on`, etc.) live in `probpipe.core.ops` as `WorkflowFunction`
-  instances. Users call `mean(dist)`, never `dist.mean()` or `dist._mean()`.
-- **Protocol-based dispatch** — Capabilities are declared via `@runtime_checkable`
-  protocols (`SupportsSampling`, `SupportsLogProb`, etc.). Concrete classes
-  implement the underscore methods (`_sample`, `_log_prob`, `_mean`).
-- **Private method convention** — Protocol methods use single underscore prefix.
-  Public API is always through ops.
-- **WorkflowFunction patterns** — Standalone workflow functions follow the
-  `_<name>_impl` + `<name> = WorkflowFunction(...)` pattern.
+- Custom weight handling instead of using existing weight abstractions
+- Manual sampling loops instead of using `WorkflowFunction` broadcasting
+- Bespoke protocol checks instead of `isinstance` with existing protocols
+- Re-implementing ops logic instead of calling the ops
+- Duplicating registry dispatch logic instead of using existing registries
 
-### 2.4 API consistency
+Also flag:
+- Copy-pasted code that should be factored into a shared helper
+- Unnecessary abstractions or over-engineering for what the PR actually needs
 
-- Do new names follow STYLE_GUIDE.md conventions? (`Supports<Cap>` for protocols,
-  `_method` for protocol methods, `snake_case` for ops, CamelCase for classes,
-  `_underscore.py` for private modules.)
-- Are reserved parameter names (`seed`, `n_broadcast_samples`, `include_inputs`)
-  avoided in user-defined functions?
-- Does the `.n` property convention hold for new finite-sample distribution
-  classes?
-- Are imports structured correctly? (`from __future__ import annotations` first,
-  relative internal imports, proper grouping.)
-- Are `__all__` exports updated?
-- Is the subpackage dependency graph respected? (See STYLE_GUIDE.md section 6.)
-
-### 2.5 Duplicate and redundant code
-
-- Does the PR reimplement logic that already exists in ProbPipe's abstractions?
-  Common offenders:
-  - Custom weight handling instead of using the `Weights` class
-  - Manual sampling loops instead of using `WorkflowFunction` broadcasting
-  - Bespoke protocol checks instead of using `isinstance` with existing protocols
-  - Re-implementing ops logic instead of calling the ops
-- Is there copy-pasted code that should be factored into a shared helper?
-- Are there unnecessary abstractions or over-engineering for what the PR needs?
-
-### 2.6 AI artifact comments
+### 2.5 AI artifact comments
 
 Flag any comments that look like AI thinking artifacts rather than intentional
 documentation:
@@ -115,7 +124,7 @@ documentation:
   like AI planning artifacts rather than genuine action items
 - Comments that narrate the development process rather than explain the code
 
-### 2.7 General concerns
+### 2.6 General concerns
 
 - Are there edge cases that could cause runtime errors (e.g., empty arrays,
   shape mismatches, division by zero)?
@@ -124,7 +133,7 @@ documentation:
   large arrays, repeated recompilation)?
 - Are error messages clear and actionable when protocol checks fail?
 
-### 2.8 Code quality
+### 2.7 Code quality
 
 - Can any code be simplified without losing clarity?
 - Are there overly complex expressions that should be broken up?

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -68,7 +68,10 @@ the docs actually say over this summary:
   reserved parameter names, the `.n` property convention (see STYLE_GUIDE.md)
 - **Imports** — `from __future__ import annotations`, relative internals, import
   order, optional dependency patterns, `TYPE_CHECKING` guards
-- **Type annotations** — modern Python 3.12+ syntax, project type aliases
+- **Type annotations** — modern Python 3.12+ syntax, project type aliases.
+  Also check for *missing* type hints: all new or modified public function
+  signatures (parameters and return types) and class attributes should be
+  annotated
 - **Subpackage dependency graph** — no illegal cross-imports (see STYLE_GUIDE.md
   section 6 and CONTRIBUTING.md)
 - **Registry patterns** — if the PR adds or modifies registry-dispatched

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: review-pr
+description: Review a ProbPipe PR for documentation, tests, API consistency, philosophy adherence, and code quality. Use when asked to review a PR or check for issues.
+allowed-tools: Read Grep Glob Bash(gh *) Bash(git *) Agent
+argument-hint: [pr-number]
+---
+
+# ProbPipe PR Review
+
+Review pull request **$ARGUMENTS** (if no number given, detect the PR for the current branch using `gh pr view`).
+
+## Instructions
+
+You are performing a read-only review. **Do not edit any files.** Your job is to
+analyze the PR and present a structured report of findings with concrete
+suggestions. The user will decide which suggestions to act on before any changes
+are made.
+
+## Step 1: Gather context
+
+Fetch the PR metadata and diff:
+
+```
+gh pr view $ARGUMENTS --json title,body,baseRefName,headRefName,files
+gh pr diff $ARGUMENTS
+```
+
+Identify which files were added, modified, or deleted. Read the full contents of
+every modified and newly added file so you have complete context (not just the
+diff hunks).
+
+Also read these project references — they define the conventions you are checking
+against:
+
+- `STYLE_GUIDE.md`
+- `CONTRIBUTING.md`
+
+## Step 2: Run the review checklist
+
+Work through **every** category below. For each, note specific findings with
+file paths and line numbers. If a category has no issues, say so briefly.
+
+### 2.1 Documentation
+
+- Are new or modified public classes, functions, and modules documented with
+  NumPy-style docstrings (`Parameters`, `Returns`, `Raises`)?
+- Are existing docstrings still accurate after the changes, or have they become
+  stale (e.g., parameter added but not documented, behavior changed but docstring
+  not updated)?
+- Do new modules have a module-level docstring explaining their purpose?
+- If the PR adds user-facing features, are the relevant docs pages in `docs/`
+  updated?
+
+### 2.2 Test coverage
+
+- Does every new public function/class/method have corresponding tests?
+- Are there edge cases that lack test coverage (empty inputs, boundary values,
+  error paths)?
+- Have any existing tests become stale — testing behavior that no longer matches
+  the implementation?
+- Do tests follow project conventions: `Test*` classes, pytest fixtures,
+  parametrized distribution families, `pytest.importorskip` for optional deps?
+- Is `__all__` updated in `__init__.py` files when new public symbols are added?
+
+### 2.3 ProbPipe philosophy
+
+Check that the PR adheres to the core design principles:
+
+- **Immutability** — Distribution parameters are fixed at construction. No
+  mutation of distribution state after `__init__`.
+- **Ops, not methods** — Public operations (`sample`, `mean`, `log_prob`,
+  `condition_on`, etc.) live in `probpipe.core.ops` as `WorkflowFunction`
+  instances. Users call `mean(dist)`, never `dist.mean()` or `dist._mean()`.
+- **Protocol-based dispatch** — Capabilities are declared via `@runtime_checkable`
+  protocols (`SupportsSampling`, `SupportsLogProb`, etc.). Concrete classes
+  implement the underscore methods (`_sample`, `_log_prob`, `_mean`).
+- **Private method convention** — Protocol methods use single underscore prefix.
+  Public API is always through ops.
+- **WorkflowFunction patterns** — Standalone workflow functions follow the
+  `_<name>_impl` + `<name> = WorkflowFunction(...)` pattern.
+
+### 2.4 API consistency
+
+- Do new names follow STYLE_GUIDE.md conventions? (`Supports<Cap>` for protocols,
+  `_method` for protocol methods, `snake_case` for ops, CamelCase for classes,
+  `_underscore.py` for private modules.)
+- Are reserved parameter names (`seed`, `n_broadcast_samples`, `include_inputs`)
+  avoided in user-defined functions?
+- Does the `.n` property convention hold for new finite-sample distribution
+  classes?
+- Are imports structured correctly? (`from __future__ import annotations` first,
+  relative internal imports, proper grouping.)
+- Are `__all__` exports updated?
+- Is the subpackage dependency graph respected? (See STYLE_GUIDE.md section 6.)
+
+### 2.5 Duplicate and redundant code
+
+- Does the PR reimplement logic that already exists in ProbPipe's abstractions?
+  Common offenders:
+  - Custom weight handling instead of using the `Weights` class
+  - Manual sampling loops instead of using `WorkflowFunction` broadcasting
+  - Bespoke protocol checks instead of using `isinstance` with existing protocols
+  - Re-implementing ops logic instead of calling the ops
+- Is there copy-pasted code that should be factored into a shared helper?
+- Are there unnecessary abstractions or over-engineering for what the PR needs?
+
+### 2.6 AI artifact comments
+
+Flag any comments that look like AI thinking artifacts rather than intentional
+documentation:
+
+- Comments starting with "wait", "hmm", "actually", "let me think", etc.
+- Overly verbose explainer comments that restate what the code obviously does
+- `# TODO` or `# FIXME` comments that were not in the original code and seem
+  like AI planning artifacts rather than genuine action items
+- Comments that narrate the development process rather than explain the code
+
+### 2.7 General concerns
+
+- Are there edge cases that could cause runtime errors (e.g., empty arrays,
+  shape mismatches, division by zero)?
+- Could any changes break backward compatibility for existing users?
+- Are there performance concerns (unnecessary copies, unvectorized loops over
+  large arrays, repeated recompilation)?
+- Are error messages clear and actionable when protocol checks fail?
+
+### 2.8 Code quality
+
+- Can any code be simplified without losing clarity?
+- Are there overly complex expressions that should be broken up?
+- Is there dead code, unused imports, or unreachable branches?
+- Are there opportunities to use JAX idioms more effectively (e.g., `vmap`
+  instead of Python loops, `jnp` instead of `np` where JIT is intended)?
+
+## Step 3: Present findings
+
+Organize your findings into a structured report with this format:
+
+```
+## PR Review: <PR title>
+
+### Summary
+<1-2 sentence overall assessment>
+
+### Findings
+
+#### Critical (must fix)
+- ...
+
+#### Recommended (should fix)
+- ...
+
+#### Minor (nice to have)
+- ...
+
+### Suggested Changes
+<Numbered list of concrete, actionable changes with file paths and line numbers.
+Group related changes together.>
+```
+
+**Do not make any changes.** Present the report and wait for the user to decide
+which suggestions to implement. Once the user approves specific items, then
+proceed with edits.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -88,6 +88,13 @@ the docs actually say over this summary:
 - Do new modules have a module-level docstring explaining their purpose?
 - If the PR adds user-facing features, are the relevant docs pages in `docs/`
   updated?
+- **Convention docs consistency** — Does the PR introduce changes that affect
+  project-wide conventions (e.g., new abstractions, new patterns, changes to the
+  class hierarchy, new registry types, renamed or removed APIs, new reserved
+  parameter names, new module layout)? If so, are `STYLE_GUIDE.md` and/or
+  `CONTRIBUTING.md` updated to reflect those changes? Flag any case where a PR
+  changes how things are done but leaves the convention docs describing the old
+  way.
 
 ### 2.3 Test coverage
 


### PR DESCRIPTION
## Summary

- Adds a project-level Claude Code skill (`.claude/skills/review-pr/SKILL.md`) that any collaborator can invoke with `/review-pr` or `/review-pr <number>`
- The skill performs a structured review of ProbPipe PRs against the project's conventions and philosophy, then presents findings as a report — no changes are made until the user approves specific suggestions

## What the skill checks

1. **Documentation** — stale/missing docstrings, module docs, NumPy-style compliance
2. **Test coverage** — missing tests, stale tests, fixture/convention adherence
3. **ProbPipe philosophy** — immutability, ops-not-methods, protocol dispatch, WorkflowFunction patterns
4. **API consistency** — naming conventions per STYLE_GUIDE.md, import structure, `__all__` exports, dependency graph
5. **Duplicate code** — reimplementing existing abstractions (e.g., `Weights`, protocols, broadcasting) instead of using them
6. **AI artifact comments** — "wait, ...", thinking-aloud comments, unnecessary explainer comments
7. **General concerns** — edge cases, backward compatibility, performance
8. **Code quality** — simplification, dead code, JAX idioms

## How to use

Invoke with `/review-pr` (reviews the current branch's PR) or `/review-pr 103` (reviews PR #103).

Claude will also auto-trigger this skill when it detects a user asking for a general PR review.

## Test plan

- [ ] Invoke `/review-pr` on an open PR and verify the structured report is generated
- [ ] Confirm no file edits are made until the user approves suggestions
- [ ] Verify the skill is visible to other collaborators after checkout
