### PR TITLE
feat(dtype): honor JAX x64 mode across all distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **dtype handling** now follows JAX's rules. Distributions, weights, and
+  empirical classes preserve user-supplied dtypes and honor
+  ``jax.config.update("jax_enable_x64", True)`` end-to-end. Previously every
+  TFP-backed constructor silently downcast its parameters to ``float32``,
+  causing ``log_prob`` / ``sample`` / ``mean`` to raise ``TypeError`` under
+  x64. Multi-parameter constructors now promote inputs to a common float
+  dtype via ``jnp.result_type`` (integer inputs are promoted to JAX's
+  default float, so ``Normal(loc=0, scale=1)`` still works). Internal
+  helpers ``_default_float_dtype()`` and ``_promote_floats()`` live in
+  ``probpipe/_dtype.py``. The float64-truncation warning filter previously
+  in ``probpipe/__init__.py`` is removed.
+
 ### Added
 
 - **`_RecordArrayView`** (`RecordArray.view(field)`) — single-field view of a

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ x = jax.random.normal(jax.random.PRNGKey(0), shape=(200,))
 X = jnp.column_stack([jnp.ones_like(x), x])
 
 likelihood = GLMLikelihood(tfp_glm.Bernoulli(), X, seed=1)
-y = likelihood.generate_data(beta_true, 200).astype(jnp.float32)
+y = likelihood.generate_data(beta_true, 200)
 
 # --- 1. Build a model with named parameters ---
 prior = ProductDistribution(

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -5,14 +5,8 @@ __version__ = _version("probpipe")
 
 # Suppress known TFP-internal warnings that are harmless but noisy.
 # These are upstream issues in tfp-nightly's JAX substrate:
-#   - float64 requests truncated to float32 (TFP internals assume x64)
 #   - deprecated jax.interpreters.xla API usage
 #   - np.shape(None) deprecation in random generators
-_warnings.filterwarnings(
-    "ignore",
-    message=r"Explicitly requested dtype.*float64.*",
-    category=UserWarning,
-)
 _warnings.filterwarnings(
     "ignore",
     message=r"jax\.interpreters\.xla\.pytype_aval_mappings is deprecated",

--- a/probpipe/_dtype.py
+++ b/probpipe/_dtype.py
@@ -1,0 +1,49 @@
+"""dtype helpers for ProbPipe.
+
+ProbPipe follows JAX's dtype rules: the default float dtype is whatever
+``jnp.zeros(()).dtype`` returns (``float32`` normally, ``float64`` when
+``jax.config.jax_enable_x64`` is set). Users opt into float64 either
+globally via JAX's x64 flag, or per-distribution by passing parameters
+that already carry float64 dtype.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from .custom_types import Array, ArrayLike
+
+
+def _default_float_dtype() -> jnp.dtype:
+    """Return JAX's current default float dtype.
+
+    Honors ``jax.config.jax_enable_x64`` automatically.
+    """
+    return jnp.zeros((), dtype=float).dtype
+
+
+def _promote_floats(*xs: ArrayLike) -> tuple[jnp.dtype, list[Array]]:
+    """Convert each input to an array, promote to a common float dtype.
+
+    Returns the chosen dtype and the list of converted arrays. Inputs
+    are first converted via ``jnp.asarray`` (preserving any explicit
+    dtype the user provided), then promoted via ``jnp.result_type``.
+    Integer-only inputs are promoted to JAX's default float dtype, so
+    e.g. ``Normal(loc=0, scale=1)`` works as expected.
+    """
+    arrs = [jnp.asarray(x) for x in xs]
+    dtype = jnp.result_type(*[a.dtype for a in arrs])
+    if not jnp.issubdtype(dtype, jnp.floating):
+        dtype = jnp.result_type(dtype, _default_float_dtype())
+    return dtype, [a.astype(dtype) for a in arrs]
+
+
+def _as_float_array(x: ArrayLike) -> Array:
+    """Convert *x* to an array, promoting integer inputs to float.
+
+    Single-input variant of :func:`_promote_floats`.
+    """
+    arr = jnp.asarray(x)
+    if not jnp.issubdtype(arr.dtype, jnp.floating):
+        arr = arr.astype(_default_float_dtype())
+    return arr

--- a/probpipe/_weights.py
+++ b/probpipe/_weights.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 
+from ._dtype import _as_float_array, _default_float_dtype
 from .custom_types import Array, ArrayLike, PRNGKey
 
 __all__ = [
@@ -56,7 +57,7 @@ def _validate_to_log_weights(
         raise ValueError("Provide either weights or log_weights, not both.")
 
     if weights is not None:
-        weights = jnp.asarray(weights, dtype=jnp.float32)
+        weights = _as_float_array(weights)
         if weights.shape != (n,):
             raise ValueError(
                 f"weights shape {weights.shape} does not match "
@@ -70,7 +71,7 @@ def _validate_to_log_weights(
         return jnp.log(weights), False
 
     if log_weights is not None:
-        log_weights = jnp.asarray(log_weights, dtype=jnp.float32)
+        log_weights = _as_float_array(log_weights)
         if log_weights.shape != (n,):
             raise ValueError(
                 f"log_weights shape {log_weights.shape} does not match "
@@ -98,9 +99,14 @@ def normalized_log_weights(log_weights: Array) -> Array:
     return jax.nn.log_softmax(log_weights)
 
 
-def uniform_weights(n: int) -> Array:
-    """Return uniform weight vector of length *n*."""
-    return jnp.ones(n, dtype=jnp.float32) / n
+def uniform_weights(n: int, dtype: jnp.dtype | None = None) -> Array:
+    """Return uniform weight vector of length *n*.
+
+    *dtype* defaults to JAX's current default float dtype.
+    """
+    if dtype is None:
+        dtype = _default_float_dtype()
+    return jnp.ones(n, dtype=dtype) / n
 
 
 def weighted_mean(weights: Array | None, values: Array) -> Array:
@@ -356,12 +362,12 @@ class Weights:
         # Infer n from array length when not given explicitly.
         if n is None:
             if weights is not None:
-                weights = jnp.asarray(weights, dtype=jnp.float32)
+                weights = _as_float_array(weights)
                 if weights.ndim != 1 or weights.shape[0] == 0:
                     raise ValueError("weights must be a non-empty 1-D array.")
                 n = weights.shape[0]
             elif log_weights is not None:
-                log_weights = jnp.asarray(log_weights, dtype=jnp.float32)
+                log_weights = _as_float_array(log_weights)
                 if log_weights.ndim != 1 or log_weights.shape[0] == 0:
                     raise ValueError("log_weights must be a non-empty 1-D array.")
                 n = log_weights.shape[0]
@@ -474,8 +480,13 @@ class Weights:
 
     @property
     def dtype(self) -> jnp.dtype:
-        """Data type: always ``float32``."""
-        return jnp.float32
+        """Data type of the underlying log-weights array.
+
+        For uniform weights, returns JAX's current default float dtype.
+        """
+        if self._log_weights is not None:
+            return self._log_weights.dtype
+        return _default_float_dtype()
 
     def __len__(self) -> int:
         return self._n

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -380,7 +380,7 @@ def _make_marginal(
                 pass
         try:
             stacked = jnp.stack(
-                [jnp.asarray(r, dtype=jnp.float32) for r in output_samples], axis=0
+                [jnp.asarray(r) for r in output_samples], axis=0
             )
             return _ArrayMarginal(stacked, weights, name=name)
         except (ValueError, TypeError):
@@ -391,7 +391,7 @@ def _make_marginal(
         return _ListMarginal(output_samples, weights, name=name)
 
     # Single array result (e.g., from vmap); ensure at least 1D for the sample axis
-    arr = jnp.atleast_1d(jnp.asarray(output_samples, dtype=jnp.float32))
+    arr = jnp.atleast_1d(jnp.asarray(output_samples))
     return _ArrayMarginal(arr, weights, name=name)
 
 

--- a/probpipe/core/_empirical.py
+++ b/probpipe/core/_empirical.py
@@ -29,6 +29,7 @@ import jax
 import jax.numpy as jnp
 
 from ..custom_types import Array, ArrayLike, PRNGKey
+from .._dtype import _as_float_array
 from .._weights import Weights, weighted_mean
 from .constraints import Constraint, real
 from . import _distribution_base as _base
@@ -279,7 +280,7 @@ class NumericEmpiricalDistribution(
         name: str | None = None,
     ):
         # Store only the JAX array — bypass the generic base's storage.
-        self._samples = jnp.asarray(samples, dtype=jnp.float32)
+        self._samples = _as_float_array(samples)
         if self._samples.ndim == 0:
             raise ValueError("samples must have at least 1 dimension (the sample axis).")
 
@@ -699,12 +700,12 @@ class ArrayBootstrapReplicateDistribution(BootstrapReplicateDistribution[Array],
     ):
         # Coerce to JAX array, then let the generic base store it.
         if isinstance(source, EmpiricalDistribution):
-            jax_data = jnp.asarray(list(source.samples), dtype=jnp.float32)
+            jax_data = _as_float_array(list(source.samples))
             self._data = jax_data
             self._w = source._w
             default_n = source.n
         else:
-            jax_data = jnp.asarray(source, dtype=jnp.float32)
+            jax_data = _as_float_array(source)
             if jax_data.ndim == 0:
                 raise ValueError("source must have at least 1 dimension (the observation axis).")
             self._data = jax_data

--- a/probpipe/core/_numeric_record_distribution.py
+++ b/probpipe/core/_numeric_record_distribution.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Any, Callable
 
+from .._dtype import _as_float_array, _default_float_dtype
 from .._utils import prod
 from .protocols import (
     SupportsExpectation,
@@ -162,10 +163,16 @@ class NumericRecordDistribution(RecordDistribution):
 
     @property
     def dtypes(self) -> dict[str, jnp.dtype]:
-        """Per-field dtypes.  Default: ``float32`` for every field."""
+        """Per-field dtypes.
+
+        Default: JAX's current default float dtype (``float32`` normally,
+        ``float64`` when ``jax_enable_x64`` is set).  Subclasses with
+        concrete arrays should override to report the actual dtype.
+        """
         tpl = self.record_template
         if tpl is not None:
-            return {name: jnp.float32 for name in tpl.fields}
+            default = _default_float_dtype()
+            return {name: default for name in tpl.fields}
         return {}
 
     @property
@@ -349,7 +356,7 @@ class BootstrapDistribution(NumericRecordDistribution, SupportsSampling, Support
         log_weights: ArrayLike | Weights | None = None,
         name: str | None = None,
     ):
-        self._evaluations = jnp.asarray(evaluations, dtype=jnp.float32)
+        self._evaluations = _as_float_array(evaluations)
         if self._evaluations.ndim == 0:
             raise ValueError("evaluations must have at least 1 dimension.")
         self._n = self._evaluations.shape[0]
@@ -374,6 +381,10 @@ class BootstrapDistribution(NumericRecordDistribution, SupportsSampling, Support
     @property
     def event_shape(self) -> tuple[int, ...]:
         return self._evaluations.shape[1:]
+
+    @property
+    def dtype(self) -> jnp.dtype:
+        return self._evaluations.dtype
 
     def _mean(self) -> Array:
         """Point estimate: (weighted) mean of evaluations."""

--- a/probpipe/core/_random_functions.py
+++ b/probpipe/core/_random_functions.py
@@ -168,7 +168,7 @@ class ArrayRandomFunction(RandomFunction[Array, Array]):
             A distribution whose ``batch_shape`` and ``event_shape`` follow
             the shape table in the class docstring.
         """
-        X = jnp.asarray(X, dtype=jnp.float32)
+        X = jnp.asarray(X)
         self._validate_joint_request(joint_inputs, joint_outputs)
         self._validate_X(X)
         return self.predict(X, joint_inputs=joint_inputs, joint_outputs=joint_outputs)

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -747,7 +747,10 @@ class WorkflowFunction(Node):
                     else:
                         dist = v
                         es = dist.event_shape
-                        dummy_kw[name] = jnp.zeros(es) if es else jnp.zeros(())
+                        # Match the distribution's own dtype so the probe
+                        # mirrors what the inner function actually sees.
+                        dt = getattr(dist, "dtype", None) or jnp.zeros((), dtype=float).dtype
+                        dummy_kw[name] = jnp.zeros(es, dtype=dt) if es else jnp.zeros((), dtype=dt)
                 elif name in values:
                     v = values[name]
                     if isinstance(v, jnp.ndarray):

--- a/probpipe/distributions/_joint_empirical.py
+++ b/probpipe/distributions/_joint_empirical.py
@@ -24,6 +24,7 @@ from typing import Any
 
 import jax.numpy as jnp
 import numpy as np
+from .._dtype import _as_float_array
 from .._utils import prod, _is_numeric_array
 
 from ..custom_types import Array, ArrayLike, PRNGKey
@@ -292,8 +293,10 @@ class NumericJointEmpirical(JointEmpirical, SupportsLogProb, SupportsMean, Suppo
     Gaussian approximation), :class:`~probpipe.core.protocols.SupportsMean`,
     and :class:`~probpipe.core.protocols.SupportsVariance`.
 
-    Construction coerces every field to ``jnp.float32``; fields that
-    aren't numeric arrays raise ``TypeError``. Typically constructed via
+    Construction coerces every field to a floating-point JAX array
+    (preserving ``float64`` when JAX's x64 mode is enabled, otherwise
+    promoting integer inputs to ``float32``); fields that aren't
+    numeric arrays raise ``TypeError``. Typically constructed via
     :class:`JointEmpirical`, which dispatches here automatically when all
     fields are numeric.
     """
@@ -312,8 +315,8 @@ class NumericJointEmpirical(JointEmpirical, SupportsLogProb, SupportsMean, Suppo
         if not samples:
             raise ValueError("NumericJointEmpirical requires at least one component.")
 
-        # Coerce every field to jnp.float32 up front. Non-numeric inputs
-        # raise ``TypeError`` with a clear message before any bookkeeping.
+        # Coerce every field to a floating-point JAX array up front.
+        # Non-numeric inputs raise ``TypeError`` with a clear message.
         coerced: dict[str, Array] = {}
         for cname, arr in samples.items():
             if not _is_numeric_array(arr):
@@ -322,7 +325,7 @@ class NumericJointEmpirical(JointEmpirical, SupportsLogProb, SupportsMean, Suppo
                     f"numeric array, got {type(arr).__name__}. Use "
                     f"JointEmpirical directly for non-numeric components."
                 )
-            coerced[cname] = jnp.asarray(arr, dtype=jnp.float32)
+            coerced[cname] = _as_float_array(arr)
 
         super().__init__(
             weights=weights, log_weights=log_weights, name=name, **coerced,

--- a/probpipe/distributions/_joint_gaussian.py
+++ b/probpipe/distributions/_joint_gaussian.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 
 import jax
 import jax.numpy as jnp
+from .._dtype import _as_float_array, _promote_floats
 from .._utils import prod
 
 from ..custom_types import Array, ArrayLike, PRNGKey
@@ -75,8 +76,7 @@ class JointGaussian(RecordDistribution, SupportsSampling, SupportsLogProb, Suppo
         if not component_shapes:
             raise ValueError("JointGaussian requires at least one component.")
 
-        mean = jnp.asarray(mean, dtype=jnp.float32)
-        cov = jnp.asarray(cov, dtype=jnp.float32)
+        _, (mean, cov) = _promote_floats(mean, cov)
 
         total_dim = sum(component_shapes.values())
         if mean.shape != (total_dim,):
@@ -255,7 +255,7 @@ class JointGaussian(RecordDistribution, SupportsSampling, SupportsLogProb, Suppo
         for cname in self._component_shapes:
             if cname in observed:
                 o_vals_parts.append(
-                    jnp.asarray(observed[cname], dtype=jnp.float32).reshape(-1)
+                    jnp.asarray(observed[cname], dtype=self._mean_vec.dtype).reshape(-1)
                 )
         o_vals = jnp.concatenate(o_vals_parts)
 

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -415,7 +415,7 @@ class SequentialJointDistribution(RecordDistribution, SupportsSampling, Supports
         result._conditioned_names = all_conditioned
         result._conditioned_values = {
             **self._conditioned_values,
-            **{k: jnp.asarray(v, dtype=jnp.float32) for k, v in observed.items()},
+            **{k: jnp.asarray(v) for k, v in observed.items()},
         }
         result._sampleable_error = self._compute_sampleable_error(
             result._conditioned_names, result._callable_parents,

--- a/probpipe/distributions/continuous.py
+++ b/probpipe/distributions/continuous.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from ._tfp_base import TFPDistribution
+from .._dtype import _as_float_array, _promote_floats
 from ..core.distribution import (
     NumericRecordDistribution,
     EmpiricalDistribution,
@@ -70,8 +71,7 @@ class Normal(TFPDistribution):
         *,
         name: str,
     ):
-        self._loc = jnp.asarray(loc, dtype=jnp.float32)
-        self._scale = jnp.asarray(scale, dtype=jnp.float32)
+        _, (self._loc, self._scale) = _promote_floats(loc, scale)
         self._tfp_dist = tfd.Normal(loc=self._loc, scale=self._scale)
         super().__init__(name=name)
 
@@ -118,8 +118,7 @@ class Beta(TFPDistribution):
         *,
         name: str,
     ):
-        self._alpha = jnp.asarray(alpha, dtype=jnp.float32)
-        self._beta = jnp.asarray(beta, dtype=jnp.float32)
+        _, (self._alpha, self._beta) = _promote_floats(alpha, beta)
         self._tfp_dist = tfd.Beta(concentration1=self._alpha, concentration0=self._beta)
         super().__init__(name=name)
 
@@ -166,8 +165,7 @@ class Gamma(TFPDistribution):
         *,
         name: str,
     ):
-        self._concentration = jnp.asarray(concentration, dtype=jnp.float32)
-        self._rate = jnp.asarray(rate, dtype=jnp.float32)
+        _, (self._concentration, self._rate) = _promote_floats(concentration, rate)
         self._tfp_dist = tfd.Gamma(concentration=self._concentration, rate=self._rate)
         super().__init__(name=name)
 
@@ -214,8 +212,7 @@ class InverseGamma(TFPDistribution):
         *,
         name: str,
     ):
-        self._concentration = jnp.asarray(concentration, dtype=jnp.float32)
-        self._scale = jnp.asarray(scale, dtype=jnp.float32)
+        _, (self._concentration, self._scale) = _promote_floats(concentration, scale)
         self._tfp_dist = tfd.InverseGamma(
             concentration=self._concentration, scale=self._scale
         )
@@ -261,7 +258,7 @@ class Exponential(TFPDistribution):
         *,
         name: str,
     ):
-        self._rate = jnp.asarray(rate, dtype=jnp.float32)
+        self._rate = _as_float_array(rate)
         self._tfp_dist = tfd.Exponential(rate=self._rate)
         super().__init__(name=name)
 
@@ -304,8 +301,7 @@ class LogNormal(TFPDistribution):
         *,
         name: str,
     ):
-        self._loc = jnp.asarray(loc, dtype=jnp.float32)
-        self._scale = jnp.asarray(scale, dtype=jnp.float32)
+        _, (self._loc, self._scale) = _promote_floats(loc, scale)
         self._tfp_dist = tfd.LogNormal(loc=self._loc, scale=self._scale)
         super().__init__(name=name)
 
@@ -355,9 +351,7 @@ class StudentT(TFPDistribution):
         *,
         name: str,
     ):
-        self._df = jnp.asarray(df, dtype=jnp.float32)
-        self._loc = jnp.asarray(loc, dtype=jnp.float32)
-        self._scale = jnp.asarray(scale, dtype=jnp.float32)
+        _, (self._df, self._loc, self._scale) = _promote_floats(df, loc, scale)
         self._tfp_dist = tfd.StudentT(df=self._df, loc=self._loc, scale=self._scale)
         super().__init__(name=name)
 
@@ -408,8 +402,7 @@ class Uniform(TFPDistribution):
         *,
         name: str,
     ):
-        self._low = jnp.asarray(low, dtype=jnp.float32)
-        self._high = jnp.asarray(high, dtype=jnp.float32)
+        _, (self._low, self._high) = _promote_floats(low, high)
         self._tfp_dist = tfd.Uniform(low=self._low, high=self._high)
         super().__init__(name=name)
 
@@ -456,8 +449,7 @@ class Cauchy(TFPDistribution):
         *,
         name: str,
     ):
-        self._loc = jnp.asarray(loc, dtype=jnp.float32)
-        self._scale = jnp.asarray(scale, dtype=jnp.float32)
+        _, (self._loc, self._scale) = _promote_floats(loc, scale)
         self._tfp_dist = tfd.Cauchy(loc=self._loc, scale=self._scale)
         super().__init__(name=name)
 
@@ -504,8 +496,7 @@ class Laplace(TFPDistribution):
         *,
         name: str,
     ):
-        self._loc = jnp.asarray(loc, dtype=jnp.float32)
-        self._scale = jnp.asarray(scale, dtype=jnp.float32)
+        _, (self._loc, self._scale) = _promote_floats(loc, scale)
         self._tfp_dist = tfd.Laplace(loc=self._loc, scale=self._scale)
         super().__init__(name=name)
 
@@ -549,7 +540,7 @@ class HalfNormal(TFPDistribution):
         *,
         name: str,
     ):
-        self._scale = jnp.asarray(scale, dtype=jnp.float32)
+        self._scale = _as_float_array(scale)
         self._tfp_dist = tfd.HalfNormal(scale=self._scale)
         super().__init__(name=name)
 
@@ -592,8 +583,7 @@ class HalfCauchy(TFPDistribution):
         *,
         name: str,
     ):
-        self._loc = jnp.asarray(loc, dtype=jnp.float32)
-        self._scale = jnp.asarray(scale, dtype=jnp.float32)
+        _, (self._loc, self._scale) = _promote_floats(loc, scale)
         self._tfp_dist = tfd.HalfCauchy(loc=self._loc, scale=self._scale)
         super().__init__(name=name)
 
@@ -640,8 +630,7 @@ class Pareto(TFPDistribution):
         *,
         name: str,
     ):
-        self._concentration = jnp.asarray(concentration, dtype=jnp.float32)
-        self._scale = jnp.asarray(scale, dtype=jnp.float32)
+        _, (self._concentration, self._scale) = _promote_floats(concentration, scale)
         self._tfp_dist = tfd.Pareto(
             concentration=self._concentration, scale=self._scale
         )
@@ -696,10 +685,9 @@ class TruncatedNormal(TFPDistribution):
         *,
         name: str,
     ):
-        self._loc = jnp.asarray(loc, dtype=jnp.float32)
-        self._scale = jnp.asarray(scale, dtype=jnp.float32)
-        self._low = jnp.asarray(low, dtype=jnp.float32)
-        self._high = jnp.asarray(high, dtype=jnp.float32)
+        _, (self._loc, self._scale, self._low, self._high) = _promote_floats(
+            loc, scale, low, high
+        )
         self._tfp_dist = tfd.TruncatedNormal(
             loc=self._loc, scale=self._scale, low=self._low, high=self._high
         )

--- a/probpipe/distributions/discrete.py
+++ b/probpipe/distributions/discrete.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from ._tfp_base import TFPDistribution
+from .._dtype import _as_float_array, _promote_floats
 from .._utils import _auto_key
 from ..core.distribution import (
     NumericRecordDistribution,
@@ -59,11 +60,11 @@ class Bernoulli(TFPDistribution):
         if (probs is None) == (logits is None):
             raise ValueError("Exactly one of probs or logits must be provided.")
         if probs is not None:
-            self._probs = jnp.asarray(probs, dtype=jnp.float32)
+            self._probs = _as_float_array(probs)
             self._logits = None
             self._tfp_dist = tfd.Bernoulli(probs=self._probs)
         else:
-            self._logits = jnp.asarray(logits, dtype=jnp.float32)
+            self._logits = _as_float_array(logits)
             self._probs = None
             self._tfp_dist = tfd.Bernoulli(logits=self._logits)
         super().__init__(name=name)
@@ -133,15 +134,14 @@ class Binomial(TFPDistribution):
     ):
         if (probs is None) == (logits is None):
             raise ValueError("Exactly one of probs or logits must be provided.")
-        self._total_count = jnp.asarray(total_count, dtype=jnp.float32)
         if probs is not None:
-            self._probs = jnp.asarray(probs, dtype=jnp.float32)
+            _, (self._total_count, self._probs) = _promote_floats(total_count, probs)
             self._logits = None
             self._tfp_dist = tfd.Binomial(
                 total_count=self._total_count, probs=self._probs
             )
         else:
-            self._logits = jnp.asarray(logits, dtype=jnp.float32)
+            _, (self._total_count, self._logits) = _promote_floats(total_count, logits)
             self._probs = None
             self._tfp_dist = tfd.Binomial(
                 total_count=self._total_count, logits=self._logits
@@ -209,7 +209,7 @@ class Poisson(TFPDistribution):
         *,
         name: str,
     ):
-        self._rate = jnp.asarray(rate, dtype=jnp.float32)
+        self._rate = _as_float_array(rate)
         self._tfp_dist = tfd.Poisson(rate=self._rate)
         super().__init__(name=name)
 
@@ -256,11 +256,11 @@ class Categorical(TFPDistribution):
         if (probs is None) == (logits is None):
             raise ValueError("Exactly one of probs or logits must be provided.")
         if probs is not None:
-            self._probs = jnp.asarray(probs, dtype=jnp.float32)
+            self._probs = _as_float_array(probs)
             self._logits = None
             self._tfp_dist = tfd.Categorical(probs=self._probs)
         else:
-            self._logits = jnp.asarray(logits, dtype=jnp.float32)
+            self._logits = _as_float_array(logits)
             self._probs = None
             self._tfp_dist = tfd.Categorical(logits=self._logits)
         super().__init__(name=name)
@@ -331,15 +331,14 @@ class NegativeBinomial(TFPDistribution):
     ):
         if (probs is None) == (logits is None):
             raise ValueError("Exactly one of probs or logits must be provided.")
-        self._total_count = jnp.asarray(total_count, dtype=jnp.float32)
         if probs is not None:
-            self._probs = jnp.asarray(probs, dtype=jnp.float32)
+            _, (self._total_count, self._probs) = _promote_floats(total_count, probs)
             self._logits = None
             self._tfp_dist = tfd.NegativeBinomial(
                 total_count=self._total_count, probs=self._probs
             )
         else:
-            self._logits = jnp.asarray(logits, dtype=jnp.float32)
+            _, (self._total_count, self._logits) = _promote_floats(total_count, logits)
             self._probs = None
             self._tfp_dist = tfd.NegativeBinomial(
                 total_count=self._total_count, logits=self._logits

--- a/probpipe/distributions/gaussian_random_function.py
+++ b/probpipe/distributions/gaussian_random_function.py
@@ -137,31 +137,31 @@ class GaussianRandomFunction(ArrayRandomFunction):
         *other* must be a 2-D array of shape ``(d_out, d_w)`` and
         ``self.output_shape`` must be 1-D ``(d_w,)``.
         """
-        return _LinearMapGRF(self, jnp.asarray(other, dtype=jnp.float32))
+        return _LinearMapGRF(self, jnp.asarray(other))
 
     def __add__(self, other):
         if isinstance(other, GaussianRandomFunction):
             return _IndependentSumGRF(self, other)
-        return _ShiftedGRF(self, jnp.asarray(other, dtype=jnp.float32))
+        return _ShiftedGRF(self, jnp.asarray(other))
 
     def __radd__(self, other):
         if isinstance(other, GaussianRandomFunction):
             return _IndependentSumGRF(other, self)
-        return _ShiftedGRF(self, jnp.asarray(other, dtype=jnp.float32))
+        return _ShiftedGRF(self, jnp.asarray(other))
 
     def __mul__(self, other):
-        return _ScaledGRF(self, jnp.asarray(other, dtype=jnp.float32))
+        return _ScaledGRF(self, jnp.asarray(other))
 
     def __rmul__(self, other):
-        return _ScaledGRF(self, jnp.asarray(other, dtype=jnp.float32))
+        return _ScaledGRF(self, jnp.asarray(other))
 
     def __neg__(self):
-        return _ScaledGRF(self, jnp.float32(-1.0))
+        return _ScaledGRF(self, -1.0)
 
     def __sub__(self, other):
         if isinstance(other, GaussianRandomFunction):
             return self + (-other)
-        return _ShiftedGRF(self, -jnp.asarray(other, dtype=jnp.float32))
+        return _ShiftedGRF(self, -jnp.asarray(other))
 
     def __rsub__(self, other):
         return (-self) + other
@@ -302,12 +302,14 @@ class LinearBasisFunction(GaussianRandomFunction, SupportsSampling):
         self._w_mean = weights.loc          # (d_w,)
         self._w_cov = weights.cov           # (d_w, d_w)
 
+        # Bias inherits dtype from the weight distribution.
+        bias_dtype = self._w_mean.dtype
         if bias is not None:
-            self._bias = jnp.asarray(bias, dtype=jnp.float32)
+            self._bias = jnp.asarray(bias, dtype=bias_dtype)
         elif output_shape:
-            self._bias = jnp.zeros(output_shape, dtype=jnp.float32)
+            self._bias = jnp.zeros(output_shape, dtype=bias_dtype)
         else:
-            self._bias = jnp.float32(0.0)
+            self._bias = jnp.zeros((), dtype=bias_dtype)
 
         super().__init__(input_shape=input_shape, output_shape=output_shape)
 
@@ -405,8 +407,7 @@ class LinearBasisFunction(GaussianRandomFunction, SupportsSampling):
             w = self._weights._sample(key)  # (d_w,)
 
             def f_one(X: ArrayLike) -> Array:
-                X = jnp.asarray(X, dtype=jnp.float32)
-                phi = feature_map(X)  # (*eb, n, [*out,] d_w)
+                phi = feature_map(jnp.asarray(X))  # (*eb, n, [*out,] d_w)
                 return bias + jnp.einsum("...w,w->...", phi, w)
 
             return f_one
@@ -417,7 +418,7 @@ class LinearBasisFunction(GaussianRandomFunction, SupportsSampling):
         reshape_to = sample_shape
 
         def f(X: ArrayLike) -> Array:
-            X = jnp.asarray(X, dtype=jnp.float32)
+            X = jnp.asarray(X)
             phi = feature_map(X)  # (*eb, n_pts, [*out,] d_w)
             # w_samples: (n_samples, d_w), phi: (*eb, n_pts, [*out,] d_w)
             # result: (n_samples, *eb, n_pts, [*out])

--- a/probpipe/distributions/kde.py
+++ b/probpipe/distributions/kde.py
@@ -13,6 +13,7 @@ import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from ._tfp_base import TFPDistribution
+from .._dtype import _as_float_array
 from ..core.constraints import Constraint, real
 from ..custom_types import ArrayLike
 from .._weights import Weights
@@ -56,7 +57,7 @@ class KDEDistribution(TFPDistribution):
         bandwidth: ArrayLike | None = None,
         name: str | None = None,
     ):
