### PR TITLE
docs(contributing): add branch-naming guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,21 @@ with the implementation and request another review.
 For small fixes (typos, bug fixes, test additions), skip the plan step and
 go straight to an implementation PR.
 
+### Branch naming
+
+Use `dev/<short-kebab-case-description>` for branches. Examples:
+`dev/record-array-views`, `dev/pr-129-review-fixes`,
+`dev/bijector-for-constraint`. Keep the description short (3–5 words)
+and tied to the change, not the author or date.
+
+Claude Code auto-generates branch names like
+`claude/<adjective-name>-<hash>`. Rename these to a `dev/...` name
+**before** opening a PR, or via the GitHub web UI's Branches page
+(Branches → pencil icon). The REST `rename` API does **not** redirect
+open PRs to the new branch — it silently closes them
+(see [#157](https://github.com/TARPS-group/prob-pipe/pull/157) for an
+example). If you must rename after a PR is open, use the web UI.
+
 ---
 
 ## Development Setup


### PR DESCRIPTION
@jhuggins — I know guidance on branch names existed at some point, but it no longer seems to be present. (Searched `CONTRIBUTING.md`, `STYLE_GUIDE.md`, `README.md`, all `*.md` files in `docs/` and `.claude/`, and project/user `CLAUDE.md`; nothing turned up.)

## Summary

Adds a "Branch naming" subsection to `CONTRIBUTING.md`'s PR Workflow:

- Documents the de-facto `dev/<short-kebab-case-description>` convention observed in recent merges (`dev/record-array-views`, `dev/pr-129-review-fixes`, `dev/design-hierarchy`, etc.).
- Notes that Claude Code's auto-generated `claude/<adjective-name>-<hash>` branches should be renamed to `dev/...` **before** opening a PR.
- Warns that the GitHub REST `rename` endpoint **does not** redirect open PRs — it silently closes them. References #157 (where this happened) and points users to the web UI's Branches page for post-open renames.

## Test plan

- [x] `mkdocs build --strict` (CONTRIBUTING.md is not in mkdocs nav, so this is just a markdown sanity check).
- [x] Visual review of the new section in the rendered file.

If the prior guidance had a different convention (e.g., `feature/`, `fix/`, etc.), happy to adjust.
