### PR TITLE
feat(record): _RecordArrayView + parent-identity sweep grouping

### DIFF
--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -21,7 +21,11 @@ from ._numeric_record import NumericRecord, _NUMERIC_DTYPE_KINDS
 from .provenance import Provenance
 from .record import Record, RecordTemplate, _spec_size
 
-__all__ = ["RecordArray", "NumericRecordArray"]
+__all__ = [
+    "RecordArray",
+    "NumericRecordArray",
+    "_RecordArrayView",
+]
 
 
 class RecordArray(Record):
@@ -152,6 +156,20 @@ class RecordArray(Record):
         raise TypeError(
             f"key must be str or int, got {type(key).__name__}"
         )
+
+    def view(self, field: str) -> "_RecordArrayView":
+        """Return a single-field view carrying parent identity.
+
+        Unlike ``ra[field]`` (which returns the raw column), a view
+        remembers the parent ``RecordArray``. When multiple views of
+        the same parent land in a single ``WorkflowFunction`` call,
+        the sweep layer groups them by parent identity and iterates
+        them in lockstep (zip) rather than cartesian-producting.
+
+        Used internally by :meth:`~probpipe.record.Design.select_all`.
+        Direct construction by end-users is supported but rarely needed.
+        """
+        return _RecordArrayView(self, field)
 
     _record_cls: type = Record
     """Class used to materialise a single element via integer indexing.
@@ -479,6 +497,131 @@ class NumericRecordArray(RecordArray):
 
 
 # ---------------------------------------------------------------------------
+# Single-field view
+# ---------------------------------------------------------------------------
+#
+# A view is a ``RecordArray`` with exactly one field, aliased into the
+# parent's storage, plus a ``_parent`` reference. It's consciously a
+# *plain* ``RecordArray`` subclass — not a ``NumericRecordArray``
+# subclass — to avoid inheriting per-field batch-reduction methods
+# (``.mean`` / ``.var`` / ``.flatten``) that clash with the "act like
+# the underlying column" intuition. Users who want numeric column ops
+# convert explicitly: ``jnp.asarray(view).mean()``.
+#
+# Parallel to :class:`~probpipe.core._record_distribution._RecordDistributionView`:
+# same "thin wrapper carrying parent identity for WF-layer sweep
+# grouping" role. The WF layer detects ``view._parent`` as the
+# shared-identity key; sibling views from the same parent zip into a
+# single sweep axis, different parents product.
+# ---------------------------------------------------------------------------
+
+
+class _RecordArrayView(RecordArray):
+    """View of a single named field in a :class:`RecordArray`.
+
+    Constructed via ``parent[field]``. The underlying column is aliased
+    — no copy — and ``view._parent`` carries the parent reference used
+    by the ``WorkflowFunction`` sweep layer to group sibling views.
+
+    Minimal surface: ``__array__`` / ``__jax_array__`` for conversion,
+    ``.shape`` / ``.dtype`` / ``.ndim`` for introspection,
+    ``view[i]`` / ``view[slice]`` to slice the underlying column,
+    ``.parent`` / ``.field`` for sweep metadata. Arithmetic /
+    reductions / reshaping require explicit
+    ``jnp.asarray(view)`` conversion, matching the explicit-conversion
+    policy already used for ``NumericRecord`` / ``NumericRecordArray``.
+
+    Parameters
+    ----------
+    parent : RecordArray
+        The source RecordArray.
+    field : str
+        Name of the field to view. Must be present in ``parent``.
+    """
+
+    __slots__ = ("_parent", "_field")
+
+    def __init__(self, parent: RecordArray, field: str):
+        if field not in parent._store:
+            raise KeyError(
+                f"field {field!r} not in parent "
+                f"{type(parent).__name__}(fields={parent.fields})"
+            )
+        leaf_spec = parent.template[field]
+        store = OrderedDict([(field, parent._store[field])])
+        template = RecordTemplate({field: leaf_spec})
+        # Populate RecordArray state directly — data was validated at
+        # the parent's construction.
+        object.__setattr__(self, "_store", store)
+        object.__setattr__(self, "_template", template)
+        object.__setattr__(self, "_batch_shape", parent._batch_shape)
+        object.__setattr__(self, "_name", f"{parent._name}[{field!r}]")
+        object.__setattr__(self, "_source", None)
+        object.__setattr__(self, "_parent", parent)
+        object.__setattr__(self, "_field", field)
+
+    @property
+    def parent(self) -> RecordArray:
+        """The parent ``RecordArray`` this view points at.
+
+        Shared-identity signal for the ``WorkflowFunction`` sweep layer:
+        views with the same ``parent`` zip into one sweep axis; views
+        with different parents (and plain ``RecordArray``s) product.
+        """
+        return self._parent
+
+    @property
+    def field(self) -> str:
+        """The name of the viewed field."""
+        return self._field
+
+    # -- Column conversion + introspection ------------------------------------
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return tuple(getattr(self._store[self._field], "shape", ()))
+
+    @property
+    def dtype(self):
+        return getattr(self._store[self._field], "dtype", None)
+
+    @property
+    def ndim(self) -> int:
+        return int(getattr(self._store[self._field], "ndim", 0))
+
+    def __array__(self, dtype=None):
+        leaf = self._store[self._field]
+        return np.asarray(leaf, dtype=dtype) if dtype is not None else np.asarray(leaf)
+
+    def __jax_array__(self):
+        return jnp.asarray(self._store[self._field])
+
+    # Int / slice / tuple indexing acts on the underlying column —
+    # ``view[i]`` is the i-th row, matching the raw-array behaviour
+    # users expect from ``ra["field"][i]`` prior to the view contract.
+    # String indexing is idempotent (same field) or raises.
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            if key == self._field:
+                return self
+            raise KeyError(key)
+        return self._store[self._field][key]
+
+    def __len__(self) -> int:
+        leaf = self._store[self._field]
+        return int(leaf.shape[0]) if getattr(leaf, "shape", ()) else 0
+
+    def __iter__(self):
+        return iter(self._store[self._field])
+
+    def __repr__(self) -> str:
+        return (
+            f"_RecordArrayView(parent={type(self._parent).__name__}, "
+            f"field={self._field!r}, batch_shape={self._batch_shape})"
+        )
+
+
+# ---------------------------------------------------------------------------
 # JAX PyTree registration
 # ---------------------------------------------------------------------------
 
@@ -524,3 +667,14 @@ jax.tree_util.register_pytree_node(
 jax.tree_util.register_pytree_node(
     NumericRecordArray, _record_array_flatten, _numeric_record_array_unflatten
 )
+
+
+# Views are intentionally **not** registered as pytree nodes. JAX
+# treats them as leaves, which means ``jnp.sum(view)`` / ``jnp.mean(view)``
+# /etc. go through ``__jax_array__`` and operate on the underlying
+# column — the expected "column-like" behaviour. If we registered the
+# view as a pytree, JAX's tree-flatten machinery would unpack it into
+# a leaf plus aux and then re-unflatten as a plain ``RecordArray``
+# (since the parent pointer isn't reconstructible), which doesn't
+# support ``jnp.sum`` etc. Keeping the view as a leaf sidesteps that
+# round-trip entirely.

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -35,7 +35,7 @@ from .distribution import (
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
 from ._numeric_record import NumericRecord, _is_numeric_leaf
-from ._record_array import RecordArray
+from ._record_array import RecordArray, _RecordArrayView
 from .provenance import Provenance
 from .record import Record
 from .protocols import (
@@ -786,18 +786,23 @@ class WorkflowFunction(Node):
                 "provenance on the stacked output."
             )
 
-        # Product rule: each array arg contributes its own batch_shape
-        # as a block of leading axes in the sweep output. The sweep
-        # iterates the Cartesian product across all blocks.
+        # Group ``ra_args`` by parent identity. Views from the same
+        # ``RecordArray`` (e.g. ``Design.select_all()`` outputs) zip —
+        # they contribute a single axis block to the sweep. Plain
+        # ``RecordArray`` / ``DistributionArray`` args and views from
+        # different parents each form their own group and product
+        # across the sweep. Insertion order of first occurrence
+        # preserves axis ordering in the output.
+        ra_groups = self._group_ra_args_by_parent(values, ra_args)
         sweep_batch_shape = tuple(
-            ax for name in ra_args for ax in values[name].batch_shape
+            ax for _, bshape, _ in ra_groups for ax in bshape
         )
         n_total = prod(sweep_batch_shape) if sweep_batch_shape else 1
 
         # ---- Pure sweep (no Distribution args) -------------------------
         if not dist_args:
             per_row = self._execute_sweep_rows(
-                values, ra_args, n_total, sweep_batch_shape,
+                values, ra_args, n_total, sweep_batch_shape, ra_groups,
             )
             aggregate = _make_stack(
                 per_row,
@@ -822,9 +827,8 @@ class WorkflowFunction(Node):
         # them into a DistributionArray that presents the sweep's
         # multi-d batch_shape.
         per_row_marginals: list[Distribution] = []
-        sizes = [prod(values[name].batch_shape) for name in ra_args]
         for i in range(n_total):
-            row_values = self._slice_ra_args(values, ra_args, i, sizes)
+            row_values = self._slice_ra_args(values, ra_args, i, ra_groups)
             inner = self._broadcast_distributions_only(
                 row_values, dist_args, n_broadcast_samples,
                 do_include_inputs=True,
@@ -853,35 +857,76 @@ class WorkflowFunction(Node):
 
     # ----- Helpers for the array-broadcast path ---------------------------
 
+    def _group_ra_args_by_parent(
+        self,
+        values: dict[str, Any],
+        ra_args: list[str],
+    ) -> list[tuple[list[str], tuple[int, ...], int]]:
+        """Group array-valued sweep args by parent identity.
+
+        Views (``_RecordArrayView``) from the same parent
+        ``RecordArray`` — e.g. the output dict of
+        ``Design.select_all()`` — belong to one group and iterate in
+        lockstep (zip). Plain ``RecordArray`` / ``DistributionArray``
+        args and views from distinct parents each form their own group
+        and product across the sweep.
+
+        Returns a list of tuples ``(arg_names, batch_shape, size)``
+        in first-occurrence order; each tuple is one axis block of the
+        sweep. ``size`` is ``prod(batch_shape)``.
+        """
+        groups: list[tuple[list[str], tuple[int, ...], int]] = []
+        groups_by_parent: dict[int, int] = {}  # parent_id → index into groups
+        for name in ra_args:
+            value = values[name]
+            if isinstance(value, _RecordArrayView):
+                parent_id = id(value.parent)
+            else:
+                # Plain RecordArray / DistributionArray: its own parent.
+                parent_id = id(value)
+            if parent_id in groups_by_parent:
+                group_names, bshape, size = groups[groups_by_parent[parent_id]]
+                if tuple(value.batch_shape) != bshape:
+                    raise ValueError(
+                        f"sweep args {group_names + [name]!r} share a "
+                        f"parent RecordArray but have mismatched "
+                        f"batch_shapes: first was {bshape}, "
+                        f"{name!r} is {tuple(value.batch_shape)}"
+                    )
+                group_names.append(name)
+                continue
+            bshape = tuple(value.batch_shape)
+            groups_by_parent[parent_id] = len(groups)
+            groups.append(([name], bshape, prod(bshape) if bshape else 1))
+        return groups
+
     def _slice_ra_args(
         self,
         values: dict[str, Any],
         ra_args: list[str],
         i: int,
-        sizes: list[int],
+        ra_groups: list[tuple[list[str], tuple[int, ...], int]],
     ) -> dict[str, Any]:
-        """Materialise the ``i``-th sweep cell under the product rule.
+        """Materialise the ``i``-th sweep cell under parent-grouped sweep.
 
-        ``sizes`` is the flat batch size of each ``ra_args`` arg — the
-        sweep caller computes it once outside the cell loop to avoid
-        repeating ``prod`` per cell.
-
-        Each array arg is integer-indexed along its own batch — yielding
-        a ``Record`` / ``NumericRecord`` (``RecordArray``) or a scalar
-        component ``Distribution`` (``DistributionArray``).
+        ``ra_groups`` is the per-parent grouping from
+        :meth:`_group_ra_args_by_parent`. Each group's args share a flat
+        in-group index (zip); groups compose by row-major unravel of
+        the outer flat index ``i`` over the concatenated batch shapes.
         """
         out = dict(values)
         rem = i