-        samples = jnp.asarray(samples, dtype=jnp.float32)
+        samples = _as_float_array(samples)
         if samples.ndim == 0:
             raise ValueError("samples must have at least 1 dimension.")
         if samples.ndim == 1:
@@ -78,7 +79,7 @@ class KDEDistribution(TFPDistribution):
 
         # Bandwidth (Silverman's rule default)
         if bandwidth is not None:
-            bw = jnp.broadcast_to(jnp.asarray(bandwidth, dtype=jnp.float32), (d,))
+            bw = jnp.broadcast_to(jnp.asarray(bandwidth, dtype=samples.dtype), (d,))
         else:
             std = jnp.sqrt(self._w.variance(samples))
             # Silverman's rule: n^{-1/(d+4)} * std

--- a/probpipe/distributions/multivariate.py
+++ b/probpipe/distributions/multivariate.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from ._tfp_base import TFPDistribution
+from .._dtype import _as_float_array, _promote_floats
 from ..core.constraints import (
     Constraint,
     real,
@@ -57,24 +58,25 @@ class MultivariateNormal(TFPDistribution):
         cov: ArrayLike | None = None,
         name: str,
     ):
-        loc = jnp.asarray(loc, dtype=jnp.float32)
-        if loc.ndim == 0:
-            loc = loc.reshape(1)
-
         if scale_tril is not None and cov is not None:
             raise ValueError("Provide exactly one of scale_tril or cov, not both.")
 
         if scale_tril is not None:
