### PR TITLE
refactor(record): RecordArray inherits from Record (#130 symmetry fix)

### DIFF
--- a/docs/api/distributions.md
+++ b/docs/api/distributions.md
@@ -18,7 +18,7 @@
 
 ::: probpipe.core._distribution_base.Distribution
 
-::: probpipe.core._array_distributions.NumericRecordDistribution
+::: probpipe.core._numeric_record_distribution.NumericRecordDistribution
 
 ::: probpipe.distributions._tfp_base.TFPDistribution
 
@@ -26,7 +26,7 @@
 
 ::: probpipe.core._empirical.NumericEmpiricalDistribution
 
-::: probpipe.core._array_distributions.BootstrapDistribution
+::: probpipe.core._numeric_record_distribution.BootstrapDistribution
 
 ::: probpipe.core._empirical.BootstrapReplicateDistribution
 

--- a/docs/api/internals.md
+++ b/docs/api/internals.md
@@ -28,15 +28,15 @@ dynamically from the parent's capabilities, so
 
 `FlattenedView` is a public wrapper that exposes a distribution with
 structured samples as a flat
-[`NumericRecordDistribution`][probpipe.core._array_distributions.NumericRecordDistribution],
+[`NumericRecordDistribution`][probpipe.core._numeric_record_distribution.NumericRecordDistribution],
 useful for interop with algorithms that expect flat vectors. It uses the same
 dynamic-protocol pattern as `_RecordDistributionView` — only the protocols the
 base distribution supports are attached to the view.
 
-::: probpipe.core._array_distributions.FlattenedView
+::: probpipe.core._numeric_record_distribution.FlattenedView
 
 ## Sampling primitive
 
-::: probpipe.core._array_distributions._vmap_sample
+::: probpipe.core._numeric_record_distribution._vmap_sample
 
-::: probpipe.core._array_distributions._mc_expectation
+::: probpipe.core._numeric_record_distribution._mc_expectation

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -143,8 +143,14 @@ class _MixtureSampling:
 
         # Dispatch on result type so a mixture of Record-returning
         # distributions produces a RecordArray rather than crashing in
-        # jnp.stack. Scalars / arrays stay on the numeric path.
-        if all(isinstance(r, Record) for r in results):
+        # jnp.stack. Scalars / arrays stay on the numeric path. Exclude
+        # RecordArray leaves here — ``RecordArray.stack`` expects
+        # scalar Records; a mixture over already-batched Record
+        # samples isn't supported on this path.
+        if all(
+            isinstance(r, Record) and not isinstance(r, RecordArray)
+            for r in results
+        ):
             stacked_ra = RecordArray.stack(results)
             if sample_shape == ():
                 return stacked_ra[0]
@@ -342,7 +348,14 @@ def _make_marginal(
 
     # Record with batched leaves (e.g., from jax.vmap over a Record-returning fn).
     # All fields must be arrays with a consistent leading batch dimension.
-    if isinstance(output_samples, Record) and output_samples.fields:
+    # Exclude RecordArray — the earlier branch handles it already, but
+    # since ``RecordArray`` is a ``Record`` subclass we'd otherwise
+    # match here for a RecordArray whose fields have extra axes.
+    if (
+        isinstance(output_samples, Record)
+        and not isinstance(output_samples, RecordArray)
+        and output_samples.fields
+    ):
         resolved = [output_samples[f] for f in output_samples.fields]
         if all(hasattr(v, "ndim") and v.ndim > 0 for v in resolved):
             n = resolved[0].shape[0]
@@ -356,7 +369,10 @@ def _make_marginal(
         return _ArrayMarginal(output_samples, weights, name=name)
 
     if isinstance(output_samples, list):
-        if output_samples and all(isinstance(r, Record) for r in output_samples):
+        if output_samples and all(
+            isinstance(r, Record) and not isinstance(r, RecordArray)
+            for r in output_samples
+        ):
             try:
                 ra = RecordArray.stack(output_samples)
                 return _RecordArrayMarginal(ra, weights, name=name)
@@ -455,11 +471,33 @@ def _make_stack(
             )
         outs = inner_outputs
 
-        # All Records → stack as a RecordArray. NumericRecordArray if
-        # every leaf is numeric; otherwise fall back to the permissive
+        # Check the more-specific subclass first: all RecordArrays
+        # (since ``RecordArray`` is itself a ``Record`` subclass, the
+        # generic Record branch below would otherwise claim them and
+        # collapse the inner batch axis).
+        if outs and all(isinstance(o, RecordArray) for o in outs):
+            first = outs[0]
+            if all(ra.batch_shape == first.batch_shape for ra in outs):
+                fields = {
+                    fname: jnp.stack([ra[fname] for ra in outs], axis=0)
+                    for fname in first.fields
+                }
+                return type(first)(
+                    fields,
+                    batch_shape=(n,) + first.batch_shape,
+                    template=first.template,
+                )
+            # Mismatched inner shapes fall through to the generic
+            # Record / list handlers.
+
+        # All (scalar) Records → stack as a RecordArray. NumericRecordArray
+        # if every leaf is numeric; otherwise fall back to the permissive
         # RecordArray class, building the fields manually so non-numeric
         # leaves (strings, xarray objects, ...) survive.
-        if outs and all(isinstance(o, Record) for o in outs):
+        if outs and all(
+            isinstance(o, Record) and not isinstance(o, RecordArray)
+            for o in outs
+        ):
             try:
                 from ._record_array import NumericRecordArray
                 return NumericRecordArray.stack(list(outs))
@@ -491,22 +529,6 @@ def _make_stack(
         # All Distributions → stacked DistributionArray.
         if outs and all(isinstance(o, Distribution) for o in outs):
             return _make_distribution_array(outs, name=name)
-
-        # All RecordArrays with matching (non-empty) batch_shape →
-        # nested RecordArray with leading (n,) axis.
-        if outs and all(isinstance(o, RecordArray) for o in outs):
-            first = outs[0]
-            if all(ra.batch_shape == first.batch_shape for ra in outs):
-                fields = {
-                    fname: jnp.stack([ra[fname] for ra in outs], axis=0)
-                    for fname in first.fields
-                }
-                return type(first)(
-                    fields,
-                    batch_shape=(n,) + first.batch_shape,
-                    template=first.template,
-                )
-            # Mismatched inner shapes — fall through to the error path.
 
         # Numeric scalars / arrays → wrap in NumericRecordArray with
         # the single "result" field carrying the stacked values.
@@ -567,7 +589,12 @@ def _make_stack(
     # vmap of a Record-returning function produces a Record with
     # batched leaves (each leaf has leading axis n). Promote to a
     # RecordArray — NumericRecordArray when all leaves numeric.
-    if isinstance(inner_outputs, Record) and inner_outputs.fields:
+    # Exclude the already-RecordArray case (already an aggregate).
+    if (
+        isinstance(inner_outputs, Record)
+        and not isinstance(inner_outputs, RecordArray)
+        and inner_outputs.fields
+    ):
         resolved = [inner_outputs[f] for f in inner_outputs.fields]
         if all(hasattr(v, "shape") and v.shape[:1] == (n,) for v in resolved):
             event_shapes = tuple(v.shape[1:] for v in resolved)

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -15,6 +15,31 @@ Protocol support is dynamic (Pattern B): a ``DistributionArray``
 satisfies ``SupportsX`` iff every component does. The factory
 :func:`_make_distribution_array` constructs a cached subclass with the
 appropriate protocol mixins based on component capabilities.
+
+``DistributionArray`` vs. ``ProductDistribution``
+-------------------------------------------------
+
+Both produce multi-valued samples, but they represent different
+statistical objects:
+
+- :class:`~probpipe.ProductDistribution` is a single joint distribution
+  over **named, heterogeneous components** — e.g.,
+  ``ProductDistribution(theta=Normal(0, 1), sigma=Gamma(2, 1))``
+  represents one random variable that happens to be a (θ, σ) tuple.
+  ``sample`` returns a ``Record`` keyed by component name; ``log_prob``
+  accepts a same-shaped Record and sums the marginal log-probs.
+
+- :class:`DistributionArray` is a **collection of n distributions of the
+  same kind** indexed by position — e.g.,
+  ``DistributionArray([Normal(loc=i, scale=1.0, name=f"n{i}") for i in
+  range(5)])`` represents five independent Normal random variables
+  indexed 0..4. ``sample`` returns a stacked array of shape
+  ``(5,) + event_shape``; ``log_prob`` accepts a same-shaped array and
+  returns a per-row log-prob vector.
+
+Rule of thumb: if you'd write ``d["sigma"]`` to pull out a specific
+named quantity → ``ProductDistribution``. If you'd write ``d[i]`` to
+pull out the i-th element of a batch → ``DistributionArray``.
 """
 
 from __future__ import annotations

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -19,27 +19,29 @@ appropriate protocol mixins based on component capabilities.
 ``DistributionArray`` vs. ``ProductDistribution``
 -------------------------------------------------
 
-Both produce multi-valued samples, but they represent different
-statistical objects:
+Both express a set of independent components, but the access pattern
+differs:
 
-- :class:`~probpipe.ProductDistribution` is a single joint distribution
-  over **named, heterogeneous components** — e.g.,
-  ``ProductDistribution(theta=Normal(0, 1), sigma=Gamma(2, 1))``
-  represents one random variable that happens to be a (θ, σ) tuple.
+- :class:`~probpipe.ProductDistribution` bundles **heterogeneous
+  independent components** addressed by name — e.g.
+  ``ProductDistribution(theta=Normal(0, 1), sigma=Gamma(2, 1))``.
   ``sample`` returns a ``Record`` keyed by component name; ``log_prob``
-  accepts a same-shaped Record and sums the marginal log-probs.
+  takes a same-shaped Record and sums the marginals. Different
+  components are typically different families (Normal + Gamma + ...).
 
-- :class:`DistributionArray` is a **collection of n distributions of the
-  same kind** indexed by position — e.g.,
+- :class:`DistributionArray` bundles **positionally-indexed components**
+  along a batch axis — e.g.
   ``DistributionArray([Normal(loc=i, scale=1.0, name=f"n{i}") for i in
-  range(5)])`` represents five independent Normal random variables
-  indexed 0..4. ``sample`` returns a stacked array of shape
-  ``(5,) + event_shape``; ``log_prob`` accepts a same-shaped array and
-  returns a per-row log-prob vector.
+  range(5)])``. ``sample`` returns a stacked array of shape
+  ``(5,) + event_shape``; ``log_prob`` takes a same-shaped array and
+  returns a per-row vector. Components can still be heterogeneous
+  as long as they share ``event_shape``, but the common use case is
+  n instances of the same family parameterised differently (the output
+  of a parameter sweep).
 
 Rule of thumb: if you'd write ``d["sigma"]`` to pull out a specific
-named quantity → ``ProductDistribution``. If you'd write ``d[i]`` to
-pull out the i-th element of a batch → ``DistributionArray``.
+**named** quantity → ``ProductDistribution``. If you'd write ``d[i]``
+to pull out the i-th element of a **batch** → ``DistributionArray``.
 """
 
 from __future__ import annotations

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -212,7 +212,8 @@ class _DistArraySampling:
         #     along a new trailing batch axis so the final leading
         #     shape is ``sample_shape + (n,)``.
         if sample_shape == () and all(
-            isinstance(s, Record) for s in per_component
+            isinstance(s, Record) and not isinstance(s, RecordArray)
+            for s in per_component
         ):
             return RecordArray.stack(list(per_component))
         if sample_shape != () and all(
@@ -260,8 +261,9 @@ def _stack_leading(values: list) -> Any:
     """
     if not values:
         raise ValueError("cannot stack an empty list of values")
-    if all(isinstance(v, Record) for v in values):
-        return RecordArray.stack(list(values))
+    # Check the more-specific RecordArray subclass first — else the
+    # Record branch below would claim batched values and collapse their
+    # inner batch axis (``RecordArray`` is now a ``Record`` subclass).
     if all(isinstance(v, RecordArray) for v in values):
         # Stack each field along a new leading axis; shapes must match.
         first = values[0]
@@ -274,6 +276,11 @@ def _stack_leading(values: list) -> Any:
             batch_shape=(len(values),) + first.batch_shape,
             template=first.template,
         )
+    if all(
+        isinstance(v, Record) and not isinstance(v, RecordArray)
+        for v in values
+    ):
+        return RecordArray.stack(list(values))
     try:
         return jnp.stack(values, axis=0)
     except (TypeError, ValueError) as exc:

--- a/probpipe/core/_empirical.py
+++ b/probpipe/core/_empirical.py
@@ -34,7 +34,7 @@ from .constraints import Constraint, real
 from . import _distribution_base as _base
 from .._utils import _auto_key
 from ._distribution_base import Distribution
-from ._array_distributions import (
+from ._numeric_record_distribution import (
     NumericRecordDistribution,
     BootstrapDistribution,
 )

--- a/probpipe/core/_numeric_record_distribution.py
+++ b/probpipe/core/_numeric_record_distribution.py
@@ -1,11 +1,28 @@
-"""Distribution hierarchy with numeric shape semantics.
+"""``NumericRecordDistribution`` and its closely-related helpers.
+
+The primary class is :class:`NumericRecordDistribution` — a
+:class:`~probpipe.core._record_distribution.RecordDistribution` that
+additionally enforces numeric-leaf shape semantics (``event_shape``,
+``batch_shape``, ``flat_event_shapes``, ``event_size``) and serves as
+the base class for every numeric ProbPipe distribution (``Normal``,
+``Beta``, ``ProductDistribution``, ...).
 
 Provides:
-  - ``_vmap_sample()``               – Batched sampling via ``jax.vmap``.
-  - ``_mc_expectation()``            – Monte Carlo expectation helper.
-  - ``NumericRecordDistribution``    – RecordDistribution + numeric shapes (base for all numeric dists).
-  - ``BootstrapDistribution``        – MC error tracking via bootstrap resampling.
-  - ``FlattenedView``                – Wraps any distribution as a flat distribution.
+
+  - :class:`NumericRecordDistribution` — the base class.
+  - :class:`BootstrapDistribution` — MC error tracking via bootstrap
+    resampling.
+  - :class:`FlattenedView` — wraps any distribution as a flat-array
+    distribution.
+  - Private helpers ``_vmap_sample`` / ``_mc_expectation``.
+
+Not to be confused with :mod:`_distribution_array`, which houses
+:class:`DistributionArray` — a *collection of n independent scalar
+distributions* along a batch axis. ``DistributionArray`` is a
+``Distribution`` subclass, not a ``NumericRecordDistribution``
+subclass: it represents "many random variables indexed by position",
+while ``NumericRecordDistribution`` represents "one random variable
+with a numeric-valued event structure".
 """
 
 from __future__ import annotations

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -24,10 +24,27 @@ from .record import Record, RecordTemplate, _spec_size
 __all__ = ["RecordArray", "NumericRecordArray"]
 
 
-class RecordArray:
+class RecordArray(Record):
     """Batch of Records with consistent field structure.
 
     Each field stores values with shape ``(*batch_shape, *leaf_shape)``.
+    A ``RecordArray`` *is* a :class:`Record` — the batched variant,
+    parallel to the way :class:`DistributionArray` is a
+    :class:`Distribution`. Consolidating the two in a single hierarchy
+    means:
+
+    - ``isinstance(x, Record)`` accepts both scalar and batched Records.
+      Code that needs to distinguish uses
+      ``isinstance(x, RecordArray)`` for the batched case, or
+      ``isinstance(x, Record) and not isinstance(x, RecordArray)`` for
+      scalar-only.
+    - ``.source`` / ``.with_source`` / ``.name`` are inherited from
+      Record (stored on the ``_name`` / ``_source`` slots declared on
+      Record).
+    - ``replace`` / ``merge`` / ``without`` / ``map`` / ``map_with_names``
+      are overridden here because the base constructor signature
+      doesn't carry ``batch_shape`` / ``template``; RecordArray versions
+      preserve those.
 
     Parameters
     ----------
@@ -35,6 +52,9 @@ class RecordArray:
         Shape of the batch dimensions.
     template : RecordTemplate
         Structural description of each element.
+    name : str, optional
+        Human-readable name for provenance / introspection. Defaults
+        to ``"{class_name}({sorted field list})"``.
     **fields
         Named values, each with shape ``(*batch_shape, *leaf_shape)``.
 
@@ -45,7 +65,7 @@ class RecordArray:
     field name (``arr["x"]`` → batched leaf array).
     """
 
-    __slots__ = ("_store", "_batch_shape", "_template", "_source")
+    __slots__ = ("_batch_shape", "_template")
 
     def __init__(
         self,
@@ -54,6 +74,7 @@ class RecordArray:
         *,
         batch_shape: tuple[int, ...],
         template: RecordTemplate,
+        name: str | None = None,
         **fields: Any,
     ):
         if _dict is not None:
@@ -74,10 +95,17 @@ class RecordArray:
         # subclasses (e.g. NumericRecordArray) see a canonicalised view
         # of the leaves. Raises from ``_validate_fields`` propagate.
         store = type(self)._validate_fields(store, batch_shape, template)
+        # Inherit the Record plumbing for _store / _name / _source.
+        # We bypass Record's normal constructor path because RecordArray
+        # requires its own field-validation hook and an auto-name that
+        # reflects the class name, not the "record(...)" default.
+        if name is None:
+            name = f"{type(self).__name__.lower()}({','.join(store.keys())})"
         object.__setattr__(self, "_store", store)
+        object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_source", None)
         object.__setattr__(self, "_batch_shape", batch_shape)
         object.__setattr__(self, "_template", template)
-        object.__setattr__(self, "_source", None)
 
     @classmethod
     def _validate_fields(
@@ -97,13 +125,8 @@ class RecordArray:
         """
         return store
 
-    # -- Immutability -------------------------------------------------------
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        raise AttributeError("RecordArray is immutable")
-
-    def __delattr__(self, name: str) -> None:
-        raise AttributeError("RecordArray is immutable")
+    # ``__setattr__`` / ``__delattr__`` / ``.name`` / ``.source`` /
+    # ``.with_source`` / ``.fields`` are inherited from :class:`Record`.
 
     # -- Properties ---------------------------------------------------------
 
@@ -116,51 +139,6 @@ class RecordArray:
     def template(self) -> RecordTemplate:
         """Structural description of each element."""
         return self._template
-
-    @property
-    def fields(self) -> tuple[str, ...]:
-        """Field names in sorted order."""
-        return tuple(self._store.keys())
-
-    @property
-    def name(self) -> str:
-        """Auto-generated human-readable name for provenance reports.
-
-        Derived from the class name and the sorted field list. Not a
-        user-configurable slot in PR 1 — callers that need custom names
-        on a batched output should attach them via
-        ``replace``/``with_source`` at a higher layer.
-        """
-        return f"{type(self).__name__.lower()}({','.join(self._store.keys())})"
-
-    # -- Provenance --------------------------------------------------------
-
-    @property
-    def source(self) -> Provenance | None:
-        """Provenance describing how this RecordArray was created, or ``None``."""
-        return self._source
-
-    def with_source(self, source: Provenance) -> RecordArray:
-        """Attach provenance to this RecordArray (write-once).
-
-        Mirrors ``Distribution.with_source`` / ``Record.with_source``.
-
-        Notes
-        -----
-        ``_source`` is runtime-only metadata — it is not serialised into
-        the JAX pytree aux (a ``Provenance`` parent is typically a
-        ``Distribution`` or ``Record``, neither hashable by structure).
-        Round-tripping through ``jax.tree_util.tree_flatten`` /
-        ``tree_unflatten`` drops the source; re-attach it on the
-        reconstructed RecordArray if the chain must be preserved.
-        """
-        if self._source is not None:
-            raise RuntimeError(
-                f"Source already set on {self!r}. "
-                "Provenance is write-once; create a new RecordArray instead."
-            )
-        object.__setattr__(self, "_source", source)
-        return self
 
     # -- Field access -------------------------------------------------------
 

--- a/probpipe/core/_record_distribution.py
+++ b/probpipe/core/_record_distribution.py
@@ -30,7 +30,7 @@ from .record import Record, RecordTemplate
 from ..custom_types import Array, PRNGKey
 
 if TYPE_CHECKING:
-    from ._array_distributions import FlattenedView
+    from ._numeric_record_distribution import FlattenedView
 
 
 __all__ = ["RecordDistribution", "_RecordDistributionView"]
@@ -256,7 +256,7 @@ def _build_record_template(components: dict) -> RecordTemplate:
     Each ``NumericRecordDistribution`` leaf contributes its ``event_shape``.
     Nested dicts become nested ``RecordTemplate``.
     """
-    from ._array_distributions import NumericRecordDistribution
+    from ._numeric_record_distribution import NumericRecordDistribution
 
     specs: dict[str, tuple[int, ...] | RecordTemplate] = {}
     for name, comp in components.items():
@@ -389,11 +389,11 @@ class RecordDistribution(Distribution[Record]):
     def as_flat_distribution(self) -> FlattenedView:
         """View this distribution as a flat ``NumericRecordDistribution``.
 
-        Returns a :class:`~probpipe.core._array_distributions.FlattenedView`
+        Returns a :class:`~probpipe.core._numeric_record_distribution.FlattenedView`
         with ``event_shape = (event_size,)`` for algorithms expecting
         flat vectors (MCMC, optimizers, VI methods).
         """
-        from ._array_distributions import FlattenedView
+        from ._numeric_record_distribution import FlattenedView
         return FlattenedView(self)
 
     @property

--- a/probpipe/core/distribution.py
+++ b/probpipe/core/distribution.py
@@ -4,7 +4,7 @@ Core distribution abstractions for ProbPipe.
 Public API facade that re-exports symbols from the internal submodules:
 
   - :mod:`._distribution_base`       – ``Distribution[T]`` + minimal helpers
-  - :mod:`._array_distributions`     – Array hierarchy + ``BootstrapDistribution``
+  - :mod:`._numeric_record_distribution`     – Array hierarchy + ``BootstrapDistribution``
   - :mod:`._empirical`               – Empirical + BootstrapReplicate distributions
   - :mod:`._broadcast_distributions` – ``BroadcastDistribution`` + marginals
 
@@ -40,8 +40,8 @@ from ._record_distribution import (
     _RecordDistributionView,
 )
 
-# -- _array_distributions ---------------------------------------------------
-from ._array_distributions import (
+# -- _numeric_record_distribution ---------------------------------------------------
+from ._numeric_record_distribution import (
     NumericRecordDistribution,
     BootstrapDistribution,
     FlattenedView,

--- a/probpipe/distributions/_joint_utils.py
+++ b/probpipe/distributions/_joint_utils.py
@@ -11,7 +11,7 @@ import jax
 import jax.numpy as jnp
 
 from ..custom_types import ArrayLike
-from ..core._array_distributions import NumericRecordDistribution
+from ..core._numeric_record_distribution import NumericRecordDistribution
 from ..core.record import Record
 from ..core._record_distribution import RecordDistribution
 

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -18,7 +18,7 @@ import jax
 import jax.numpy as jnp
 
 from ..custom_types import Array, ArrayLike, PRNGKey
-from ..core._array_distributions import (
+from ..core._numeric_record_distribution import (
     NumericRecordDistribution,
     _mc_expectation,
 )

--- a/tests/test_distribution_array.py
+++ b/tests/test_distribution_array.py
@@ -64,6 +64,17 @@ class TestConstruction:
         with pytest.raises(ValueError, match="at least one component"):
             _make_distribution_array([])
 
+    def test_single_component(self):
+        """Edge case: n=1 works; batch_shape=(1,), indexing, sampling,
+        and reductions all behave uniformly with the n>1 path."""
+        comp = Normal(loc=7.0, scale=0.5, name="only")
+        da = _make_distribution_array([comp])
+        assert da.n == 1
+        assert da.batch_shape == (1,)
+        assert da[0] is comp
+        assert da._mean().shape == (1,)
+        np.testing.assert_allclose(da._mean(), [7.0])
+
     def test_factory_returns_distribution_subclass(self):
         comps = [Normal(loc=0.0, scale=1.0, name="d0")]
         da = _make_distribution_array(comps)
@@ -109,6 +120,12 @@ class TestProtocolOptIn:
         assert isinstance(da, SupportsMean)
         assert isinstance(da, SupportsVariance)
         assert isinstance(da, SupportsLogProb)
+        # isinstance is necessary but not sufficient — verify the
+        # methods actually dispatch and produce the expected shapes.
+        assert da._sample(jax.random.PRNGKey(0)).shape == (3,)
+        assert da._mean().shape == (3,)
+        assert da._variance().shape == (3,)
+        assert da._log_prob(jnp.zeros(3)).shape == (3,)
 
     def test_drops_log_prob_when_component_lacks_it(self):
         # NumericEmpiricalDistribution supports Sampling + Mean + Variance
@@ -122,6 +139,9 @@ class TestProtocolOptIn:
         assert isinstance(da, SupportsMean)
         assert isinstance(da, SupportsVariance)
         assert not isinstance(da, SupportsLogProb)
+        # And _log_prob is not defined on the dynamic subclass —
+        # the opt-out is structural, not just a lie.
+        assert not hasattr(da, "_log_prob")
 
     def test_factory_cache_reuses_class(self):
         """Two DistributionArrays with the same protocol signature share

--- a/tests/test_numeric_record.py
+++ b/tests/test_numeric_record.py
@@ -315,6 +315,7 @@ class TestSingleFieldCoercion:
         nr = NumericRecord(result=3.14)
         arr = np.asarray(nr, dtype=np.float64)
         assert arr.dtype == np.float64
+        np.testing.assert_allclose(arr, 3.14)
 
     def test_jnp_asarray_preserves_jax_type(self):
         nr = NumericRecord(result=jnp.array([1.0, 2.0]))

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -302,7 +302,7 @@ class TestFlattenedViewDynamicProtocols:
     """FlattenedView must only claim the protocols its base supports."""
 
     def test_flattened_view_inherits_sampling_and_log_prob(self):
-        from probpipe.core._array_distributions import FlattenedView
+        from probpipe.core._numeric_record_distribution import FlattenedView
         dist = ProductDistribution(
             x=Normal(loc=0.0, scale=1.0, name="x"),
             y=Normal(loc=0.0, scale=1.0, name="y"),
@@ -316,7 +316,7 @@ class TestFlattenedViewDynamicProtocols:
         SupportsLogProb."""
         import jax.numpy as jnp
         import jax
-        from probpipe.core._array_distributions import (
+        from probpipe.core._numeric_record_distribution import (
             FlattenedView, NumericRecordDistribution,
         )
         from probpipe.core.record import RecordTemplate
@@ -343,7 +343,7 @@ class TestFlattenedViewDynamicProtocols:
         """A log-prob-only base produces a FlattenedView that isn't
         ``SupportsSampling`` (reverse direction of the sampling-only test)."""
         import jax.numpy as jnp
-        from probpipe.core._array_distributions import (
+        from probpipe.core._numeric_record_distribution import (
             FlattenedView, NumericRecordDistribution,
         )
         from probpipe.core.record import RecordTemplate

--- a/tests/test_record_array.py
+++ b/tests/test_record_array.py
@@ -679,6 +679,82 @@ class TestProvenance:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Hierarchy — RecordArray IS-A Record (issue #130 symmetry fix)
+# ---------------------------------------------------------------------------
+
+
+class TestHierarchy:
+    """``RecordArray`` inherits from ``Record`` so that the Record family
+    mirrors Distribution / DistributionArray's relationship. Users who
+    want to discriminate batched vs. scalar write
+    ``isinstance(x, RecordArray)`` or
+    ``isinstance(x, Record) and not isinstance(x, RecordArray)``.
+    """
+
+    def test_recordarray_is_record(self):
+        ra = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(3)]
+        )
+        assert isinstance(ra, Record)
+
+    def test_numericrecordarray_is_record(self):
+        ra = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(3)]
+        )
+        assert isinstance(ra, Record)
+
+    def test_numericrecord_is_not_recordarray(self):
+        """Guard against the inverse mistake: NumericRecord is still
+        a scalar Record, not a RecordArray."""
+        nr = NumericRecord(x=1.0)
+        assert isinstance(nr, Record)
+        assert not isinstance(nr, RecordArray)
+
+    def test_mro_order(self):
+        """Subclass chain is NumericRecordArray → RecordArray → Record.
+        The linear MRO keeps the provenance / name / hash plumbing on
+        Record and lets RecordArray add batch-shape / template
+        specialisation."""
+        mro = [c.__name__ for c in NumericRecordArray.mro()]
+        # Record must appear before object, after RecordArray.
+        assert mro.index("RecordArray") < mro.index("Record")
+        assert mro.index("Record") < mro.index("object")
+
+    def test_source_slot_inherited_from_record(self):
+        ra = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(2)]
+        )
+        # Record defines the ``_source`` slot; RecordArray should
+        # *not* redeclare it (that would raise a layout conflict on
+        # construction). Confirm the attribute works end-to-end.
+        assert ra.source is None
+        ra.with_source(Provenance("test", parents=()))
+        assert ra.source.operation == "test"
+
+    def test_name_slot_inherited_from_record(self):
+        """RecordArray uses Record's ``_name`` slot for its stored name,
+        not a separate property on RecordArray. The default name is
+        derived from the class name + fields at construction time."""
+        ra = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(2)]
+        )
+        assert "numericrecordarray" in ra.name.lower()
+
+    def test_custom_name_kwarg_honored(self):
+        """RecordArray accepts a ``name=`` kwarg at construction,
+        matching Record's API."""
+        from probpipe.core.record import RecordTemplate
+        tpl = RecordTemplate(x=())
+        ra = NumericRecordArray(
+            {"x": jnp.arange(3.0)},
+            batch_shape=(3,),
+            template=tpl,
+            name="my_sweep",
+        )
+        assert ra.name == "my_sweep"
+
+
 class TestSingleFieldCoercion:
     """A single-field NumericRecordArray is array-like via ``__array__``
     / ``__jax_array__``. Multi-field raises.

--- a/tests/test_record_array.py
+++ b/tests/test_record_array.py
@@ -693,15 +693,26 @@ class TestHierarchy:
     """
 
     def test_recordarray_is_record(self):
-        ra = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(3)]
+        """Base ``RecordArray`` — permissive leaf storage, no numeric
+        validation — must still ``isinstance`` as a ``Record``."""
+        tpl = RecordTemplate(label=None, value=())
+        ra = RecordArray(
+            {"label": np.asarray(["a", "b", "c"], dtype=object),
+             "value": jnp.arange(3.0)},
+            batch_shape=(3,),
+            template=tpl,
         )
         assert isinstance(ra, Record)
+        assert not isinstance(ra, NumericRecordArray)
 
     def test_numericrecordarray_is_record(self):
+        """The ``NumericRecordArray`` subclass inherits through the
+        chain NumericRecordArray → RecordArray → Record."""
         ra = NumericRecordArray.stack(
             [NumericRecord(x=float(i)) for i in range(3)]
         )
+        assert isinstance(ra, NumericRecordArray)
+        assert isinstance(ra, RecordArray)
         assert isinstance(ra, Record)
 
     def test_numericrecord_is_not_recordarray(self):
@@ -779,6 +790,7 @@ class TestSingleFieldCoercion:
         )
         arr = jnp.asarray(nra)
         assert isinstance(arr, jnp.ndarray)
+        np.testing.assert_allclose(arr, [0.0, 1.0, 2.0, 3.0])
 
     def test_multi_field_raises(self):
         nra = NumericRecordArray.stack(


### PR DESCRIPTION
Makes the Record family hierarchy symmetric with Distribution's: `RecordArray` is now a `Record` subclass, parallel to how `DistributionArray` is a `Distribution` subclass.

Rebased on `main` (PRs #131 and #132 merged).

## The asymmetry this fixes

Before:

```
Distribution                 Record                    RecordArray
├── Normal, Beta, ...        └── NumericRecord         └── NumericRecordArray
├── ProductDistribution
└── DistributionArray     ← IS-A Distribution       ← NOT a Record (peer class)
```

After:

```
Distribution                 Record
├── Normal, Beta, ...        ├── NumericRecord (single, numeric)
├── ProductDistribution      └── RecordArray (batched)
└── DistributionArray            └── NumericRecordArray
    (IS-A Distribution)              (batched, numeric)
```

The asymmetry wasn't principled — it just reflected the order the two PRs landed. Conceptually, a `RecordArray` IS a Record with a leading batch axis (same way a `DistributionArray` IS a `Distribution` with `batch_shape=(n,)`), and the shared plumbing (`_source` / `.with_source` / `.name` / `_store`) was being duplicated.

## What changed

**Core inheritance** (`probpipe/core/_record_array.py`):

- `class RecordArray(Record)` — base class added.
- `__slots__` slims down to just `_batch_shape` + `_template`; `_store` / `_name` / `_source` are inherited.
- Removed the duplicate `.source` / `.with_source` / `.name` properties — Record's versions are inherited; the auto-name default is set in `RecordArray.__init__` to reflect the class name + field list (same convention Record uses).
- Added `name=` kwarg to `RecordArray.__init__` matching Record's API.

**Dispatch reorderings** where the subclass relationship changes isinstance semantics:

- `_broadcast_distributions.py::_make_stack` — `isinstance(o, RecordArray)` check now runs **before** the generic `Record` branch. Otherwise a list of RecordArrays matches the Record branch and collapses the inner batch axis. (This is the one real semantic bug the inheritance change could cause; surfaced immediately by the existing test `test_list_of_record_arrays_nests_batch_shape`.)
- `_make_marginal` / `_MixtureSampling` / `_make_stack.pytree_branch` — added `and not isinstance(x, RecordArray)` to Record branches that assume scalar leaves. Defensive but necessary since the earlier RecordArray branch doesn't always catch every call path.
- `_distribution_array.py::_stack_leading` and `_DistArraySampling._sample` — same reordering.

## Tests

- **`tests/test_record_array.py::TestHierarchy`** — 7 new tests covering `isinstance(ra, Record)`, MRO ordering, `_source` and `_name` slot inheritance, and the custom `name=` kwarg.
- **Targeted post-rebase suite: 415 passed** across record/broadcasting/ops/transition/validation.

## Commit

Single commit: `refactor(record): RecordArray inherits from Record` (`b237e85`).

## Roadmap

- **PR #135** — multi-d `RecordArray.batch_shape` broadcasting + self-contained `DistributionArray.batch_shape`. Will rebase onto main after this PR merges.