-        # Highest-index arg is the fastest-varying axis (row-major over
-        # the concatenated sweep shape).
-        for name, size in zip(reversed(ra_args), reversed(sizes)):
+        # Highest-index group varies fastest (row-major over the
+        # concatenated sweep shape).
+        for arg_names, _, size in reversed(ra_groups):
             idx = rem % size
             rem = rem // size
-            source = values[name]
-            if isinstance(source, DistributionArray):
-                out[name] = source._flat_component(idx)
-            else:
-                out[name] = source[idx]
+            for name in arg_names:
+                source = values[name]
+                if isinstance(source, DistributionArray):
+                    out[name] = source._flat_component(idx)
+                else:
+                    out[name] = source[idx]
         return out
 
     def _execute_sweep_rows(
@@ -890,6 +935,7 @@ class WorkflowFunction(Node):
         ra_args: list[str],
         n_total: int,
         sweep_batch_shape: tuple[int, ...],
+        ra_groups: list[tuple[list[str], tuple[int, ...], int]],
     ) -> Any:
         """Execute ``n_total`` inner calls, one per sweep cell in flat
         row-major order over the concatenated ``sweep_batch_shape``.
@@ -900,13 +946,17 @@ class WorkflowFunction(Node):
         """
         vectorize = self._resolve_vectorize(values, ra_args)
 
