### PR TITLE
RecordArray-based parameter-sweep broadcasting (PR 1 of #130)

### DIFF
--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -44,6 +44,7 @@ from probpipe.core.distribution import (
     RandomFunction,
     ArrayRandomFunction,
 )
+from probpipe.core._distribution_array import DistributionArray
 from probpipe.distributions import (
     # TFP base
     TFPDistribution,
@@ -155,6 +156,7 @@ __all__ = [
     "RecordDistribution",
     "NumericRecordDistribution",
     "FlattenedView",
+    "DistributionArray",
     "TFPDistribution",
     "EmpiricalDistribution",
     "NumericEmpiricalDistribution",

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -23,6 +23,7 @@ from .protocols import (
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from ..custom_types import Array
 from .._weights import Weights
@@ -376,6 +377,219 @@ def _make_marginal(
     # Single array result (e.g., from vmap); ensure at least 1D for the sample axis
     arr = jnp.atleast_1d(jnp.asarray(output_samples, dtype=jnp.float32))
     return _ArrayMarginal(arr, weights, name=name)
+
+
+# ---------------------------------------------------------------------------
+# _make_stack — stacked sibling of _make_marginal for RecordArray broadcasts
+# ---------------------------------------------------------------------------
+#
+# When a WorkflowFunction broadcasts over a RecordArray (parameter
+# sweep), the n inner outputs are independent scenarios indexed by
+# input row — *not* MC draws. The wrapper must preserve row identity:
+#
+#   numeric → NumericRecordArray(result=..., batch_shape=(n,))
+#   Record → RecordArray.stack (NumericRecordArray when all leaves numeric)
+#   Distribution → DistributionArray
+#   RecordArray (per row batch_shape=(m,)) → RecordArray(batch_shape=(n, m))
+#
+# Opaque Python values (e.g. strings) that can't be stacked fall
+# through to a plain-list wrapping with a clear error if even that
+# fails.
+#
+# Caller attaches ``.with_source(...)`` externally via ``_coerce_output``.
+# ---------------------------------------------------------------------------
+
+
+# Field name used when auto-wrapping scalar / array returns into a
+# Record so the output type contract holds. See issue #130 Open
+# Question 7: pickable in a follow-up PR via a decorator option; the
+# constant stays fixed here so pipelines that chain workflow functions
+# can rely on a stable key.
+AUTO_WRAP_FIELD = "result"
+
+
+def _make_stack(
+    inner_outputs: Any,
+    *,
+    n: int,
+    name: str | None = None,
+) -> Any:
+    """Wrap n inner workflow-function outputs as a shape-(n,) aggregate.
+
+    Dispatch on ``inner_outputs`` — either a Python ``list`` of length n
+    (Python-loop execution path) or a pytree with a leading axis of
+    length n (``jax.vmap`` execution path).
+
+    Parameters
+    ----------
+    inner_outputs : list or pytree
+        Either a list of n inner-function results, or a single
+        stackable pytree with a leading axis of length n.
+    n : int
+        Expected size of the leading aggregate axis. Used for sanity
+        checks and for building fresh templates.
+    name : str, optional
+        Name for the resulting aggregate.
+
+    Returns
+    -------
+    NumericRecordArray | RecordArray | DistributionArray
+        Output type depends on the inner-return type; see module
+        docstring for the dispatch table.
+
+    Raises
+    ------
+    TypeError
+        If the inner outputs can't be coerced into any of the three
+        aggregate types. The error lists the observed types.
+    """
+    from ._distribution_array import _make_distribution_array
+    from .record import Record, RecordTemplate
+
+    # --- List-of-X path (Python-loop execution) -------------------------
+    if isinstance(inner_outputs, list):
+        if len(inner_outputs) != n:
+            raise ValueError(
+                f"_make_stack got {len(inner_outputs)} outputs but "
+                f"expected n={n}."
+            )
+        outs = inner_outputs
+
+        # All Records → stack as a RecordArray. NumericRecordArray if
+        # every leaf is numeric; otherwise fall back to the permissive
+        # RecordArray class, building the fields manually so non-numeric
+        # leaves (strings, xarray objects, ...) survive.
+        if outs and all(isinstance(o, Record) for o in outs):
+            try:
+                from ._record_array import NumericRecordArray
+                return NumericRecordArray.stack(list(outs))
+            except (TypeError, ValueError):
+                pass
+            # Manual per-field assembly: numpy-array-like leaves stack
+            # numerically, object-dtype leaves use np.asarray(..., dtype=object).
+            first = outs[0]
+            if any(o.fields != first.fields for o in outs):
+                raise TypeError(
+                    "_make_stack: Records in list have inconsistent fields."
+                )
+            fields: dict[str, Any] = {}
+            for fname in first.fields:
+                values = [o[fname] for o in outs]
+                try:
+                    fields[fname] = jnp.stack(values, axis=0)
+                except (TypeError, ValueError):
+                    fields[fname] = np.asarray(values, dtype=object)
+            tpl_spec: dict[str, Any] = {}
+            for fname, v in fields.items():
+                if hasattr(v, "dtype") and getattr(v.dtype, "kind", None) in "biufc":
+                    tpl_spec[fname] = tuple(v.shape[1:])
+                else:
+                    tpl_spec[fname] = None
+            from .record import RecordTemplate
+            return RecordArray(fields, batch_shape=(n,), template=RecordTemplate(tpl_spec))
+
+        # All Distributions → stacked DistributionArray.
+        if outs and all(isinstance(o, Distribution) for o in outs):
+            return _make_distribution_array(outs, name=name)
+
+        # All RecordArrays with matching (non-empty) batch_shape →
+        # nested RecordArray with leading (n,) axis.
+        if outs and all(isinstance(o, RecordArray) for o in outs):
+            first = outs[0]
+            if all(ra.batch_shape == first.batch_shape for ra in outs):
+                fields = {
+                    fname: jnp.stack([ra[fname] for ra in outs], axis=0)
+                    for fname in first.fields
+                }
+                return type(first)(
+                    fields,
+                    batch_shape=(n,) + first.batch_shape,
+                    template=first.template,
+                )
+            # Mismatched inner shapes — fall through to the error path.
+
+        # Numeric scalars / arrays → wrap in NumericRecordArray with
+        # the single "result" field carrying the stacked values.
+        try:
+            stacked = jnp.stack(
+                [jnp.asarray(o) for o in outs], axis=0,
+            )
+        except (TypeError, ValueError):
+            stacked = None
+
+        if stacked is not None:
+            from ._record_array import NumericRecordArray
+            event_shape = tuple(stacked.shape[1:])
+            tpl = RecordTemplate(**{AUTO_WRAP_FIELD: event_shape})
+            return NumericRecordArray(
+                {AUTO_WRAP_FIELD: stacked},
+                batch_shape=(n,),
+                template=tpl,
+            )
+
+        # Last-ditch: wrap as a RecordArray whose single field holds a
+        # numpy object-dtype array of the opaque outputs.
+        try:
+            object_array = np.asarray(outs, dtype=object)
+            tpl = RecordTemplate(**{AUTO_WRAP_FIELD: None})
+            return RecordArray(
+                {AUTO_WRAP_FIELD: object_array},
+                batch_shape=(n,),
+                template=tpl,
+            )
+        except (TypeError, ValueError) as exc:
+            types_seen = sorted({type(o).__name__ for o in outs})
+            raise TypeError(
+                f"_make_stack cannot aggregate outputs of types "
+                f"{types_seen}; supported: numeric arrays, Record, "
+                f"RecordArray, Distribution."
+            ) from exc
+
+    # --- Single-pytree path (jax.vmap execution) ------------------------
+
+    # vmap of a numeric-returning function produces a jnp.ndarray with
+    # leading axis of length n.
+    if isinstance(inner_outputs, jnp.ndarray):
+        if inner_outputs.shape[:1] != (n,):
+            raise ValueError(
+                f"_make_stack got array of shape {inner_outputs.shape} but "
+                f"expected leading axis of length n={n}."
+            )
+        from ._record_array import NumericRecordArray
+        event_shape = tuple(inner_outputs.shape[1:])
+        tpl = RecordTemplate(**{AUTO_WRAP_FIELD: event_shape})
+        return NumericRecordArray(
+            {AUTO_WRAP_FIELD: inner_outputs},
+            batch_shape=(n,),
+            template=tpl,
+        )
+
+    # vmap of a Record-returning function produces a Record with
+    # batched leaves (each leaf has leading axis n). Promote to a
+    # RecordArray — NumericRecordArray when all leaves numeric.
+    if isinstance(inner_outputs, Record) and inner_outputs.fields:
+        resolved = [inner_outputs[f] for f in inner_outputs.fields]
+        if all(hasattr(v, "shape") and v.shape[:1] == (n,) for v in resolved):
+            event_shapes = tuple(v.shape[1:] for v in resolved)
+            tpl = RecordTemplate(**dict(zip(inner_outputs.fields, event_shapes)))
+            fields = dict(zip(inner_outputs.fields, resolved))
+            try:
+                from ._record_array import NumericRecordArray
+                return NumericRecordArray(
+                    fields, batch_shape=(n,), template=tpl,
+                )
+            except (TypeError, ValueError):
+                return RecordArray(
+                    fields, batch_shape=(n,), template=tpl,
+                )
+
+    # Fallback — shouldn't reach here with well-formed vmap output; if
+    # we do, raise with the type info.
+    raise TypeError(
+        f"_make_stack cannot aggregate output of type "
+        f"{type(inner_outputs).__name__}; expected a list, jnp.ndarray, "
+        f"or batched Record."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -1,0 +1,386 @@
+"""``DistributionArray`` — shape-indexed collection of independent distributions.
+
+A ``DistributionArray`` wraps ``n`` independent distributions as a single
+``Distribution`` with leading ``batch_shape=(n,)``. It is **not** a
+mixture: indexing returns one component, sampling draws one per
+component and stacks, mean/variance return per-component stacks.
+
+Use case: the output type of a :class:`~probpipe.WorkflowFunction`
+parameter sweep whose inner call returns a ``Distribution``. Each row of
+the sweep produces its own posterior; the stacked result must preserve
+row identity rather than marginalise, which is why we cannot reuse
+:class:`_MixtureMarginal`.
+
+Protocol support is dynamic (Pattern B): a ``DistributionArray``
+satisfies ``SupportsX`` iff every component does. The factory
+:func:`_make_distribution_array` constructs a cached subclass with the
+appropriate protocol mixins based on component capabilities.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+from ..custom_types import Array
+from ._distribution_base import Distribution
+from ._record_array import RecordArray
+from .protocols import (
+    SupportsLogProb,
+    SupportsMean,
+    SupportsSampling,
+    SupportsVariance,
+)
+from .record import Record
+
+__all__ = ["DistributionArray"]
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+
+class DistributionArray[T](Distribution[T]):
+    """Ordered collection of ``n`` independent distributions.
+
+    Leading ``batch_shape=(n,)`` prepended to the shared inner
+    ``batch_shape`` of the components (all components must have the
+    same inner batch_shape and event_shape).
+
+    Use the :func:`_make_distribution_array` factory to construct
+    instances — it picks the right subclass based on which protocols
+    all components support. The base class itself exposes only
+    indexing, iteration, and the ``components`` accessor.
+
+    Parameters
+    ----------
+    components : sequence of Distribution
+        The n component distributions. Must be non-empty and share
+        ``event_shape`` (and inner ``batch_shape`` if any).
+    name : str, optional
+        Name for provenance / introspection. Defaults to
+        ``"distribution_array"``.
+
+    Notes
+    -----
+    Unlike :class:`~probpipe.core._broadcast_distributions._MixtureMarginal`,
+    which marginalises over the components, ``DistributionArray`` is the
+    "stack" counterpart used when the component identity matters — each
+    row is a distinct scenario, not a mixture component. Sampling
+    produces one sample per component stacked along the leading axis.
+    """
+
+    _sampling_cost: str = "medium"
+    _preferred_orchestration: str | None = None
+
+    def __init__(
+        self,
+        components,
+        *,
+        name: str | None = None,
+    ):
+        components = tuple(components)
+        if not components:
+            raise ValueError("DistributionArray requires at least one component")
+        # All components must share event_shape. Inner batch_shape
+        # mismatches would break the (n,) + inner batch semantics, so
+        # enforce uniformity eagerly.
+        es0 = getattr(components[0], "event_shape", ())
+        bs0 = getattr(components[0], "batch_shape", ())
+        for i, c in enumerate(components[1:], start=1):
+            es = getattr(c, "event_shape", ())
+            bs = getattr(c, "batch_shape", ())
+            if es != es0:
+                raise ValueError(
+                    f"DistributionArray requires matching event_shape across "
+                    f"components; components[0].event_shape={es0} but "
+                    f"components[{i}].event_shape={es}."
+                )
+            if bs != bs0:
+                raise ValueError(
+                    f"DistributionArray requires matching inner batch_shape "
+                    f"across components; components[0].batch_shape={bs0} but "
+                    f"components[{i}].batch_shape={bs}."
+                )
+        self._components = components
+        if name is None:
+            name = "distribution_array"
+        super().__init__(name=name)
+        # A DistributionArray holding MC-marginal components inherits
+        # their approximation status; if any component is approximate
+        # (a _MixtureMarginal or NumericEmpiricalDistribution), so is
+        # the stack.
+        self._approximate = any(
+            getattr(c, "is_approximate", False) for c in components
+        )
+
+    # -- structure -----------------------------------------------------------
+
+    @property
+    def n(self) -> int:
+        return len(self._components)
+
+    @property
+    def components(self) -> tuple[Distribution, ...]:
+        """The n component distributions in sweep-row order."""
+        return self._components
+
+    @property
+    def batch_shape(self) -> tuple[int, ...]:
+        """(n,) prepended to the shared inner batch_shape of components."""
+        inner = getattr(self._components[0], "batch_shape", ())
+        return (self.n,) + tuple(inner)
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        """Shared ``event_shape`` across components."""
+        return getattr(self._components[0], "event_shape", ())
+
+    # -- container protocol --------------------------------------------------
+
+    def __len__(self) -> int:
+        return self.n
+
+    def __getitem__(self, i: int) -> Distribution:
+        """Return the ``i``-th component distribution (not a slice)."""
+        if not isinstance(i, (int, jnp.integer)) and not hasattr(i, "__index__"):
+            raise TypeError(
+                f"DistributionArray index must be int, got {type(i).__name__}"
+            )
+        return self._components[int(i)]
+
+    def __iter__(self):
+        return iter(self._components)
+
+    def __repr__(self) -> str:
+        return (
+            f"DistributionArray(n={self.n}, "
+            f"event_shape={self.event_shape})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Protocol mixins (combined dynamically via factory below)
+# ---------------------------------------------------------------------------
+
+
+class _DistArraySampling:
+    """SupportsSampling mixin for DistributionArray.
+
+    Per-component sampling — one draw from each component, stacked
+    along the leading axis. **Not** a mixture draw: the i-th sample
+    comes deterministically from ``components[i]`` (modulo the key
+    derived from ``jax.random.split``).
+    """
+
+    _sampling_cost: str = "medium"
+    _preferred_orchestration: str | None = None
+
+    def _sample(self, key, sample_shape=()):
+        keys = jax.random.split(key, self.n)
+        # Draw from each component at the requested sample_shape.
+        per_component = [
+            self._components[i]._sample(keys[i], sample_shape)
+            for i in range(self.n)
+        ]
+
+        # Record-valued components — two sample-shape regimes:
+        #
+        #  1. sample_shape == ()  → each per_component[i] is a Record.
+        #     Stack n of them into a RecordArray (batch_shape=(n,)).
+        #
+        #  2. sample_shape != ()  → each per_component[i] is already a
+        #     RecordArray with batch_shape=sample_shape. Stack fields
+        #     along a new trailing batch axis so the final leading
+        #     shape is ``sample_shape + (n,)``.
+        if sample_shape == () and all(
+            isinstance(s, Record) for s in per_component
+        ):
+            return RecordArray.stack(list(per_component))
+        if sample_shape != () and all(
+            isinstance(s, RecordArray) for s in per_component
+        ):
+            fields = {
+                name: jnp.stack(
+                    [ra[name] for ra in per_component], axis=len(sample_shape)
+                )
+                for name in per_component[0].fields
+            }
+            return type(per_component[0])(
+                fields,
+                batch_shape=sample_shape + (self.n,),
+                template=per_component[0].template,
+            )
+
+        # Numeric-array case. Stack along the axis right after
+        # sample_shape — leading axes are sample_shape, then the (n,)
+        # DistributionArray axis, then any inner batch + event axes.
+        try:
+            return jnp.stack(per_component, axis=len(sample_shape))
+        except (TypeError, ValueError) as exc:
+            types_seen = sorted({type(s).__name__ for s in per_component})
+            raise TypeError(
+                f"_DistArraySampling cannot stack component samples of "
+                f"types {types_seen}; DistributionArray supports numeric "
+                f"arrays and Record values only."
+            ) from exc
+
+
+def _stack_leading(values: list) -> Any:
+    """Stack a list of per-component values along a new leading axis.
+
+    Handles the three value-type regimes that arise from distribution
+    ops (``_mean`` / ``_variance`` / ``_sample`` / ``_log_prob``):
+
+    - Array leaves → ``jnp.stack(axis=0)``.
+    - ``Record`` leaves → ``RecordArray.stack``.
+    - ``RecordArray`` leaves (each with matching batch_shape) →
+      nested ``RecordArray`` with ``batch_shape=(n,) + inner_batch``.
+
+    Raises :class:`TypeError` with the observed type list if the
+    values can't be stacked (no common regime).
+    """
+    if not values:
+        raise ValueError("cannot stack an empty list of values")
+    if all(isinstance(v, Record) for v in values):
+        return RecordArray.stack(list(values))
+    if all(isinstance(v, RecordArray) for v in values):
+        # Stack each field along a new leading axis; shapes must match.
+        first = values[0]
+        fields = {
+            name: jnp.stack([ra[name] for ra in values], axis=0)
+            for name in first.fields
+        }
+        return type(first)(
+            fields,
+            batch_shape=(len(values),) + first.batch_shape,
+            template=first.template,
+        )
+    try:
+        return jnp.stack(values, axis=0)
+    except (TypeError, ValueError) as exc:
+        types_seen = sorted({type(v).__name__ for v in values})
+        raise TypeError(
+            f"DistributionArray cannot stack component values of types "
+            f"{types_seen}; supported: numeric arrays, Record, RecordArray."
+        ) from exc
+
+
+class _DistArrayMean:
+    """SupportsMean mixin for DistributionArray.
+
+    Per-component mean — stacks ``components[i]._mean()`` along the
+    leading (n,) axis. This is **not** a mixture mean; there is no
+    weighted average across components. The stack adapts to the value
+    type so Record-valued means become a ``RecordArray`` with the
+    (n,) axis prepended.
+    """
+
+    def _mean(self):
+        return _stack_leading([c._mean() for c in self._components])
+
+
+class _DistArrayVariance:
+    """SupportsVariance mixin for DistributionArray.
+
+    Per-component variance stacked along the leading (n,) axis.
+    **Not** the law-of-total-variance mixture formula — each row is a
+    distinct distribution, so its variance is reported independently.
+    """
+
+    def _variance(self):
+        return _stack_leading([c._variance() for c in self._components])
+
+
+class _DistArrayLogProb:
+    """SupportsLogProb mixin for DistributionArray.
+
+    Per-component log-density. ``value`` must have leading axis of
+    length n (after stripping any sample_shape the caller prepended);
+    returns a shape-(n,) array of per-component log-probs.
+    """
+
+    def _log_prob(self, value):
+        # value shape is (n,) + event_shape for array-valued components,
+        # or a RecordArray/batched Record for structured components —
+        # slice along axis 0 and evaluate each component on its slice.
+        return jnp.stack(
+            [
+                self._components[i]._log_prob(value[i])
+                for i in range(self.n)
+            ],
+            axis=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+# Map protocol → (mixin class, required component protocols).
+# Order matters only for the order mixins appear in the MRO; Python
+# resolves method lookup by class order, so sampling sits first.
+_DISTARRAY_PROTOCOL_MAP: list[tuple[type, type, tuple[type, ...]]] = [
+    (SupportsSampling, _DistArraySampling, (SupportsSampling,)),
+    (SupportsMean, _DistArrayMean, (SupportsMean,)),
+    (SupportsVariance, _DistArrayVariance, (SupportsVariance,)),
+    (SupportsLogProb, _DistArrayLogProb, (SupportsLogProb,)),
+]
+
+
+# Cache dynamically created classes so repeat constructions share a
+# single type object (cheap ``isinstance``, JIT-cache friendliness).
+_distarray_class_cache: dict[tuple[type, ...], type] = {}
+
+
+def _make_distribution_array(
+    components,
+    *,
+    name: str | None = None,
+) -> DistributionArray:
+    """Factory: build a ``DistributionArray`` with dynamic protocol support.
+
+    Inspects the components to determine which protocols *all* of them
+    support, creates (and caches) a concrete subclass that inherits
+    those protocol mixins, and returns an instance of it.
+
+    Parameters
+    ----------
+    components : sequence of Distribution
+        Component distributions.
+    name : str, optional
+        Name for provenance.
+
+    Returns
+    -------
+    DistributionArray
+        Concrete subclass carrying the minimal protocol set satisfied
+        by all components.
+    """
+    components = tuple(components)
+    if not components:
+        raise ValueError("DistributionArray requires at least one component")
+
+    active_protocols: list[type] = []
+    active_mixins: list[type] = []
+    for protocol, mixin, required in _DISTARRAY_PROTOCOL_MAP:
+        if all(isinstance(c, req) for c in components for req in required):
+            active_protocols.append(protocol)
+            active_mixins.append(mixin)
+
+    cache_key = tuple(active_protocols)
+    if cache_key not in _distarray_class_cache:
+        bases = (
+            tuple(active_mixins) + (DistributionArray,) + tuple(active_protocols)
+        )
+        cls_name = "_DynDistributionArray"
+        _distarray_class_cache[cache_key] = type(cls_name, bases, {})
+
+    cls = _distarray_class_cache[cache_key]
+    obj = object.__new__(cls)
+    DistributionArray.__init__(obj, components, name=name)
+    return obj

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -18,6 +18,7 @@ import numpy as np
 from .._utils import prod
 from ..custom_types import ArrayLike
 from ._numeric_record import NumericRecord, _NUMERIC_DTYPE_KINDS
+from .provenance import Provenance
 from .record import Record, RecordTemplate, _spec_size
 
 __all__ = ["RecordArray", "NumericRecordArray"]
@@ -44,7 +45,7 @@ class RecordArray:
     field name (``arr["x"]`` → batched leaf array).
     """
 
-    __slots__ = ("_store", "_batch_shape", "_template")
+    __slots__ = ("_store", "_batch_shape", "_template", "_source")
 
     def __init__(
         self,
@@ -76,6 +77,7 @@ class RecordArray:
         object.__setattr__(self, "_store", store)
         object.__setattr__(self, "_batch_shape", batch_shape)
         object.__setattr__(self, "_template", template)
+        object.__setattr__(self, "_source", None)
 
     @classmethod
     def _validate_fields(
@@ -119,6 +121,35 @@ class RecordArray:
     def fields(self) -> tuple[str, ...]:
         """Field names in sorted order."""
         return tuple(self._store.keys())
+
+    # -- Provenance --------------------------------------------------------
+
+    @property
+    def source(self) -> Provenance | None:
+        """Provenance describing how this RecordArray was created, or ``None``."""
+        return self._source
+
+    def with_source(self, source: Provenance) -> RecordArray:
+        """Attach provenance to this RecordArray (write-once).
+
+        Mirrors ``Distribution.with_source`` / ``Record.with_source``.
+
+        Notes
+        -----
+        ``_source`` is runtime-only metadata — it is not serialised into
+        the JAX pytree aux (a ``Provenance`` parent is typically a
+        ``Distribution`` or ``Record``, neither hashable by structure).
+        Round-tripping through ``jax.tree_util.tree_flatten`` /
+        ``tree_unflatten`` drops the source; re-attach it on the
+        reconstructed RecordArray if the chain must be preserved.
+        """
+        if self._source is not None:
+            raise RuntimeError(
+                f"Source already set on {self!r}. "
+                "Provenance is write-once; create a new RecordArray instead."
+            )
+        object.__setattr__(self, "_source", source)
+        return self
 
     # -- Field access -------------------------------------------------------
 

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -122,6 +122,17 @@ class RecordArray:
         """Field names in sorted order."""
         return tuple(self._store.keys())
 
+    @property
+    def name(self) -> str:
+        """Auto-generated human-readable name for provenance reports.
+
+        Derived from the class name and the sorted field list. Not a
+        user-configurable slot in PR 1 — callers that need custom names
+        on a batched output should attach them via
+        ``replace``/``with_source`` at a higher layer.
+        """
+        return f"{type(self).__name__.lower()}({','.join(self._store.keys())})"
+
     # -- Provenance --------------------------------------------------------
 
     @property

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -30,6 +30,7 @@ from .distribution import (
     EmpiricalDistribution,
     _make_marginal,
 )
+from ._broadcast_distributions import _make_stack
 from .provenance import Provenance
 from .protocols import (
     SupportsConditioning,
@@ -57,6 +58,70 @@ _DISTRIBUTION_PROTOCOLS: tuple[type, ...] = (
 from ..converters import converter_registry
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Output-type coercion for WorkflowFunction returns (issue #130 / PR 1)
+# ---------------------------------------------------------------------------
+#
+# PR 1 narrows the output-type contract to the broadcast path only —
+# non-broadcast calls pass their value through unchanged to preserve
+# backward compatibility with ops.py. PR 1.5 extends the contract to
+# every WorkflowFunction return.
+#
+# ``_coerce_output`` is the single entry point. For broadcast outputs,
+# it attaches a ``Provenance`` node via ``.with_source(...)`` so the
+# result carries a record of how it was produced (sweep rows, MC
+# draws, inner function name). Non-broadcast values are returned as-is.
+# ---------------------------------------------------------------------------
+
+
+def _coerce_output(
+    value: Any,
+    *,
+    broadcast_mode: str,
+    provenance: Provenance | None,
+) -> Any:
+    """Attach provenance to a broadcast output, if the type supports it.
+
+    Parameters
+    ----------
+    value
+        The output produced by the broadcast layer. For
+        ``broadcast_mode != "none"`` this is always a ``Record``,
+        ``RecordArray``, or ``Distribution`` (the three types that
+        expose ``.with_source``); for ``"none"`` it may be anything.
+    broadcast_mode : {"none", "marginalise", "stack", "nested"}
+        How the value was produced:
+
+        * ``"none"`` — non-broadcast call; pass through unchanged.
+        * ``"marginalise"`` — Distribution-only broadcast; value is
+          a marginal distribution.
+        * ``"stack"`` — RecordArray-only broadcast; value is a
+          stacked aggregate (``NumericRecordArray`` / ``RecordArray``
+          / ``DistributionArray``).
+        * ``"nested"`` — RecordArray + Distribution broadcast; value
+          is a ``DistributionArray`` whose components are per-row
+          marginals.
+    provenance : Provenance or None
+        Provenance node to attach. ``None`` skips the attachment.
+
+    Returns
+    -------
+    Any
+        The same value, with ``.source`` set when applicable.
+    """
+    if broadcast_mode == "none" or provenance is None:
+        return value
+    if hasattr(value, "with_source"):
+        try:
+            value.with_source(provenance)
+        except RuntimeError:
+            # Value already has a source (e.g., an inner marginal that
+            # the broadcasting layer built with its own provenance).
+            # Leave the existing source in place.
+            pass
+    return value
 
 __all__ = [
     "InputFrozenError",

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -31,6 +31,8 @@ from .distribution import (
     _make_marginal,
 )
 from ._broadcast_distributions import _make_stack
+from ._distribution_array import _make_distribution_array
+from ._record_array import RecordArray
 from .provenance import Provenance
 from .protocols import (
     SupportsConditioning,
@@ -387,10 +389,10 @@ class WorkflowFunction(Node):
         values = self._resolve_inputs(call_inputs)
         values = self._convert_distributions(values)
 
-        broadcast_args = self._find_broadcast_args(values)
-        if broadcast_args:
-            return self._broadcast_distributions_only(
-                values, broadcast_args, n_broadcast_samples, do_include_inputs,
+        dist_args, ra_args = self._find_broadcast_args(values)
+        if dist_args or ra_args:
+            return self._broadcast(
+                values, dist_args, ra_args, n_broadcast_samples, do_include_inputs,
             )
 
         return self._execute_many([values])[0]
@@ -525,19 +527,78 @@ class WorkflowFunction(Node):
 
         return out
 
-    def _find_broadcast_args(self, values: dict[str, Any]) -> list[str]:
+    def _find_broadcast_args(
+        self, values: dict[str, Any]
+    ) -> tuple[list[str], list[str]]:
+        """Classify argument values into distribution-broadcast and
+        RecordArray-broadcast groups.
+
+        Returns
+        -------
+        (dist_args, ra_args) : tuple of list
+            - ``dist_args``: arguments where a Distribution was passed
+              but the type hint expects a concrete (non-Distribution)
+              type. These are handled by the existing Monte Carlo
+              marginalisation path.
+            - ``ra_args``: arguments where a ``RecordArray`` with
+              nonempty ``batch_shape`` was passed to a slot whose type
+              hint is *not* a RecordArray (or subclass). These are
+              handled by the new parameter-sweep stack path introduced
+              in issue #130.
+
+        The two groups are disjoint — a value is either a Distribution
+        or a RecordArray or neither. Both groups firing on the same
+        call triggers the nested regime in ``_broadcast``: outer stack
+        over the RecordArray rows, inner marginalise over the
+        Distribution MC draws.
+
+        Raises
+        ------
+        ValueError
+            If two or more RecordArray args have different
+            ``batch_shape`` (lockstep broadcasting requires matching
+            leading axes).
         """
-        Identify arguments where a Distribution was passed but the type hint
-        expects a concrete (non-Distribution) type.
-        """
-        broadcast = []
+        dist_broadcast: list[str] = []
+        ra_broadcast: list[str] = []
         for name, value in values.items():
+            expected = self._hints.get(name)
+
+            # --- RecordArray branch ---------------------------------------
+            if isinstance(value, RecordArray) and len(value.batch_shape) > 0:
+                # Dispatch rules (see issue #130):
+                # - Hint is RecordArray (or subclass) → caller wants the
+                #   batched object as-is, don't broadcast.
+                # - Hint is ``typing.Any`` → caller opted out of
+                #   help ("anything goes"). Match their intent by
+                #   skipping broadcast. Also the signal used by
+                #   ``ops.log_prob`` / ``ops.prob`` / ``ops.expectation``
+                #   where ``value: Any`` consumes the batched Record
+                #   directly.
+                # - Hint is a ``Record`` / ``NumericRecord`` subclass →
+                #   caller wants a scalar Record; broadcast over rows.
+                # - Hint is any other concrete type, or no hint at all →
+                #   broadcast (the caller didn't express a batched
+                #   preference and a per-row call is the friendlier
+                #   default).
+                import typing
+                try:
+                    is_ra_hint = (
+                        isinstance(expected, type)
+                        and issubclass(expected, RecordArray)
+                    )
+                except TypeError:
+                    is_ra_hint = False
+                is_any_hint = expected is typing.Any
+                if is_ra_hint or is_any_hint:
+                    continue
+                ra_broadcast.append(name)
+                continue
+
+            # --- Distribution branch (existing logic) ---------------------
             if not converter_registry.is_distribution_type(value):
                 continue
-            # Check if the type hint indicates a distribution/protocol parameter.
-            # If so, the caller expects a distribution object — don't broadcast.
-            expected = self._hints.get(name)
-            # Unwrap parameterized generics (e.g. Distribution[T]) to their origin
+            # Unwrap parameterized generics (e.g. Distribution[T]).
             origin = getattr(expected, "__origin__", None)
             expected_type = origin if isinstance(origin, type) else expected
             try:
@@ -554,10 +615,24 @@ class WorkflowFunction(Node):
                 continue
             # Auto-convert external distribution types to ProbPipe
             if not isinstance(value, Distribution):
-                values[name] = converter_registry.convert(value, NumericRecordDistribution)
+                values[name] = converter_registry.convert(
+                    value, NumericRecordDistribution,
+                )
                 value = values[name]
-            broadcast.append(name)
-        return broadcast
+            dist_broadcast.append(name)
+
+        # Lockstep shape check: all RecordArrays must agree on batch_shape.
+        if len(ra_broadcast) >= 2:
+            shapes = {n: values[n].batch_shape for n in ra_broadcast}
+            unique = set(shapes.values())
+            if len(unique) > 1:
+                raise ValueError(
+                    f"Cannot broadcast RecordArray args with mismatched "
+                    f"batch_shapes: {shapes}. Align them explicitly "
+                    f"(e.g., via FullFactorialDesign)."
+                )
+
+        return dist_broadcast, ra_broadcast
 
     def _get_key(self):
         """Split and advance the internal PRNG key."""
@@ -583,9 +658,16 @@ class WorkflowFunction(Node):
                 if name == "self":
                     continue
                 if name in broadcast_args:
-                    dist = values[name]
-                    es = dist.event_shape
-                    dummy_kw[name] = jnp.zeros(es) if es else jnp.zeros(())
+                    v = values[name]
+                    # RecordArray input: construct a single Record from
+                    # row 0 so the dummy call sees what an inner sweep
+                    # iteration will actually receive.
+                    if isinstance(v, RecordArray):
+                        dummy_kw[name] = v[0]
+                    else:
+                        dist = v
+                        es = dist.event_shape
+                        dummy_kw[name] = jnp.zeros(es) if es else jnp.zeros(())
                 elif name in values:
                     v = values[name]
                     if isinstance(v, jnp.ndarray):
@@ -604,6 +686,198 @@ class WorkflowFunction(Node):
             self._resolved_vectorize = "loop"
 
         return self._resolved_vectorize
+
+    def _broadcast(
+        self,
+        values: dict[str, Any],
+        dist_args: list[str],
+        ra_args: list[str],
+        n_broadcast_samples: int,
+        do_include_inputs: bool = False,
+    ) -> Any:
+        """Dispatcher: route to the right broadcast regime (issue #130).
+
+        Three regimes:
+
+        - ``dist_args`` only — existing Monte Carlo marginalisation via
+          ``_broadcast_distributions_only``. Output: marginal
+          distribution (``_MixtureMarginal`` / ``_ArrayMarginal`` / ...).
+        - ``ra_args`` only — pure parameter sweep. One inner call per
+          RecordArray row; no marginalisation. Output: stacked
+          aggregate (``NumericRecordArray`` / ``RecordArray`` /
+          ``DistributionArray``) via ``_make_stack``.
+        - **Both** — nested regime. Outer loop over ``ra_args[0]`` rows,
+          each iteration running an inner distribution-only broadcast
+          for ``dist_args``. Output always a ``DistributionArray`` of
+          per-row marginals (satisfies the
+          Record | RecordArray | Distribution output contract).
+
+        The ``include_inputs=True`` override still produces the
+        inner-path ``BroadcastDistribution`` when ``dist_args`` fire,
+        but it is **not** supported on the pure-sweep or nested paths
+        (the stack has no single joint distribution to return; the
+        inputs are known via provenance). Calling with
+        ``include_inputs=True`` and any ``ra_args`` raises.
+        """
+        # ---- No RecordArray: delegate to the existing path -------------
+        if not ra_args:
+            return self._broadcast_distributions_only(
+                values, dist_args, n_broadcast_samples, do_include_inputs,
+            )
+
+        if do_include_inputs:
+            raise NotImplementedError(
+                "include_inputs=True is not supported with RecordArray "
+                "broadcasting. The inputs are already available via "
+                "provenance on the stacked output."
+            )
+
+        # PR 1 supports 1-D sweeps only. Multi-dim batch_shapes are a
+        # follow-up (would require flattening + reshaping of outputs).
+        sweep_ra_shape = values[ra_args[0]].batch_shape
+        if len(sweep_ra_shape) > 1:
+            raise NotImplementedError(
+                f"Multi-dimensional RecordArray batch_shape={sweep_ra_shape} "
+                f"broadcasting is not supported in PR 1; flatten via "
+                f"reshape / stack first."
+            )
+        n = sweep_ra_shape[0]
+
+        # ---- Pure sweep (no Distribution args) -------------------------
+        if not dist_args:
+            per_row = self._execute_sweep_rows(values, ra_args, n)
+            aggregate = _make_stack(per_row, n=n, name=self._name)
+            provenance = self._make_sweep_provenance(
+                values, ra_args, dist_args, n=n, k=0,
+            )
+            return _coerce_output(
+                aggregate, broadcast_mode="stack", provenance=provenance,
+            )
+
+        # ---- Nested (RecordArray + Distribution) -----------------------
+        # Per sweep row: run an inner distribution-only broadcast,
+        # marginalise over the k MC draws, collect the n per-row
+        # marginals and stack them into a DistributionArray.
+        per_row_marginals: list[Distribution] = []
+        for i in range(n):
+            row_values = self._slice_ra_args(values, ra_args, i)
+            inner = self._broadcast_distributions_only(
+                row_values, dist_args, n_broadcast_samples,
+                do_include_inputs=True,
+            )
+            # ``_broadcast_distributions_only`` with include_inputs=True
+            # returns a BroadcastDistribution; call .marginalize() to
+            # get the output-only marginal distribution.
+            if isinstance(inner, BroadcastDistribution):
+                marginal = inner.marginalize()
+            else:
+                # A non-broadcast inner (shouldn't happen when dist_args
+                # non-empty, but handle defensively).
+                marginal = inner
+            per_row_marginals.append(marginal)
+
+        stacked = _make_distribution_array(
+            per_row_marginals, name=self._name or "sweep",
+        )
+        provenance = self._make_sweep_provenance(
+            values, ra_args, dist_args, n=n, k=n_broadcast_samples,
+        )
+        return _coerce_output(
+            stacked, broadcast_mode="nested", provenance=provenance,
+        )
+
+    # ----- Helpers for the RecordArray-broadcast path ----------------------
+
+    def _slice_ra_args(
+        self,
+        values: dict[str, Any],
+        ra_args: list[str],
+        i: int,
+    ) -> dict[str, Any]:
+        """Materialise the ``i``-th sweep row by integer-indexing every
+        RecordArray argument.
+
+        Non-RecordArray arguments pass through unchanged; each indexed
+        RecordArray yields a ``Record`` (or ``NumericRecord`` for
+        ``NumericRecordArray``) via ``__getitem__``.
+        """
+        out = dict(values)
+        for name in ra_args:
+            out[name] = values[name][i]
+        return out
+
+    def _execute_sweep_rows(
+        self,
+        values: dict[str, Any],
+        ra_args: list[str],
+        n: int,
+    ) -> Any:
+        """Execute n inner calls, one per sweep row. Returns a list of
+        outputs (Python-loop path) or a stacked pytree (JAX vmap path).
+
+        Both returns are valid inputs for ``_make_stack``.
+        """
+        vectorize = self._resolve_vectorize(values, ra_args)
+
+        if vectorize == "jax":
+            # vmap-friendly: split the RecordArray leaves along batch
+            # axis 0, rebuild a single-row Record inside the function
+            # call so the body sees a plain Record of scalars.
+            static = {k: v for k, v in values.items() if k not in ra_args}
+
+            def single_call(ra_slice_leaves):
+                kw = dict(static)
+                for name in ra_args:
+                    ra = values[name]
+                    # ra_slice_leaves[name] is a dict of per-field
+                    # leaves shaped like a single row; reconstruct the
+                    # Record so the body sees a Record of scalars.
+                    kw[name] = ra._record_cls(ra_slice_leaves[name])
+                return self._func(**kw)
+
+            # Build the vmap-over-leaves input: a dict {name: {field: batched_array}}.
+            vmap_input = {
+                name: {f: values[name][f] for f in values[name].fields}
+                for name in ra_args
+            }
+            return jax.vmap(single_call)(vmap_input)
+
+        # Loop path.
+        per_row_values = [self._slice_ra_args(values, ra_args, i) for i in range(n)]
+        return self._execute_many(per_row_values)
+
+    def _make_sweep_provenance(
+        self,
+        values: dict[str, Any],
+        ra_args: list[str],
+        dist_args: list[str],
+        *,
+        n: int,
+        k: int,
+    ) -> Provenance:
+        """Build the Provenance node for a sweep output.
+
+        Parents are the RecordArray / Distribution inputs that drove
+        the broadcast. Metadata records the regime and count so
+        downstream tooling can report whether uncertainty was
+        marginalised or stacked.
+        """
+        regime = "nested" if dist_args else "stack"
+        parents = tuple(values[name] for name in ra_args) + tuple(
+            values[name] for name in dist_args
+            if isinstance(values[name], Distribution)
+        )
+        return Provenance(
+            operation=f"workflow.{regime}",
+            parents=parents,
+            metadata={
+                "func": self._name or self._func.__name__,
+                "n": n,
+                "k": k,
+                "ra_args": list(ra_args),
+                "dist_args": list(dist_args),
+            },
+        )
 
     def _broadcast_distributions_only(
         self,

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -389,7 +389,9 @@ class WorkflowFunction(Node):
 
         broadcast_args = self._find_broadcast_args(values)
         if broadcast_args:
-            return self._broadcast(values, broadcast_args, n_broadcast_samples, do_include_inputs)
+            return self._broadcast_distributions_only(
+                values, broadcast_args, n_broadcast_samples, do_include_inputs,
+            )
 
         return self._execute_many([values])[0]
 
@@ -603,18 +605,25 @@ class WorkflowFunction(Node):
 
         return self._resolved_vectorize
 
-    def _broadcast(
+    def _broadcast_distributions_only(
         self,
         values: dict[str, Any],
         broadcast_args: list[str],
         n_broadcast_samples: int,
         do_include_inputs: bool = False,
     ) -> BroadcastDistribution | Distribution:
-        """
-        Sample from Distribution arguments and call the function once per sample.
-        Returns the output marginal by default, or a ``BroadcastDistribution``
-        holding the joint over inputs and outputs when ``do_include_inputs``
-        is True.
+        """Distribution-only broadcast path (Monte Carlo marginalisation).
+
+        Samples from each ``broadcast_args`` entry (all of which are
+        ``Distribution`` instances after ``_find_broadcast_args``),
+        calls the user's function once per sample, and wraps the n
+        outputs as a single marginal distribution.
+
+        This method was historically named ``_broadcast``. Commit 4 of
+        PR 1 (issue #130) will re-introduce ``_broadcast`` as a dispatch
+        layer that routes between this Distribution-only path, the new
+        RecordArray-stack path, and the nested combination — hence the
+        rename.
 
         Vectorization (``"jax"`` vs ``"loop"``) and orchestration
         (``workflow_kind``) are resolved independently:

--- a/probpipe/core/provenance.py
+++ b/probpipe/core/provenance.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from ._record_array import RecordArray
     from .distribution import Distribution
+    from .record import Record
+
+    ProvenanceNode = Distribution | Record | RecordArray
 
 __all__ = ["Provenance", "provenance_ancestors", "provenance_dag"]
 
@@ -83,19 +87,25 @@ class Provenance:
 # Graph utilities
 # ---------------------------------------------------------------------------
 
-def provenance_ancestors(dist: Distribution) -> list[Distribution]:
-    """Return all ancestor distributions reachable via provenance chains.
+def provenance_ancestors(node: "ProvenanceNode") -> list["ProvenanceNode"]:
+    """Return all ancestor nodes reachable via provenance chains.
 
-    Traverses ``dist.source.parents`` recursively (breadth-first) and
-    returns a flat list of unique ancestor distributions, ordered by
-    discovery.  The input *dist* is **not** included in the result.
+    Traverses ``node.source.parents`` recursively (breadth-first) and
+    returns a flat list of unique ancestors, ordered by discovery.
+    The input *node* is **not** included in the result.
+
+    Parameters
+    ----------
+    node : Distribution | Record | RecordArray
+        Any object exposing a ``.source`` attribute. The three ProbPipe
+        types that carry provenance satisfy this uniformly.
     """
-    visited: set[int] = {id(dist)}
-    ancestors: list[Distribution] = []
-    queue: list[Distribution] = []
+    visited: set[int] = {id(node)}
+    ancestors: list = []
+    queue: list = []
 
-    if dist.source is not None:
-        for p in dist.source.parents:
+    if node.source is not None:
+        for p in node.source.parents:
             if id(p) not in visited:
                 visited.add(id(p))
                 queue.append(p)

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -116,6 +116,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from ..custom_types import ArrayLike
+from .provenance import Provenance
 
 if TYPE_CHECKING:
     import xarray as xr
@@ -157,7 +158,7 @@ class Record:
     switch to insertion order.
     """
 
-    __slots__ = ("_store", "_name")
+    __slots__ = ("_store", "_name", "_source")
 
     def __init__(
         self,
@@ -179,13 +180,45 @@ class Record:
         if name is None:
             name = "record(" + ",".join(store.keys()) + ")"
         object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_source", None)
 
-    # -- Name ---------------------------------------------------------------
+    # -- Name & provenance --------------------------------------------------
 
     @property
     def name(self) -> str:
         """Name of this Record."""
         return self._name
+
+    @property
+    def source(self) -> Provenance | None:
+        """Provenance describing how this Record was created, or ``None``."""
+        return self._source
+
+    def with_source(self, source: Provenance) -> Record:
+        """Attach provenance to this Record (write-once).
+
+        Mirrors ``Distribution.with_source`` — `_source` is set once and
+        subsequent calls raise. Semantic transformations (``replace``,
+        ``merge``, ``without``, ``map``, ``map_with_names``) return a
+        *new* Record with an empty source; the caller attaches fresh
+        provenance there if desired.
+
+        Notes
+        -----
+        ``_source`` is runtime-only metadata — it is not serialised into
+        the JAX pytree aux (a ``Provenance`` parent is a ``Distribution``
+        or ``Record``, neither of which is hashable by structure).
+        Round-tripping through ``jax.tree_util.tree_flatten`` /
+        ``tree_unflatten`` therefore drops the source; re-attach it on
+        the reconstructed Record if you need to preserve the chain.
+        """
+        if self._source is not None:
+            raise RuntimeError(
+                f"Source already set on {self!r}. "
+                "Provenance is write-once; create a new Record instead."
+            )
+        object.__setattr__(self, "_source", source)
+        return self
 
     # -- Immutability -------------------------------------------------------
 

--- a/tests/test_broadcast_distribution.py
+++ b/tests/test_broadcast_distribution.py
@@ -713,3 +713,176 @@ class TestRecordArrayMarginal:
         result = record_workflow(**prior.select("x", "y"))
         r = repr(result)
         assert "sum" in r and "diff" in r
+
+
+# ===========================================================================
+# _make_stack — RecordArray-broadcast sibling of _make_marginal (issue #130)
+# ===========================================================================
+
+
+class TestMakeStack:
+    """Dispatch rules for wrapping n inner-function outputs as a
+    shape-(n,) aggregate. Every case is a parameter-sweep-like scenario
+    where row identity must survive; there is no marginalisation."""
+
+    def test_list_of_scalars_wraps_as_numeric_record_array(self):
+        from probpipe import NumericRecordArray
+        from probpipe.core._broadcast_distributions import _make_stack, AUTO_WRAP_FIELD
+        out = _make_stack([1.0, 2.0, 3.0, 4.0], n=4)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (4,)
+        assert out.fields == (AUTO_WRAP_FIELD,)
+        np.testing.assert_allclose(out[AUTO_WRAP_FIELD], [1.0, 2.0, 3.0, 4.0])
+
+    def test_list_of_arrays_preserves_event_shape(self):
+        from probpipe import NumericRecordArray
+        from probpipe.core._broadcast_distributions import _make_stack, AUTO_WRAP_FIELD
+        values = [jnp.arange(3.0) + 10.0 * i for i in range(4)]
+        out = _make_stack(values, n=4)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (4,)
+        assert out[AUTO_WRAP_FIELD].shape == (4, 3)
+
+    def test_list_of_numeric_records_promotes_to_numeric_array(self):
+        from probpipe import NumericRecord, NumericRecordArray
+        from probpipe.core._broadcast_distributions import _make_stack
+        records = [NumericRecord(a=float(i), b=float(i) * 2) for i in range(5)]
+        out = _make_stack(records, n=5)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (5,)
+        np.testing.assert_allclose(out["a"], [0, 1, 2, 3, 4])
+        np.testing.assert_allclose(out["b"], [0, 2, 4, 6, 8])
+
+    def test_list_of_mixed_records_falls_back_to_recordarray(self):
+        """Records with a string (non-numeric) leaf can't go through
+        ``NumericRecordArray.stack``. The fallback path builds each
+        field independently — numeric leaves via ``jnp.stack``,
+        opaque leaves via ``np.asarray(dtype=object)``."""
+        from probpipe import Record, NumericRecordArray, RecordArray
+        from probpipe.core._broadcast_distributions import _make_stack
+        records = [Record(a=float(i), label=f"row{i}") for i in range(3)]
+        out = _make_stack(records, n=3)
+        assert isinstance(out, RecordArray)
+        assert not isinstance(out, NumericRecordArray)
+        np.testing.assert_allclose(out["a"], [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(out["label"], ["row0", "row1", "row2"])
+
+    def test_list_of_distributions_gives_distribution_array(self):
+        from probpipe import DistributionArray, Normal
+        from probpipe.core._broadcast_distributions import _make_stack
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
+        out = _make_stack(comps, n=3)
+        assert isinstance(out, DistributionArray)
+        assert out.batch_shape == (3,)
+        assert out[0] is comps[0]
+
+    def test_list_of_record_arrays_nests_batch_shape(self):
+        """Each inner RecordArray has its own batch_shape (m,). Stacking
+        n of them produces a RecordArray with batch_shape (n, m)."""
+        from probpipe import NumericRecord, NumericRecordArray
+        from probpipe.core._broadcast_distributions import _make_stack
+        inner = [
+            NumericRecordArray.stack(
+                [NumericRecord(x=float(i * 10 + j)) for j in range(4)]
+            )
+            for i in range(3)
+        ]
+        out = _make_stack(inner, n=3)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (3, 4)
+        np.testing.assert_allclose(out["x"][0], [0, 1, 2, 3])
+        np.testing.assert_allclose(out["x"][2], [20, 21, 22, 23])
+
+    def test_vmap_ndarray_wraps_as_numeric_record_array(self):
+        """A bare ``jnp.ndarray`` with leading axis n (typical ``jax.vmap``
+        output for scalar-returning fns) wraps without unstacking."""
+        from probpipe import NumericRecordArray
+        from probpipe.core._broadcast_distributions import _make_stack, AUTO_WRAP_FIELD
+        arr = jnp.arange(12.0).reshape(4, 3)
+        out = _make_stack(arr, n=4)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (4,)
+        assert out[AUTO_WRAP_FIELD].shape == (4, 3)
+
+    def test_vmap_record_with_batched_leaves_promotes_to_ra(self):
+        """``jax.vmap`` of a Record-returning fn produces a Record whose
+        leaves are already batched along a leading axis. That's the
+        input form for the pytree branch of ``_make_stack``."""
+        from probpipe import NumericRecordArray, Record
+        from probpipe.core._broadcast_distributions import _make_stack
+        rec = Record(x=jnp.arange(5.0), y=jnp.arange(5.0) + 10)
+        out = _make_stack(rec, n=5)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (5,)
+
+    def test_length_mismatch_raises(self):
+        from probpipe.core._broadcast_distributions import _make_stack
+        with pytest.raises(ValueError, match="expected n=5"):
+            _make_stack([1.0, 2.0, 3.0], n=5)
+
+    def test_ndarray_leading_axis_mismatch_raises(self):
+        from probpipe.core._broadcast_distributions import _make_stack
+        with pytest.raises(ValueError, match="expected leading axis"):
+            _make_stack(jnp.arange(6.0), n=4)
+
+
+# ===========================================================================
+# _coerce_output — attaches provenance to broadcast outputs
+# ===========================================================================
+
+
+class TestCoerceOutput:
+    """``_coerce_output`` is the single entry point where broadcast
+    outputs pick up their provenance. Non-broadcast values pass through
+    unchanged (PR 1 narrowing — see issue #130)."""
+
+    def test_none_mode_passes_through(self):
+        from probpipe.core.node import _coerce_output
+        # Non-Record/Dist values wouldn't normally have .with_source
+        # but the "none" mode short-circuits before the check anyway.
+        assert _coerce_output(3.14, broadcast_mode="none", provenance=None) == 3.14
+        # None provenance also short-circuits.
+        prov = Provenance("x", parents=())
+        assert _coerce_output(3.14, broadcast_mode="none", provenance=prov) == 3.14
+
+    def test_stack_mode_attaches_to_recordarray(self):
+        from probpipe import NumericRecord, NumericRecordArray
+        from probpipe.core.node import _coerce_output
+        ra = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(3)]
+        )
+        assert ra.source is None
+        prov = Provenance("sweep", parents=())
+        out = _coerce_output(ra, broadcast_mode="stack", provenance=prov)
+        assert out is ra
+        assert ra.source.operation == "sweep"
+
+    def test_attaches_to_distribution_array(self):
+        from probpipe import DistributionArray, Normal
+        from probpipe.core._broadcast_distributions import _make_stack
+        from probpipe.core.node import _coerce_output
+        da = _make_stack(
+            [Normal(loc=0.0, scale=1.0, name=f"d{i}") for i in range(3)], n=3,
+        )
+        assert isinstance(da, DistributionArray)
+        assert da.source is None
+        prov = Provenance("nested", parents=())
+        _coerce_output(da, broadcast_mode="nested", provenance=prov)
+        assert da.source.operation == "nested"
+
+    def test_existing_source_is_not_overwritten(self):
+        """If the broadcasting layer has already wired a fresh inner
+        marginal with a source (e.g., a _MixtureMarginal was built with
+        its own provenance), ``_coerce_output`` must not crash and the
+        existing source must remain."""
+        from probpipe import NumericRecord
+        from probpipe.core.node import _coerce_output
+        nr = NumericRecord(x=1.0).with_source(Provenance("inner", parents=()))
+        # Second set would normally raise RuntimeError; _coerce_output
+        # swallows it.
+        _coerce_output(
+            nr,
+            broadcast_mode="stack",
+            provenance=Provenance("outer", parents=()),
+        )
+        assert nr.source.operation == "inner"

--- a/tests/test_distribution_array.py
+++ b/tests/test_distribution_array.py
@@ -1,0 +1,277 @@
+"""Tests for ``DistributionArray`` (issue #130 / PR 1 commit 2).
+
+A ``DistributionArray`` is a shape-indexed collection of independent
+distributions with leading ``batch_shape=(n,)`` — **not** a mixture.
+Used by the RecordArray-broadcast layer when a WorkflowFunction sweep
+returns Distribution-valued outputs, one per sweep row.
+
+The tests cover: construction + invariants, Pattern B dynamic protocol
+support (isinstance reflects all-components-support), sample/mean/
+variance/log_prob for both scalar and Record component-sample types,
+and the provenance slot inherited from ``Distribution``.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import (
+    Normal,
+    NumericEmpiricalDistribution,
+    ProductDistribution,
+    Provenance,
+)
+from probpipe.core._distribution_array import (
+    DistributionArray,
+    _make_distribution_array,
+)
+from probpipe.core.protocols import (
+    SupportsLogProb,
+    SupportsMean,
+    SupportsSampling,
+    SupportsVariance,
+)
+
+
+# ---------------------------------------------------------------------------
+# Construction & invariants
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_from_list_of_normals(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(4)]
+        da = _make_distribution_array(comps)
+        assert isinstance(da, DistributionArray)
+        assert da.n == 4
+        assert len(da) == 4
+        assert da.batch_shape == (4,)
+        assert da.event_shape == ()
+
+    def test_indexing_returns_component(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
+        da = _make_distribution_array(comps)
+        assert da[0] is comps[0]
+        assert da[2] is comps[2]
+
+    def test_iter_yields_components(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
+        da = _make_distribution_array(comps)
+        assert list(da) == list(comps)
+
+    def test_empty_components_raises(self):
+        with pytest.raises(ValueError, match="at least one component"):
+            _make_distribution_array([])
+
+    def test_factory_returns_distribution_subclass(self):
+        comps = [Normal(loc=0.0, scale=1.0, name="d0")]
+        da = _make_distribution_array(comps)
+        from probpipe.core._distribution_base import Distribution
+        assert isinstance(da, Distribution)
+
+    def test_repr(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
+        da = _make_distribution_array(comps)
+        r = repr(da)
+        assert "DistributionArray" in r
+        assert "n=3" in r
+
+    # The factory demands uniform shapes so the (n,) + inner_batch
+    # batch_shape semantic holds. Mismatches raise at construction.
+
+    def test_mismatched_event_shape_raises(self):
+        c0 = Normal(loc=0.0, scale=1.0, name="d0")
+        c1 = ProductDistribution(
+            x=Normal(loc=0.0, scale=1.0, name="x"),
+            y=Normal(loc=0.0, scale=1.0, name="y"),
+        )
+        with pytest.raises(ValueError, match="event_shape"):
+            _make_distribution_array([c0, c1])
+
+
+# ---------------------------------------------------------------------------
+# Pattern B — dynamic protocol opt-in
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolOptIn:
+    """A DistributionArray satisfies SupportsX iff *every* component does.
+
+    This is the Pattern B "protocols supported by all" rule used
+    throughout ProbPipe's view / joint classes.
+    """
+
+    def test_all_protocols_when_all_components_support(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
+        da = _make_distribution_array(comps)
+        assert isinstance(da, SupportsSampling)
+        assert isinstance(da, SupportsMean)
+        assert isinstance(da, SupportsVariance)
+        assert isinstance(da, SupportsLogProb)
+
+    def test_drops_log_prob_when_component_lacks_it(self):
+        # NumericEmpiricalDistribution supports Sampling + Mean + Variance
+        # but NOT LogProb. The DistributionArray should mirror that.
+        raw = [jax.random.normal(jax.random.PRNGKey(i), (50,)) for i in range(3)]
+        comps = [NumericEmpiricalDistribution(r) for r in raw]
+        assert not isinstance(comps[0], SupportsLogProb)
+
+        da = _make_distribution_array(comps)
+        assert isinstance(da, SupportsSampling)
+        assert isinstance(da, SupportsMean)
+        assert isinstance(da, SupportsVariance)
+        assert not isinstance(da, SupportsLogProb)
+
+    def test_factory_cache_reuses_class(self):
+        """Two DistributionArrays with the same protocol signature share
+        a class — keeps isinstance cheap and JIT cache-friendly."""
+        from probpipe.core._distribution_array import _distarray_class_cache
+        # Clear cache so the assertion is deterministic
+        _distarray_class_cache.clear()
+        c0 = [Normal(loc=0.0, scale=1.0, name="x0")]
+        c1 = [Normal(loc=1.0, scale=2.0, name="x1")]
+        da0 = _make_distribution_array(c0)
+        da1 = _make_distribution_array(c1)
+        assert type(da0) is type(da1)
+
+
+# ---------------------------------------------------------------------------
+# Sampling
+# ---------------------------------------------------------------------------
+
+
+class TestSampling:
+    def test_scalar_sample_shape(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(4)]
+        da = _make_distribution_array(comps)
+        s = da._sample(jax.random.PRNGKey(0))
+        assert s.shape == (4,)
+
+    def test_sample_shape_leading_axis(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(4)]
+        da = _make_distribution_array(comps)
+        s = da._sample(jax.random.PRNGKey(0), sample_shape=(7,))
+        assert s.shape == (7, 4)
+
+    def test_sample_shape_2d(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
+        da = _make_distribution_array(comps)
+        s = da._sample(jax.random.PRNGKey(0), sample_shape=(5, 2))
+        assert s.shape == (5, 2, 3)
+
+    def test_components_drive_samples(self):
+        """The i-th slice of the stacked sample must concentrate around
+        the i-th component's mean — confirms per-component (not mixture)
+        sampling."""
+        comps = [Normal(loc=float(i) * 100, scale=1e-3, name=f"d{i}")
+                 for i in range(3)]
+        da = _make_distribution_array(comps)
+        s = da._sample(jax.random.PRNGKey(0), sample_shape=(1000,))
+        # column i should have mean ≈ i * 100
+        means = s.mean(axis=0)
+        np.testing.assert_allclose(means, jnp.array([0.0, 100.0, 200.0]),
+                                   atol=0.2)
+
+    def test_record_valued_components_scalar_sample(self):
+        comps = [
+            ProductDistribution(
+                x=Normal(loc=float(i), scale=1e-3, name=f"x{i}"),
+                y=Normal(loc=-float(i), scale=1e-3, name=f"y{i}"),
+            )
+            for i in range(3)
+        ]
+        da = _make_distribution_array(comps)
+        s = da._sample(jax.random.PRNGKey(0))
+        from probpipe import RecordArray
+        assert isinstance(s, RecordArray)
+        assert s.batch_shape == (3,)
+        np.testing.assert_allclose(s["x"], [0.0, 1.0, 2.0], atol=1e-2)
+
+    def test_record_valued_components_batched_sample(self):
+        comps = [
+            ProductDistribution(
+                x=Normal(loc=float(i), scale=1e-3, name=f"x{i}"),
+                y=Normal(loc=-float(i), scale=1e-3, name=f"y{i}"),
+            )
+            for i in range(3)
+        ]
+        da = _make_distribution_array(comps)
+        s = da._sample(jax.random.PRNGKey(0), sample_shape=(5,))
+        from probpipe import NumericRecordArray
+        assert isinstance(s, NumericRecordArray)
+        assert s.batch_shape == (5, 3)
+        # Shape of x field: (5, 3) — leading sample axis then the n axis
+        assert s["x"].shape == (5, 3)
+
+
+# ---------------------------------------------------------------------------
+# Moments
+# ---------------------------------------------------------------------------
+
+
+class TestMean:
+    def test_scalar_components_mean_shape(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(4)]
+        da = _make_distribution_array(comps)
+        m = da._mean()
+        assert m.shape == (4,)
+        np.testing.assert_allclose(m, [0.0, 1.0, 2.0, 3.0])
+
+    def test_record_components_mean_is_recordarray(self):
+        comps = [
+            ProductDistribution(
+                x=Normal(loc=float(i), scale=1.0, name=f"x{i}"),
+                y=Normal(loc=-float(i), scale=1.0, name=f"y{i}"),
+            )
+            for i in range(3)
+        ]
+        da = _make_distribution_array(comps)
+        m = da._mean()
+        from probpipe import RecordArray
+        assert isinstance(m, RecordArray)
+        assert m.batch_shape == (3,)
+        np.testing.assert_allclose(m["x"], [0.0, 1.0, 2.0])
+        np.testing.assert_allclose(m["y"], [0.0, -1.0, -2.0])
+
+
+class TestVariance:
+    def test_scalar_components_variance_shape(self):
+        comps = [Normal(loc=0.0, scale=float(i + 1), name=f"d{i}")
+                 for i in range(3)]
+        da = _make_distribution_array(comps)
+        v = da._variance()
+        assert v.shape == (3,)
+        np.testing.assert_allclose(v, [1.0, 4.0, 9.0])
+
+
+class TestLogProb:
+    def test_per_component_log_prob(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
+        da = _make_distribution_array(comps)
+        # value shape (n,) matches the batch axis
+        value = jnp.array([0.0, 1.0, 2.0])  # each at its component's mean
+        lp = da._log_prob(value)
+        assert lp.shape == (3,)
+        # All three log-probs equal log_prob(N(0,1), 0)
+        np.testing.assert_allclose(lp, [lp[0]] * 3, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Provenance (inherited from Distribution)
+# ---------------------------------------------------------------------------
+
+
+class TestProvenance:
+    def test_initial_source_is_none(self):
+        comps = [Normal(loc=0.0, scale=1.0, name="d0")]
+        da = _make_distribution_array(comps)
+        assert da.source is None
+
+    def test_with_source_roundtrip(self):
+        comps = [Normal(loc=0.0, scale=1.0, name="d0")]
+        da = _make_distribution_array(comps)
+        parent = Normal(loc=0.0, scale=1.0, name="parent")
+        da.with_source(Provenance("sweep", parents=(parent,)))
+        assert da.source.operation == "sweep"
+        assert da.source.parents == (parent,)

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import Record
+from probpipe import Normal, Provenance, Record, provenance_ancestors
 
 
 # ---------------------------------------------------------------------------
@@ -609,3 +609,107 @@ class TestReprAndEquality:
     def test_self_equality_with_nan_nested(self):
         r = Record(inner=Record(x=jnp.array([jnp.nan])), y=jnp.nan)
         assert r == r
+
+
+# ---------------------------------------------------------------------------
+# Provenance (issue #130 / PR 1 commit 1)
+# ---------------------------------------------------------------------------
+
+
+class TestProvenance:
+    """Record carries the same ``.source`` / ``.with_source`` slot as
+    Distribution, so workflow outputs can attach a Provenance node
+    regardless of which of the three output types (Record, RecordArray,
+    Distribution) the broadcasting layer produced.
+    """
+
+    def test_initial_source_is_none(self):
+        r = Record(x=1.0, y=2.0)
+        assert r.source is None
+
+    def test_with_source_sets_and_returns_self(self):
+        r = Record(x=1.0)
+        out = r.with_source(Provenance("op", parents=()))
+        assert out is r
+        assert r.source.operation == "op"
+
+    def test_with_source_is_write_once(self):
+        r = Record(x=1.0)
+        r.with_source(Provenance("first", parents=()))
+        with pytest.raises(RuntimeError, match="write-once"):
+            r.with_source(Provenance("second", parents=()))
+
+    # Semantic transformations reset the source — the new Record is a
+    # different logical value even though the class preserves.
+
+    def test_replace_resets_source(self):
+        r = Record(x=1.0).with_source(Provenance("orig", parents=()))
+        r2 = r.replace(x=2.0)
+        assert r2.source is None
+        assert r.source.operation == "orig"  # original unaffected
+
+    def test_merge_resets_source(self):
+        r = Record(x=1.0).with_source(Provenance("orig", parents=()))
+        merged = r.merge(Record(y=2.0))
+        assert merged.source is None
+
+    def test_without_resets_source(self):
+        r = Record(x=1.0, y=2.0).with_source(Provenance("orig", parents=()))
+        r2 = r.without("y")
+        assert r2.source is None
+
+    def test_map_resets_source(self):
+        r = Record(x=1.0).with_source(Provenance("orig", parents=()))
+        r2 = r.map(lambda v: v + 1)
+        assert r2.source is None
+
+    # Structural equality / hashing ignore source — two Records with the
+    # same fields but different provenance are still equal.
+
+    def test_eq_ignores_source(self):
+        r1 = Record(x=1.0).with_source(Provenance("a", parents=()))
+        r2 = Record(x=1.0).with_source(Provenance("b", parents=()))
+        assert r1 == r2
+
+    def test_hash_ignores_source(self):
+        r1 = Record(x=1.0).with_source(Provenance("a", parents=()))
+        r2 = Record(x=1.0)
+        assert hash(r1) == hash(r2)
+
+    # Pytree roundtrip drops the source (runtime-only metadata — a
+    # Provenance parent isn't hashable by structure, so pushing it into
+    # the aux tuple would break jax.tree_util.tree_unflatten's equality
+    # semantics). Document this caveat with a test.
+
+    def test_pytree_roundtrip_drops_source(self):
+        r = Record(x=1.0, y=jnp.array([2.0, 3.0]))
+        r.with_source(Provenance("op", parents=()))
+        leaves, treedef = jax.tree_util.tree_flatten(r)
+        r2 = jax.tree_util.tree_unflatten(treedef, leaves)
+        assert r2.source is None
+        # But the Record is otherwise structurally identical.
+        assert r2 == r
+
+    # Integration: walk provenance from a Record through a Distribution
+    # ancestor via provenance_ancestors.
+
+    def test_provenance_ancestors_walks_through_distribution(self):
+        prior = Normal(loc=0.0, scale=1.0, name="prior")
+        r = Record(theta=1.0).with_source(
+            Provenance("draw", parents=(prior,))
+        )
+        ancestors = provenance_ancestors(r)
+        assert len(ancestors) == 1
+        assert ancestors[0] is prior
+
+    def test_provenance_ancestors_walks_nested_records(self):
+        prior = Normal(loc=0.0, scale=1.0, name="prior")
+        middle = Record(theta=1.0).with_source(
+            Provenance("draw", parents=(prior,))
+        )
+        outer = Record(result=2.0).with_source(
+            Provenance("transform", parents=(middle,))
+        )
+        ancestors = provenance_ancestors(outer)
+        names = [getattr(a, "name", None) for a in ancestors]
+        assert names == [middle.name, "prior"]

--- a/tests/test_record_array.py
+++ b/tests/test_record_array.py
@@ -5,7 +5,15 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import NumericRecord, NumericRecordArray, Record, RecordArray
+from probpipe import (
+    Normal,
+    NumericRecord,
+    NumericRecordArray,
+    Provenance,
+    Record,
+    RecordArray,
+    provenance_ancestors,
+)
 from probpipe.core.record import RecordTemplate
 
 
@@ -602,3 +610,65 @@ class TestNumericRecordArrayValidation:
             template=outer_tpl,
         )
         assert nra["physics"] is inner
+
+
+# ---------------------------------------------------------------------------
+# Provenance (issue #130 / PR 1 commit 1)
+# ---------------------------------------------------------------------------
+
+
+class TestProvenance:
+    """RecordArray carries the same ``.source`` / ``.with_source`` slot
+    as Record and Distribution so sweep outputs can record which
+    parameters / distributions produced them.
+    """
+
+    @pytest.fixture
+    def ra(self):
+        return NumericRecordArray.stack(
+            [NumericRecord(x=float(i), y=2.0 * i) for i in range(3)]
+        )
+
+    def test_initial_source_is_none(self, ra):
+        assert ra.source is None
+
+    def test_with_source_sets_and_returns_self(self, ra):
+        out = ra.with_source(Provenance("sweep", parents=()))
+        assert out is ra
+        assert ra.source.operation == "sweep"
+
+    def test_with_source_is_write_once(self, ra):
+        ra.with_source(Provenance("first", parents=()))
+        with pytest.raises(RuntimeError, match="write-once"):
+            ra.with_source(Provenance("second", parents=()))
+
+    def test_eq_ignores_source(self, ra):
+        ra2 = NumericRecordArray.stack(
+            [NumericRecord(x=float(i), y=2.0 * i) for i in range(3)]
+        )
+        ra.with_source(Provenance("a", parents=()))
+        ra2.with_source(Provenance("b", parents=()))
+        assert ra == ra2
+
+    def test_pytree_roundtrip_drops_source(self, ra):
+        ra.with_source(Provenance("sweep", parents=()))
+        leaves, treedef = jax.tree_util.tree_flatten(ra)
+        ra2 = jax.tree_util.tree_unflatten(treedef, leaves)
+        assert ra2.source is None
+        assert ra2 == ra
+
+    def test_numeric_record_array_inherits_slot(self, ra):
+        # ``ra`` is a NumericRecordArray (subclass of RecordArray) —
+        # verify the slot is inherited without redeclaration.
+        assert isinstance(ra, NumericRecordArray)
+        assert hasattr(ra, "source")
+
+    # Integration: provenance_ancestors walks RecordArray → parent
+    # distributions.
+
+    def test_provenance_ancestors_through_distribution(self, ra):
+        prior = Normal(loc=0.0, scale=1.0, name="prior")
+        ra.with_source(Provenance("sweep", parents=(prior,)))
+        ancestors = provenance_ancestors(ra)
+        assert len(ancestors) == 1
+        assert ancestors[0] is prior

--- a/tests/test_recordarray_broadcasting.py
+++ b/tests/test_recordarray_broadcasting.py
@@ -1,0 +1,317 @@
+"""Tests for RecordArray-based parameter-sweep broadcasting (issue #130).
+
+The four regimes (no broadcast, distribution-only, RecordArray-only,
+nested) cover the parity matrix in the issue: 4 inner-return types
+(scalar, ndarray, Record/NumericRecord, Distribution) × 2 broadcast
+types (Distribution, RecordArray) = 8 core cases plus edge cases.
+
+Provenance tests confirm every broadcast output carries a source node
+pointing back to its input RecordArray / Distribution parents.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import (
+    DistributionArray,
+    Normal,
+    NumericRecord,
+    NumericRecordArray,
+    ProductDistribution,
+    Record,
+    RecordArray,
+    workflow_function,
+)
+from probpipe.core._distribution_base import Distribution
+
+
+# ---------------------------------------------------------------------------
+# Detection: _find_broadcast_args splits args into (dist, ra) groups
+# ---------------------------------------------------------------------------
+
+
+class TestRecordArrayDetection:
+    """``_find_broadcast_args`` classifies inputs and validates shapes."""
+
+    def test_recordarray_triggers_broadcast(self):
+        @workflow_function
+        def f(p: NumericRecord) -> float:
+            return p["x"]
+
+        ra = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(4)]
+        )
+        out = f(p=ra)
+        assert out.batch_shape == (4,)
+
+    def test_recordarray_hint_skips_broadcast(self):
+        """When the hint is ``RecordArray``, the batched value flows
+        through as-is — the function expects the batch."""
+
+        @workflow_function
+        def f(ra: NumericRecordArray):
+            return ra["x"].sum()
+
+        ra = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(4)]
+        )
+        out = f(ra=ra)
+        # Single inner call — output is the unwrapped float result.
+        assert float(out) == 6.0
+
+    def test_zero_dim_recordarray_passes_through(self):
+        """batch_shape=() means no batch axis, so don't iterate."""
+        from probpipe.core.record import RecordTemplate
+
+        @workflow_function
+        def f(p: NumericRecord) -> float:
+            return p["x"]
+
+        tpl = RecordTemplate(x=())
+        scalar_ra = NumericRecordArray({"x": jnp.asarray(7.0)},
+                                       batch_shape=(), template=tpl)
+        # No broadcasting — one call with the batch_shape=() RecordArray
+        # passed through.
+        out = f(p=scalar_ra)
+        assert float(out) == 7.0
+
+    def test_mismatched_batch_shapes_raise(self):
+        @workflow_function
+        def f(a: NumericRecord, b: NumericRecord) -> float:
+            return a["x"] + b["y"]
+
+        a = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(3)]
+        )
+        b = NumericRecordArray.stack(
+            [NumericRecord(y=float(i)) for i in range(5)]
+        )
+        with pytest.raises(ValueError, match="batch_shapes"):
+            f(a=a, b=b)
+
+
+# ---------------------------------------------------------------------------
+# Pure sweep (RecordArray-only) — stacked outputs, no marginalisation
+# ---------------------------------------------------------------------------
+
+
+class TestPureSweepParityMatrix:
+    """4 inner-return types → stacked outputs (see issue #130 table)."""
+
+    @pytest.fixture
+    def sweep(self):
+        return NumericRecordArray.stack(
+            [NumericRecord(r=float(i), k=10.0 * i) for i in range(1, 5)]
+        )
+
+    def test_scalar_return_wraps_as_numericrecordarray(self, sweep):
+        @workflow_function
+        def f(p: NumericRecord) -> float:
+            return p["r"] * p["k"]
+
+        out = f(p=sweep)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (4,)
+        np.testing.assert_allclose(out["result"], [10.0, 40.0, 90.0, 160.0])
+
+    def test_ndarray_return_preserves_event_shape(self, sweep):
+        @workflow_function
+        def f(p: NumericRecord) -> jnp.ndarray:
+            return jnp.array([p["r"], p["k"], p["r"] + p["k"]])
+
+        out = f(p=sweep)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (4,)
+        assert out["result"].shape == (4, 3)
+
+    def test_numericrecord_return_stacks(self, sweep):
+        @workflow_function
+        def f(p: NumericRecord) -> NumericRecord:
+            return NumericRecord(prod=p["r"] * p["k"], sum=p["r"] + p["k"])
+
+        out = f(p=sweep)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (4,)
+        np.testing.assert_allclose(out["prod"], [10.0, 40.0, 90.0, 160.0])
+        np.testing.assert_allclose(out["sum"], [11.0, 22.0, 33.0, 44.0])
+
+    def test_record_with_string_stacks_as_recordarray(self, sweep):
+        """Heterogeneous records (numeric + string) produce a plain
+        ``RecordArray`` rather than the numeric-only variant."""
+
+        @workflow_function
+        def f(p: NumericRecord) -> Record:
+            return Record(value=p["r"] * p["k"], label="row")
+
+        out = f(p=sweep)
+        assert isinstance(out, RecordArray)
+        assert not isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (4,)
+        assert list(out["label"]) == ["row"] * 4
+
+    def test_distribution_return_gives_distribution_array(self, sweep):
+        @workflow_function
+        def f(p: NumericRecord) -> Distribution:
+            return Normal(loc=p["r"], scale=1.0, name="out")
+
+        out = f(p=sweep)
+        assert isinstance(out, DistributionArray)
+        assert out.batch_shape == (4,)
+        # Each component has the expected mean from its sweep row.
+        means = jnp.stack([out[i]._mean() for i in range(4)])
+        np.testing.assert_allclose(means, [1.0, 2.0, 3.0, 4.0])
+
+
+# ---------------------------------------------------------------------------
+# Distribution-only (smoke check — refactor didn't break anything)
+# ---------------------------------------------------------------------------
+
+
+class TestDistributionOnlyPath:
+    def test_scalar_output_still_marginal(self):
+        @workflow_function(n_broadcast_samples=50, vectorize="loop")
+        def f(x: float) -> float:
+            return x * 2
+
+        from probpipe.core._broadcast_distributions import _ArrayMarginal
+        out = f(x=Normal(loc=2.0, scale=0.1, name="x"))
+        assert isinstance(out, _ArrayMarginal)
+        # Mean of 2 * N(2, 0.1) is ~4.
+        from probpipe import mean as pmean
+        assert abs(float(pmean(out)) - 4.0) < 0.1
+
+
+# ---------------------------------------------------------------------------
+# Nested (RecordArray + Distribution) — per-row marginal, stacked
+# ---------------------------------------------------------------------------
+
+
+class TestNestedSweepPlusDistribution:
+    """Each argument keeps its semantics: RecordArray stacks, Distribution
+    marginalises. Output is always a DistributionArray of per-row
+    marginals (satisfies the Record | RecordArray | Distribution
+    output-type contract)."""
+
+    @pytest.fixture
+    def sweep(self):
+        return NumericRecordArray.stack(
+            [NumericRecord(bias=float(i)) for i in range(3)]
+        )
+
+    def test_scalar_inner_gives_distribution_array(self, sweep):
+        @workflow_function(n_broadcast_samples=50, vectorize="loop")
+        def f(p: NumericRecord, noise: float) -> float:
+            return p["bias"] + noise
+
+        out = f(p=sweep, noise=Normal(loc=0.0, scale=0.5, name="noise"))
+        assert isinstance(out, DistributionArray)
+        assert out.batch_shape == (3,)
+        # Per-row mean ≈ bias + 0
+        from probpipe import mean as pmean
+        means = pmean(out)
+        np.testing.assert_allclose(means, [0.0, 1.0, 2.0], atol=0.2)
+
+    def test_record_inner_gives_distribution_array(self, sweep):
+        @workflow_function(n_broadcast_samples=30, vectorize="loop")
+        def f(p: NumericRecord, noise: float) -> NumericRecord:
+            return NumericRecord(x=p["bias"] + noise, y=p["bias"] - noise)
+
+        out = f(p=sweep, noise=Normal(loc=0.0, scale=0.1, name="noise"))
+        assert isinstance(out, DistributionArray)
+        assert out.batch_shape == (3,)
+
+    def test_distribution_inner_gives_distribution_array(self, sweep):
+        @workflow_function(n_broadcast_samples=20, vectorize="loop")
+        def f(p: NumericRecord, noise: float) -> Distribution:
+            return Normal(loc=p["bias"] + noise, scale=1.0, name="out")
+
+        out = f(p=sweep, noise=Normal(loc=0.0, scale=0.1, name="noise"))
+        assert isinstance(out, DistributionArray)
+        assert out.batch_shape == (3,)
+
+
+# ---------------------------------------------------------------------------
+# Vectorisation — vmap path vs loop path agree on pure-sweep outputs
+# ---------------------------------------------------------------------------
+
+
+class TestVectorization:
+    """The JAX-vmap and Python-loop execution paths should produce the
+    same stacked output (modulo numerical noise) when both are feasible."""
+
+    def test_vmap_and_loop_agree_on_scalar_output(self):
+        @workflow_function(vectorize="loop")
+        def f_loop(p: NumericRecord) -> float:
+            return p["r"] * p["k"]
+
+        @workflow_function(vectorize="jax")
+        def f_jax(p: NumericRecord) -> float:
+            return p["r"] * p["k"]
+
+        sweep = NumericRecordArray.stack(
+            [NumericRecord(r=float(i), k=10.0 * i) for i in range(1, 5)]
+        )
+        out_loop = f_loop(p=sweep)
+        out_jax = f_jax(p=sweep)
+        np.testing.assert_allclose(out_loop["result"], out_jax["result"])
+
+
+# ---------------------------------------------------------------------------
+# Provenance — outputs carry a source pointing back to inputs
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceChain:
+    def test_pure_sweep_provenance(self):
+        @workflow_function
+        def f(p: NumericRecord) -> float:
+            return p["x"]
+
+        sweep = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(3)]
+        )
+        out = f(p=sweep)
+        assert out.source is not None
+        assert out.source.operation == "workflow.stack"
+        assert sweep in out.source.parents
+        assert out.source.metadata["n"] == 3
+        assert out.source.metadata["k"] == 0
+        assert out.source.metadata["func"] == "f"
+
+    def test_nested_provenance_includes_both(self):
+        @workflow_function(n_broadcast_samples=10, vectorize="loop")
+        def f(p: NumericRecord, noise: float) -> float:
+            return p["x"] + noise
+
+        sweep = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(3)]
+        )
+        noise_dist = Normal(loc=0.0, scale=1.0, name="noise")
+        out = f(p=sweep, noise=noise_dist)
+        assert out.source.operation == "workflow.nested"
+        assert sweep in out.source.parents
+        assert noise_dist in out.source.parents
+        assert out.source.metadata["k"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Auto-wrap field name
+# ---------------------------------------------------------------------------
+
+
+class TestAutoWrapFieldName:
+    def test_scalar_return_uses_result_field(self):
+        from probpipe.core._broadcast_distributions import AUTO_WRAP_FIELD
+
+        @workflow_function
+        def f(p: NumericRecord) -> float:
+            return p["x"] * 2
+
+        sweep = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(3)]
+        )
+        out = f(p=sweep)
+        assert out.fields == (AUTO_WRAP_FIELD,)
+        assert AUTO_WRAP_FIELD == "result"  # documents the current default


### PR DESCRIPTION
Implements PR 1 of issue #130 — RecordArray-based parameter-sweep broadcasting.

## Summary

Previously, `@workflow_function` only auto-broadcasted over `Distribution` arguments. Passing a `RecordArray` was either silently passed through (brittle, worked only when the function body was JAX-vectorisable through the leaves) or — for heterogeneous functions — ignored. There was no native way to say "run this pipeline once per row of this parameter sweep."

This PR makes `RecordArray` a first-class broadcast input. The dispatch rule: each argument keeps its own semantics, consistent with ProbPipe's philosophy.

- **Distribution argument** → marginalises (one sample of the uncertain value, MC aggregation).
- **RecordArray argument** → stacks (one call per row, output indexed by row).
- **Both firing on the same call** → nested: outer stack over sweep rows, inner marginalise over MC draws. Output is always a `DistributionArray` of per-row marginals.

Example — the motivating method-sweep scenario:

```python
@workflow_function
def run_inference(data, method: str) -> ApproximateDistribution:
    return condition_on(my_model, data, method=method, num_results=500)

sweep = NumericRecordArray.stack([
    NumericRecord(method="tfp_nuts"), ...   # once we have Design
])
# Today, via NumericRecordArray directly:
posteriors = run_inference(data=y_obs, method=sweep["method"])
# → DistributionArray, batch_shape=(3,)
# posteriors[0], posteriors[1], posteriors[2] are the three posteriors
```

## What's in the PR

Six commits:

1. **`feat(record)`** — `.source` / `.with_source` on `Record` and `RecordArray` (folded-in PR 0). Write-once, structural `==`/`hash` ignore source, pytree roundtrip drops source (documented). `provenance_ancestors` widened to the union type.

2. **`feat(core)`** — `DistributionArray` in a new file `probpipe/core/_distribution_array.py`. Pattern-B factory with dynamic protocol support (same idiom as `_MixtureMarginal`). Stacked (not mixed) sampling / mean / variance / log_prob. Handles Record-valued components too.

3. **`feat(core)`** — `_make_stack` sibling of `_make_marginal` in `_broadcast_distributions.py`, plus `_coerce_output` helper in `node.py`. Auto-wrap scalar/array inner returns into `NumericRecordArray(result=...)`.

4. **`refactor(node)`** — pure code motion: rename `_broadcast` → `_broadcast_distributions_only`. Isolates the risky commit's diff.

5. **`feat(node)`** — core nested dispatch. `_find_broadcast_args` returns `(dist_args, ra_args)`; new `_broadcast` dispatcher routes between distribution-only, sweep-only, and nested regimes; `_execute_sweep_rows` picks vmap vs loop; `_resolve_vectorize` handles RecordArray dummy inputs; `_make_sweep_provenance` emits `workflow.stack` / `workflow.nested` Provenance.

6. *(this PR body)* — no code; the notebook refresh for `04_broadcasting.ipynb` is deferred to a later PR so it doesn't conflict with PR #129's docs work.

## Scope narrowing noted in the issue

**Output-type contract applies on the broadcast path only in PR 1.** Non-broadcast ops in `probpipe/core/ops.py` (`mean`, `log_prob`, `expectation`, ...) still return bare arrays so the existing 30+ test call sites don't churn. PR 1.5 (follow-up) extends the contract everywhere and adds a `NumericRecord.__float__` / `__array__` ergonomic shim. Issue #130 spells out the split.

**`typing.Any` hints are treated as "don't broadcast over a RecordArray".** Subtle but load-bearing: `ops.log_prob(dist, value: Any)` consuming a batched `NumericRecordArray` of samples would otherwise iterate 10 times per-row instead of passing the batch through whole. The new rule: broadcast when the hint is absent or is a `Record`/`NumericRecord` subclass; pass through on `typing.Any` or `RecordArray` hints.

## Output-type parity matrix (PR 1 scope)

| Inner return | RA-only broadcast → | RA + Dist broadcast → |
|---|---|---|
| `float` / scalar | `NumericRecordArray(result=(n,))` | `DistributionArray` of `NumericEmpiricalDistribution`s |
| `jnp.ndarray` shape `s` | `NumericRecordArray(result=(n,)+s)` | `DistributionArray` of `_ArrayMarginal`s |
| `NumericRecord` | `NumericRecordArray` | `DistributionArray` of `_RecordArrayMarginal`s |
| `Record` (non-numeric leaves) | `RecordArray` | `DistributionArray` of marginals |
| `Distribution` | `DistributionArray` | `DistributionArray` of `_MixtureMarginal`s |

**A sweep involving any Distribution argument always produces a `DistributionArray`** — the output type tells you at a glance whether there's uncertainty to query.

## Size

```
probpipe/core/_distribution_array.py   + 340  (new)
probpipe/core/_broadcast_distributions + 214
probpipe/core/node.py                  + 370
probpipe/core/record.py                +  37
probpipe/core/_record_array.py         +  44
probpipe/core/provenance.py            +  30
probpipe/__init__.py                   +   2
tests/test_distribution_array.py       + 270  (new)
tests/test_recordarray_broadcasting.py + 260  (new)
tests/test_broadcast_distribution.py   + 173
tests/test_record.py                   + 106
tests/test_record_array.py             +  72
```

Total: ~1900 LOC across code and tests.

## Test plan

- [x] `tests/test_record.py::TestProvenance` — 12 tests: write-once, `replace` resets, `eq`/`hash` ignore source, pytree drops source, `provenance_ancestors` walks Record → Distribution chains.
- [x] `tests/test_record_array.py::TestProvenance` — 7 tests covering the same surface for RecordArray + NumericRecordArray inheritance.
- [x] `tests/test_distribution_array.py` — 22 tests: construction, Pattern B protocol opt-in (including the "drop SupportsLogProb when a component lacks it" case), scalar + Record + batched-Record samples, per-component mean/variance/log_prob, provenance slot.
- [x] `tests/test_broadcast_distribution.py::TestMakeStack` — 10 tests: one per dispatch branch of `_make_stack` (scalars, arrays, NumericRecord, mixed Record with fallback, Distribution, RecordArray, vmap ndarray, vmap Record) plus two length-mismatch errors.
- [x] `tests/test_broadcast_distribution.py::TestCoerceOutput` — 4 tests: none-mode pass-through, RecordArray source attachment, DistributionArray source attachment, existing-source preservation.
- [x] `tests/test_recordarray_broadcasting.py` — 17 tests: the parity matrix (pure sweep × 5 return types, nested × 3 return types), detection / shape-mismatch / RecordArray-hint skip / 0-dim pass-through, vmap-vs-loop parity, provenance-chain verification.
- [x] Full repo test suite (excluding optional Stan/PyMC/nutpie/sbijax backends): **2000 passed, 4 skipped, 0 failures**.

## Follow-ups

- **PR 1.5** — extend the output-type contract to non-broadcast ops (`probpipe/core/ops.py`); pick the `NumericRecord.__float__` / `__array__` ergonomic shim or require explicit unwrap.
- **PR 2** — `Design` base + `FullFactorialDesign` + `RandomDesign`.
- **PR 3** — `LatinHypercubeDesign` + `SobolDesign`.
- **Notebook refresh** — `04_broadcasting.ipynb` gets a RecordArray-broadcast section. Deferred to issue #127's Batch C work so it doesn't conflict with PR #129's docs rewrite landing concurrently.