-            scale_tril = jnp.asarray(scale_tril, dtype=jnp.float32)
+            _, (loc, scale_tril) = _promote_floats(loc, scale_tril)
         elif cov is not None:
-            cov = jnp.asarray(cov, dtype=jnp.float32)
+            _, (loc, cov) = _promote_floats(loc, cov)
+        else:
+            raise ValueError("One of scale_tril or cov must be provided.")
+
+        if loc.ndim == 0:
+            loc = loc.reshape(1)
+
+        if cov is not None:
             if cov.shape != (loc.shape[0], loc.shape[0]):
                 raise ValueError(
                     f"cov shape {cov.shape} does not match loc length {loc.shape[0]}."
                 )
             scale_tril = jnp.linalg.cholesky(cov)
-        else:
-            raise ValueError("One of scale_tril or cov must be provided.")
 
         self._loc = loc
         self._scale_tril = scale_tril
@@ -136,7 +138,7 @@ class Dirichlet(TFPDistribution):
         *,
         name: str,
     ):
-        concentration = jnp.asarray(concentration, dtype=jnp.float32)
+        concentration = _as_float_array(concentration)
         if concentration.ndim == 0:
             raise ValueError("concentration must be at least 1-D.")
 
@@ -199,17 +201,15 @@ class Multinomial(TFPDistribution):
         if (probs is None) == (logits is None):
             raise ValueError("Exactly one of probs or logits must be provided.")
 