-        # Mixed-kind arg lists (RecordArray + DistributionArray) and
-        # product-rule expansion aren't supported by the single-axis
-        # vmap path; drop to the loop.
+        # The vmap path only handles the simple single-RecordArray
+        # case: one group, one RA arg, no DistributionArray, no views
+        # (views carry parent references that would confuse vmap's
+        # leading-axis flattening).
         has_dist_array = any(
             isinstance(values[name], DistributionArray) for name in ra_args
         )
-        if has_dist_array or len(ra_args) > 1:
+        has_view = any(
+            isinstance(values[name], _RecordArrayView) for name in ra_args
+        )
+        if has_dist_array or has_view or len(ra_groups) > 1 or len(ra_args) > 1:
             vectorize = "loop"
 
         if vectorize == "jax":
@@ -927,15 +977,15 @@ class WorkflowFunction(Node):
                 ra = values[name]
                 n_batch = len(ra.batch_shape)
                 vmap_input[name] = {
-                    f: ra[f].reshape((n_total,) + ra[f].shape[n_batch:])
+                    f: ra._store[f].reshape((n_total,) + ra._store[f].shape[n_batch:])
                     for f in ra.fields
                 }
             return jax.vmap(single_call)(vmap_input)
 
         # Loop path.
-        sizes = [prod(values[name].batch_shape) for name in ra_args]
         per_row_values = [
-            self._slice_ra_args(values, ra_args, i, sizes) for i in range(n_total)
+            self._slice_ra_args(values, ra_args, i, ra_groups)
+            for i in range(n_total)
         ]
         return self._execute_many(per_row_values)
 

