### PR TITLE
fix(core): resolve PEP 695 type params so probpipe imports on Python 3.12

### DIFF
--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -366,7 +366,14 @@ class WorkflowFunction(Node):
     ):
         self._func = func
         self._sig = inspect.signature(func)
-        self._hints = get_type_hints(func)
+        # PEP 695 type parameters (``def f[T](...)``) live on
+        # ``__type_params__`` and are not in the function's globals, so
+        # ``get_type_hints`` cannot resolve them when annotations are
+        # strings (PEP 563 / ``from __future__ import annotations``).
+        # Pass them through ``localns`` to avoid NameError on Python 3.12.
+        type_params = getattr(func, "__type_params__", ())
+        type_param_ns = {tp.__name__: tp for tp in type_params}
+        self._hints = get_type_hints(func, localns=type_param_ns or None)
         self._workflow_kind = workflow_kind
         self._name = name or getattr(func, "__name__", self.__class__.__name__)
 

--- a/tests/test_pep695_workflow.py
+++ b/tests/test_pep695_workflow.py
@@ -1,0 +1,60 @@
+"""Regression tests for PEP 695 generics in @workflow_function.
+
+PEP 695 ``def f[T](...)`` syntax stores type parameters on
+``func.__type_params__`` rather than injecting them into the function's
+globals. With ``from __future__ import annotations`` enabled, all
+annotations are lazy strings, so ``get_type_hints`` would raise
+``NameError: name 'T' is not defined`` on Python 3.12 unless the type
+parameters are passed through ``localns``.
+
+Python 3.13 fixed ``get_type_hints`` to consult ``__type_params__``
+automatically; these tests guard the 3.12 path.
+"""
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+from probpipe.core.node import WorkflowFunction, workflow_function
+
+
+_T = TypeVar("_T")
+
+
+class _Box(Generic[_T]):
+    def __init__(self, value: _T):
+        self.value = value
+
+
+def test_pep695_generic_function_can_be_wrapped():
+    """A PEP 695 generic function should wrap without NameError."""
+
+    @workflow_function
+    def identity[T](x: _Box[T]) -> _Box[T]:
+        return x
+
+    assert isinstance(identity, WorkflowFunction)
+    assert identity.__name__ == "identity"
+    # The hint for ``x`` should resolve to a parameterized _Box, not raise.
+    assert "x" in identity._hints
+    assert "return" in identity._hints
+
+
+def test_pep695_multiple_type_params():
+    """Multiple PEP 695 type parameters should all resolve."""
+
+    @workflow_function
+    def pair[T, S](a: _Box[T], b: _Box[S]) -> tuple[_Box[T], _Box[S]]:
+        return (a, b)
+
+    assert "a" in pair._hints
+    assert "b" in pair._hints
+    assert "return" in pair._hints
+
+
+def test_iterate_imports():
+    """``probpipe.iterate`` (declared with PEP 695 syntax) must import."""
+
+    from probpipe import iterate
+
+    assert iterate.__name__ == "iterate"


### PR DESCRIPTION
## Summary

Fixes a `NameError` that makes `import probpipe` fail outright on Python 3.12.

## Problem

`probpipe/core/transition.py` and `probpipe/validation/_predictive_check.py` declare functions with PEP 695 generic syntax and then wrap them with `@workflow_function`:

```python
# probpipe/core/transition.py
from __future__ import annotations

@workflow_function
def iterate[T, S](
    step_fn: Callable[[Distribution[T], S], Distribution[T]],
    initial: Distribution[T],
    inputs: Iterable[S],
    ...
) -> list[Distribution[T]]:
    ...
```

`WorkflowFunction.__init__` introspects the wrapped function with `get_type_hints(func)`. PEP 695 type parameters live on `func.__type_params__` rather than the function's globals; combined with `from __future__ import annotations`, `get_type_hints` evaluates `"Distribution[T]"` against the module globalns, fails to find `T`, and raises:

```
NameError: name 'T' is not defined
```

On **Python 3.12** this fires during package import, so any `import probpipe` raises immediately. **Python 3.13** patched `get_type_hints` to consult `__type_params__` automatically, which is why CI on 3.13 has not caught this.

`pyproject.toml` declares `requires-python = ">=3.12"`, so 3.12 users are blocked.

## Fix

Pass PEP 695 type parameters to `get_type_hints` via `localns` in [probpipe/core/node.py](probpipe/core/node.py):

```python
type_params = getattr(func, "__type_params__", ())
type_param_ns = {tp.__name__: tp for tp in type_params}
self._hints = get_type_hints(func, localns=type_param_ns or None)
```

This is the standard workaround for PEP 695 + PEP 563 interaction and is a no-op on 3.13+ (where `get_type_hints` already handles it).

## Test plan

- [x] Reproduce `NameError` on Python 3.12 with `python -c "import probpipe"` before fix.
- [x] After fix, `import probpipe` succeeds on Python 3.12 (verified in a fresh `python3.12 -m venv`).
- [x] New regression test `tests/test_pep695_workflow.py` wraps PEP 695 generic functions with `@workflow_function` under `from __future__ import annotations`. Passes on both 3.12 and 3.13; would fail on 3.12 without the fix.
- [x] Full existing test suite passes on Python 3.13 (`2102 passed, 8 skipped`).