-        total_count = jnp.asarray(total_count, dtype=jnp.float32)
-
         if probs is not None:
-            probs = jnp.asarray(probs, dtype=jnp.float32)
+            _, (total_count, probs) = _promote_floats(total_count, probs)
             self._probs = probs
             self._logits = None
             self._tfp_dist = tfd.Multinomial(
                 total_count=total_count, probs=probs
             )
         else:
-            logits = jnp.asarray(logits, dtype=jnp.float32)
+            _, (total_count, logits) = _promote_floats(total_count, logits)
             self._logits = logits
             self._probs = None
             self._tfp_dist = tfd.Multinomial(
@@ -282,13 +282,11 @@ class Wishart(TFPDistribution):
         if scale_tril is None and scale is None:
             raise ValueError("One of scale_tril or scale must be provided.")
 
-        df = jnp.asarray(df, dtype=jnp.float32)
-
         if scale is not None:
-            scale = jnp.asarray(scale, dtype=jnp.float32)
+            _, (df, scale) = _promote_floats(df, scale)
             scale_tril = jnp.linalg.cholesky(scale)
         else:
-            scale_tril = jnp.asarray(scale_tril, dtype=jnp.float32)
+            _, (df, scale_tril) = _promote_floats(df, scale_tril)
 
         self._df = df
         self._scale_tril = scale_tril
@@ -351,8 +349,9 @@ class VonMisesFisher(TFPDistribution):
         *,
         name: str,
     ):