--- a/probpipe/record/design.py
+++ b/probpipe/record/design.py
@@ -110,24 +110,25 @@ class Design(RecordArray):
         return dict(self._marginals)
 
     def select_all(self) -> dict[str, Any]:
-        """Return ``{field: column_array}`` for splat-as-kwargs calls.
+        """Return ``{field: view}`` for splat-as-kwargs calls.
 
-        The returned values are the underlying field columns, not
-        single-field ``RecordArray`` wrappers. Splatting them as
-        kwargs into a ``@workflow_function`` therefore **does not**
-        trigger the WF sweep path — the WF runs once with full column
-        arrays and relies on whatever broadcasting the inner body
-        naturally provides.
+        Each value is a single-field view that carries the Design's
+        identity. When the result is splatted into a
+        ``@workflow_function`` — e.g. ``f(**design.select_all())`` —
+        the WF sweep layer recognises the shared parent and iterates
+        the views in lockstep (one inner call per row, matching
+        ``f(p=design)``), rather than treating them as independent
+        axes to cartesian-product.
 
-        Use this as a faster alternative to the single-Record-arg
-        sweep pattern (``f(p=design)``) when the body's ops broadcast
-        over column arrays — typically pure JAX arithmetic. It is
-        **not** a general substitute: anything that expects per-element
-        values (``f'{x:.1f}'``, ``float(x)``, ``if x > 0``, scalar-only
-        external library calls) will fail because those receive full
-        arrays, not per-row scalars.
+        Works with any inner body: no constraint on what ``f`` does
+        per cell, since each cell receives a scalar element (same as
+        the single-Record-arg pattern). For a faster JAX-traceable
+        shortcut on purely numeric bodies, pass the raw columns
+        instead (``f(r=design["r"], K=design["K"])``) — those are
+        independent arrays, so they'll cartesian-product rather than
+        zip.
         """
-        return {f: self._store[f] for f in self.fields}
+        return {f: self.view(f) for f in self.fields}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -145,22 +145,66 @@ class TestDesignAsSweep:
             [1.5 * 60, 1.8 * 60, 2.0 * 60, 1.5 * 80, 1.8 * 80, 2.0 * 80],
         )
 
-    def test_select_all_splat_for_jax_vectorized_body(self):
+    def test_select_all_splat_triggers_zip_sweep(self):
+        """Splatting ``**design.select_all()`` yields sibling views of
+        the same Design. The WF sweep layer groups them by parent
+        identity and iterates in lockstep — one inner call per row —
+        producing a ``NumericRecordArray`` identical to the single
+        Record-arg pattern (``fit(p=design)``)."""
+
         @workflow_function
         def product(r, K):
             return r * K
 
         ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
         out = product(**ff.select_all())
-        # Splat into a vectorizable body: WF runs once, JAX broadcasts
-        # to a (6,)-array, WF wraps as NumericRecord with the function
-        # name as the single field.
-        assert isinstance(out, NumericRecord)
-        assert "product" in out.fields
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (6,)
         np.testing.assert_allclose(
             np.asarray(out["product"]),
             [1.5 * 60, 1.8 * 60, 2.0 * 60, 1.5 * 80, 1.8 * 80, 2.0 * 80],
         )
+
+    def test_patterns_a_and_b_are_equivalent(self):
+        """Pattern A (``f(p=design)``) and Pattern B
+        (``f(**design.select_all())``) produce identical outputs."""
+        ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
+
+        @workflow_function
+        def fit_a(p: NumericRecord):
+            return p["r"] * p["K"]
+
+        @workflow_function
+        def fit_b(r, K):
+            return r * K
+
+        out_a = fit_a(p=ff)
+        out_b = fit_b(**ff.select_all())
+        assert out_a.batch_shape == out_b.batch_shape == (6,)
+        np.testing.assert_allclose(
+            np.asarray(out_a["fit_a"]),
+            np.asarray(out_b["fit_b"]),
+        )
+
+    def test_raw_fields_still_cartesian_product(self):
+        """Passing raw columns (``design["r"]``, ``design["K"]``) gives
+        the expected independent-arrays behaviour: they cartesian-product
+        because they carry no parent-identity signal the WF layer can
+        use to zip them."""
+
+        @workflow_function
+        def product(r, K):
+            return r * K
+
+        ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
+        # Raw columns → two independent jnp.ndarrays. With no type
+        # hints they're passed to the body wholesale and JAX broadcasts
+        # the arithmetic to a (6,)-array; WF wraps as NumericRecord.
+        out = product(r=ff["r"], K=ff["K"])
+        # Confirm the output is a single Record with the arithmetic
+        # result, not a swept NumericRecordArray.
+        assert isinstance(out, NumericRecord)
+        assert out["product"].shape == (6,)
 
     def test_mixed_field_sweep_uses_record_arg_pattern(self):
         """Categorical fields can't ride JAX broadcasting — the single
