### PR TITLE
fix(constraints): array-safe equality and tighten parameterized type hints

### DIFF
--- a/probpipe/core/constraints.py
+++ b/probpipe/core/constraints.py
@@ -120,7 +120,7 @@ class _Sphere(Constraint):
 
 class _Interval(Constraint):
     """Half-open or closed interval [low, high]."""
-    def __init__(self, low: float, high: float):
+    def __init__(self, low: ArrayLike, high: ArrayLike):
         self.low = low
         self.high = high
     def check(self, value: ArrayLike) -> Array:
@@ -128,19 +128,36 @@ class _Interval(Constraint):
         return (v >= self.low) & (v <= self.high)
     def __repr__(self) -> str:
         return f"interval({self.low}, {self.high})"
+    def __eq__(self, other: object) -> bool:
+        if type(self) is not type(other):
+            return False
+        return bool(jnp.array_equal(self.low, other.low)) and bool(
+            jnp.array_equal(self.high, other.high)
+        )
+    def __hash__(self) -> int:
+        # Coarse but valid: equal instances hash equal. Parameterized
+        # constraints rarely end up in sets/dicts, and array-valued
+        # bounds aren't directly hashable, so we hash on type only.
+        return hash(type(self))
 
 class _GreaterThan(Constraint):
     """Record strictly greater than a lower bound."""
-    def __init__(self, lower_bound: float):
+    def __init__(self, lower_bound: ArrayLike):
         self.lower_bound = lower_bound
     def check(self, value: ArrayLike) -> Array:
         return jnp.asarray(value) > self.lower_bound
     def __repr__(self) -> str:
         return f"greater_than({self.lower_bound})"
+    def __eq__(self, other: object) -> bool:
+        if type(self) is not type(other):
+            return False
+        return bool(jnp.array_equal(self.lower_bound, other.lower_bound))
+    def __hash__(self) -> int:
+        return hash(type(self))
 
 class _IntegerInterval(Constraint):
     """Integer values in [low, high]."""
-    def __init__(self, low: int, high: int):
+    def __init__(self, low: ArrayLike, high: ArrayLike):
         self.low = low
         self.high = high
     def check(self, value: ArrayLike) -> Array:
@@ -148,6 +165,14 @@ class _IntegerInterval(Constraint):
         return (v >= self.low) & (v <= self.high) & (v == jnp.floor(v))
     def __repr__(self) -> str:
         return f"integer_interval({self.low}, {self.high})"
+    def __eq__(self, other: object) -> bool:
+        if type(self) is not type(other):
+            return False
+        return bool(jnp.array_equal(self.low, other.low)) and bool(
+            jnp.array_equal(self.high, other.high)
+        )
+    def __hash__(self) -> int:
+        return hash(type(self))
 
 
 # ---------------------------------------------------------------------------
@@ -169,13 +194,13 @@ sphere = _Sphere()
 # Factory functions for parameterized constraints
 # ---------------------------------------------------------------------------
 
-def interval(low: float, high: float) -> _Interval:
+def interval(low: ArrayLike, high: ArrayLike) -> _Interval:
     return _Interval(low, high)
 
-def greater_than(lower_bound: float) -> _GreaterThan:
+def greater_than(lower_bound: ArrayLike) -> _GreaterThan:
     return _GreaterThan(lower_bound)
 
-def integer_interval(low: int, high: int) -> _IntegerInterval:
+def integer_interval(low: ArrayLike, high: ArrayLike) -> _IntegerInterval:
     return _IntegerInterval(low, high)
 
 