-        mean_direction = jnp.asarray(mean_direction, dtype=jnp.float32)
-        concentration = jnp.asarray(concentration, dtype=jnp.float32)
+        _, (mean_direction, concentration) = _promote_floats(
+            mean_direction, concentration
+        )
 
         self._mean_direction = mean_direction
         self._concentration = concentration

--- a/probpipe/inference/_cmdstan_method.py
+++ b/probpipe/inference/_cmdstan_method.py
@@ -73,9 +73,7 @@ class CmdStanNutsMethod(InferenceMethod):
 
         chains = []
         for c in range(num_chains):
-            chain_draws = jnp.asarray(
-                fit.draws(concat_chains=False)[c], dtype=jnp.float32,
-            )
+            chain_draws = jnp.asarray(fit.draws(concat_chains=False)[c])
             chains.append(chain_draws)
 
         inference_data = az.from_cmdstanpy(fit)

--- a/probpipe/inference/_pymc_method.py
+++ b/probpipe/inference/_pymc_method.py
@@ -122,7 +122,7 @@ class PyMCADVIMethod(InferenceMethod):
             [np.atleast_2d(d).reshape(num_results, -1) for d in chain_draws],
             axis=1,
         )
-        chains = [jnp.asarray(samples, dtype=jnp.float32)]
+        chains = [jnp.asarray(samples)]
         algorithm = f"pymc_{vi_method}"
 
         return make_posterior(

--- a/probpipe/inference/_tfp_mcmc.py
+++ b/probpipe/inference/_tfp_mcmc.py
@@ -38,8 +38,15 @@ def _get_init_state(
     dist: Distribution, init: ArrayLike | None, data: ArrayLike | None,
 ) -> jnp.ndarray:
     """Determine an initial chain state from the distribution or data."""
+    # Inherit dtype from the target distribution when available, so that
+    # log_prob/sample stay self-consistent under JAX x64.
+    target_dtype = getattr(dist, "dtype", None)
+    if not isinstance(target_dtype, jnp.dtype):
+        from .._dtype import _default_float_dtype
+        target_dtype = _default_float_dtype()
+
     if init is not None:
-        return jnp.atleast_1d(jnp.asarray(init, dtype=jnp.float32))
+        return jnp.atleast_1d(jnp.asarray(init, dtype=target_dtype))
 
     if isinstance(dist, SupportsMean):
         try:
@@ -49,7 +56,7 @@ def _get_init_state(
                 if not isinstance(m, NumericRecord):
                     m = NumericRecord.from_record(m)
                 m = m.flatten()
-            return jnp.atleast_1d(jnp.asarray(m, dtype=jnp.float32))
+            return jnp.atleast_1d(jnp.asarray(m, dtype=target_dtype))
         except Exception:
             pass
 
@@ -57,7 +64,7 @@ def _get_init_state(
         return jnp.atleast_1d(jnp.mean(jnp.asarray(data), axis=0))
 
     if hasattr(dist, "event_shape"):
-        return jnp.zeros(dist.event_shape, dtype=jnp.float32)
+        return jnp.zeros(dist.event_shape, dtype=target_dtype)
 
     raise ValueError(
         "Cannot determine initial state: provide init=, "

--- a/probpipe/linalg/linear_operator.py
+++ b/probpipe/linalg/linear_operator.py
@@ -103,7 +103,7 @@ class LinOp(ABC):
     @property
     @abstractmethod
     def dtype(self) -> Any:
-        """Return dtype (e.g., jnp.float32)."""
+        """Return the dtype of this operator's elements."""
         ...
 
     # ---- Minimal numeric primitives ----

--- a/probpipe/modeling/_glm.py
+++ b/probpipe/modeling/_glm.py
@@ -68,7 +68,7 @@ class GLMLikelihood:
     ):
         self.family = family
         if x is not None:
-            self._x = jnp.atleast_2d(jnp.asarray(x, dtype=jnp.float32))
+            self._x = jnp.atleast_2d(jnp.asarray(x))
             if self._x.ndim == 2 and self._x.shape[0] == 1 and self._x.shape[1] > 1:
                 self._x = self._x.T
         else:

--- a/probpipe/modeling/_stan.py
+++ b/probpipe/modeling/_stan.py
@@ -111,7 +111,7 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
         """
         params_constrained = jnp.asarray(value)
         params_unc = self.param_unconstrain(params_constrained)
-        return jnp.float32(self._bs_model.log_density(params_unc))
+        return jnp.asarray(self._bs_model.log_density(params_unc))
 
     def _unnormalized_log_prob(self, value: Any) -> Array:
         """Delegates to _log_prob (Stan provides the full joint)."""
@@ -175,7 +175,7 @@ class _UnconstrainedStanView(Distribution[Any], SupportsLogProb):
     def _log_prob(self, value: Any) -> Array:
         """Log-density directly in unconstrained space."""
         params_unc = jnp.asarray(value)
-        return jnp.float32(self._model._bs_model.log_density(params_unc))
+        return jnp.asarray(self._model._bs_model.log_density(params_unc))
 
     def _unnormalized_log_prob(self, value: Any) -> Array:
         return self._log_prob(value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,9 @@ def dim():
 
 @pytest.fixture
 def loc(dim):
-    return jnp.arange(dim, dtype=jnp.float32)
+    # Use JAX's default float dtype so the fixture stays consistent with
+    # the cov_matrix fixture (which also uses defaults) under x64 mode.
+    return jnp.arange(dim, dtype=float)
 
 
 @pytest.fixture

--- a/tests/test_bootstrap_replicate.py
+++ b/tests/test_bootstrap_replicate.py
@@ -342,7 +342,8 @@ class TestArrayBootstrapReplicateDistribution:
 
     def test_dtype(self):
         dist = ArrayBootstrapReplicateDistribution(jnp.ones((5, 2)))
-        assert dist.dtype == jnp.float32
+        # Inherits dtype from the source array (default float dtype here).
+        assert dist.dtype == jnp.zeros((), dtype=float).dtype
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -32,7 +32,9 @@ def dim():
 
 @pytest.fixture
 def loc(dim):
-    return jnp.arange(dim, dtype=jnp.float32)
+    # Use JAX's default float dtype so loc and cov_matrix share dtype
+    # under x64 mode.
+    return jnp.arange(dim, dtype=float)
 
 
 @pytest.fixture
@@ -167,8 +169,8 @@ class TestMultivariateNormal:
         assert "test_gaussian" in r
         assert "event_shape=(3,)" in r
 
-    def test_dtype(self, gaussian):
-        assert gaussian.dtype == jnp.float32
+    def test_dtype(self, gaussian, loc):
+        assert gaussian.dtype == loc.dtype
 
     def test_from_distribution_empirical(self, gaussian, key):
         ed = from_distribution(
@@ -464,8 +466,8 @@ class TestDistributionABC:
     def test_default_batch_shape(self, gaussian):
         assert gaussian.batch_shape == ()
 
-    def test_default_dtype(self, gaussian):
-        assert gaussian.dtype == jnp.float32
+    def test_default_dtype(self, gaussian, loc):
+        assert gaussian.dtype == loc.dtype
 
     def test_prob_delegates_to_log_prob(self, gaussian, key):
         x = sample(gaussian, key=key, sample_shape=(3,))
@@ -548,8 +550,8 @@ class TestTFPDistribution:
         assert isinstance(gaussian, TFPDistribution)
         assert isinstance(gaussian, NumericRecordDistribution)
 
-    def test_dtype(self, gaussian):
-        assert gaussian.dtype == jnp.float32
+    def test_dtype(self, gaussian, loc):
+        assert gaussian.dtype == loc.dtype
 
     def test_mean_delegates(self, gaussian, loc):
         np.testing.assert_allclose(mean(gaussian), loc, atol=1e-6)

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -1,0 +1,250 @@
+"""Regression tests for dtype handling under JAX's x64 mode.
+
+Each test runs in a subprocess so that ``jax.config.update("jax_enable_x64",
+True)`` is set before any JAX/TFP/probpipe code runs. Setting the flag
+mid-process is unreliable because JAX caches a default dtype on import.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+
+def _run_x64(snippet: str) -> str:
+    """Execute *snippet* in a fresh Python process with x64 enabled.
+
+    Returns the captured stdout, stripped. Stderr is included only on
+    failure to surface useful tracebacks.
+    """
+    program = textwrap.dedent(
+        """
+        import jax
+        jax.config.update("jax_enable_x64", True)
+        import jax.numpy as jnp
+        """
+    ) + textwrap.dedent(snippet)
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"x64 subprocess failed:\nSTDOUT:\n{result.stdout}\n"
+            f"STDERR:\n{result.stderr}"
+        )
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# x32 default — distributions follow JAX's default float dtype
+# ---------------------------------------------------------------------------
+
+
+def test_x32_default_normal_is_float32():
+    from probpipe.distributions.continuous import Normal
+    import probpipe.core.ops as ops
+
+    n = Normal(loc=0.0, scale=1.0, name="n")
+    assert n.dtype == jnp.float32
+    assert ops.log_prob(n, 0.5).dtype == jnp.float32
+    assert ops.sample(n, key=jax.random.key(0)).dtype == jnp.float32
+
+
+def test_x32_explicit_float32_array_preserved():
+    from probpipe.distributions.continuous import Normal
+
+    loc = jnp.array(0.0, dtype=jnp.float32)
+    scale = jnp.array(1.0, dtype=jnp.float32)
+    assert Normal(loc=loc, scale=scale, name="n").dtype == jnp.float32
+
+
+def test_x32_int_inputs_promote_to_float32():
+    from probpipe.distributions.continuous import Normal
+
+    # Integer inputs should not silently produce an int distribution;
+    # they are promoted to JAX's default float dtype.
+    n = Normal(loc=0, scale=1, name="n")
+    assert n.dtype == jnp.float32
+
+
+# ---------------------------------------------------------------------------
+# x64 mode — distributions, log_prob, sample, and mean all stay float64
+# ---------------------------------------------------------------------------
+
+
+def test_x64_normal_full_pipeline():
+    out = _run_x64(
+        """
+        from probpipe.distributions.continuous import Normal
+        import probpipe.core.ops as ops
+        n = Normal(loc=0.0, scale=1.0, name='n')
+        assert n.dtype == jnp.float64, n.dtype
+        assert ops.log_prob(n, 0.5).dtype == jnp.float64
+        assert ops.sample(n, key=__import__('jax').random.key(0)).dtype == jnp.float64
+        assert ops.mean(n).dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_uniform_beta_gamma():
+    out = _run_x64(
+        """
+        from probpipe.distributions.continuous import Uniform, Beta, Gamma
+        import probpipe.core.ops as ops
+        import jax
+
+        for cls, kwargs in [
+            (Uniform, dict(low=0.0, high=1.0)),
+            (Beta, dict(alpha=2.0, beta=3.0)),
+            (Gamma, dict(concentration=2.0, rate=1.0)),
+        ]:
+            d = cls(**kwargs, name='d')
+            assert d.dtype == jnp.float64, (cls.__name__, d.dtype)
+            assert ops.sample(d, key=jax.random.key(0)).dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_multivariate_normal_does_not_raise():
+    """The original failure mode: log_prob raised TypeError under x64."""
+    out = _run_x64(
+        """
+        from probpipe.distributions.multivariate import MultivariateNormal
+        import probpipe.core.ops as ops
+        import jax
+
+        mvn = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name='m')
+        assert mvn.dtype == jnp.float64, mvn.dtype
+        assert ops.log_prob(mvn, jnp.asarray([0.5, -0.5])).dtype == jnp.float64
+        assert ops.sample(mvn, key=jax.random.key(0)).dtype == jnp.float64
+        assert ops.mean(mvn).dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_explicit_float32_input_preserved_under_x64():
+    """User passing float32 explicitly under x64 should keep float32."""
+    out = _run_x64(
+        """
+        from probpipe.distributions.continuous import Normal
+        loc = jnp.array(0.0, dtype=jnp.float32)
+        scale = jnp.array(1.0, dtype=jnp.float32)
+        n = Normal(loc=loc, scale=scale, name='n')
+        assert n.dtype == jnp.float32, n.dtype
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_promotion_mixed_dtype():
+    """Mixed float32 / float64 inputs promote to the wider dtype."""
+    out = _run_x64(
+        """
+        from probpipe.distributions.continuous import Normal
+        loc32 = jnp.array(0.0, dtype=jnp.float32)
+        scale64 = jnp.array(1.0, dtype=jnp.float64)
+        n = Normal(loc=loc32, scale=scale64, name='n')
+        assert n.dtype == jnp.float64, n.dtype
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_empirical_distribution_preserves_dtype():
+    out = _run_x64(
+        """
+        from probpipe import EmpiricalDistribution
+        samples = jnp.array([[1.0], [2.0], [3.0]])  # float64 under x64
+        d = EmpiricalDistribution(samples)
+        assert d.samples.dtype == jnp.float64, d.samples.dtype
+        assert d.dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_transformed_distribution_preserves_dtype():
+    out = _run_x64(
+        """
+        import tensorflow_probability.substrates.jax.bijectors as tfb
+        from probpipe.distributions.continuous import Normal
+        from probpipe.distributions.transformed import TransformedDistribution
+        import probpipe.core.ops as ops
+        import jax
+
+        base = Normal(loc=0.0, scale=1.0, name='base')
+        td = TransformedDistribution(base, tfb.Exp())
+        assert td.dtype == jnp.float64, td.dtype
+        assert ops.log_prob(td, 1.0).dtype == jnp.float64
+        assert ops.sample(td, key=jax.random.key(0)).dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_joint_gaussian_preserves_dtype():
+    out = _run_x64(
+        """
+        from probpipe.distributions.joint import JointGaussian
+        import probpipe.core.ops as ops
+        import jax
+
+        jg = JointGaussian(
+            mean=jnp.zeros(3),
+            cov=jnp.eye(3),
+            x=1, y=2,
+        )
+        sample = ops.sample(jg, key=jax.random.key(0))
+        assert sample['x'].dtype == jnp.float64, sample['x'].dtype
+        assert sample['y'].dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_weights_preserves_dtype():
+    out = _run_x64(
+        """
+        from probpipe import Weights
+
+        w = Weights(weights=jnp.array([0.2, 0.3, 0.5]))
+        assert w.dtype == jnp.float64, w.dtype
+        assert w.normalized.dtype == jnp.float64
+
+        # Uniform weights default to JAX's default float
+        u = Weights.uniform(5)
+        assert u.dtype == jnp.float64
+        assert u.normalized.dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x32_weights_default():
+    """Without x64, Weights still defaults to float32."""
+    from probpipe import Weights
+
+    w = Weights(weights=jnp.array([0.2, 0.3, 0.5]))
+    assert w.dtype == jnp.float32
+    u = Weights.uniform(5)
+    assert u.dtype == jnp.float32

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -248,3 +248,144 @@ def test_x32_weights_default():
     assert w.dtype == jnp.float32
     u = Weights.uniform(5)
     assert u.dtype == jnp.float32
+
+
+# ---------------------------------------------------------------------------
+# Discrete distributions, KDE, GRF, and joint conditioning under x64
+# ---------------------------------------------------------------------------
+
+
+def test_x64_discrete_distributions():
+    out = _run_x64(
+        """
+        from probpipe.distributions.discrete import (
+            Bernoulli, Binomial, Poisson, Categorical, NegativeBinomial,
+        )
+        import probpipe.core.ops as ops
+        import jax
+
+        cases = [
+            Bernoulli(probs=0.5, name='b'),
+            Binomial(total_count=10, probs=0.3, name='bn'),
+            Poisson(rate=2.0, name='p'),
+            Categorical(probs=jnp.array([0.2, 0.3, 0.5]), name='c'),
+            NegativeBinomial(total_count=5.0, probs=0.4, name='nb'),
+        ]
+        for d in cases:
+            # log_prob on int-valued support should not raise
+            sample = ops.sample(d, key=jax.random.key(0))
+            ops.log_prob(d, sample)
+        # The float-valued probs/rate/logits should produce float64 internals
+        b = Bernoulli(probs=0.5, name='b2')
+        assert b._probs.dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_kde_distribution():
+    out = _run_x64(
+        """
+        from probpipe.distributions.kde import KDEDistribution
+        import probpipe.core.ops as ops
+        import jax
+
+        samples = jnp.linspace(-2.0, 2.0, 50)
+        kde = KDEDistribution(samples, name='kde')
+        assert kde.dtype == jnp.float64
+        assert ops.sample(kde, key=jax.random.key(0)).dtype == jnp.float64
+        assert ops.log_prob(kde, 0.5).dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_gaussian_random_function():
+    out = _run_x64(
+        """
+        from probpipe.distributions import MultivariateNormal
+        from probpipe.distributions.gaussian_random_function import LinearBasisFunction
+        import jax
+
+        weights = MultivariateNormal(
+            loc=jnp.zeros(3), cov=jnp.eye(3), name='w',
+        )
+        feature_map = lambda X: jnp.stack([jnp.ones_like(X[..., 0]),
+                                            X[..., 0],
+                                            X[..., 0] ** 2], axis=-1)
+        grf = LinearBasisFunction(
+            feature_map, weights, input_shape=(1,), output_shape=(),
+        )
+        X = jnp.linspace(-1.0, 1.0, 5)[:, None]
+        d = grf(X)
+        assert d.dtype == jnp.float64, d.dtype
+        # bias defaults to zeros at the weight dtype
+        assert grf._bias.dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_product_distribution_promotes():
+    out = _run_x64(
+        """
+        from probpipe.distributions import ProductDistribution
+        from probpipe.distributions.continuous import Normal
+        import probpipe.core.ops as ops
+        import jax
+
+        prod = ProductDistribution(
+            a=Normal(loc=0.0, scale=1.0, name='a'),
+            b=Normal(loc=0.0, scale=1.0, name='b'),
+        )
+        sample = ops.sample(prod, key=jax.random.key(0))
+        assert sample['a'].dtype == jnp.float64
+        assert sample['b'].dtype == jnp.float64
+        assert ops.log_prob(prod, sample).dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_joint_gaussian_conditioning():
+    """Conditioning on observed data must respect the parent's dtype under x64."""
+    out = _run_x64(
+        """
+        from probpipe.distributions.joint import JointGaussian
+        from probpipe.core.ops import condition_on, sample
+        import jax
+
+        jg = JointGaussian(
+            mean=jnp.zeros(3), cov=jnp.eye(3), x=1, y=2,
+        )
+        # Conditioning on a float32 observed value must not corrupt the
+        # parent's float64 dtype.
+        cond = condition_on(jg, x=jnp.array([1.0], dtype=jnp.float32))
+        sample_y = sample(cond, key=jax.random.key(0))
+        assert sample_y['y'].dtype == jnp.float64, sample_y['y'].dtype
+        print('OK')
+        """
+    )
+    assert out == "OK"
+
+
+def test_x64_bootstrap_distribution():
+    out = _run_x64(
+        """
+        from probpipe.core._numeric_record_distribution import BootstrapDistribution
+        import probpipe.core.ops as ops
+        import jax
+
+        evals = jnp.linspace(0.0, 1.0, 10)
+        b = BootstrapDistribution(evals, name='b')
+        assert b.dtype == jnp.float64
+        assert ops.mean(b).dtype == jnp.float64
+        assert ops.sample(b, key=jax.random.key(0)).dtype == jnp.float64
+        print('OK')
+        """
+    )
+    assert out == "OK"

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -17,13 +17,13 @@ def _sigmoid(x):
 
 @pytest.fixture
 def poisson_lik():
-    X = np.column_stack([np.ones(20), np.linspace(-1, 1, 20)]).astype(np.float32)
+    X = np.column_stack([np.ones(20), np.linspace(-1, 1, 20)]).astype(float)
     return GLMLikelihood(tfp_glm.Poisson(), X)
 
 
 @pytest.fixture
 def bernoulli_lik():
-    X = np.column_stack([np.ones(30), np.linspace(-2, 2, 30)]).astype(np.float32)
+    X = np.column_stack([np.ones(30), np.linspace(-2, 2, 30)]).astype(float)
     return GLMLikelihood(tfp_glm.Bernoulli(), X)
 
 
@@ -46,7 +46,7 @@ class TestGLMLikelihood:
         """Poisson GLM log-likelihood must match sum of scipy.stats.poisson.logpmf."""
         params = jnp.array([1.0, 0.5])
         data = jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1,
-                          0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=jnp.float32)
+                          0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=float)
         ll = float(poisson_lik.log_likelihood(params, data))
 
         # Independent baseline: Poisson log link -> rate = exp(X @ params).
@@ -60,7 +60,7 @@ class TestGLMLikelihood:
         """Bernoulli GLM log-likelihood must match sum of scipy.stats.bernoulli.logpmf."""
         params = jnp.array([0.2, 1.0])
         rng = np.random.default_rng(0)
-        data = rng.binomial(1, 0.5, size=30).astype(np.float32)
+        data = rng.binomial(1, 0.5, size=30).astype(float)
         ll = float(bernoulli_lik.log_likelihood(params, jnp.asarray(data)))
 
         # Independent baseline: Bernoulli logit link -> p = sigmoid(X @ params).
@@ -73,7 +73,7 @@ class TestGLMLikelihood:
     def test_poisson_generate_data_moments(self):
         """Sample mean must approximate exp(intercept) for constant-rate Poisson."""
         n = 2000
-        X = np.column_stack([np.ones(n), np.zeros(n)]).astype(np.float32)
+        X = np.column_stack([np.ones(n), np.zeros(n)]).astype(float)
         lik = GLMLikelihood(tfp_glm.Poisson(), X, seed=7)
         params = jnp.array([0.5, 0.0])  # constant rate = exp(0.5)
         expected_rate = np.exp(0.5)
@@ -92,7 +92,7 @@ class TestGLMLikelihood:
 
     def test_bernoulli_log_likelihood(self, bernoulli_lik):
         params = jnp.array([0.0, 1.0])
-        data = jnp.ones(30, dtype=jnp.float32)
+        data = jnp.ones(30, dtype=float)
         ll = bernoulli_lik.log_likelihood(params, data)
         assert jnp.isfinite(ll)
 
@@ -103,7 +103,7 @@ class TestGLMLikelihood:
 
     def test_1d_covariate(self):
         """1-D x should be handled (transposed to column vector)."""
-        x = np.linspace(-1, 1, 15).astype(np.float32)
+        x = np.linspace(-1, 1, 15).astype(float)
         lik = GLMLikelihood(tfp_glm.Poisson(), x)
         assert lik._x.shape == (15, 1)
         params = jnp.array([0.5])
@@ -111,7 +111,7 @@ class TestGLMLikelihood:
         assert jnp.isfinite(ll)
 
     def test_negbin(self):
-        X = np.column_stack([np.ones(20), np.linspace(-1, 1, 20)]).astype(np.float32)
+        X = np.column_stack([np.ones(20), np.linspace(-1, 1, 20)]).astype(float)
         lik = GLMLikelihood(tfp_glm.NegativeBinomial(), X)
         params = jnp.array([1.0, 0.3])
         ll = lik.log_likelihood(params, jnp.ones(20))
@@ -124,13 +124,13 @@ class TestGLMLikelihood:
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=5.0 * jnp.eye(2), name="beta")
         model = SimpleModel(prior, poisson_lik)
         data = jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1,
-                           0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=jnp.float32)
+                           0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=float)
         posterior = condition_on(model, data, num_results=100, num_warmup=50, random_seed=0)
         m = mean(posterior)
         assert m.shape == (2,)
 
     def test_seed_reproducibility(self):
-        X = np.column_stack([np.ones(10), np.zeros(10)]).astype(np.float32)
+        X = np.column_stack([np.ones(10), np.zeros(10)]).astype(float)
         params = jnp.array([1.0, 0.0])
         lik1 = GLMLikelihood(tfp_glm.Poisson(), X, seed=42)
         lik2 = GLMLikelihood(tfp_glm.Poisson(), X, seed=42)
@@ -179,7 +179,7 @@ class TestGLMLikelihoodWithValues:
 
     def test_values_matches_raw(self, poisson_lik):
         params_raw = jnp.array([1.0, 0.5])
-        data_raw = jnp.ones(20, dtype=jnp.float32)
+        data_raw = jnp.ones(20, dtype=float)
         ll_raw = float(poisson_lik.log_likelihood(params_raw, data_raw))
 
         params_v = Record(beta=params_raw)
@@ -201,7 +201,7 @@ class TestGLMLikelihoodWithValues:
         model = SimpleModel(prior, poisson_lik)
         data = Record(y=jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1,
                                     0, 2, 6, 1, 3, 2, 0, 4, 1, 3],
-                                   dtype=jnp.float32))
+                                   dtype=float))
         posterior = condition_on(model, data, num_results=50, num_warmup=25, random_seed=0)
         assert mean(posterior).shape == (2,)
         # Prior has no record_template, so draws are raw arrays.
