### PR TITLE
fix(distributions): support array-valued bounds in .support

### DIFF
--- a/probpipe/core/constraints.py
+++ b/probpipe/core/constraints.py
@@ -234,8 +234,12 @@ def _supports_compatible(source: Constraint, target: Constraint) -> bool:
     Conservative: returns ``True`` when in doubt (e.g. for parameterized
     constraints that can't be compared structurally).
     """
-    # Identical constraints are always compatible
-    if source == target:
+    # Fast path: identical constraint instances are always compatible.
+    # Use ``is`` rather than ``==`` because ``Constraint.__eq__`` compares
+    # ``__dict__``s, which raises ValueError when constraint attributes
+    # are multi-element JAX arrays (e.g., per-dim ``interval`` bounds).
+    # The parameterized branches below cover the equal-but-distinct case.
+    if source is target:
         return True
 
     supersets = _all_supersets()
@@ -250,19 +254,25 @@ def _supports_compatible(source: Constraint, target: Constraint) -> bool:
     if source_type in supersets.get(target_type, set()):
         return False
 
-    # Parameterized constraints: interval/greater_than
+    # Parameterized constraints: interval/greater_than. Bounds may be
+    # array-valued (per-dim Uniform, TruncatedNormal, ...), so reduce
+    # element-wise comparisons with ``jnp.all``.
     if isinstance(source, _Interval) and isinstance(target, _Interval):
-        return source.low >= target.low and source.high <= target.high
+        return bool(jnp.all(source.low >= target.low)) and bool(
+            jnp.all(source.high <= target.high)
+        )
     if isinstance(source, _Interval) and isinstance(target, _Real):
         return True
     if isinstance(source, _GreaterThan) and isinstance(target, _GreaterThan):
-        return source.lower_bound >= target.lower_bound
+        return bool(jnp.all(source.lower_bound >= target.lower_bound))
     if isinstance(source, _GreaterThan) and isinstance(target, _Real):
         return True
     if isinstance(source, (_Positive, _NonNegative)) and isinstance(target, _GreaterThan):
         return True  # (0, inf) or [0, inf) ⊂ (lb, inf) when lb <= 0
     if isinstance(source, _IntegerInterval) and isinstance(target, _IntegerInterval):
-        return source.low >= target.low and source.high <= target.high
+        return bool(jnp.all(source.low >= target.low)) and bool(
+            jnp.all(source.high <= target.high)
+        )
     if isinstance(source, _IntegerInterval) and isinstance(target, (_NonNegativeInteger, _Real)):
         return True
 

--- a/probpipe/distributions/continuous.py
+++ b/probpipe/distributions/continuous.py
@@ -416,7 +416,7 @@ class Uniform(TFPDistribution):
 
     @property
     def support(self) -> Constraint:
-        return interval(float(self._low), float(self._high))
+        return interval(self._low, self._high)
 
     @classmethod
     def _default_support(cls) -> Constraint:
@@ -597,7 +597,7 @@ class HalfCauchy(TFPDistribution):
 
     @property
     def support(self) -> Constraint:
-        return greater_than(float(self._loc))
+        return greater_than(self._loc)
 
     @classmethod
     def _default_support(cls) -> Constraint:
@@ -646,7 +646,7 @@ class Pareto(TFPDistribution):
 
     @property
     def support(self) -> Constraint:
-        return greater_than(float(self._scale))
+        return greater_than(self._scale)
 
     @classmethod
     def _default_support(cls) -> Constraint:
@@ -711,7 +711,7 @@ class TruncatedNormal(TFPDistribution):
 
     @property
     def support(self) -> Constraint:
-        return interval(float(self._low), float(self._high))
+        return interval(self._low, self._high)
 
     @classmethod
     def _default_support(cls) -> Constraint:

--- a/tests/test_support_and_conversion.py
+++ b/tests/test_support_and_conversion.py
@@ -106,6 +106,23 @@ class TestSupportCompatibility:
         assert _supports_compatible(interval(0, 1), interval(-1, 2))
         assert not _supports_compatible(interval(-1, 2), interval(0, 1))
 
+    def test_interval_subset_array_bounds(self):
+        # Per-dim bounds: each source dim must lie within the
+        # corresponding target dim.
+        src = interval(jnp.array([0.0, 0.5]), jnp.array([1.0, 1.5]))
+        tgt_super = interval(jnp.array([-1.0, 0.0]), jnp.array([2.0, 2.0]))
+        tgt_partial = interval(jnp.array([-1.0, 1.0]), jnp.array([2.0, 2.0]))
+        assert _supports_compatible(src, tgt_super)
+        # src dim 1 starts at 0.5, which is below tgt_partial dim 1's 1.0.
+        assert not _supports_compatible(src, tgt_partial)
+
+    def test_greater_than_subset_array_bounds(self):
+        src = greater_than(jnp.array([1.0, 2.0]))
+        tgt_super = greater_than(jnp.array([0.0, 1.0]))
+        tgt_partial = greater_than(jnp.array([0.0, 3.0]))
+        assert _supports_compatible(src, tgt_super)
+        assert not _supports_compatible(src, tgt_partial)
+
 
 # ── Section 3: Support properties on distributions ────────────────────────────
 
@@ -126,6 +143,51 @@ class TestDistributionSupport:
 
     def test_uniform_support(self):
         assert Uniform(low=-1.0, high=2.0, name="u").support == interval(-1.0, 2.0)
+
+    def test_uniform_support_array_bounds(self):
+        # Regression: ``float(self._low)`` previously crashed for
+        # non-scalar low/high. Per-dim bounds should produce a working
+        # interval whose ``.check`` returns a per-dim boolean.
+        u = Uniform(
+            low=jnp.array([0.0, -1.0]),
+            high=jnp.array([1.0, 2.0]),
+            name="u_arr",
+        )
+        c = u.support
+        assert jnp.array_equal(c.check(jnp.array([0.5, 0.5])), jnp.array([True, True]))
+        assert jnp.array_equal(c.check(jnp.array([2.0, 0.5])), jnp.array([False, True]))
+
+    def test_half_cauchy_support_array_bounds(self):
+        hc = HalfCauchy(
+            loc=jnp.array([0.0, 1.0]),
+            scale=jnp.array([1.0, 1.0]),
+            name="hc_arr",
+        )
+        c = hc.support
+        assert jnp.array_equal(c.check(jnp.array([0.5, 1.5])), jnp.array([True, True]))
+        assert jnp.array_equal(c.check(jnp.array([-0.5, 0.5])), jnp.array([False, False]))
+
+    def test_pareto_support_array_bounds(self):
+        p = Pareto(
+            concentration=jnp.array([2.0, 2.0]),
+            scale=jnp.array([1.0, 2.0]),
+            name="p_arr",
+        )
+        c = p.support
+        assert jnp.array_equal(c.check(jnp.array([1.5, 2.5])), jnp.array([True, True]))
+        assert jnp.array_equal(c.check(jnp.array([0.5, 2.5])), jnp.array([False, True]))
+
+    def test_truncated_normal_support_array_bounds(self):
+        tn = TruncatedNormal(
+            loc=jnp.array([0.0, 0.0]),
+            scale=jnp.array([1.0, 1.0]),
+            low=jnp.array([-1.0, 0.0]),
+            high=jnp.array([1.0, 2.0]),
+            name="tn_arr",
+        )
+        c = tn.support
+        assert jnp.array_equal(c.check(jnp.array([0.0, 1.0])), jnp.array([True, True]))
+        assert jnp.array_equal(c.check(jnp.array([-2.0, 1.0])), jnp.array([False, True]))
 
     def test_bernoulli_support(self):
         assert Bernoulli(probs=0.5, name="d").support == boolean


### PR DESCRIPTION
## Summary

`Uniform`, `HalfCauchy`, `Pareto`, and `TruncatedNormal` `.support`
crash on the natural per-dim batched construction
(`Uniform(low=jnp.zeros(d), high=jnp.ones(d))`) because they cast
bound parameters to Python scalars before handing them to
`interval` / `greater_than`. Drop the casts; the constraint
factories broadcast correctly already.

While there, harden `_supports_compatible` for the same case:
replace the `source == target` early-out with `source is target`
(dict equality on JAX-array attributes raises ValueError) and
reduce the parameterized branches with `bool(jnp.all(...))`. Those
parameterized-vs-parameterized branches were latent dead code
(no `_default_support` returns a parameterized constraint today),
but they become reachable for any direct comparison of two
parameterized supports.

## Related

Related to #159 — that PR's `bijector_for` already wraps its
constraint-instance lookup in `try/except TypeError` to handle
unhashable array-bounded `Constraint`s, which is exactly the kind
of constraint this PR starts emitting from built-in distributions.
The two PRs are independent and can land in either order.

## Test plan

- [x] New regression tests in `tests/test_support_and_conversion.py`:
  - `test_uniform_support_array_bounds`,
    `test_half_cauchy_support_array_bounds`,
    `test_pareto_support_array_bounds`,
    `test_truncated_normal_support_array_bounds` — each builds the
    distribution with vector bounds and asserts `.support.check(...)`
    returns per-dim booleans.
  - `test_interval_subset_array_bounds`,
    `test_greater_than_subset_array_bounds` — exercise the newly
    array-aware branches of `_supports_compatible`.
- [x] `pytest tests/` — full suite passes (2236 passed, 8 skipped).
- [x] Verified on top of #159: scalar `Uniform.support` becomes
  unhashable after this fix (0-d JAX arrays are unhashable too),
  but `bijector_for`'s `try/except TypeError` catches it cleanly
  and falls through to type-keyed lookup. All 24 tests in
  `tests/test_bijector_for.py` pass with this fix layered in.
