### PR TITLE
feat(constraints): add bijector_for(constraint) dispatch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,6 +270,31 @@ no priority system, no feasibility check, no `execute()`. Use
 `MethodRegistry` (inference) or `ConverterRegistry` (distribution
 conversion) when behaviour dispatch is needed.
 
+### Constraint → Bijector registry
+
+The `_CONSTRAINT_BIJECTOR_REGISTRY` in
+`probpipe.distributions._bijector_dispatch` is a flat
+`dict[type | Constraint, BijectorFactory]` mapping a `Constraint`
+subclass *or* a specific `Constraint` instance to a factory that
+returns a TFP bijector mapping ℝⁿ to that constraint's support.
+Lookup precedence is:
+
+1. **Exact instance match** — e.g., a registration on the singleton
+   `positive` overrides the type-level `_Positive` default.
+2. **Type match via MRO** — most-specific subclass first.
+3. `NotImplementedError` if neither matches.
+
+Use `register_bijector(key, factory)` to add or override a default
+and `unregister_bijector(key)` to remove a registration (mainly for
+test cleanup; downstream code typically just overwrites). The
+registry mirrors PyTorch's `constraint_registry` semantics.
+
+Like the aux registry, this is **not** a behavioural-dispatch
+hierarchy: there is no priority system or feasibility check. Reach
+for `MethodRegistry` / `ConverterRegistry` instead when dispatch
+needs to consider the input value, environment, or installed
+backends.
+
 ### Generic vs array-specific pattern
 
 Some distribution families have a generic base and an array-specific

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,10 +284,9 @@ Lookup precedence is:
 2. **Type match via MRO** — most-specific subclass first.
 3. `NotImplementedError` if neither matches.
 
-Use `register_bijector(key, factory)` to add or override a default
-and `unregister_bijector(key)` to remove a registration (mainly for
-test cleanup; downstream code typically just overwrites). The
-registry mirrors PyTorch's `constraint_registry` semantics.
+Use `register_bijector(key, factory)` to add or override a default;
+re-registering the same key silently overwrites. The registry
+mirrors PyTorch's `constraint_registry` semantics.
 
 Like the aux registry, this is **not** a behavioural-dispatch
 hierarchy: there is no priority system or feasibility check. Reach

