### PR TITLE
Switch Pages deploy to actions/deploy-pages + prune old records

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,12 +7,18 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+  deployments: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  docs:
+  build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -30,6 +36,36 @@ jobs:
       - name: Build docs
         run: mkdocs build --strict
 
-      - name: Deploy to GitHub Pages
+      - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: mkdocs gh-deploy --force
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Prune old gh-pages deployments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Keep the newest deployment; mark older ones inactive and delete.
+          ids=$(gh api \
+            "repos/${{ github.repository }}/deployments?environment=github-pages&per_page=100" \
+            --jq '.[1:] | .[].id')
+          for id in $ids; do
+            gh api -X POST \
+              "repos/${{ github.repository }}/deployments/$id/statuses" \
+              -f state=inactive >/dev/null
+            gh api -X DELETE \
+              "repos/${{ github.repository }}/deployments/$id"
+          done


### PR DESCRIPTION
## Summary

- Replaces `mkdocs gh-deploy --force` with the modern `actions/deploy-pages@v4` workflow, so the docs site is published via the Pages API instead of pushing to a `gh-pages` branch.
- Adds a cleanup step that, after each successful deploy, marks every `github-pages` deployment record except the newest as inactive and deletes it — so the environment history stays a single entry instead of accumulating one per PR merge.
- Adds `concurrency: group: pages` so concurrent merges cannot race the Pages API.
- PRs still build with `mkdocs build --strict` (no deploy), preserving the pre-merge check.

## Required manual step before merging

In **Settings → Pages → Build and deployment → Source**, switch from "Deploy from a branch" to **GitHub Actions**. Without this, `actions/deploy-pages@v4` will fail.

Equivalent API call:

```
gh api -X POST repos/TARPS-group/prob-pipe/pages -f build_type=workflow
```

After the first successful deploy on `main`, the old `gh-pages` branch can be deleted:

```
git push origin --delete gh-pages
```

## Test plan

- [x] Flip the Pages source setting as described above
- [ ] Merge this PR and confirm the `Docs` workflow succeeds on `main`
- [ ] Verify https://tarps-group.github.io/prob-pipe/ reflects the new build
- [ ] Check `Settings → Environments → github-pages` shows exactly one deployment record
- [ ] Optionally delete the `gh-pages` branch
