### PR TITLE
test: isolate test suite from user's Prefect profile

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,42 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from probpipe import EmpiricalDistribution
+from probpipe import EmpiricalDistribution, WorkflowKind, prefect_config
+
+
+@pytest.fixture(autouse=True)
+def _disable_prefect_for_tests():
+    """Force ``WorkflowKind.OFF`` globally for each test.
+
+    The default ``WorkflowKind.DEFAULT`` auto-promotes to ``TASK`` when
+    Prefect is importable (see ``WorkflowFunction.effective_workflow_kind``).
+    That auto-promotion picks up whatever ``PREFECT_API_URL`` the user
+    has in ``~/.prefect/profiles.toml`` — if the configured server isn't
+    running, every ``WorkflowFunction`` call raises
+    ``RuntimeError: Failed to reach API at ...``. CI happens to escape
+    because it has no profile and falls back to ephemeral mode, but
+    contributors with an existing Prefect setup hit it immediately.
+
+    Function-scoped (not session-scoped) so the OFF state is restored
+    around every test — otherwise other test classes that flip the
+    global (``test_prefect_config.py`` resets to ``DEFAULT`` between
+    its tests) leak that state into later tests.
+
+    The Prefect-orchestration tests in ``test_prefect_orchestration.py``
+    don't depend on the global config — they pass ``workflow_kind="task"``
+    or ``"flow"`` explicitly, which is a per-instance override that
+    bypasses the global, so this fixture doesn't interfere with them.
+    The ``test_prefect_config.py`` tests have their own function-scoped
+    autouse fixture that resets to ``DEFAULT``; pytest runs the
+    conftest fixture first and the test-class fixture second, so those
+    tests still see ``DEFAULT`` when they expect to.
+    """
+    saved = prefect_config.workflow_kind
+    prefect_config.workflow_kind = WorkflowKind.OFF
+    try:
+        yield
+    finally:
+        prefect_config.workflow_kind = saved
 
 
 @pytest.fixture

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -22,11 +22,19 @@ def _run_x64(snippet: str) -> str:
     Returns the captured stdout, stripped. Stderr is included only on
     failure to surface useful tracebacks.
     """
+    # Disable Prefect for the subprocess too. The session-scoped autouse
+    # fixture in tests/conftest.py only affects the parent process; this
+    # subprocess starts fresh and would otherwise pick up whatever
+    # ``WorkflowKind.DEFAULT`` auto-resolves to (TASK if Prefect is
+    # importable, which then fails for any user whose ``PREFECT_API_URL``
+    # points at an unreachable server).
     program = textwrap.dedent(
         """
         import jax
         jax.config.update("jax_enable_x64", True)
         import jax.numpy as jnp
+        from probpipe import WorkflowKind, prefect_config
+        prefect_config.workflow_kind = WorkflowKind.OFF
         """
     ) + textwrap.dedent(snippet)
     result = subprocess.run(


### PR DESCRIPTION
## Summary

- Adds an autouse conftest fixture that pins `prefect_config.workflow_kind = WorkflowKind.OFF` around every test, so the suite is independent of whatever Prefect profile the contributor's user account happens to have.
- Patches the `tests/test_dtype.py` subprocess preamble to do the same — those tests run probpipe in fresh Python processes and would otherwise bypass the conftest fixture.

## Background

The `WorkflowKind.DEFAULT` resolution in `WorkflowFunction.effective_workflow_kind` (added in #120) auto-promotes to `TASK` whenever `prefect` is importable. At dispatch time the Prefect client uses whatever `PREFECT_API_URL` the user's `~/.prefect/profiles.toml` sets. If that server isn't running, every test that goes through a `WorkflowFunction` fails with:

```
RuntimeError: Failed to reach API at http://127.0.0.1:4200/api/
```

CI sidesteps this because its runner has no profile and Prefect falls back to ephemeral mode — but any contributor who's previously run `prefect cloud login` or set up a local server profile hits 100+ failures locally.

## Why this approach

- **Test-only fix, no runtime behavior change.** The auto-promote-to-TASK semantic for users is the documented design and isn't touched here.
- **Function-scoped (not session-scoped).** `test_prefect_config.py` has its own autouse fixture that calls `prefect_config.reset()` (→ `DEFAULT`); without function scope here, that DEFAULT would leak into later tests.
- **Doesn't interfere with the Prefect tests.** `test_prefect_orchestration.py` passes `workflow_kind="task"` per-instance (a per-instance override beats the global). `test_prefect_config.py`'s own fixture runs after the conftest one, so the DEFAULT they expect is preserved.

## Test plan

- [x] `pytest tests/` is green locally with `~/.prefect/profiles.toml` pointed at an unreachable server: **2270 passed, 7 skipped, 0 failed**.
- [x] `pytest tests/test_prefect_config.py` — 29 passed (the DEFAULT auto-detect tests still see DEFAULT correctly).
- [x] `pytest tests/test_prefect_orchestration.py` — 17 passed (the in-process Prefect harness still works).
- [x] CI run on this PR (Prefect-less ephemeral mode) stays green — should be a no-op there.