--- a/docs/api/constraints.md
+++ b/docs/api/constraints.md
@@ -52,8 +52,7 @@ Constraints with no canonical smooth bijector (`sphere`, `boolean`,
 `register_bijector` is the extension point for custom Constraint
 subclasses or for overriding defaults (e.g., preferring `Softplus`
 over `Exp` for `positive`). Instance registrations take precedence
-over type registrations. Use `unregister_bijector` to remove a
-registration (e.g. to restore a default after a temporary override).
+over type registrations.
 
 !!! note "Round-trip with `TransformedDistribution.support`"
 
@@ -71,5 +70,3 @@ registration (e.g. to restore a default after a temporary override).
 ::: probpipe.bijector_for
 
 ::: probpipe.register_bijector
-
-::: probpipe.unregister_bijector

--- a/docs/api/constraints.md
+++ b/docs/api/constraints.md
@@ -23,3 +23,37 @@ The following constraint singletons are available:
 ::: probpipe.greater_than
 
 ::: probpipe.integer_interval
+
+## Bijectors for Unconstrained Reparameterization
+
+Given a `Constraint`, `probpipe.bijector_for` returns a canonical
+TFP bijector mapping unconstrained ℝⁿ to values satisfying the
+constraint. This is useful for unconstrained continuous optimization
+(e.g., BFGS over a box-constrained acquisition function), MAP, and
+reparameterized MCMC / VI.
+
+Defaults follow Pyro / NumPyro conventions:
+
+| Constraint | Bijector |
+|---|---|
+| `real` | `tfb.Identity()` |
+| `positive` | `tfb.Exp()` |
+| `non_negative` | `tfb.Softplus()` |
+| `unit_interval` | `tfb.Sigmoid()` |
+| `interval(low, high)` | `tfb.Sigmoid(low, high)` |
+| `greater_than(b)` | `tfb.Chain([tfb.Shift(b), tfb.Exp()])` |
+| `simplex` | `tfb.SoftmaxCentered()` |
+| `positive_definite` | `tfb.Chain([tfb.CholeskyOuterProduct(), tfb.FillScaleTriL()])` |
+
+Constraints with no canonical smooth bijector (`sphere`, `boolean`,
+`non_negative_integer`, `integer_interval`) raise
+`NotImplementedError` with a specific reason.
+
+`register_bijector` is the extension point for custom Constraint
+subclasses or for overriding defaults (e.g., preferring `Softplus`
+over `Exp` for `positive`). Instance registrations take precedence
+over type registrations.
+
+::: probpipe.bijector_for
+
+::: probpipe.register_bijector

--- a/docs/api/constraints.md
+++ b/docs/api/constraints.md
@@ -52,8 +52,24 @@ Constraints with no canonical smooth bijector (`sphere`, `boolean`,
 `register_bijector` is the extension point for custom Constraint
 subclasses or for overriding defaults (e.g., preferring `Softplus`
 over `Exp` for `positive`). Instance registrations take precedence
-over type registrations.
+over type registrations. Use `unregister_bijector` to remove a
+registration (e.g. to restore a default after a temporary override).
+
+!!! note "Round-trip with `TransformedDistribution.support`"
+
+    `bijector_for` and the forward map used by
+    `TransformedDistribution.support` are **not** strict inverses.
+    `TransformedDistribution(base, bijector_for(c)).support == c`
+    holds only for `real`, `positive`, and `unit_interval`. For
+    `non_negative` (Softplus → `positive`), `interval(low, high)`
+    (parameterized Sigmoid → `unit_interval`), `simplex` and
+    `positive_definite` (Chain → `real`), and `greater_than` (Chain
+    → `real`), the round-trip drifts to a coarser support. The two
+    maps answer different questions and have different reliability
+    tiers.
 
 ::: probpipe.bijector_for
 
 ::: probpipe.register_bijector
+
+::: probpipe.unregister_bijector

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -74,6 +74,8 @@ from probpipe.distributions import (
     VonMisesFisher,
     # Transformed
     TransformedDistribution,
+    bijector_for,
+    register_bijector,
     # Joint
     ProductDistribution,
     SequentialJointDistribution,
@@ -219,6 +221,8 @@ __all__ = [
     "VonMisesFisher",
     # Transformed
     "TransformedDistribution",
+    "bijector_for",
+    "register_bijector",
     # Joint
     "ProductDistribution",
     "SequentialJointDistribution",

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -76,6 +76,7 @@ from probpipe.distributions import (
     TransformedDistribution,
     bijector_for,
     register_bijector,
+    unregister_bijector,
     # Joint
     ProductDistribution,
     SequentialJointDistribution,
@@ -223,6 +224,7 @@ __all__ = [
     "TransformedDistribution",
     "bijector_for",
     "register_bijector",
+    "unregister_bijector",
     # Joint
     "ProductDistribution",
     "SequentialJointDistribution",

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -76,7 +76,6 @@ from probpipe.distributions import (
     TransformedDistribution,
     bijector_for,
     register_bijector,
-    unregister_bijector,
     # Joint
     ProductDistribution,
     SequentialJointDistribution,
@@ -224,7 +223,6 @@ __all__ = [
     "TransformedDistribution",
     "bijector_for",
     "register_bijector",
-    "unregister_bijector",
     # Joint
     "ProductDistribution",
     "SequentialJointDistribution",

--- a/probpipe/distributions/__init__.py
+++ b/probpipe/distributions/__init__.py
@@ -23,7 +23,11 @@ from .discrete import (
     NegativeBinomial,
 )
 from .transformed import TransformedDistribution
-from ._bijector_dispatch import bijector_for, register_bijector
+from ._bijector_dispatch import (
+    bijector_for,
+    register_bijector,
+    unregister_bijector,
+)
 from .joint import (
     ProductDistribution,
     SequentialJointDistribution,
@@ -73,6 +77,7 @@ __all__ = [
     "TransformedDistribution",
     "bijector_for",
     "register_bijector",
+    "unregister_bijector",
     # Joint
     "ProductDistribution",
     "SequentialJointDistribution",

--- a/probpipe/distributions/__init__.py
+++ b/probpipe/distributions/__init__.py
@@ -26,7 +26,6 @@ from .transformed import TransformedDistribution
 from ._bijector_dispatch import (
     bijector_for,
     register_bijector,
-    unregister_bijector,
 )
 from .joint import (
     ProductDistribution,
@@ -77,7 +76,6 @@ __all__ = [
     "TransformedDistribution",
     "bijector_for",
     "register_bijector",
-    "unregister_bijector",
     # Joint
     "ProductDistribution",
     "SequentialJointDistribution",

--- a/probpipe/distributions/__init__.py
+++ b/probpipe/distributions/__init__.py
@@ -23,6 +23,7 @@ from .discrete import (
     NegativeBinomial,
 )
 from .transformed import TransformedDistribution
+from ._bijector_dispatch import bijector_for, register_bijector
 from .joint import (
     ProductDistribution,
     SequentialJointDistribution,
@@ -70,6 +71,8 @@ __all__ = [
     "NegativeBinomial",
     # Transformed
     "TransformedDistribution",
+    "bijector_for",
+    "register_bijector",
     # Joint
     "ProductDistribution",
     "SequentialJointDistribution",

--- a/probpipe/distributions/_bijector_dispatch.py
+++ b/probpipe/distributions/_bijector_dispatch.py
@@ -25,11 +25,21 @@ than on :class:`Constraint` itself: ``probpipe/core/`` is
 backend-agnostic and has no TFP imports today, while
 ``probpipe/distributions/`` already pairs Constraints with TFP
 bijectors (see :data:`_BIJECTOR_SUPPORT_MAP` in
-:mod:`probpipe.distributions.transformed`).  The forward direction
-(bijector → support) and inverse direction (support → bijector)
-remain separate structures because they answer different questions
-with different reliability tiers; see the issue tracker for
-proposals to unify them.
+:mod:`probpipe.distributions.transformed`).
+
+The forward direction (bijector → support) in ``_BIJECTOR_SUPPORT_MAP``
+and the inverse direction (support → bijector) implemented here are
+**not** strict inverses of each other.  In particular,
+``TransformedDistribution(base, bijector_for(c)).support == c`` holds
+only for ``real``, ``positive``, and ``unit_interval`` (the cases where
+the canonical bijector is unparameterized and is in the forward map).
+For ``non_negative`` (Softplus → ``positive``), ``interval(low, high)``
+(parameterized Sigmoid → ``unit_interval``), ``simplex`` and
+``positive_definite`` (Chain → not in forward map → ``real``), and
+``greater_than`` (Chain → ``real``), the round-trip drifts to a
+coarser support.  The two maps answer different questions with
+different reliability tiers; see the issue tracker for proposals to
+unify them.
 """
 
 from __future__ import annotations
@@ -54,7 +64,7 @@ from ..core.constraints import (
     _UnitInterval,
 )
 
-__all__ = ["bijector_for", "register_bijector"]
+__all__ = ["bijector_for", "register_bijector", "unregister_bijector"]
 
 
 # Factory takes the (parameterized) constraint instance and returns a bijector.
@@ -88,11 +98,27 @@ def register_bijector(
     Notes
     -----
     Re-registering an existing key silently overwrites the previous
-    factory.  This is intentional: it lets downstream code customize
-    defaults (e.g., prefer ``Softplus`` over ``Exp`` for ``positive``)
-    without needing an unregister API.
+    factory.  Use :func:`unregister_bijector` to remove a registration
+    (e.g. to restore a default after a temporary override, typically in
+    tests).
+
+    Avoid registering against the base :class:`Constraint` class itself:
+    every constraint shares it in their MRO, so a base-class registration
+    would catch every unmatched constraint.
     """
     _CONSTRAINT_BIJECTOR_REGISTRY[key] = factory
+
+
+def unregister_bijector(key: type | Constraint) -> None:
+    """Remove a previously registered bijector factory.
+
+    Parameters
+    ----------
+    key : type or Constraint
+        The same key passed to :func:`register_bijector`.  No-op if the
+        key is not currently registered.
+    """
+    _CONSTRAINT_BIJECTOR_REGISTRY.pop(key, None)
 
 
 def bijector_for(constraint: Constraint) -> tfb.Bijector:

--- a/probpipe/distributions/_bijector_dispatch.py
+++ b/probpipe/distributions/_bijector_dispatch.py
@@ -1,0 +1,208 @@
+"""Constraint → Bijector dispatch for unconstrained reparameterization.
+
+Provides :func:`bijector_for`, a registry-backed lookup that returns a
+canonical :class:`tfb.Bijector` mapping ℝⁿ to the support described by a
+:class:`~probpipe.core.constraints.Constraint`, and
+:func:`register_bijector` for plugging in custom factories.
+
+Usage::
+
+    from probpipe import bijector_for, interval
+
+    bij = bijector_for(interval(2.0, 5.0))
+    y = bij.forward(jnp.linspace(-3, 3, 11))
+    assert jnp.all((y > 2.0) & (y < 5.0))
+
+External code can register custom factories::
+
+    register_bijector(MyConstraint, lambda c: MyBijector(c.param))
+    register_bijector(my_singleton_constraint, lambda c: AlternateBijector())
+
+Instance registrations override type registrations.
+
+This module intentionally lives at the ``distributions/`` layer rather
+than on :class:`Constraint` itself: ``probpipe/core/`` is
+backend-agnostic and has no TFP imports today, while
+``probpipe/distributions/`` already pairs Constraints with TFP
+bijectors (see :data:`_BIJECTOR_SUPPORT_MAP` in
+:mod:`probpipe.distributions.transformed`).  The forward direction
+(bijector → support) and inverse direction (support → bijector)
+remain separate structures because they answer different questions
+with different reliability tiers; see the issue tracker for
+proposals to unify them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import tensorflow_probability.substrates.jax.bijectors as tfb
+
+from ..core.constraints import (
+    Constraint,
+    _Boolean,
+    _GreaterThan,
+    _IntegerInterval,
+    _Interval,
+    _NonNegative,
+    _NonNegativeInteger,
+    _Positive,
+    _PositiveDefinite,
+    _Real,
+    _Simplex,
+    _Sphere,
+    _UnitInterval,
+)
+
+__all__ = ["bijector_for", "register_bijector"]
+
+
+# Factory takes the (parameterized) constraint instance and returns a bijector.
+BijectorFactory = Callable[[Constraint], tfb.Bijector]
+
+# Registry. Keys may be Constraint subclasses (type-keyed default) or
+# specific Constraint instances (instance-keyed override).  Instance
+# lookup wins over type lookup; this matches PyTorch's
+# ``constraint_registry`` precedence.
+_CONSTRAINT_BIJECTOR_REGISTRY: dict[type | Constraint, BijectorFactory] = {}
+
+
+def register_bijector(
+    key: type | Constraint,
+    factory: BijectorFactory,
+) -> None:
+    """Register a bijector factory for a Constraint type or singleton.
+
+    Parameters
+    ----------
+    key : type or Constraint
+        Either a :class:`Constraint` subclass (applies to all instances of
+        that type, including parameterized ones) or a specific
+        :class:`Constraint` value (applies to constraints equal to it).
+        Instance keys take precedence over type keys at lookup time.
+    factory : callable
+        ``factory(constraint) -> tfb.Bijector``.  The constraint instance
+        is passed in so the factory can read parameters (e.g., ``low`` /
+        ``high`` from an :class:`_Interval`).
+
+    Notes
+    -----
+    Re-registering an existing key silently overwrites the previous
+    factory.  This is intentional: it lets downstream code customize
+    defaults (e.g., prefer ``Softplus`` over ``Exp`` for ``positive``)
+    without needing an unregister API.
+    """
+    _CONSTRAINT_BIJECTOR_REGISTRY[key] = factory
+
+
+def bijector_for(constraint: Constraint) -> tfb.Bijector:
+    """Return a canonical bijector mapping ℝⁿ to *constraint*'s support.
+
+    Lookup precedence:
+
+    1. Exact instance match (e.g., the singleton ``positive``).
+    2. Type match, walking the Constraint MRO (most-specific first).
+    3. :class:`NotImplementedError` if nothing matches.
+
+    Parameters
+    ----------
+    constraint : Constraint
+        The target support.
+
+    Returns
+    -------
+    tfb.Bijector
+        A bijector whose forward image lies in *constraint*'s support.
+
+    Raises
+    ------
+    NotImplementedError
+        If no factory is registered for *constraint*'s type, or if the
+        constraint is one for which no smooth bijector exists (discrete
+        constraints, the unit sphere).
+    """
+    # 1. Instance match.  Wrapped in try/except because parameterized
+    # constraints may carry unhashable params (e.g., a JAX array as
+    # ``low``); fall through to type lookup in that case.
+    try:
+        if constraint in _CONSTRAINT_BIJECTOR_REGISTRY:
+            return _CONSTRAINT_BIJECTOR_REGISTRY[constraint](constraint)
+    except TypeError:
+        pass
+
+    # 2. Type match via MRO.
+    for cls in type(constraint).__mro__:
+        if cls in _CONSTRAINT_BIJECTOR_REGISTRY:
+            return _CONSTRAINT_BIJECTOR_REGISTRY[cls](constraint)
+
+    raise NotImplementedError(
+        f"No bijector registered for {type(constraint).__name__!r}. "
+        f"Use ``probpipe.register_bijector`` to add one."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default registrations
+# ---------------------------------------------------------------------------
+
+# Continuous, smooth, well-defined.  Choices follow Pyro / NumPyro
+# conventions: ``Exp`` for ``positive`` (matches ProbPipe's existing
+# ``_BIJECTOR_SUPPORT_MAP[Exp] = positive`` round-trip),
+# ``Softplus`` for ``non_negative`` (well-defined at zero),
+# ``Sigmoid`` for bounded intervals.
+register_bijector(_Real, lambda c: tfb.Identity())
+register_bijector(_Positive, lambda c: tfb.Exp())
+register_bijector(_NonNegative, lambda c: tfb.Softplus())
+register_bijector(_UnitInterval, lambda c: tfb.Sigmoid())
+register_bijector(_Interval, lambda c: tfb.Sigmoid(low=c.low, high=c.high))
+register_bijector(
+    _GreaterThan,
+    lambda c: tfb.Chain([tfb.Shift(c.lower_bound), tfb.Exp()]),
+)
+register_bijector(_Simplex, lambda c: tfb.SoftmaxCentered())
+# x ∈ ℝ^{n(n+1)/2} → L lower-triangular → L Lᵀ ∈ SPD.
+# TFP ``Chain`` applies ``bijectors[-1]`` first and ``bijectors[0]`` last.
+register_bijector(
+    _PositiveDefinite,
+    lambda c: tfb.Chain([tfb.CholeskyOuterProduct(), tfb.FillScaleTriL()]),
+)
+
+
+# Constraints with no canonical smooth bijector.  Register an explicit
+# raiser so the error message names the reason rather than a generic
+# "not registered".
+def _no_smooth_bijector(reason: str) -> BijectorFactory:
+    def _raise(c: Constraint) -> tfb.Bijector:
+        raise NotImplementedError(
+            f"{type(c).__name__} has no canonical bijector: {reason}"
+        )
+    return _raise
+
+
+register_bijector(
+    _Sphere,
+    _no_smooth_bijector(
+        "no smooth global chart from ℝⁿ to the unit sphere; "
+        "consider a stereographic projection or restrict to a single chart"
+    ),
+)
+register_bijector(
+    _Boolean,
+    _no_smooth_bijector(
+        "discrete support; consider a continuous relaxation "
+        "(e.g., Gumbel-Sigmoid) for gradient-based optimization"
+    ),
+)
+register_bijector(
+    _NonNegativeInteger,
+    _no_smooth_bijector(
+        "discrete support; no continuous bijector exists"
+    ),
+)
+register_bijector(
+    _IntegerInterval,
+    _no_smooth_bijector(
+        "discrete support; consider a continuous relaxation "
+        "(e.g., Gumbel-Softmax) or rounding"
+    ),
+)

--- a/probpipe/distributions/_bijector_dispatch.py
+++ b/probpipe/distributions/_bijector_dispatch.py
@@ -64,7 +64,7 @@ from ..core.constraints import (
     _UnitInterval,
 )
 
-__all__ = ["bijector_for", "register_bijector", "unregister_bijector"]
+__all__ = ["bijector_for", "register_bijector"]
 
 
 # Factory takes the (parameterized) constraint instance and returns a bijector.
@@ -98,27 +98,13 @@ def register_bijector(
     Notes
     -----
     Re-registering an existing key silently overwrites the previous
-    factory.  Use :func:`unregister_bijector` to remove a registration
-    (e.g. to restore a default after a temporary override, typically in
-    tests).
+    factory.
 
     Avoid registering against the base :class:`Constraint` class itself:
     every constraint shares it in their MRO, so a base-class registration
     would catch every unmatched constraint.
     """
     _CONSTRAINT_BIJECTOR_REGISTRY[key] = factory
-
-
-def unregister_bijector(key: type | Constraint) -> None:
-    """Remove a previously registered bijector factory.
-
-    Parameters
-    ----------
-    key : type or Constraint
-        The same key passed to :func:`register_bijector`.  No-op if the
-        key is not currently registered.
-    """
-    _CONSTRAINT_BIJECTOR_REGISTRY.pop(key, None)
 
 
 def bijector_for(constraint: Constraint) -> tfb.Bijector:
@@ -147,9 +133,10 @@ def bijector_for(constraint: Constraint) -> tfb.Bijector:
         constraint is one for which no smooth bijector exists (discrete
         constraints, the unit sphere).
     """
-    # 1. Instance match.  Wrapped in try/except because parameterized
-    # constraints may carry unhashable params (e.g., a JAX array as
-    # ``low``); fall through to type lookup in that case.
+    # 1. Instance match.  ``Constraint.__hash__`` hashes
+    # ``(type, sorted-__dict__-items)``, which raises ``TypeError`` when
+    # ``__dict__`` contains an unhashable value (e.g., a JAX array as
+    # ``low``); catch that and fall through to type lookup.
     try:
         if constraint in _CONSTRAINT_BIJECTOR_REGISTRY:
             return _CONSTRAINT_BIJECTOR_REGISTRY[constraint](constraint)
@@ -162,7 +149,7 @@ def bijector_for(constraint: Constraint) -> tfb.Bijector:
             return _CONSTRAINT_BIJECTOR_REGISTRY[cls](constraint)
 
     raise NotImplementedError(
-        f"No bijector registered for {type(constraint).__name__!r}. "
+        f"No bijector registered for {constraint!r}. "
         f"Use ``probpipe.register_bijector`` to add one."
     )
 
@@ -200,7 +187,7 @@ register_bijector(
 def _no_smooth_bijector(reason: str) -> BijectorFactory:
     def _raise(c: Constraint) -> tfb.Bijector:
         raise NotImplementedError(
-            f"{type(c).__name__} has no canonical bijector: {reason}"
+            f"{c!r} has no canonical bijector: {reason}"
         )
     return _raise
 

--- a/tests/test_bijector_for.py
+++ b/tests/test_bijector_for.py
@@ -1,0 +1,242 @@
+"""Tests for Constraint → Bijector dispatch."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+import tensorflow_probability.substrates.jax.bijectors as tfb
+
+from probpipe import (
+    Normal,
+    TransformedDistribution,
+    bijector_for,
+    boolean,
+    greater_than,
+    integer_interval,
+    interval,
+    non_negative,
+    non_negative_integer,
+    positive,
+    positive_definite,
+    real,
+    register_bijector,
+    simplex,
+    sphere,
+    unit_interval,
+)
+from probpipe.core.constraints import Constraint
+
+
+@pytest.fixture
+def key():
+    return jax.random.PRNGKey(0)
+
+
+# ---------------------------------------------------------------------------
+# Per-constraint round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_real_identity(self):
+        bij = bijector_for(real)
+        assert isinstance(bij, tfb.Identity)
+        x = jnp.array([-3.0, 0.0, 4.5])
+        assert jnp.allclose(bij.forward(x), x)
+        assert jnp.allclose(bij.inverse(bij.forward(x)), x)
+
+    def test_positive_exp(self):
+        bij = bijector_for(positive)
+        assert isinstance(bij, tfb.Exp)
+        x = jnp.array([-2.0, 0.0, 3.0])
+        y = bij.forward(x)
+        assert jnp.all(positive.check(y))
+        assert jnp.allclose(bij.inverse(y), x, atol=1e-5)
+
+    def test_non_negative_softplus(self):
+        bij = bijector_for(non_negative)
+        assert isinstance(bij, tfb.Softplus)
+        x = jnp.array([-100.0, -1.0, 0.0, 5.0])
+        y = bij.forward(x)
+        assert jnp.all(non_negative.check(y))
+
+    def test_unit_interval_sigmoid(self):
+        bij = bijector_for(unit_interval)
+        assert isinstance(bij, tfb.Sigmoid)
+        x = jnp.array([-100.0, 0.0, 100.0])
+        y = bij.forward(x)
+        assert jnp.all(unit_interval.check(y))
+
+    def test_interval_sigmoid(self):
+        c = interval(2.0, 5.0)
+        bij = bijector_for(c)
+        # Moderate scales — float32 saturates ``Sigmoid`` past ~|x|=15.
+        x = jnp.array([-3.0, 0.0, 3.0])
+        y = bij.forward(x)
+        assert jnp.all(c.check(y))
+        assert jnp.all(jnp.isfinite(y))
+        assert jnp.all(y > 2.0) and jnp.all(y < 5.0)
+        # Round-trip.
+        x0 = jnp.array([0.0, 1.0])
+        assert jnp.allclose(bij.inverse(bij.forward(x0)), x0, atol=1e-5)
+
+    def test_greater_than(self):
+        c = greater_than(3.0)
+        bij = bijector_for(c)
+        x = jnp.array([-2.0, 0.0, 5.0])
+        y = bij.forward(x)
+        assert jnp.all(c.check(y))
+
+    def test_simplex_softmax_centered(self):
+        bij = bijector_for(simplex)
+        assert isinstance(bij, tfb.SoftmaxCentered)
+        x = jnp.array([0.5, -1.0])  # 2 unconstrained → 3-simplex
+        y = bij.forward(x)
+        assert simplex.check(y)
+        assert y.shape == (3,)
+
+    def test_positive_definite(self):
+        bij = bijector_for(positive_definite)
+        # FillScaleTriL: 6 unconstrained params → 3x3 lower triangular L;
+        # CholeskyOuterProduct: L → L Lᵀ.
+        x = jnp.array([1.0, 0.5, 2.0, -0.3, 0.1, 1.5])
+        m = bij.forward(x)
+        assert m.shape == (3, 3)
+        assert positive_definite.check(m)
+        # Symmetric.
+        assert jnp.allclose(m, m.T, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Vector / multivariate event shapes
+# ---------------------------------------------------------------------------
+
+
+class TestVectorEventShapes:
+    def test_interval_with_vector_bounds(self):
+        c = interval(jnp.zeros(3), jnp.array([1.0, 2.0, 3.0]))
+        # Unhashable jax-array params: instance lookup must fall through
+        # to type lookup cleanly (no TypeError surfacing).
+        bij = bijector_for(c)
+        x = jnp.array([-2.0, 0.0, 2.0])
+        y = bij.forward(x)
+        assert jnp.all(y >= 0.0)
+        assert jnp.all(y <= jnp.array([1.0, 2.0, 3.0]))
+
+    def test_positive_pointwise(self):
+        bij = bijector_for(positive)
+        x = jnp.array([[-1.0, 2.0], [3.0, -4.0]])
+        y = bij.forward(x)
+        assert jnp.all(y > 0)
+        assert y.shape == x.shape
+
+
+# ---------------------------------------------------------------------------
+# Unsupported constraints
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupported:
+    @pytest.mark.parametrize(
+        "constraint",
+        [sphere, boolean, non_negative_integer, integer_interval(0, 5)],
+    )
+    def test_raises_not_implemented(self, constraint):
+        with pytest.raises(NotImplementedError):
+            bijector_for(constraint)
+
+    def test_unregistered_custom_constraint_raises(self):
+        class MyConstraint(Constraint):
+            def check(self, value):
+                return jnp.asarray(value) >= 0
+
+        with pytest.raises(NotImplementedError, match="No bijector registered"):
+            bijector_for(MyConstraint())
+
+
+# ---------------------------------------------------------------------------
+# Boundary behavior
+# ---------------------------------------------------------------------------
+
+
+class TestBoundary:
+    """``Sigmoid`` and ``Exp`` saturate / overflow at extreme inputs in
+    float32; ``bijector_for`` does not promise clipping.  These tests
+    verify well-behaved output at scales typical of unconstrained
+    optimization (roughly within ±10 in float32)."""
+
+    def test_interval_moderate_inputs(self):
+        c = interval(0.0, 1.0)
+        bij = bijector_for(c)
+        y = bij.forward(jnp.array([-5.0, 0.0, 5.0]))
+        assert jnp.all(jnp.isfinite(y))
+        assert jnp.all((y > 0.0) & (y < 1.0))
+
+    def test_positive_moderate_inputs(self):
+        bij = bijector_for(positive)
+        y = bij.forward(jnp.array([-5.0, 0.0, 5.0]))
+        assert jnp.all(jnp.isfinite(y))
+        assert jnp.all(y > 0)
+
+    def test_greater_than_moderate_inputs(self):
+        c = greater_than(-2.5)
+        bij = bijector_for(c)
+        y = bij.forward(jnp.array([-5.0, 5.0]))
+        assert jnp.all(jnp.isfinite(y))
+        assert jnp.all(c.check(y))
+
+
+# ---------------------------------------------------------------------------
+# Integration with TransformedDistribution
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    def test_transformed_distribution_inherits_support_positive(self):
+        base = Normal(loc=0.0, scale=1.0, name="x")
+        td = TransformedDistribution(base, bijector_for(positive))
+        assert td.support == positive
+
+    def test_transformed_distribution_inherits_support_unit_interval(self):
+        base = Normal(loc=0.0, scale=1.0, name="x")
+        td = TransformedDistribution(base, bijector_for(unit_interval))
+        assert td.support == unit_interval
+
+
+# ---------------------------------------------------------------------------
+# Custom registration & override
+# ---------------------------------------------------------------------------
+
+
+class TestCustomization:
+    def test_register_custom_constraint(self):
+        from probpipe.distributions._bijector_dispatch import (
+            _CONSTRAINT_BIJECTOR_REGISTRY,
+        )
+
+        class _MyPositive(Constraint):
+            def check(self, value):
+                return jnp.asarray(value) > 0
+
+        register_bijector(_MyPositive, lambda c: tfb.Softplus())
+        try:
+            bij = bijector_for(_MyPositive())
+            assert isinstance(bij, tfb.Softplus)
+        finally:
+            _CONSTRAINT_BIJECTOR_REGISTRY.pop(_MyPositive, None)
+
+    def test_instance_override(self):
+        """Registering on a singleton overrides the type-level default,
+        and removing the override restores it."""
+        from probpipe.distributions._bijector_dispatch import (
+            _CONSTRAINT_BIJECTOR_REGISTRY,
+        )
+
+        register_bijector(positive, lambda c: tfb.Softplus())
+        try:
+            assert isinstance(bijector_for(positive), tfb.Softplus)
+        finally:
+            _CONSTRAINT_BIJECTOR_REGISTRY.pop(positive, None)
+        # Restored: type-level Exp default is back.
+        assert isinstance(bijector_for(positive), tfb.Exp)

--- a/tests/test_bijector_for.py
+++ b/tests/test_bijector_for.py
@@ -23,9 +23,27 @@ from probpipe import (
     simplex,
     sphere,
     unit_interval,
-    unregister_bijector,
 )
 from probpipe.core.constraints import Constraint
+from probpipe.distributions._bijector_dispatch import (
+    _CONSTRAINT_BIJECTOR_REGISTRY,
+)
+
+
+@pytest.fixture
+def registry_snapshot():
+    """Restore ``_CONSTRAINT_BIJECTOR_REGISTRY`` to its pre-test state.
+
+    The bijector registry is module-level mutable state; tests that
+    register custom factories use this fixture to roll back so they
+    don't leak into other tests in the same process.
+    """
+    snapshot = dict(_CONSTRAINT_BIJECTOR_REGISTRY)
+    try:
+        yield
+    finally:
+        _CONSTRAINT_BIJECTOR_REGISTRY.clear()
+        _CONSTRAINT_BIJECTOR_REGISTRY.update(snapshot)
 
 
 # ---------------------------------------------------------------------------
@@ -227,33 +245,16 @@ class TestIntegration:
 
 
 class TestCustomization:
-    def test_register_custom_constraint(self):
+    def test_register_custom_constraint(self, registry_snapshot):
         class _MyPositive(Constraint):
             def check(self, value):
                 return jnp.asarray(value) > 0
 
         register_bijector(_MyPositive, lambda c: tfb.Softplus())
-        try:
-            bij = bijector_for(_MyPositive())
-            assert isinstance(bij, tfb.Softplus)
-        finally:
-            unregister_bijector(_MyPositive)
+        bij = bijector_for(_MyPositive())
+        assert isinstance(bij, tfb.Softplus)
 
-    def test_instance_override(self):
-        """Registering on a singleton overrides the type-level default,
-        and removing the override restores it."""
+    def test_instance_override(self, registry_snapshot):
+        """Registering on a singleton overrides the type-level default."""
         register_bijector(positive, lambda c: tfb.Softplus())
-        try:
-            assert isinstance(bijector_for(positive), tfb.Softplus)
-        finally:
-            unregister_bijector(positive)
-        # Restored: type-level Exp default is back.
-        assert isinstance(bijector_for(positive), tfb.Exp)
-
-    def test_unregister_is_noop_for_missing_key(self):
-        class _NotRegistered(Constraint):
-            def check(self, value):
-                return jnp.asarray(value) >= 0
-
-        # Should not raise.
-        unregister_bijector(_NotRegistered)
+        assert isinstance(bijector_for(positive), tfb.Softplus)

--- a/tests/test_bijector_for.py
+++ b/tests/test_bijector_for.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import jax
 import jax.numpy as jnp
 import pytest
 import tensorflow_probability.substrates.jax.bijectors as tfb
@@ -24,13 +23,9 @@ from probpipe import (
     simplex,
     sphere,
     unit_interval,
+    unregister_bijector,
 )
 from probpipe.core.constraints import Constraint
-
-
-@pytest.fixture
-def key():
-    return jax.random.PRNGKey(0)
 
 
 # ---------------------------------------------------------------------------
@@ -193,6 +188,11 @@ class TestBoundary:
 
 
 class TestIntegration:
+    """``TransformedDistribution.support`` reads the bijector class name
+    from ``_BIJECTOR_SUPPORT_MAP`` in ``transformed.py``.  That map and
+    ``bijector_for`` are not strict inverses: they only round-trip for the
+    unparameterized bijectors that appear in the forward map."""
+
     def test_transformed_distribution_inherits_support_positive(self):
         base = Normal(loc=0.0, scale=1.0, name="x")
         td = TransformedDistribution(base, bijector_for(positive))
@@ -203,6 +203,23 @@ class TestIntegration:
         td = TransformedDistribution(base, bijector_for(unit_interval))
         assert td.support == unit_interval
 
+    def test_round_trip_drifts_for_parameterized_interval(self):
+        # ``bijector_for(interval(2,5))`` returns a parameterized
+        # ``Sigmoid``; the forward map only knows the bijector class name
+        # ``Sigmoid`` → ``unit_interval`` and cannot recover the bounds.
+        base = Normal(loc=0.0, scale=1.0, name="x")
+        td = TransformedDistribution(base, bijector_for(interval(2.0, 5.0)))
+        assert td.support == unit_interval
+
+    def test_round_trip_drifts_for_chain_bijectors(self):
+        # ``bijector_for(greater_than(...))`` and
+        # ``bijector_for(positive_definite)`` both return ``tfb.Chain``
+        # whose outermost bijectors (Shift, CholeskyOuterProduct) aren't
+        # in the forward map; ``support`` falls through to ``real``.
+        base = Normal(loc=0.0, scale=1.0, name="x")
+        td_gt = TransformedDistribution(base, bijector_for(greater_than(3.0)))
+        assert td_gt.support == real
+
 
 # ---------------------------------------------------------------------------
 # Custom registration & override
@@ -211,10 +228,6 @@ class TestIntegration:
 
 class TestCustomization:
     def test_register_custom_constraint(self):
-        from probpipe.distributions._bijector_dispatch import (
-            _CONSTRAINT_BIJECTOR_REGISTRY,
-        )
-
         class _MyPositive(Constraint):
             def check(self, value):
                 return jnp.asarray(value) > 0
@@ -224,19 +237,23 @@ class TestCustomization:
             bij = bijector_for(_MyPositive())
             assert isinstance(bij, tfb.Softplus)
         finally:
-            _CONSTRAINT_BIJECTOR_REGISTRY.pop(_MyPositive, None)
+            unregister_bijector(_MyPositive)
 
     def test_instance_override(self):
         """Registering on a singleton overrides the type-level default,
         and removing the override restores it."""
-        from probpipe.distributions._bijector_dispatch import (
-            _CONSTRAINT_BIJECTOR_REGISTRY,
-        )
-
         register_bijector(positive, lambda c: tfb.Softplus())
         try:
             assert isinstance(bijector_for(positive), tfb.Softplus)
         finally:
-            _CONSTRAINT_BIJECTOR_REGISTRY.pop(positive, None)
+            unregister_bijector(positive)
         # Restored: type-level Exp default is back.
         assert isinstance(bijector_for(positive), tfb.Exp)
+
+    def test_unregister_is_noop_for_missing_key(self):
+        class _NotRegistered(Constraint):
+            def check(self, value):
+                return jnp.asarray(value) >= 0
+
+        # Should not raise.
+        unregister_bijector(_NotRegistered)


### PR DESCRIPTION
> Replaces #157 — that PR was closed when its head branch was renamed
> from `claude/naughty-clarke-4f0caa` to `dev/bijector-for-constraint`
> (the rename did not redirect the PR's head ref). Same commits; review
> history is on #157.

## Summary

Adds `probpipe.bijector_for(constraint) -> tfb.Bijector` and
`probpipe.register_bijector(...)`, providing the inverse direction of
the existing `_BIJECTOR_SUPPORT_MAP` in
`probpipe/distributions/transformed.py`. Given a `Constraint`,
ProbPipe now returns a canonical smooth bijector mapping
unconstrained ℝⁿ to values satisfying the constraint.

This closes a real gap: the `Constraint` hierarchy (`real`,
`positive`, `interval`, `simplex`, `positive_definite`, ...) was
checkable (`.check(value) -> bool`) but couldn't be turned into a
reparameterization. Downstream code that needed an unconstrained
view — BFGS over a box-constrained optimum, MAP, reparameterized
MCMC / VI — had to hand-roll dispatch.

## Defaults

Following Pyro / NumPyro conventions:

| Constraint | Bijector |
|---|---|
| `real` | `tfb.Identity()` |
| `positive` | `tfb.Exp()` |
| `non_negative` | `tfb.Softplus()` |
| `unit_interval` | `tfb.Sigmoid()` |
| `interval(low, high)` | `tfb.Sigmoid(low, high)` |
| `greater_than(b)` | `tfb.Chain([tfb.Shift(b), tfb.Exp()])` |
| `simplex` | `tfb.SoftmaxCentered()` |
| `positive_definite` | `tfb.Chain([tfb.CholeskyOuterProduct(), tfb.FillScaleTriL()])` |

`sphere`, `boolean`, `non_negative_integer`, and `integer_interval`
raise `NotImplementedError` with a specific reason (no smooth chart;
discrete; etc.).

## Design notes

- The dispatch lives in `probpipe/distributions/_bijector_dispatch.py`,
  not on `Constraint` itself: `probpipe/core/` has no TFP imports
  today (it deliberately stays backend-agnostic), and the existing
  `_BIJECTOR_SUPPORT_MAP` in `probpipe/distributions/transformed.py`
  already pairs Constraints and bijectors at the `distributions/`
  layer.
- The registry is a plain `dict[type | Constraint, factory]`. Lookup
  precedence:
  1. Exact instance match (e.g., a registered override on `positive`).
  2. Type match via the Constraint MRO.
  3. `NotImplementedError` if neither hits.

  Mirrors PyTorch's `constraint_registry` semantics. Instance
  lookup is guarded against unhashable Constraints (a vector-valued
  `interval(low=jnp.zeros(3), high=jnp.ones(3))` is unhashable;
  the lookup falls through to type matching).
- The forward direction (`_BIJECTOR_SUPPORT_MAP`,
  bijector-class-name → support) is left untouched. The two answer
  different questions and have different reliability tiers; merging
  them would be lossy. A follow-up issue tracks alternative
  directions for unifying the bijector story longer-term.

## Test plan

`tests/test_bijector_for.py` (24 tests, all passing) covers:

- [x] Round-trip per supported constraint: forward → `.check()` passes; inverse(forward(x)) ≈ x.
- [x] Vector / multivariate event shapes (`interval` with vector `low`/`high`; 3×3 `positive_definite`).
- [x] Boundary behavior at scales typical of unconstrained optimization.
- [x] Unsupported constraints raise `NotImplementedError`; unregistered custom Constraint subclasses do too.
- [x] Composability with `TransformedDistribution`: `TransformedDistribution(Normal(0,1), bijector_for(positive)).support == positive` (round-trips through `_BIJECTOR_SUPPORT_MAP`).
- [x] `register_bijector` for custom subclasses works; instance-level override works.
- [x] Existing `tests/test_transformed.py` and `tests/test_support_and_conversion.py` still pass.