@@ -188,11 +232,20 @@ class TestDesignAsSweep:
 
 
 class TestSelectAll:
-    def test_select_all_returns_column_arrays(self):
+    def test_select_all_returns_views(self):
+        """``select_all()`` returns single-field views that share the
+        Design as their parent. Sibling views passed to a
+        ``WorkflowFunction`` zip rather than cartesian-product — the
+        mechanism behind ``f(**design.select_all()) ≡ f(p=design)``."""
+        from probpipe.core._record_array import _RecordArrayView
         ff = FullFactorialDesign(r=[1.5, 1.8], K=[60.0, 80.0])
         cols = ff.select_all()
         assert set(cols) == {"r", "K"}
-        # Each column is the raw field array (not a single-field RecordArray).
-        assert not isinstance(cols["r"], RecordArray)
+        # Views carry the Design as their parent.
+        assert isinstance(cols["r"], _RecordArrayView)
+        assert isinstance(cols["K"], _RecordArrayView)
+        assert cols["r"].parent is ff
+        assert cols["K"].parent is ff
+        # Shape / leaf access forwards to the underlying column.
         assert cols["r"].shape == (4,)
         assert cols["K"].shape == (4,)

--- a/tests/test_record_array_view.py
+++ b/tests/test_record_array_view.py
@@ -1,0 +1,402 @@
+"""Tests for ``_RecordArrayView`` and the parent-identity sweep grouping.
+
+A ``_RecordArrayView`` is a thin single-field wrapper around a
+``RecordArray`` column, carrying the parent RA as shared-identity
+metadata. The ``WorkflowFunction`` sweep layer recognises sibling
+views (views of the same parent) and iterates them in lockstep (zip)
+rather than cartesian-producting them.
+
+Views are constructed via ``RecordArray.view("field")`` or via
+``Design.select_all()``; ``ra["field"]`` still returns the raw column.
+These tests cover:
+
+- View construction + attribute/conversion forwarding.
+- Parent-identity grouping in the sweep layer:
+  * Views from the same parent → zip (one axis block).
+  * Views from different parents → product (independent blocks).
+  * Views + plain ``RecordArray`` / ``DistributionArray`` compose
+    correctly (zip within sibling group, product across groups).
+- Pattern-B parity: ``f(**design.select_all()) ≡ f(p=design)``.
+- Raw columns (``ra["field"]``) still behave as plain ndarrays — no
+  sweep grouping, independent axes.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import (
+    FullFactorialDesign,
+    Normal,
+    NumericRecord,
+    NumericRecordArray,
+    Record,
+    RecordArray,
+    DistributionArray,
+    workflow_function,
+)
+from probpipe.core._record_array import _RecordArrayView
+from probpipe.core.record import RecordTemplate
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def numeric_ra():
+    """A NumericRecordArray with two numeric fields, batch_shape=(4,)."""
+    return NumericRecordArray.stack(
+        [NumericRecord(x=float(i), y=float(i * 2)) for i in range(4)]
+    )
+
+
+@pytest.fixture
+def mixed_ra():
+    """A plain RecordArray with one numeric and one string field."""
+    tpl = RecordTemplate(method=None, scale=())
+    return RecordArray(
+        {
+            "method": np.asarray(["nutpie", "pymc", "stan"], dtype=object),
+            "scale": jnp.array([0.5, 1.0, 2.0]),
+        },
+        batch_shape=(3,),
+        template=tpl,
+    )
+
+
+# ---------------------------------------------------------------------------
+# View construction + basic behavior
+# ---------------------------------------------------------------------------
+
+
+class TestViewConstruction:
+    """``ra.view(field)`` returns a single-field view; ``ra["field"]``
+    still returns the raw column. The view aliases the parent's data —
+    no copy."""
+
+    def test_view_is_recordarray_subclass(self, numeric_ra):
+        v = numeric_ra.view("x")
+        assert isinstance(v, _RecordArrayView)
+        assert isinstance(v, RecordArray)
+
+    def test_view_parent_identity(self, numeric_ra):
+        v = numeric_ra.view("x")
+        assert v.parent is numeric_ra
+        assert v.field == "x"
+
+    def test_view_single_field(self, numeric_ra):
+        v = numeric_ra.view("x")
+        assert v.fields == ("x",)
+
+    def test_view_batch_shape_matches_parent(self, numeric_ra):
+        v = numeric_ra.view("x")
+        assert v.batch_shape == numeric_ra.batch_shape == (4,)
+
+    def test_view_aliases_underlying_column(self, numeric_ra):
+        v = numeric_ra.view("x")
+        # No copy — the underlying array is the parent's store entry.
+        assert v._store["x"] is numeric_ra._store["x"]
+
+    def test_view_unknown_field_raises(self, numeric_ra):
+        with pytest.raises(KeyError):
+            numeric_ra.view("not_a_field")
+
+    def test_ra_getitem_still_returns_raw(self, numeric_ra):
+        """The ``ra[field]`` contract is unchanged — it returns the
+        raw column. Views are opt-in via ``ra.view(field)`` or
+        ``Design.select_all()``."""
+        assert isinstance(numeric_ra["x"], jnp.ndarray)
+        assert not isinstance(numeric_ra["x"], _RecordArrayView)
+
+    def test_mixed_field_view_object_dtype(self, mixed_ra):
+        """View works on non-numeric (object-dtype) fields too."""
+        v = mixed_ra.view("method")
+        assert isinstance(v, _RecordArrayView)
+        assert v.parent is mixed_ra
+        assert v.shape == (3,)
+
+
+# ---------------------------------------------------------------------------
+# View attribute / conversion forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestViewForwarding:
+    """Views forward a minimal set of array-like accessors: conversion
+    (``__array__`` / ``__jax_array__``), shape / dtype / ndim, indexing,
+    iteration, len. Arithmetic / reductions require explicit
+    ``jnp.asarray(view)`` — consistent with the explicit-conversion
+    policy used elsewhere for single-field shims."""
+
+    def test_shape_forwards_to_column(self, numeric_ra):
+        v = numeric_ra.view("x")
+        assert v.shape == (4,)
+
+    def test_dtype_forwards_to_column(self, numeric_ra):
+        v = numeric_ra.view("x")
+        assert v.dtype == jnp.float32
+
+    def test_ndim_forwards_to_column(self, numeric_ra):
+        v = numeric_ra.view("x")
+        assert v.ndim == 1
+
+    def test_jnp_asarray_returns_underlying_column(self, numeric_ra):
+        v = numeric_ra.view("x")
+        arr = jnp.asarray(v)
+        np.testing.assert_allclose(np.asarray(arr), [0.0, 1.0, 2.0, 3.0])
+
+    def test_np_asarray_returns_underlying_column(self, numeric_ra):
+        v = numeric_ra.view("x")
+        arr = np.asarray(v)
+        np.testing.assert_allclose(arr, [0.0, 1.0, 2.0, 3.0])
+
+    def test_view_indexing_slices_column(self, numeric_ra):
+        """``view[i]`` forwards to the underlying column's i-th row —
+        matching the raw-array intuition users have for ``ra["x"][i]``."""
+        v = numeric_ra.view("x")
+        assert float(v[0]) == 0.0
+        assert float(v[2]) == 2.0
+
+    def test_view_string_index_is_idempotent(self, numeric_ra):
+        v = numeric_ra.view("x")
+        assert v["x"] is v
+
+    def test_view_string_index_wrong_field_raises(self, numeric_ra):
+        v = numeric_ra.view("x")
+        with pytest.raises(KeyError):
+            v["y"]
+
+    def test_view_len_forwards(self, numeric_ra):
+        v = numeric_ra.view("x")
+        assert len(v) == 4
+
+    def test_view_iteration_forwards(self, numeric_ra):
+        v = numeric_ra.view("x")
+        collected = [float(x) for x in v]
+        assert collected == [0.0, 1.0, 2.0, 3.0]
+
+    def test_jnp_ops_need_explicit_conversion(self, numeric_ra):
+        """Recent JAX rejects ``__jax_array__`` during abstractification,
+        so ``jnp.sum(view)`` raises. Users must convert explicitly."""
+        v = numeric_ra.view("x")
+        assert float(jnp.sum(jnp.asarray(v))) == pytest.approx(6.0)
+        assert float(jnp.mean(jnp.asarray(v))) == pytest.approx(1.5)
+
+    def test_arithmetic_requires_explicit_conversion(self, numeric_ra):
+        """Arithmetic operators are *not* forwarded; users must
+        ``jnp.asarray(view)`` before arithmetic. Documents the
+        explicit-conversion policy."""
+        v = numeric_ra.view("x")
+        with pytest.raises(TypeError):
+            v + 1           # no __add__ on view
+        np.testing.assert_allclose(
+            np.asarray(jnp.asarray(v) + 1),
+            [1.0, 2.0, 3.0, 4.0],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sweep grouping — parent identity drives zip vs product
+# ---------------------------------------------------------------------------
+
+
+class TestSweepGroupingByParent:
+    """The ``WorkflowFunction`` sweep layer groups array-valued args by
+    parent identity. Views sharing a parent iterate in lockstep (zip);
+    distinct parents (including two independent ``RecordArray``s or
+    two views of different parents) product."""
+
+    def test_two_views_same_parent_zip(self, numeric_ra):
+        """Two views of ``numeric_ra`` zip into a single (4,) axis."""
+
+        @workflow_function
+        def f(x, y):
+            return x + y
+
+        out = f(x=numeric_ra.view("x"), y=numeric_ra.view("y"))
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (4,)
+        # Row i: x[i] + y[i] = i + 2i = 3i
+        np.testing.assert_allclose(
+            np.asarray(out["f"]),
+            [0.0, 3.0, 6.0, 9.0],
+        )
+
+    def test_two_views_different_parents_product(self):
+        """Views from two different ``RecordArray``s carry different
+        parent ids → distinct groups → cartesian product."""
+        ra_a = NumericRecordArray.stack(
+            [NumericRecord(a=float(i)) for i in range(3)]
+        )
+        ra_b = NumericRecordArray.stack(
+            [NumericRecord(b=float(j * 10)) for j in range(2)]
+        )
+
+        @workflow_function
+        def f(a, b):
+            return a + b
+
+        out = f(a=ra_a.view("a"), b=ra_b.view("b"))
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (3, 2)   # cartesian product
+
+    def test_view_plus_plain_ra_products(self, numeric_ra):
+        """A view and an independent ``RecordArray`` are in different
+        groups (the view's parent ≠ the independent RA) → product."""
+        other = NumericRecordArray.stack(
+            [NumericRecord(z=float(k * 100)) for k in range(2)]
+        )
+
+        @workflow_function
+        def f(x, p):
+            return x + p["z"]
+
+        out = f(x=numeric_ra.view("x"), p=other)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (4, 2)
+
+    def test_three_views_same_parent_zip_to_single_axis(self):
+        """A 3-field NumericRecordArray with three sibling views
+        collapses to one (n,) axis, not (n, n, n)."""
+        ra = NumericRecordArray.stack(
+            [NumericRecord(a=float(i), b=float(i * 2), c=float(i * 10))
+             for i in range(5)]
+        )
+
+        @workflow_function
+        def g(a, b, c):
+            return a + b + c
+
+        out = g(a=ra.view("a"), b=ra.view("b"), c=ra.view("c"))
+        assert out.batch_shape == (5,)
+        # Row i: i + 2i + 10i = 13i
+        np.testing.assert_allclose(
+            np.asarray(out["g"]),
+            [0.0, 13.0, 26.0, 39.0, 52.0],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pattern A ≡ Pattern B on Designs
+# ---------------------------------------------------------------------------
+
+
+class TestPatternParity:
+    """``Design.select_all()`` returns sibling views — splatting them
+    through a ``WorkflowFunction`` produces the same output as passing
+    the whole Design as a single ``Record``-typed arg."""
+
+    def test_parity_on_full_factorial(self):
+        ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
+
+        @workflow_function
+        def fit_a(p: NumericRecord):
+            return p["r"] * p["K"]
+
+        @workflow_function
+        def fit_b(r, K):
+            return r * K
+
+        out_a = fit_a(p=ff)
+        out_b = fit_b(**ff.select_all())
+        assert out_a.batch_shape == out_b.batch_shape == (6,)
+        np.testing.assert_allclose(
+            np.asarray(out_a["fit_a"]),
+            np.asarray(out_b["fit_b"]),
+        )
+
+    def test_parity_on_mixed_fields(self):
+        """Works with mixed numeric/categorical marginals too."""
+        ff = FullFactorialDesign(
+            method=["nutpie", "pymc"], scale=[0.5, 1.0],
+        )
+
+        @workflow_function
+        def label_a(p: Record):
+            return f'{p["method"]}-{float(p["scale"]):.1f}'
+
+        @workflow_function
+        def label_b(method, scale):
+            return f'{method}-{float(scale):.1f}'
+
+        out_a = label_a(p=ff)
+        out_b = label_b(**ff.select_all())
+        assert out_a.batch_shape == out_b.batch_shape == (4,)
+        assert list(out_a["label_a"]) == list(out_b["label_b"])
+
+    def test_select_all_returns_views(self):
+        ff = FullFactorialDesign(r=[1.5, 1.8], K=[60.0, 80.0])
+        cols = ff.select_all()
+        # Sibling views — share the Design as their parent.
+        assert all(isinstance(v, _RecordArrayView) for v in cols.values())
+        assert all(v.parent is ff for v in cols.values())
+
+
+# ---------------------------------------------------------------------------
+# Raw-column behaviour stays unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestRawColumnsUnchanged:
+    """Raw columns (``ra["field"]``) carry no parent-identity signal,
+    so two raw columns from the same RA behave as **independent**
+    arrays in a WF call — JAX broadcasts the body once and the result
+    is a single ``NumericRecord``, not a per-cell sweep."""
+
+    def test_raw_columns_go_through_body_once(self, numeric_ra):
+        @workflow_function
+        def f(x, y):
+            return x + y
+
+        out = f(x=numeric_ra["x"], y=numeric_ra["y"])
+        # Raw arrays aren't sweep sources under the scaled-back contract;
+        # body runs once with full columns and JAX broadcasts.
+        assert isinstance(out, NumericRecord)
+        assert out["f"].shape == (4,)
+
+
+# ---------------------------------------------------------------------------
+# Composition with DistributionArray and Distribution args
+# ---------------------------------------------------------------------------
+
+
+class TestMixedGroupingComposition:
+    """Views + ``DistributionArray`` + ``Distribution`` args compose:
+    within-parent views zip, distinct-parent array args product, and
+    Distribution args MC-marginalise per outer cell (nested regime)."""
+
+    def test_view_plus_distribution_array(self, numeric_ra):
+        """A view group (zip on (4,)) crossed with a
+        ``DistributionArray`` of shape (2,) products to batch (4, 2).
+        Each cell sees scalar ``x`` and one component Distribution
+        (``d``), so the inner body can call ``d.mean()``-style ops."""
+        from probpipe import mean
+        da = DistributionArray(
+            [Normal(loc=float(i), scale=1.0, name=f"n{i}") for i in range(2)],
+        )
+
+        @workflow_function
+        def f(x, d):
+            # d is a scalar Distribution per cell — add x to its mean.
+            return x + float(d._mean())
+
+        out = f(x=numeric_ra.view("x"), d=da)
+        assert isinstance(out, NumericRecordArray)
+        assert out.batch_shape == (4, 2)
+
+    def test_view_plus_scalar_distribution_nested(self, numeric_ra):
+        """View sweep + scalar Distribution arg (in a scalar slot) →
+        nested regime: outer stack over view, inner MC-marginalise.
+        Output is a DistributionArray of (4,) per-row marginals."""
+        noise = Normal(loc=0.0, scale=0.1, name="noise")
+
+        @workflow_function(n_broadcast_samples=20, vectorize="loop")
+        def f(x, noise: float):
+            return x + noise
+
+        out = f(x=numeric_ra.view("x"), noise=noise)
+        assert isinstance(out, DistributionArray)
+        assert out.batch_shape == (4,)


### PR DESCRIPTION
Makes Pattern A (`f(p=design)`) and Pattern B (`f(**design.select_all())`) produce identical sweep outputs, via a scaled-back form of the view contract discussed in #138.

## What changes

- **New `_RecordArrayView` class** (`probpipe/core/_record_array.py`). A single-field `RecordArray` subclass that aliases one column from a parent RA and carries the parent reference as shared-identity metadata. Minimal surface — conversion (`__array__` / `__jax_array__`), introspection (`.shape` / `.dtype` / `.ndim`), indexing, iteration, `len()`, plus `.parent` / `.field`. No operator forwarding, no array-reduction shims — users `jnp.asarray(view)` before arithmetic, consistent with the existing `NumericRecord` single-field-shim policy.

- **`RecordArray.view(field)`** accessor — opt-in construction of a view. `ra["field"]` itself still returns the raw column.

- **`Design.select_all()`** now returns views (`self.view(f)` for each field).

- **WF sweep grouping** (`probpipe/core/node.py`). `_broadcast` groups array-valued sweep args by parent identity: views sharing a parent form one group and iterate in lockstep (zip); distinct parents (independent `RecordArray`s, independent `DistributionArray`s, views from different parents) each form their own group and product across the sweep. Within-group shape mismatches raise.

## What this buys

```python
ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])

# Pattern A — single Record-typed arg
@workflow_function
def fit_a(p: NumericRecord):
    return p["r"] * p["K"]
out_a = fit_a(p=ff)                 # NumericRecordArray, batch=(6,)

# Pattern B — splat via select_all
@workflow_function
def fit_b(r, K):
    return r * K
out_b = fit_b(**ff.select_all())    # NumericRecordArray, batch=(6,)

# Identical output — parent-identity grouping zips the two views.
assert out_a.batch_shape == out_b.batch_shape == (6,)
```

Independent array args still cartesian-product (no parent shared):

```python
ra_a = NumericRecordArray.stack([NumericRecord(a=float(i)) for i in range(3)])
ra_b = NumericRecordArray.stack([NumericRecord(b=float(j * 10)) for j in range(2)])

@workflow_function
def f(a, b): return a + b

out = f(a=ra_a.view("a"), b=ra_b.view("b"))     # batch=(3, 2) — cartesian
```

## Intentional non-change

`ra["field"]` still returns the raw column `jnp.ndarray`. The fuller version of the contract (views as default) would need ~31 test migrations and careful design around operator forwarding / `__getattr__` magic / multi-inheritance with `NumericRecordArray`. Tracked in #138 as an open design question — ship this narrower version first; flip the contract in a follow-up if/when we settle the open questions there.

## Tests

30 new tests in `tests/test_record_array_view.py`:

- **Construction + parent identity** (7 tests): `ra.view(f)` builds a view; alias semantics; unknown field raises; raw-column behaviour unchanged; mixed numeric/object fields.
- **Attribute forwarding** (10 tests): `.shape` / `.dtype` / `.ndim`; `jnp.asarray(view)` / `np.asarray(view)`; indexing / slicing / iteration / `len`; arithmetic requires explicit conversion (documents the policy).
- **Sweep grouping** (4 tests): two views same parent zip; two views different parents product; view + plain RA product; three sibling views collapse to single axis.
- **Pattern A ≡ Pattern B parity** (3 tests): numeric-only FullFactorialDesign; mixed numeric/categorical; `select_all()` returns views.
- **Raw columns stay independent** (1 test): `f(x=ra["x"], y=ra["y"])` runs body once with JAX broadcasting — no zip sweep, since raw columns carry no parent-identity signal.
- **Mixed composition** (2 tests): view + DistributionArray (product); view + scalar Distribution (nested regime).

Full suite: **2169 passed, 7 skipped, 0 failed** (was 2139; +30 new).

## Stack

Builds on PR #137 (Design hierarchy). Once #137 rebases onto main, this rebases cleanly on top of it.

## Related issues

- #138 — tracks the open design question: should `ra["field"]` return a view by default? Shipped this PR deliberately without the contract change; if we decide to flip, that's a separate follow-up PR.