@@ -220,11 +220,11 @@ class TestIncrementalConditionerAutoConvert:
         from probpipe.inference import ApproximateDistribution
         from probpipe.core.protocols import SupportsLogProb
 
-        X = np.column_stack([np.ones(20), np.linspace(-1, 1, 20)]).astype(np.float32)
+        X = np.column_stack([np.ones(20), np.linspace(-1, 1, 20)]).astype(float)
         lik = GLMLikelihood(tfp_glm.Poisson(), X)
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=5.0 * jnp.eye(2), name="beta")
         model = SimpleModel(prior, lik)
-        data = jnp.ones(20, dtype=jnp.float32)
+        data = jnp.ones(20, dtype=float)
 
         # Get an ApproximateDistribution (does NOT support SupportsLogProb)
         post = condition_on(model, data, num_results=100, num_warmup=50, random_seed=0)

--- a/tests/test_inference_registry.py
+++ b/tests/test_inference_registry.py
@@ -59,7 +59,7 @@ def simple_model():
 
 @pytest.fixture
 def data():
-    return jnp.ones(20, dtype=jnp.float32)
+    return jnp.ones(20, dtype=float)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_record_array_view.py
+++ b/tests/test_record_array_view.py
@@ -137,7 +137,8 @@ class TestViewForwarding:
 
     def test_dtype_forwards_to_column(self, numeric_ra):
         v = numeric_ra.view("x")
