### PR TITLE
feat(record): FullFactorialDesign — Cartesian parameter sweeps (#130 PR 2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,7 @@ Docs build (`.github/workflows/docs.yml`) with `mkdocs build --strict`.
 probpipe/
 ├── core/           # Base abstractions: Distribution, protocols, ops, node, transition
 ├── distributions/  # Concrete distributions (continuous, discrete, multivariate, ...)
+├── record/         # Record-adjacent constructions: parameter-sweep Designs
 ├── modeling/       # Model wrappers (SimpleModel, StanModel, PyMCModel, likelihoods)
 ├── inference/      # Inference methods + registry (TFP, nutpie, RWMH, sbijax)
 ├── converters/     # Distribution conversion registry
@@ -195,6 +196,7 @@ full public API surface.
 | `IncrementalConditioner` | Stateful `Module` for sequential Bayesian updating via `update()` / `update_all()` |
 | `iterate` / combinators | Iterative distribution transformation; `with_conversion`, `with_resampling` |
 | `sbi_learn_conditional` / `sbi_learn_likelihood` | SBI workflow functions; return `DirectSamplerSBIModel` or `SimpleModel` with neural likelihood |
+| `Design` / `FullFactorialDesign` (`probpipe.record`) | `RecordArray` subclass carrying per-field marginals; `FullFactorialDesign(**marginals)` materialises the Cartesian product as a sweep-ready `RecordArray`. Pipe into a `WorkflowFunction` as a single `Record`-typed arg to trigger the WF sweep path. |
 
 ### Inference method registry
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -356,6 +356,7 @@ custom_types  (no internal deps — leaf)
    core/      (imports custom_types only)
      ↑
 distributions/ (imports core/, custom_types)
+record/        (imports core/, custom_types)
      ↑
 linalg/       (imports core/, custom_types; no distribution imports)
      ↑
@@ -367,16 +368,18 @@ inference/    (imports core/, custom_types)
 
 ### Rules
 
-1. **`core/`** must never import from `distributions/`, `linalg/`,
+1. **`core/`** must never import from `distributions/`, `record/`,
+   `linalg/`, `converters/`, `inference/`, or `modeling/`.
+2. **`distributions/`** must never import from `record/`, `linalg/`,
    `converters/`, `inference/`, or `modeling/`.
-2. **`distributions/`** must never import from `linalg/`, `converters/`,
-   `inference/`, or `modeling/`.
-3. **`linalg/`** is self-contained; it may import from `core/` and
+3. **`record/`** must never import from `distributions/`, `linalg/`,
+   `converters/`, `inference/`, or `modeling/`.
+4. **`linalg/`** is self-contained; it may import from `core/` and
    `custom_types` only.
-4. **`converters/`** may import from `distributions/` and `core/` but
+5. **`converters/`** may import from `distributions/` and `core/` but
    must never import from `inference/` or `modeling/`.
-5. **`inference/`** must never import from `modeling/` or `converters/`.
-6. **`modeling/`** may import from `inference/` (for MCMC result types)
+6. **`inference/`** must never import from `modeling/` or `converters/`.
+7. **`modeling/`** may import from `inference/` (for MCMC result types)
    and from `converters/` (for auto-conversion in conditioning).
 
 > **Exceptions** (intentional reverse edges):

--- a/dev-design-hierarchy_plan.md
+++ b/dev-design-hierarchy_plan.md
@@ -1,0 +1,146 @@
+# Plan — Design hierarchy (PR 2 of issue #130)
+
+## Motivation
+
+The preceding PR #135 landed **direct vectorization with the product
+rule** at the WorkflowFunction layer: passing a `RecordArray` (or
+`DistributionArray`) of batch_shape `B` to a `@workflow_function` slot
+whose hint is not that same batched type triggers a cell-by-cell sweep;
+multiple array-valued inputs combine by Cartesian product.
+
+What's missing is the **user-facing construction story for sweeps**.
+Today, to sweep a workflow function over a Cartesian grid of values,
+the user has to build a `NumericRecordArray` by hand — computing field
+shapes, materialising the Cartesian product, tracking a
+`RecordTemplate`, etc.
+
+This PR introduces `Design`, a `RecordArray` subclass that carries
+**marginals** (the candidate values per field) and **materialises them
+into a sweep-ready RecordArray** according to the subclass's rule.
+
+**Scope for this PR** is just the Cartesian case: `FullFactorialDesign`.
+Random and space-filling designs (`RandomDesign`,
+`LatinHypercubeDesign`, `SobolDesign`) land in follow-up PRs.
+
+`Design` is a RecordArray, so everything the WF broadcast path already
+knows about RecordArrays (sweep, wrap, provenance) applies. No new
+broadcast rule; no new output type.
+
+## Location
+
+New `probpipe/record/` subpackage — sibling to `distributions/`,
+`modeling/`, `inference/`. It houses record-adjacent constructions
+that build on the `Record` / `RecordArray` family in `core/` (here:
+parameter-sweep `Design`s). Re-exported from top-level `probpipe`.
+
+## API sketch
+
+```python
+from probpipe import FullFactorialDesign
+
+# Cartesian grid — 3 * 2 = 6 rows
+ff = FullFactorialDesign(
+    r=[1.5, 1.8, 2.0],
+    K=[60.0, 80.0],
+)
+ff.batch_shape                      # (6,)
+ff.fields                           # ('K', 'r')      (sorted)
+ff.marginals                        # {'K': [60.0, 80.0], 'r': [1.5, 1.8, 2.0]}
+
+# Mixed numeric + categorical marginals produce a plain RecordArray
+ff2 = FullFactorialDesign(
+    method=['nutpie', 'pymc'],
+    scale=[0.5, 1.0],
+)
+ff2.batch_shape                     # (4,)
+
+# Usage pattern A: pass the Design as a single Record-typed arg to
+# trigger the full sweep (one inner call per row).
+@workflow_function
+def fit(p): return p["r"] * p["K"]
+result = fit(p=ff)                  # NumericRecordArray, batch_shape=(6,)
+
+# Usage pattern B: splat via `select_all()` when the inner body's ops
+# broadcast naturally over the column arrays — one WF call, one JAX
+# trace; no per-row iteration. Faster than pattern A for pure JAX
+# arithmetic but not a general substitute (e.g. `float(x)` / f-strings
+# receive arrays, not scalars, so they fail).
+@workflow_function
+def product(r, K): return r * K
+result = product(**ff.select_all())  # NumericRecord(product=array(shape=(6,)))
+```
+
+## Class surface
+
+```python
+class Design(RecordArray):
+    """RecordArray that carries its per-field marginals."""
+    @property
+    def marginals(self) -> Mapping[str, Sequence]: ...
+    def select_all(self) -> dict[str, Any]: ...
+
+class FullFactorialDesign(Design):
+    def __init__(self, **marginals: Sequence): ...
+```
+
+### Design base
+
+- Inherits `RecordArray`'s field store + template + pytree machinery.
+- Adds a `._marginals` slot (frozen dict) and `.marginals` / `.select_all`.
+- `select_all()` returns `{f: self[f] for f in self.fields}` for
+  splat-based calls into JAX-vectorizable bodies. Does **not** wrap
+  the values as single-field RecordArrays — so splatting does not
+  trigger the WF sweep (by design; see pattern B above).
+
+### FullFactorialDesign
+
+- Marginals passed as keyword args of Python sequences (lists, tuples,
+  numpy / jax arrays).
+- Computes `np.meshgrid(..., indexing='ij')` across marginals, flattens
+  each to a 1-D column of length `prod(sizes)`.
+- Field dtype: if the marginal is numeric, store as `jnp.ndarray`;
+  otherwise store as a `numpy.ndarray(dtype=object)` so strings /
+  arbitrary objects survive into the sweep (heterogeneous path in
+  `_make_stack` already handles object-dtype fields).
+- Auto-infers whether to build a `NumericRecordArray` (all numeric) or
+  a plain `RecordArray`.
+
+## Tests
+
+`tests/test_design.py`. Coverage:
+
+- `TestFullFactorial`: shape, row order (lexicographic over sorted
+  fields), mixed numeric/categorical marginals, single-field edge case,
+  empty / empty-marginal raises.
+- `TestDesignAsSweep`: sweep a `@workflow_function` over a
+  `FullFactorialDesign` via pattern A (single Record arg) and pattern
+  B (splat into JAX-vectorizable body).
+- `TestMarginalsIntrospection`: `.marginals` returns a dict of the
+  original sequences for the fields; ordering matches
+  `design.fields`.
+
+## Docs
+
+- Short entry in `CONTRIBUTING.md` key-abstractions table.
+- `record/` row in `CONTRIBUTING.md` package-structure tree and in
+  the `STYLE_GUIDE.md` subpackage dependency graph.
+- One new section in `docs/api/*.md` — pointing at
+  `probpipe.record.design`.
+
+## Roadmap after this PR
+
+- PR 3 (follow-up): `RandomDesign` (Distribution-valued + sequence
+  marginals).
+- PR 4: `LatinHypercubeDesign` and `SobolDesign` (space-filling over
+  continuous ranges).
+- PR 5 (deferred): `FractionalFactorialDesign` (DoE-specific).
+
+## Out of scope (for this PR)
+
+- `RandomDesign`, `LatinHypercubeDesign`, `SobolDesign` — follow-up PRs.
+- Design composition operators (`a * b`, `a | b`) — defer until a user
+  asks.
+
+## Estimated size
+
+~150 LOC implementation + ~120 LOC tests = **~270 LOC**. One focused PR.

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -115,6 +115,7 @@ from probpipe.core.transition import (
     with_resampling,
 )
 from probpipe.modeling import GLMLikelihood, Likelihood, GenerativeLikelihood, IncrementalConditioner
+from probpipe.record import Design, FullFactorialDesign
 from probpipe.inference import (
     ApproximateDistribution,
     inference_method_registry,
@@ -251,6 +252,9 @@ __all__ = [
     "ProbabilisticModel",
     "SimpleModel",
     "SimpleGenerativeModel",
+    # Record-based designs
+    "Design",
+    "FullFactorialDesign",
     # Inference
     "ApproximateDistribution",
     "inference_method_registry",

--- a/probpipe/record/__init__.py
+++ b/probpipe/record/__init__.py
@@ -1,0 +1,22 @@
+"""Record-adjacent abstractions: parameter-sweep designs and related helpers.
+
+The base ``Record`` / ``RecordArray`` family and their distribution
+counterparts live in :mod:`probpipe.core` (they're foundational); this
+subpackage collects higher-level record-based constructions that use
+them. At present:
+
+- :class:`~probpipe.record.design.FullFactorialDesign` and its
+  :class:`Design` base — parameter-sweep ``RecordArray``s that plug
+  directly into the ``WorkflowFunction`` sweep path.
+
+Re-exported from :mod:`probpipe` for convenience.
+"""
+
+from __future__ import annotations
+
+from .design import Design, FullFactorialDesign
+
+__all__ = [
+    "Design",
+    "FullFactorialDesign",
+]

--- a/probpipe/record/design.py
+++ b/probpipe/record/design.py
@@ -1,0 +1,211 @@
+"""Parameter-sweep Designs — materialised ``RecordArray``s with marginals.
+
+A :class:`Design` is a :class:`~probpipe.RecordArray` whose rows are
+materialised from per-field **marginals** — the candidate values for
+each field — combined according to a subclass-specific rule. The
+resulting ``RecordArray`` plugs into the ``WorkflowFunction`` sweep
+path as a single array-valued input::
+
+    result = fit(p=design)    # one inner call per row of the sweep
+
+This module currently exports :class:`FullFactorialDesign` only;
+additional subclasses (`RandomDesign`, `LatinHypercubeDesign`,
+`SobolDesign`) are planned as follow-up PRs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import jax.numpy as jnp
+import numpy as np
+
+from .._utils import prod
+from ..core._record_array import RecordArray
+from ..core.record import RecordTemplate
+
+__all__ = ["Design", "FullFactorialDesign"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_numeric_sequence(seq: Any) -> bool:
+    """True if *seq* is a sequence (or array) of numeric scalars.
+
+    Strings and byte sequences are rejected (they're iterable but
+    categorical-valued). We probe via ``jnp.asarray`` and check the
+    resulting dtype's kind.
+    """
+    if isinstance(seq, (str, bytes)):
+        return False
+    try:
+        arr = jnp.asarray(seq)
+    except (TypeError, ValueError):
+        return False
+    return arr.dtype.kind in "biufc"
+
+
+def _seq_to_column(
+    values: Sequence, *, indices,
+) -> tuple[Any, tuple[int, ...] | None]:
+    """Materialise ``values[indices]`` as a column array.
+
+    Returns ``(column, leaf_shape)``. For numeric values the column is
+    a ``jnp.ndarray`` and ``leaf_shape`` is ``()`` (scalar leaves) or
+    the trailing shape of the first element. For non-numeric values
+    (strings, Python objects) the column is a ``numpy.ndarray`` with
+    ``dtype=object`` and ``leaf_shape`` is ``None`` (opaque leaf).
+    """
+    seq = list(values)
+    if _is_numeric_sequence(seq):
+        arr = jnp.asarray(seq)
+        leaf_shape = tuple(arr.shape[1:])
+        return arr[indices], leaf_shape
+    obj = np.asarray(seq, dtype=object)
+    return obj[np.asarray(indices)], None
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+
+class Design(RecordArray):
+    """``RecordArray`` that carries its per-field marginals.
+
+    A ``Design`` is not meant to be instantiated directly — concrete
+    subclasses (:class:`FullFactorialDesign`) assemble the underlying
+    rows in ``__init__`` and stash the originating marginals for
+    introspection.
+
+    Usage inside a ``@workflow_function``: pass the design as a single
+    ``Record`` / ``NumericRecord``-typed argument. The WF layer's
+    sweep path iterates over its batch and returns a stacked output::
+
+        @workflow_function
+        def fit(p): ...                  # p arrives as one row (a Record)
+        result = fit(p=design)           # one inner call per row
+
+    ``select_all()`` returns the per-field columns as raw arrays — useful
+    for inspection or for calls into JAX-vectorizable bodies that don't
+    need the sweep machinery. It does **not** trigger the WF sweep (the
+    raw arrays aren't recognised as array-valued inputs).
+
+    Attributes
+    ----------
+    marginals : Mapping[str, Any]
+        The per-field marginals this design was built from, in sorted
+        field order. Kept for introspection; read-only.
+    """
+
+    __slots__ = ("_marginals",)
+
+    @property
+    def marginals(self) -> Mapping[str, Any]:
+        """Per-field marginals this design was built from."""
+        return dict(self._marginals)
+
+    def select_all(self) -> dict[str, Any]:
+        """Return ``{field: column_array}`` for splat-as-kwargs calls.
+
+        The returned values are the underlying field columns, not
+        single-field ``RecordArray`` wrappers. Splatting them as
+        kwargs into a ``@workflow_function`` therefore **does not**
+        trigger the WF sweep path — the WF runs once with full column
+        arrays and relies on whatever broadcasting the inner body
+        naturally provides.
+
+        Use this as a faster alternative to the single-Record-arg
+        sweep pattern (``f(p=design)``) when the body's ops broadcast
+        over column arrays — typically pure JAX arithmetic. It is
+        **not** a general substitute: anything that expects per-element
+        values (``f'{x:.1f}'``, ``float(x)``, ``if x > 0``, scalar-only
+        external library calls) will fail because those receive full
+        arrays, not per-row scalars.
+        """
+        return {f: self._store[f] for f in self.fields}
+
+
+# ---------------------------------------------------------------------------
+# FullFactorialDesign
+# ---------------------------------------------------------------------------
+
+
+class FullFactorialDesign(Design):
+    """Cartesian product over all marginals — one row per combination.
+
+    Each marginal is a Python sequence (list, tuple, numpy / jax
+    array). Numeric marginals become ``jnp.ndarray`` columns and
+    categorical / string marginals become ``numpy.ndarray(dtype=object)``
+    columns. Row order is lexicographic (row-major) over the sorted
+    field names — matching the sort order :class:`~probpipe.Record`
+    uses internally for field iteration.
+
+    Parameters
+    ----------
+    **marginals : Sequence
+        Candidate values for each field. Must pass at least one
+        marginal; each must be non-empty.
+
+    Examples
+    --------
+    Cartesian grid of two numeric fields:
+
+    >>> ff = FullFactorialDesign(r=[1.5, 1.8], K=[60.0, 80.0])
+    >>> ff.batch_shape
+    (4,)
+    >>> sorted(ff.fields)
+    ['K', 'r']
+
+    Mixed numeric / categorical marginals are supported — columns fall
+    out as ``object``-dtype arrays for the categorical fields:
+
+    >>> ff2 = FullFactorialDesign(method=['nutpie', 'pymc'], scale=[0.5, 1.0])
+    >>> ff2.batch_shape
+    (4,)
+    """
+
+    def __init__(self, **marginals: Sequence) -> None:
+        if not marginals:
+            raise ValueError(
+                "FullFactorialDesign requires at least one marginal"
+            )
+        sorted_names = sorted(marginals)
+        lists = [list(marginals[n]) for n in sorted_names]
+        sizes = [len(v) for v in lists]
+        if any(s == 0 for s in sizes):
+            raise ValueError(
+                "FullFactorialDesign marginals must each be non-empty; "
+                f"got sizes {dict(zip(sorted_names, sizes))}"
+            )
+        n_total = prod(sizes)
+        # ``meshgrid(..., indexing='ij')`` then flatten: each axis
+        # iterates at its own stride; C-order flatten then yields a
+        # lexicographic row-major traversal over the sorted axes.
+        grids = np.meshgrid(
+            *(np.arange(s) for s in sizes), indexing="ij",
+        )
+        flat_indices = {
+            name: grid.reshape(-1) for name, grid in zip(sorted_names, grids)
+        }
+
+        fields: dict[str, Any] = {}
+        template_spec: dict[str, Any] = {}
+        for name, values in zip(sorted_names, lists):
+            col, leaf_shape = _seq_to_column(
+                values, indices=flat_indices[name],
+            )
+            fields[name] = col
+            template_spec[name] = leaf_shape
+
+        RecordArray.__init__(
+            self, fields,
+            batch_shape=(n_total,),
+            template=RecordTemplate(template_spec),
+            name=f"FullFactorialDesign({','.join(sorted_names)})",
+        )
+        object.__setattr__(self, "_marginals", dict(marginals))

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -1,0 +1,198 @@
+"""Tests for ``probpipe.record.design``.
+
+A ``Design`` is a ``RecordArray`` whose rows are materialised from
+per-field marginals according to a subclass-specific rule. This file
+covers :class:`FullFactorialDesign`; other subclasses land in
+follow-up PRs.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import (
+    NumericRecord,
+    NumericRecordArray,
+    Record,
+    RecordArray,
+    workflow_function,
+)
+from probpipe import FullFactorialDesign
+
+# Some assertions use NumericRecord / NumericRecordArray — these only
+# appear as WorkflowFunction outputs, not as Design types. A Design is
+# always a plain RecordArray subclass; the columns themselves are
+# jnp.ndarray for numeric marginals.
+
+
+# ---------------------------------------------------------------------------
+# FullFactorialDesign — construction + shape invariants
+# ---------------------------------------------------------------------------
+
+
+class TestFullFactorial:
+    """A FullFactorialDesign materialises the Cartesian product of its
+    marginals into a RecordArray whose ``batch_shape`` is
+    ``(prod(sizes),)`` and whose rows sweep the sorted axes in
+    lexicographic (row-major) order."""
+
+    def test_two_numeric_marginals(self):
+        ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
+        assert isinstance(ff, RecordArray)
+        assert ff.batch_shape == (6,)
+        # Fields come back sorted.
+        assert ff.fields == ("K", "r")
+        # Numeric-only marginals produce ``jnp.ndarray`` column leaves.
+        assert isinstance(ff["r"], jnp.ndarray)
+        assert isinstance(ff["K"], jnp.ndarray)
+
+    def test_row_order_is_lexicographic(self):
+        """With sorted axes K (outer) and r (inner), row order is
+        (K=60, r=1.5), (K=60, r=1.8), (K=60, r=2.0), (K=80, r=1.5), ...
+        """
+        ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
+        np.testing.assert_allclose(
+            np.asarray(ff["K"]), [60., 60., 60., 80., 80., 80.],
+        )
+        np.testing.assert_allclose(
+            np.asarray(ff["r"]), [1.5, 1.8, 2.0, 1.5, 1.8, 2.0],
+        )
+
+    def test_single_marginal_edge_case(self):
+        ff = FullFactorialDesign(method=["pymc"])
+        # Categorical-only falls back to RecordArray (non-numeric leaf).
+        assert isinstance(ff, RecordArray)
+        assert not isinstance(ff, NumericRecordArray)
+        assert ff.batch_shape == (1,)
+        assert ff.fields == ("method",)
+
+    def test_mixed_numeric_and_categorical(self):
+        """String marginals produce ``dtype=object`` columns; the
+        design falls back to the permissive ``RecordArray`` base."""
+        ff = FullFactorialDesign(
+            method=["nutpie", "pymc"], scale=[0.5, 1.0],
+        )
+        assert isinstance(ff, RecordArray)
+        assert not isinstance(ff, NumericRecordArray)
+        assert ff.batch_shape == (4,)
+        np.testing.assert_allclose(
+            np.asarray(ff["scale"]), [0.5, 1.0, 0.5, 1.0],
+        )
+        # sorted fields: ("method", "scale"); method varies slowest
+        assert list(ff["method"]) == ["nutpie", "nutpie", "pymc", "pymc"]
+
+    def test_three_axes_shape_and_count(self):
+        ff = FullFactorialDesign(
+            a=[1, 2, 3], b=[10, 20], c=[100, 200, 300, 400],
+        )
+        assert ff.batch_shape == (3 * 2 * 4,)
+
+    def test_empty_marginals_raises(self):
+        with pytest.raises(ValueError, match="at least one marginal"):
+            FullFactorialDesign()
+
+    def test_empty_marginal_column_raises(self):
+        with pytest.raises(ValueError, match="must each be non-empty"):
+            FullFactorialDesign(r=[1.0, 2.0], K=[])
+
+    def test_marginals_introspection(self):
+        """``.marginals`` returns the original per-field sequences."""
+        ff = FullFactorialDesign(r=[1.5, 1.8], K=[60.0, 80.0])
+        marginals = ff.marginals
+        assert set(marginals) == {"r", "K"}
+        assert list(marginals["r"]) == [1.5, 1.8]
+        assert list(marginals["K"]) == [60.0, 80.0]
+
+    def test_single_row_record_indexing(self):
+        """Integer-indexing a Design returns a single Record (scalar
+        row), matching the RecordArray contract."""
+        ff = FullFactorialDesign(r=[1.5, 1.8], K=[60.0, 80.0])
+        row = ff[1]  # second row in lex order → (K=60, r=1.8)
+        assert isinstance(row, Record)
+        assert float(row["r"]) == pytest.approx(1.8)
+        assert float(row["K"]) == pytest.approx(60.0)
+
+
+# ---------------------------------------------------------------------------
+# Sweep integration — the main point of Designs
+# ---------------------------------------------------------------------------
+
+
+class TestDesignAsSweep:
+    """The two idiomatic ways to pipe a Design into a WorkflowFunction.
+
+    Pattern A (general): ``f(p=design)`` with ``f(p)`` taking a
+    single ``Record`` arg — the WF sweep path runs one inner call per
+    row.
+
+    Pattern B (convenience): ``f(**design.select_all())`` with
+    per-field scalar args — runs ``f`` once with full column arrays
+    and relies on JAX broadcasting. Does not trigger the WF sweep.
+    """
+
+    def test_single_record_arg_triggers_sweep(self):
+        @workflow_function
+        def fit(p: NumericRecord):
+            return p["r"] * p["K"]
+
+        ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
+        out = fit(p=ff)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (6,)
+        np.testing.assert_allclose(
+            np.asarray(out["fit"]),
+            [1.5 * 60, 1.8 * 60, 2.0 * 60, 1.5 * 80, 1.8 * 80, 2.0 * 80],
+        )
+
+    def test_select_all_splat_for_jax_vectorized_body(self):
+        @workflow_function
+        def product(r, K):
+            return r * K
+
+        ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
+        out = product(**ff.select_all())
+        # Splat into a vectorizable body: WF runs once, JAX broadcasts
+        # to a (6,)-array, WF wraps as NumericRecord with the function
+        # name as the single field.
+        assert isinstance(out, NumericRecord)
+        assert "product" in out.fields
+        np.testing.assert_allclose(
+            np.asarray(out["product"]),
+            [1.5 * 60, 1.8 * 60, 2.0 * 60, 1.5 * 80, 1.8 * 80, 2.0 * 80],
+        )
+
+    def test_mixed_field_sweep_uses_record_arg_pattern(self):
+        """Categorical fields can't ride JAX broadcasting — the single
+        Record arg pattern is the only one that works when any marginal
+        is string-valued."""
+
+        @workflow_function
+        def label(p: Record):
+            return f'{p["method"]}-{float(p["scale"]):.1f}'
+
+        ff = FullFactorialDesign(
+            method=["nutpie", "pymc"], scale=[0.5, 1.0],
+        )
+        out = label(p=ff)
+        assert isinstance(out, RecordArray)
+        assert out.batch_shape == (4,)
+        assert list(out["label"]) == [
+            "nutpie-0.5", "nutpie-1.0", "pymc-0.5", "pymc-1.0",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Introspection + select_all
+# ---------------------------------------------------------------------------
+
+
+class TestSelectAll:
+    def test_select_all_returns_column_arrays(self):
+        ff = FullFactorialDesign(r=[1.5, 1.8], K=[60.0, 80.0])
+        cols = ff.select_all()
+        assert set(cols) == {"r", "K"}
+        # Each column is the raw field array (not a single-field RecordArray).
+        assert not isinstance(cols["r"], RecordArray)
+        assert cols["r"].shape == (4,)
+        assert cols["K"].shape == (4,)


### PR DESCRIPTION
First cut of the Design hierarchy (PR 2 of issue #130). Lands the Cartesian case; random / space-filling designs (`RandomDesign`, `LatinHypercubeDesign`, `SobolDesign`) follow in subsequent PRs.

## What it is

A `Design` is a `RecordArray` whose rows are materialised from per-field **marginals** according to a subclass-specific rule. The resulting RecordArray plugs into the `WorkflowFunction` sweep path as a single array-valued input — no new broadcast rule, no new output type.

```python
from probpipe import FullFactorialDesign

ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
ff.batch_shape                 # (6,)
ff.fields                      # ('K', 'r')      (sorted)
ff.marginals                   # {'r': [...], 'K': [...]}
```

Rows are addressed in lexicographic (row-major) order over the sorted field names. Mixed numeric / categorical marginals are supported — string fields become `object`-dtype columns, handled by the permissive `RecordArray` base.

## Usage patterns

Pattern **A** — pass the Design as a single `Record`-typed arg to trigger the WF sweep path (one inner call per row; works with any body):

```python
@workflow_function
def fit(p):
    return p["r"] * p["K"]

result = fit(p=ff)              # NumericRecordArray, batch_shape=(6,)
```

Pattern **B** — splat via `select_all()` for JAX-vectorizable bodies (WF runs once, JAX broadcasts over the columns; no per-row iteration):

```python
@workflow_function
def product(r, K):
    return r * K

result = product(**ff.select_all())     # NumericRecord(product=array(shape=(6,)))
```

Pattern A is the general path — it always works, including with categorical fields, scalar-only Python operations, and bodies that call external libraries expecting per-element values.

Pattern B is faster (one WF call / one JAX trace instead of N inner calls) but requires the body to accept array-valued inputs: essentially, its ops must broadcast naturally over the column arrays. Pure JAX arithmetic qualifies; `f'{x:.1f}'`, `float(x)`, `if x > 0`, and similar scalar-only operations do not. The body runs once with full column arrays — there is no per-cell iteration.

## Implementation

- `probpipe/record/__init__.py` — new `experimental` subpackage, re-exports `Design` / `FullFactorialDesign`. Keeps these APIs opt-in while they bake in real use, per the experimental policy.
- `probpipe/record/design.py` (~170 LOC):
  - `Design(RecordArray)` base: adds `_marginals` slot plus `marginals` / `select_all` accessors.
  - `FullFactorialDesign(**marginals)`: `np.meshgrid(..., indexing='ij')` over the sorted axes; numeric marginals become `jnp.ndarray` columns, categoricals become `np.ndarray(dtype=object)` columns; delegates row-major flattening to meshgrid's C-order reshape.
- `CONTRIBUTING.md`: entry in the key-abstractions table.

## Tests

`tests/test_design.py` — 13 tests covering construction invariants (shape, row order, mixed-field cases, single-field edge, empty-marginal raises), sweep integration via both usage patterns, and `.marginals` / `select_all()` introspection.

Full suite: **2137 passed, 7 skipped, 0 failed** (2124 before + 13 new).

## Stack

- Builds on PR #135 (uniform WF output wrap + product-rule broadcasting). The Design relies on the sweep path landed there; this branch includes #135's commits.
- Merge-base: `dev/multi-d-batch` (PR #135). Once #135 merges to main, this PR rebases cleanly.

## Scope — out this round

- `RandomDesign` (Distribution-valued and sequence marginals).
- `LatinHypercubeDesign`, `SobolDesign` (space-filling designs over continuous ranges).
- Design composition operators (`a * b`, `a | b`).
- Promotion of `probpipe.record.design` to `probpipe.core.design` (wait two PRs of real use).
