### PR TITLE
feat(inference): accept SupportsUnnormalizedLogProb for MCMC

### DIFF
--- a/probpipe/inference/_rwmh.py
+++ b/probpipe/inference/_rwmh.py
@@ -11,7 +11,7 @@ import jax.numpy as jnp
 from ..core._registry import MethodInfo
 from ..core.distribution import Distribution
 from ..core.node import workflow_function
-from ..core.protocols import SupportsLogProb
+from ..core.protocols import SupportsUnnormalizedLogProb
 from ..custom_types import Array, ArrayLike, PRNGKey
 from ._approximate_distribution import ApproximateDistribution, make_posterior
 from ._registry import InferenceMethod
@@ -29,7 +29,7 @@ __all__ = ["rwmh", "TFPRWMHMethod"]
 
 @workflow_function
 def rwmh(
-    dist: SupportsLogProb,
+    dist: SupportsUnnormalizedLogProb,
     data: ArrayLike | None = None,
     *,
     log_prob_fn: Any | None = None,
@@ -44,13 +44,15 @@ def rwmh(
 
     Parameters
     ----------
-    dist : SupportsLogProb
-        Distribution providing ``_log_prob``.
+    dist : SupportsUnnormalizedLogProb
+        Distribution providing ``_unnormalized_log_prob``.  RWMH uses
+        only the unnormalized density because the missing log
+        normalizer cancels out of every accept/reject step.
     data : array-like or None
         Observed data.
     log_prob_fn : callable or None
         ``log_prob_fn(params, data) -> float``.  Combined with
-        ``dist._log_prob(params)`` to form the target density.
+        ``dist._unnormalized_log_prob(params)`` to form the target density.
     num_results, num_warmup, num_chains, step_size, random_seed
         MCMC tuning parameters.
     init : array-like or None
@@ -61,19 +63,19 @@ def rwmh(
     ApproximateDistribution
         Posterior samples with chain structure and auxiliary DataTree.
     """
-    if not isinstance(dist, SupportsLogProb):
+    if not isinstance(dist, SupportsUnnormalizedLogProb):
         raise TypeError(
             f"{type(dist).__name__} does not support log_prob "
-            f"(does not implement SupportsLogProb)"
+            f"(does not implement SupportsUnnormalizedLogProb)"
         )
 
     if log_prob_fn is not None and data is not None:
         data_jnp = jnp.asarray(data)
         def target_log_prob(params):
-            return dist._log_prob(params) + log_prob_fn(params, data_jnp)
+            return dist._unnormalized_log_prob(params) + log_prob_fn(params, data_jnp)
     else:
         def target_log_prob(params):
-            return dist._log_prob(params)
+            return dist._unnormalized_log_prob(params)
 
     init_state = _get_init_state(dist, init, data)
 
@@ -152,9 +154,9 @@ class TFPRWMHMethod(InferenceMethod):
 
     def check(self, dist: Any, observed: Any, **kwargs: Any) -> MethodInfo:
         prior = _get_prior(dist)
-        if not isinstance(prior, SupportsLogProb):
+        if not isinstance(prior, SupportsUnnormalizedLogProb):
             return MethodInfo(feasible=False, method_name=self.name,
-                              description="Requires SupportsLogProb")
+                              description="Requires SupportsUnnormalizedLogProb")
         if observed is not None and isinstance(observed, dict):
             return MethodInfo(feasible=False, method_name=self.name,
                               description="Does not support dict-based conditioning")

--- a/probpipe/inference/_tfp_mcmc.py
+++ b/probpipe/inference/_tfp_mcmc.py
@@ -14,7 +14,7 @@ import tensorflow_probability.substrates.jax.mcmc as tfp_mcmc
 
 from ..core._registry import MethodInfo
 from ..core.distribution import Distribution
-from ..core.protocols import SupportsLogProb, SupportsMean
+from ..core.protocols import SupportsMean, SupportsUnnormalizedLogProb
 from ..custom_types import Array, ArrayLike
 from ..core.record import Record, RecordTemplate
 from ._approximate_distribution import ApproximateDistribution, make_posterior
@@ -85,9 +85,16 @@ def _build_target_log_prob(dist: Distribution, observed: ArrayLike | Record | No
 
     1. **SimpleModel** (has prior + likelihood):
        ``prior._log_prob(params) + likelihood.log_likelihood(params, data)``
-    2. **Bare SupportsLogProb with data**: ``dist._log_prob(params)``
-       (data is assumed already folded in, e.g., via closure).
-    3. **Joint over (params, data)**: ``dist._log_prob((params, data))``
+    2. **Bare SupportsUnnormalizedLogProb with data**:
+       ``dist._unnormalized_log_prob(params)`` (data is assumed already
+       folded in, e.g., via closure).
+    3. **Joint over (params, data)**: ``dist._unnormalized_log_prob((params, data))``
+
+    The unnormalized accessor is used for cases 2 and 3 because MCMC
+    samplers do not require a normalized density. Distributions that
+    only implement ``_log_prob`` are unaffected: the ``SupportsLogProb``
+    protocol provides a default ``_unnormalized_log_prob`` that
+    delegates to ``_log_prob``.
 
     Observed data is passed through to the likelihood as-is (may be a
     raw array, a ``Record`` object, or a dict — the likelihood handles
@@ -112,9 +119,9 @@ def _build_target_log_prob(dist: Distribution, observed: ArrayLike | Record | No
         return target_log_prob_fn
 
     if observed is not None:
-        return lambda params: dist._log_prob((params, observed))
+        return lambda params: dist._unnormalized_log_prob((params, observed))
 
-    return dist._log_prob
+    return dist._unnormalized_log_prob
 
 
 def _run_tfp_chains(
@@ -303,9 +310,9 @@ class _TFPGradientMethod(InferenceMethod):
         # Intentionally probes JAX traceability (via jax.make_jaxpr) to avoid
         # selecting a gradient-based method that would fail at execute() time.
         # The cost is ~one JAX trace, cached by JAX on subsequent calls.
-        if not isinstance(dist, SupportsLogProb):
+        if not isinstance(dist, SupportsUnnormalizedLogProb):
             return MethodInfo(feasible=False, method_name=self.name,
-                              description="Requires SupportsLogProb")
+                              description="Requires SupportsUnnormalizedLogProb")
         try:
             target = _build_target_log_prob(dist, observed)
             init = _get_init_state(_get_prior(dist), kwargs.get("init"), observed)

--- a/tests/test_inference_registry.py
+++ b/tests/test_inference_registry.py
@@ -192,3 +192,157 @@ class TestInferenceMethodRegistry:
             assert info.method_name == "tfp_rwmh"
         finally:
             inference_method_registry.set_priorities(tfp_rwmh=50)
+
+
+# ---------------------------------------------------------------------------
+# MCMC against unnormalized log densities
+# ---------------------------------------------------------------------------
+
+
+class _UnnormalizedTarget:
+    """Mixin: implements only ``_unnormalized_log_prob`` (no ``_log_prob``).
+
+    Used in the tests below to confirm that MCMC inference dispatches on
+    :class:`SupportsUnnormalizedLogProb`, which is the strictly weaker
+    protocol that MCMC actually needs.
+    """
+
+    def _unnormalized_log_prob(self, value):
+        # Standard normal up to an unknown additive constant. The missing
+        # log normalizer is irrelevant for accept/reject.
+        return -0.5 * jnp.sum(value ** 2)
+
+    def _mean(self):
+        return jnp.zeros(2)
+
+
+class _NormalizedTarget:
+    """Mixin: implements only ``_log_prob`` (relies on protocol default).
+
+    The :class:`SupportsLogProb` protocol provides a default
+    ``_unnormalized_log_prob`` that delegates to ``_log_prob``; this
+    fixture exercises that default path through the inference layer.
+    """
+
+    def _log_prob(self, value):
+        return -0.5 * jnp.sum(value ** 2) - jnp.log(2 * jnp.pi)
+
+    def _mean(self):
+        return jnp.zeros(2)
+
+
+def _make_unnormalized_distribution():
+    from probpipe.core._distribution_base import Distribution
+
+    class UnnormalizedDist(_UnnormalizedTarget, Distribution):
+        event_shape = (2,)
+
+        def __init__(self):
+            super().__init__(name="unnorm")
+
+    return UnnormalizedDist()
+
+
+def _make_normalized_distribution():
+    from probpipe.core._distribution_base import Distribution
+    from probpipe.core.protocols import SupportsLogProb
+
+    class NormalizedDist(_NormalizedTarget, Distribution, SupportsLogProb):
+        # Inheriting SupportsLogProb gives the default
+        # _unnormalized_log_prob (delegating to _log_prob) for free.
+        event_shape = (2,)
+
+        def __init__(self):
+            super().__init__(name="norm")
+
+    return NormalizedDist()
+
+
+class TestUnnormalizedLogProbInference:
+    """MCMC accepts distributions with only ``SupportsUnnormalizedLogProb``."""
+
+    def test_unnormalized_only_satisfies_protocol(self):
+        from probpipe.core.protocols import (
+            SupportsLogProb,
+            SupportsUnnormalizedLogProb,
+        )
+
+        dist = _make_unnormalized_distribution()
+        assert isinstance(dist, SupportsUnnormalizedLogProb)
+        assert not isinstance(dist, SupportsLogProb)
+
+    def test_auto_dispatch_to_nuts(self):
+        """Auto-dispatch picks tfp_nuts for unnormalized-only target."""
+        dist = _make_unnormalized_distribution()
+        info = inference_method_registry.check(dist, None)
+        assert info.feasible
+        assert info.method_name == "tfp_nuts"
+
+    def test_condition_on_unnormalized_runs_nuts(self):
+        from probpipe import ApproximateDistribution
+
+        dist = _make_unnormalized_distribution()
+        posterior = condition_on(
+            dist, num_results=200, num_warmup=100, random_seed=0,
+        )
+        assert isinstance(posterior, ApproximateDistribution)
+        # Standard normal: posterior mean ~0, std ~1 (loose tolerance —
+        # short chain, no thinning).
+        draws = np.asarray(posterior.draws()).reshape(-1, 2)
+        np.testing.assert_allclose(draws.mean(0), [0.0, 0.0], atol=0.4)
+        np.testing.assert_allclose(draws.std(0), [1.0, 1.0], atol=0.4)
+
+    def test_condition_on_unnormalized_runs_rwmh(self):
+        from probpipe import ApproximateDistribution
+
+        dist = _make_unnormalized_distribution()
+        posterior = condition_on(
+            dist, method="tfp_rwmh",
+            num_results=200, num_warmup=100, step_size=0.5, random_seed=0,
+        )
+        assert isinstance(posterior, ApproximateDistribution)
+
+    def test_normalized_only_still_works_via_nuts(self):
+        """SupportsLogProb-only dist still flows through unchanged.
+
+        Guards against a regression where the swap to
+        ``_unnormalized_log_prob`` accidentally breaks the protocol's
+        default delegation.
+        """
+        from probpipe import ApproximateDistribution
+
+        dist = _make_normalized_distribution()
+        posterior = condition_on(
+            dist, num_results=100, num_warmup=50, random_seed=0,
+        )
+        assert isinstance(posterior, ApproximateDistribution)
+
+    def test_normalized_only_still_works_via_rwmh(self):
+        from probpipe import ApproximateDistribution
+
+        dist = _make_normalized_distribution()
+        posterior = condition_on(
+            dist, method="tfp_rwmh",
+            num_results=100, num_warmup=50, step_size=0.5, random_seed=0,
+        )
+        assert isinstance(posterior, ApproximateDistribution)
+
+    def test_check_description_names_unnormalized_protocol(self):
+        """When MCMC methods are infeasible, error string names the right protocol."""
+        from probpipe.core._distribution_base import Distribution
+
+        class NoDensityDist(Distribution):
+            event_shape = (2,)
+
+            def __init__(self):
+                super().__init__(name="no_density")
+
+        dist = NoDensityDist()
+        for method in ("tfp_nuts", "tfp_hmc", "tfp_rwmh"):
+            m = inference_method_registry.get_method(method)
+            info = m.check(dist, None)
+            assert not info.feasible
+            assert "SupportsUnnormalizedLogProb" in info.description, (
+                f"{method}: description {info.description!r} should mention "
+                f"SupportsUnnormalizedLogProb"
+            )


### PR DESCRIPTION
## Summary

MCMC inference (NUTS, HMC, RWMH) only requires an *unnormalized*
log-density — the missing log normalizer cancels out of every
accept/reject step. Yet on `main` the inference registry rejects any
distribution that implements only `SupportsUnnormalizedLogProb`,
forcing callers with intractable normalizers (surrogate posteriors,
energy-based models, conditionals with no closed-form Z) to either
implement `_log_prob` as a contract-violating alias for
`_unnormalized_log_prob`, or fall off the auto-dispatch path entirely.

This PR relaxes the relevant `check` predicates from `SupportsLogProb`
to `SupportsUnnormalizedLogProb` and switches the target log-prob
construction to the unnormalized accessor. Distributions that
implement only `SupportsLogProb` are unaffected: the protocol provides
a default `_unnormalized_log_prob` that delegates to `_log_prob`.

## Changes

- `probpipe/inference/_tfp_mcmc.py`
  - `_TFPGradientMethod.check` (NUTS + HMC) gates on
    `SupportsUnnormalizedLogProb`.
  - `_build_target_log_prob` reads `dist._unnormalized_log_prob` in
    its non-`SimpleModel` branches. The `SimpleModel` branch is
    unchanged (it composes `prior._log_prob` with
    `likelihood.log_likelihood`, and `SimpleModel` already constrains
    its prior to `SupportsLogProb`).
  - Error description and docstring updated to name the new protocol.
- `probpipe/inference/_rwmh.py`
  - `rwmh` workflow function and `TFPRWMHMethod.check` gate on
    `SupportsUnnormalizedLogProb`. Target density uses
    `_unnormalized_log_prob`.
  - Type hint, docstring, and error message updated.

## Sites that were *not* relaxed

Per the PR brief, only the MCMC / gradient-based sampling paths
need this relaxation. Every other `SupportsLogProb` site was
inspected and intentionally left as-is:

- `probpipe/core/ops.py` — `log_prob` and `prob` workflow functions
  remain on `SupportsLogProb`. Public-API callers that ask for "the
  log probability" should get a normalized one. (`unnormalized_log_prob`
  and `unnormalized_prob` already exist as separate ops on
  `SupportsUnnormalizedLogProb`.)
- `probpipe/modeling/_simple.py` — `SimpleModel` requires a
  `SupportsLogProb` prior so the joint `prior._log_prob + log_likelihood`
  remains a normalized density. The MCMC path through `SimpleModel`
  was therefore left unchanged.
- `probpipe/modeling/_likelihood.py` — likelihood prior conversion
  resolves protocol targets via the converter registry; needs the
  same normalization guarantee as `SimpleModel`.
- `probpipe/converters/__init__.py`, `probpipe/converters/_protocol.py`
  — `SupportsLogProb` is registered as a converter target so callers
  can request a normalized distribution. Not a runtime gate on MCMC.
- `probpipe/distributions/transformed.py`, `_product.py`,
  `_sequential_joint.py`, `_joint_empirical.py`, `_joint_gaussian.py`,
  `_broadcast_distributions.py`, `core/_record_distribution.py`,
  `core/_numeric_record_distribution.py` — these use
  `SupportsLogProb` to drive the dynamic-protocol mixin machinery
  (`protocols_supported_by_all` and friends). They propagate whatever
  protocol the leaf distributions actually implement, which is the
  correct behavior; relaxing here would change the *static* type
  surface, not the inference path.
- `probpipe/modeling/_stan.py`, `probpipe/distributions/_tfp_base.py`,
  `probpipe/distributions/kde.py` — these *implement*
  `SupportsLogProb` (i.e., they expose `_log_prob`); not gates.

## Test plan

New tests in `tests/test_inference_registry.py`
(`TestUnnormalizedLogProbInference`):

- [x] Unnormalized-only distribution satisfies
      `SupportsUnnormalizedLogProb` but not `SupportsLogProb`.
- [x] `condition_on(dist)` auto-dispatches to `tfp_nuts` for the
      unnormalized-only target and produces samples whose mean and
      std match a standard normal.
- [x] `condition_on(dist, method="tfp_rwmh")` runs against the same
      unnormalized-only target.
- [x] `SupportsLogProb`-only distribution still flows through NUTS
      and RWMH — guards the protocol's default delegation.
- [x] When all MCMC methods are infeasible, the error description
      names `SupportsUnnormalizedLogProb`.
- [x] Existing `tests/test_inference_registry.py` suite passes
      (24 tests).
- [x] Full `pytest tests/` passes (2161 passed, 8 skipped).