-        assert v.dtype == jnp.float32
+        # Default float dtype: float32 normally, float64 with jax_enable_x64.
+        assert v.dtype == jnp.zeros((), dtype=float).dtype
 
     def test_ndim_forwards_to_column(self, numeric_ra):
         v = numeric_ra.view("x")

--- a/tests/test_transformed.py
+++ b/tests/test_transformed.py
@@ -92,14 +92,15 @@ class TestTFPBase:
     def test_mean_delegates_to_tfp_when_available(self):
         """Shift bijector preserves tractable mean exactly."""
         base = Normal(loc=0.0, scale=1.0, name="x")
-        td = TransformedDistribution(base, tfb.Shift(5.0))
+        # Pass a JAX array so the bijector's constant honors x64 mode.
+        td = TransformedDistribution(base, tfb.Shift(jnp.array(5.0)))
         # Analytical identity: Shift(c) on N(0,1) has mean c exactly.
         assert jnp.isclose(mean(td), 5.0, atol=1e-6)
 
     def test_variance_delegates_to_tfp_when_available(self):
         """Scale bijector has tractable variance exactly."""
         base = Normal(loc=0.0, scale=1.0, name="x")
-        td = TransformedDistribution(base, tfb.Scale(2.0))
+        td = TransformedDistribution(base, tfb.Scale(jnp.array(2.0)))
         # Analytical identity: Scale(s) on N(0,1) has variance s^2 exactly.
         assert jnp.isclose(variance(td), 4.0, atol=1e-6)
 