@@ -234,11 +259,8 @@ def _supports_compatible(source: Constraint, target: Constraint) -> bool:
     Conservative: returns ``True`` when in doubt (e.g. for parameterized
     constraints that can't be compared structurally).
     """
-    # Fast path: identical constraint instances are always compatible.
-    # Use ``is`` rather than ``==`` because ``Constraint.__eq__`` compares
-    # ``__dict__``s, which raises ValueError when constraint attributes
-    # are multi-element JAX arrays (e.g., per-dim ``interval`` bounds).
-    # The parameterized branches below cover the equal-but-distinct case.
+    # Fast path for identical instances; parameterized branches below
+    # handle the equal-but-distinct case for array-valued bounds.
     if source is target:
         return True
 

--- a/probpipe/distributions/discrete.py
+++ b/probpipe/distributions/discrete.py
@@ -183,7 +183,13 @@ class Binomial(TFPDistribution):
         return_dist: bool | None = None,
     ) -> Array:
         """Exact expectation over the finite support {0, ..., total_count}."""
-        n = int(self._total_count) + 1
+        tc = jnp.asarray(self._total_count)
+        if tc.ndim != 0:
+            raise ValueError(
+                "Binomial._expectation requires scalar total_count; "
+                f"got shape {tc.shape}"
+            )
+        n = int(tc) + 1
         support = jnp.arange(n, dtype=self.dtype)
         probs = jnp.exp(self._tfp_dist.log_prob(support))
         f_vals = jax.vmap(f)(support)

--- a/probpipe/distributions/discrete.py
+++ b/probpipe/distributions/discrete.py
@@ -166,7 +166,7 @@ class Binomial(TFPDistribution):
 
     @property
     def support(self) -> Constraint:
-        return integer_interval(0, int(self._total_count))
+        return integer_interval(0, self._total_count)
 
     @classmethod
     def _default_support(cls) -> Constraint:

--- a/tests/test_support_and_conversion.py
+++ b/tests/test_support_and_conversion.py
@@ -78,6 +78,28 @@ class TestConstraints:
         assert interval(0, 1) != interval(0, 2)
         assert real != positive
 
+    def test_parameterized_equality_array_bounds(self):
+        # __eq__ on parameterized constraints must use jnp.array_equal
+        # so it doesn't crash on multi-element JAX-array bounds.
+        a = interval(jnp.array([0.0, 0.5]), jnp.array([1.0, 1.5]))
+        b = interval(jnp.array([0.0, 0.5]), jnp.array([1.0, 1.5]))
+        c = interval(jnp.array([0.0, 0.5]), jnp.array([1.0, 2.0]))
+        assert a == b
+        assert a != c
+        assert greater_than(jnp.array([1.0, 2.0])) == greater_than(jnp.array([1.0, 2.0]))
+        assert greater_than(jnp.array([1.0, 2.0])) != greater_than(jnp.array([1.0, 3.0]))
+        assert integer_interval(jnp.array([0, 1]), jnp.array([5, 6])) == integer_interval(
+            jnp.array([0, 1]), jnp.array([5, 6])
+        )
+
+    def test_parameterized_hash_array_bounds(self):
+        # __hash__ on parameterized constraints must not raise for
+        # array-valued bounds (0-d or higher).
+        hash(interval(0.0, 1.0))
+        hash(interval(jnp.array([0.0, 0.5]), jnp.array([1.0, 1.5])))
+        hash(greater_than(jnp.array([1.0, 2.0])))
+        hash(integer_interval(jnp.array([0, 1]), jnp.array([5, 6])))
+
     def test_constraint_repr(self):
         assert repr(real) == "real"
         assert repr(positive) == "positive"
@@ -121,6 +143,14 @@ class TestSupportCompatibility:
         tgt_super = greater_than(jnp.array([0.0, 1.0]))
         tgt_partial = greater_than(jnp.array([0.0, 3.0]))
         assert _supports_compatible(src, tgt_super)
+        assert not _supports_compatible(src, tgt_partial)
+
+    def test_integer_interval_subset_array_bounds(self):
+        src = integer_interval(jnp.array([1, 2]), jnp.array([5, 6]))
+        tgt_super = integer_interval(jnp.array([0, 1]), jnp.array([10, 10]))
+        tgt_partial = integer_interval(jnp.array([0, 3]), jnp.array([10, 10]))
+        assert _supports_compatible(src, tgt_super)
+        # src dim 1 starts at 2, which is below tgt_partial dim 1's 3.
         assert not _supports_compatible(src, tgt_partial)
 
 
@@ -188,6 +218,19 @@ class TestDistributionSupport:
         c = tn.support
         assert jnp.array_equal(c.check(jnp.array([0.0, 1.0])), jnp.array([True, True]))
         assert jnp.array_equal(c.check(jnp.array([-2.0, 1.0])), jnp.array([False, True]))
+
+    def test_binomial_support_array_total_count(self):
+        # Regression: ``int(self._total_count)`` previously crashed for
+        # array-valued total_count. Per-dim total_count should produce a
+        # working integer_interval.
+        b = Binomial(
+            total_count=jnp.array([5, 10]),
+            probs=jnp.array([0.3, 0.5]),
+            name="b_arr",
+        )
+        c = b.support
+        assert jnp.array_equal(c.check(jnp.array([3, 7])), jnp.array([True, True]))
+        assert jnp.array_equal(c.check(jnp.array([6, 7])), jnp.array([False, True]))
 
     def test_bernoulli_support(self):
         assert Bernoulli(probs=0.5, name="d").support == boolean

--- a/tests/test_support_and_conversion.py
+++ b/tests/test_support_and_conversion.py
@@ -91,6 +91,16 @@ class TestConstraints:
         assert integer_interval(jnp.array([0, 1]), jnp.array([5, 6])) == integer_interval(
             jnp.array([0, 1]), jnp.array([5, 6])
         )
+        # Cross-type and non-Constraint comparisons must short-circuit
+        # via the type guard, not raise.
+        assert interval(jnp.array([0.0, 0.5]), jnp.array([1.0, 1.5])) != greater_than(
+            jnp.array([0.0, 0.5])
+        )
+        assert interval(jnp.array([0.0, 0.5]), jnp.array([1.0, 1.5])) != None  # noqa: E711
+        # Shape-mismatched bounds compare unequal rather than raising.
+        assert interval(jnp.array([0.0, 0.5]), jnp.array([1.0, 1.5])) != interval(
+            jnp.array([0.0]), jnp.array([1.0])
+        )
 
     def test_parameterized_hash_array_bounds(self):
         # __hash__ on parameterized constraints must not raise for


### PR DESCRIPTION
## Summary

Post-merge review follow-up to #161. After dropping the `float()` / `int()`
casts so `.support` works for array-valued bounds, parameterized constraints
(`_Interval`, `_GreaterThan`, `_IntegerInterval`) can now hold JAX-array
bounds — but the inherited `Constraint.__eq__` / `__hash__` from the base
class break on multi-element arrays (`==` raises `ValueError`) and on 0-d
arrays (unhashable). #161 only worked around `==` at the
`_supports_compatible` call site; this PR fixes the underlying methods so
the rough edge does not bite future callers.

While there, a few odds and ends:

- Update parameterized-constraint constructor and factory type hints from
  `float` / `int` to `ArrayLike` to match what they actually accept now.
- Drop the `int()` cast from `Binomial.support` — same latent bug as the
  four continuous distributions fixed in #161.
- Tidy the fast-path comment block in `_supports_compatible`.

## Approach for `__eq__` / `__hash__`

Per-class overrides (Option A) on the three parameterized constraints —
chosen over a base-class rewrite because the blast radius is exactly
those three classes, and the singleton constraints (`real`, `positive`,
...) work fine with the trivial inherited equality. `__hash__` returns
`hash(type(self))` — coarse but valid (`a == b → hash(a) == hash(b)`),
and these constraints almost never end up in sets/dicts in practice.

## Test plan

- [x] New regression tests in `tests/test_support_and_conversion.py`:
  - `test_parameterized_equality_array_bounds` — `==` works on
    `_Interval` / `_GreaterThan` / `_IntegerInterval` with multi-element
    JAX-array bounds (previously raised `ValueError`).
  - `test_parameterized_hash_array_bounds` — `hash()` works for scalar,
    0-d, and multi-element bounds (previously `TypeError` for 0-d).
  - `test_integer_interval_subset_array_bounds` — exercises the
    `_IntegerInterval` array-aware branch added in #161 that had no
    coverage.
  - `test_binomial_support_array_total_count` — regression for the
    `int()`-cast bug in `Binomial.support`.
- [x] `pytest tests/` — full suite passes (2264 passed, 8 skipped).