@@ -135,7 +136,7 @@ class TestNonTFPBase:
 class TestChainedBijectors:
     def test_chain_sample_shape(self, key):
         base = Normal(loc=0.0, scale=1.0, name="x")
-        chain = tfb.Chain([tfb.Exp(), tfb.Shift(1.0), tfb.Scale(2.0)])
+        chain = tfb.Chain([tfb.Exp(), tfb.Shift(jnp.array(1.0)), tfb.Scale(jnp.array(2.0))])
         td = TransformedDistribution(base, chain)
         s = jnp.asarray(sample(td, key=key, sample_shape=(10,)))
         assert s.shape == (10,)
@@ -144,7 +145,7 @@ class TestChainedBijectors:
 
     def test_chain_log_prob_finite(self, key):
         base = Normal(loc=0.0, scale=1.0, name="x")
-        chain = tfb.Chain([tfb.Exp(), tfb.Shift(1.0), tfb.Scale(2.0)])
+        chain = tfb.Chain([tfb.Exp(), tfb.Shift(jnp.array(1.0)), tfb.Scale(jnp.array(2.0))])
         td = TransformedDistribution(base, chain)
         s = sample(td, key=key, sample_shape=(5,))
         lp = log_prob(td, s)
@@ -206,7 +207,8 @@ class TestNameAndRepr:
 
     def test_dtype(self):
         td = TransformedDistribution(Normal(0.0, 1.0, name="x"), tfb.Exp())
-        assert td.dtype == jnp.float32
+        # Inherits JAX's default float dtype (float32 normally, float64 with x64).
+        assert td.dtype == jnp.zeros((), dtype=float).dtype
 
 
 class TestTransformedProtocolDuckTyping:

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -293,8 +293,9 @@ class TestWeightsArrayDuckTyping:
         assert w.shape == (5,)
 
     def test_dtype(self):
+        # Default for uniform Weights is JAX's default float dtype.
         w = Weights(n=5)
-        assert w.dtype == jnp.float32
+        assert w.dtype == jnp.zeros((), dtype=float).dtype
 
     def test_len(self):
         w = Weights(n=7)


### PR DESCRIPTION
## Summary

- Removes the float32 hardcoding that prevented every TFP-backed distribution from working when `jax.config.update("jax_enable_x64", True)` was set. ProbPipe now follows JAX's dtype rules: distributions preserve user-supplied dtypes and honor x64 end-to-end.
- Adds two private helpers in `probpipe/_dtype.py` (`_default_float_dtype()` and `_promote_floats()`) that distribution constructors use to coerce inputs to a common float dtype via `jnp.result_type` (with int → default-float promotion).
- Removes the `Explicitly requested dtype.*float64` warning filter from `probpipe/__init__.py`. The warning should no longer fire under correct usage, and silencing it now would mask real bugs.
- Adds `tests/test_dtype.py` (19 regression tests) covering Normal, Uniform, Beta, Gamma, MVN, Empirical, Transformed, JointGaussian, Weights, discrete distributions, KDE, GRF (LinearBasisFunction), ProductDistribution, JointGaussian conditioning, and BootstrapDistribution under x32, x64, and mixed-dtype inputs. Each x64 case runs in a subprocess so JAX's dtype defaults are picked up at import time.

Reproduction of the original failure (now fixed):

```python
import jax; jax.config.update("jax_enable_x64", True)
import jax.numpy as jnp
from probpipe.distributions.multivariate import MultivariateNormal
import probpipe.core.ops as ops

mvn = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="m")
ops.log_prob(mvn, jnp.asarray([0.5, -0.5]))
# Before: TypeError: Tensor conversion requested dtype float32 for array with dtype float64
# After:  Array(-2.337..., dtype=float64)
```

## Notes

- **Stacked on #145.** The downstream consumer needs the PEP 695 fix and this dtype fix together; please rebase onto main when #145 lands.
- **No new public API.** Per the design alignment we agreed on, the helpers stay private — JAX's `jax_enable_x64` config and parameter dtype are the user-facing controls. Users who want float64 either set the JAX flag globally or pass float64 arrays to a constructor.
- **Multi-parameter constructors promote.** Mixed `loc=float32, scale=float64` is now valid and promotes to float64 (consistent with `jnp.result_type`).
- **Integer inputs promote to float.** `Normal(loc=0, scale=1)` continues to work; ints are lifted to JAX's default float dtype.
- **Existing test fixtures updated.** A handful of `dtype=jnp.float32` assertions and bare-Python-float TFP bijector constants (`tfb.Shift(5.0)`) were dtype-agnostic-ified so the suite passes under both modes.

## Test plan

- [x] Full suite under x32: 2121 passed, 8 skipped.
- [x] Full suite under x64 (`JAX_ENABLE_X64=1`): 2102 passed, 8 skipped.
- [x] `tests/test_dtype.py`: 19/19 passing.
- [x] Verify downstream consumer (the project that originally reported this) works against this branch.
