### PR TITLE
PR-B.1: Address remaining review findings on PR-B (#155)

### DIFF
--- a/probpipe/converters/_probpipe.py
+++ b/probpipe/converters/_probpipe.py
@@ -56,8 +56,9 @@ def _mm_provenance(source, mean_result=None, var_result=None):
 
 def _point_estimate(x):
     """Extract a plain array from a value that may be a BootstrapDistribution
-    or a single-field NumericRecord (the auto-wrap form returned by the
-    merged ``RecordEmpiricalDistribution._mean``)."""
+    or a single-field NumericRecord (the auto-wrap form returned by
+    ``RecordEmpiricalDistribution._mean`` — numeric arrays auto-wrap
+    as a single-field Record)."""
     from ..core.distribution import BootstrapDistribution
     from ..core._numeric_record import NumericRecord
     if isinstance(x, BootstrapDistribution):
@@ -453,9 +454,13 @@ def _convert_to_kde(source, key, **kw):
     view) so KDE sees one row per sample with all parameters
     concatenated. Other sources fall back to drawing fresh samples.
 
-    A generic ``EmpiricalDistribution`` (object-array storage) is
-    rejected with a clear ``TypeError`` rather than silently
-    producing a degenerate KDE.
+    Raises
+    ------
+    TypeError
+        If *source* is a generic ``EmpiricalDistribution``
+        (non-numeric / object-array storage). KDE requires numeric
+        samples; route the source through
+        ``RecordEmpiricalDistribution`` or supply a numeric source.
     """
     from ..distributions.kde import KDEDistribution
 

--- a/probpipe/converters/_probpipe.py
+++ b/probpipe/converters/_probpipe.py
@@ -23,8 +23,9 @@ from ..custom_types import PRNGKey
 from .._utils import _auto_key
 from ..core.constraints import _supports_compatible
 from ..core.distribution import (
-    RecordEmpiricalDistribution,
     Distribution,
+    EmpiricalDistribution,
+    RecordEmpiricalDistribution,
 )
 from ..core.provenance import Provenance
 from ._registry import ConversionInfo, ConversionMethod, Converter
@@ -445,9 +446,16 @@ def _convert_to_empirical(source, key, **kw):
 def _convert_to_kde(source, key, **kw):
     """Convert any distribution to a KDEDistribution.
 
-    If the source is an ``RecordEmpiricalDistribution`` (or subclass),
-    the stored samples and weights are reused directly.  Otherwise,
-    samples are drawn from the source.
+    For a ``RecordEmpiricalDistribution`` source the stored samples
+    and weights are reused directly: single-field empiricals pass the
+    field's stacked array straight to KDE; multi-field empiricals
+    pass ``source.flat_samples`` (the ``(n, total_dim)`` flat-matrix
+    view) so KDE sees one row per sample with all parameters
+    concatenated. Other sources fall back to drawing fresh samples.
+
+    A generic ``EmpiricalDistribution`` (object-array storage) is
+    rejected with a clear ``TypeError`` rather than silently
+    producing a degenerate KDE.
     """
     from ..distributions.kde import KDEDistribution
 
@@ -458,17 +466,30 @@ def _convert_to_kde(source, key, **kw):
     name = kw.get("name") or source.name
 
     if isinstance(source, RecordEmpiricalDistribution):
-        # Pull the underlying stacked array from the (single-field by
-        # construction) Record. Multi-field empirical sources fall
-        # through to the sample-based path below.
+        # Single-field: pass the field array directly so KDE keeps the
+        # original event shape. Multi-field: collapse to the
+        # ``(n, total_dim)`` flat-matrix view.
         if len(source.samples.fields) == 1:
             field = source.samples.fields[0]
-            r = KDEDistribution(
-                source.samples[field],
-                weights=source._w, bandwidth=bandwidth, name=name,
-            )
-            r.with_source(_mm_provenance(source))
-            return r
+            arr = source.samples[field]
+        else:
+            arr = source.flat_samples
+        r = KDEDistribution(
+            arr, weights=source._w, bandwidth=bandwidth, name=name,
+        )
+        r.with_source(_mm_provenance(source))
+        return r
+
+    if isinstance(source, EmpiricalDistribution):
+        # Generic (object-array) EmpiricalDistribution: KDE is
+        # nonsensical because the samples aren't numeric.
+        raise TypeError(
+            f"Cannot KDE-convert generic (object-array) "
+            f"EmpiricalDistribution (got samples of dtype "
+            f"{getattr(source.samples, 'dtype', type(source.samples).__name__)}). "
+            f"KDE requires numeric samples; route through "
+            f"RecordEmpiricalDistribution or supply a numeric source."
+        )
 
     num_samples = kw.pop("num_samples", DEFAULT_NUM_SAMPLES)
     if key is None:

--- a/probpipe/core/_empirical.py
+++ b/probpipe/core/_empirical.py
@@ -539,6 +539,13 @@ class RecordEmpiricalDistribution(
         :attr:`event_shapes` (plural, dict-valued) for the multi-field
         case.
 
+        See Also
+        --------
+        :attr:`event_shapes` — the per-field dict, always available.
+        :attr:`RecordBootstrapReplicateDistribution.obs_shape` — the
+            symmetric single-field-only / multi-field-raises accessor
+            for bootstrap replicates' per-observation event shape.
+
         Raises
         ------
         AttributeError
@@ -1074,6 +1081,15 @@ class RecordBootstrapReplicateDistribution(
         case, or :attr:`obs_shape` for the per-observation shape on
         single-field replicates.
 
+        See Also
+        --------
+        :attr:`event_shapes` — the per-field dict, always available.
+        :attr:`obs_shape` — the per-observation event shape (replicate
+            axis stripped) for single-field replicates.
+        :attr:`RecordEmpiricalDistribution.event_shape` — the
+            symmetric single-field-only / multi-field-raises accessor
+            on the empirical-distribution side.
+
         Raises
         ------
         AttributeError
@@ -1098,6 +1114,12 @@ class RecordBootstrapReplicateDistribution(
         Multi-field replicates raise :class:`AttributeError` rather
         than returning ``()``; use :attr:`obs_shapes` (plural,
         per-field) for the multi-field case.
+
+        See Also
+        --------
+        :attr:`obs_shapes` — the per-field dict, always available.
+        :attr:`event_shape` — the full replicate event shape
+            ``(n, *obs_shape)`` for single-field replicates.
 
         Raises
         ------

--- a/probpipe/core/_empirical.py
+++ b/probpipe/core/_empirical.py
@@ -986,20 +986,21 @@ class RecordBootstrapReplicateDistribution(
             default_n = n_rows
             self._w = Weights.uniform(n_rows)
         elif isinstance(source, EmpiricalDistribution):
-            # Numeric-array-backed EmpiricalDistribution: dispatch wrapped
-            # us here. Auto-wrap the stacked array as a single-field
-            # Record using the source's name.
-            arr = source.samples
-            field_name = name or source.name or "data"
-            wrapped, field_name = _wrap_numeric_array_as_record(
-                arr, name=field_name,
-                role="RecordBootstrapReplicateDistribution",
+            # The factory path routes numeric-array-backed empiricals to
+            # ``RecordEmpiricalDistribution`` (caught above), so any
+            # ``EmpiricalDistribution`` reaching here is a generic-base
+            # instance with object-array storage — directly constructing
+            # ``RecordBootstrapReplicateDistribution`` with such a source
+            # is the only way in. Reject explicitly so users get a clear
+            # error instead of an ``_as_float_array(object_arr)``
+            # TypeError later.
+            raise TypeError(
+                f"RecordBootstrapReplicateDistribution does not accept "
+                f"generic (object-array) EmpiricalDistribution sources "
+                f"(got {type(source).__name__} with object samples). "
+                f"Pass a RecordEmpiricalDistribution, a numeric array, "
+                f"or wrap your samples in a Record first."
             )
-            self._record_data = wrapped
-            self._w = source._w
-            default_n = source.n
-            if name is None:
-                name = field_name
         elif _is_numeric_array(source):
             wrapped, field_name = _wrap_numeric_array_as_record(
                 source, name=name,

--- a/probpipe/core/_empirical.py
+++ b/probpipe/core/_empirical.py
@@ -975,14 +975,27 @@ class RecordBootstrapReplicateDistribution(
 
     Parameters
     ----------
-    source : Record | RecordEmpiricalDistribution | EmpiricalDistribution | array-like
-        Data to bootstrap from.
+    source : Record | RecordEmpiricalDistribution | array-like
+        Data to bootstrap from. A bare numeric array auto-wraps as a
+        single-field ``Record`` keyed by *name*. A generic
+        ``EmpiricalDistribution`` (object-array storage) is **not**
+        accepted — see ``Raises``.
     n : int or None
         Observations per bootstrap dataset. Defaults to the source's
         observation count.
     name : str or None
         Distribution name. Mandatory when *source* is a bare numeric
         array (used as the single-field auto-wrap field name).
+
+    Raises
+    ------
+    TypeError
+        If *source* is a generic ``EmpiricalDistribution`` (i.e.,
+        object-array storage rather than numeric / Record-backed).
+        The factory path routes numeric-array empiricals to
+        :class:`RecordEmpiricalDistribution`; only the generic-base
+        instance can reach this constructor, and its non-numeric
+        samples can't be bootstrapped meaningfully.
     """
 
     _sampling_cost: str = "low"
@@ -1013,12 +1026,16 @@ class RecordBootstrapReplicateDistribution(
             # is the only way in. Reject explicitly so users get a clear
             # error instead of an ``_as_float_array(object_arr)``
             # TypeError later.
+            sample_dtype = getattr(
+                source.samples, "dtype", type(source.samples).__name__,
+            )
             raise TypeError(
                 f"RecordBootstrapReplicateDistribution does not accept "
                 f"generic (object-array) EmpiricalDistribution sources "
-                f"(got {type(source).__name__} with object samples). "
-                f"Pass a RecordEmpiricalDistribution, a numeric array, "
-                f"or wrap your samples in a Record first."
+                f"(got {type(source).__name__} with non-numeric samples; "
+                f"dtype={sample_dtype}). Pass a "
+                f"RecordEmpiricalDistribution, a numeric array, or wrap "
+                f"your samples in a Record first."
             )
         elif _is_numeric_array(source):
             wrapped, field_name = _wrap_numeric_array_as_record(
@@ -1033,9 +1050,8 @@ class RecordBootstrapReplicateDistribution(
         else:
             raise TypeError(
                 f"RecordBootstrapReplicateDistribution: source must be a "
-                f"Record, RecordEmpiricalDistribution, numeric array, or "
-                f"numeric-array-backed EmpiricalDistribution, got "
-                f"{type(source).__name__}"
+                f"Record, RecordEmpiricalDistribution, or numeric array, "
+                f"got {type(source).__name__}"
             )
         # Bootstrap-base bookkeeping. Set self._data so the base's
         # `.data` property returns the Record (matches old behaviour).

--- a/probpipe/core/_empirical.py
+++ b/probpipe/core/_empirical.py
@@ -150,7 +150,8 @@ def _wrap_numeric_array_as_record(
     arr = _as_float_array(arr)
     if arr.ndim == 0:
         raise ValueError(
-            f"{role} samples must have at least 1 dimension (the sample axis)."
+            f"{role} samples must have at least 1 dimension (the sample "
+            f"axis); got a 0-D array (shape {arr.shape})."
         )
     if sample_shape is not None:
         n_sample_dims = len(sample_shape)
@@ -168,23 +169,34 @@ def _wrap_numeric_array_as_record(
 def _validate_record_samples(record_data: Record) -> int:
     """Validate that every field shares the same sample-axis length.
 
-    Returns the common ``n``.
+    Returns the common ``n``. Error messages always name the offending
+    field and report its shape so users can debug shape mismatches
+    without having to instrument the call site.
     """
     if not record_data.fields:
         raise ValueError("Record samples must have at least one field.")
-    first = jnp.asarray(record_data[record_data.fields[0]])
+    first_name = record_data.fields[0]
+    first = jnp.asarray(record_data[first_name])
     if first.ndim == 0:
         raise ValueError(
-            "Record empirical samples need a leading sample axis "
-            "(every field must have shape (n, *event_shape))."
+            f"Record empirical samples need a leading sample axis "
+            f"(every field must have shape (n, *event_shape)); "
+            f"field {first_name!r} has shape {first.shape}."
         )
     n = int(first.shape[0])
     for f in record_data.fields[1:]:
         arr = jnp.asarray(record_data[f])
-        if arr.ndim == 0 or int(arr.shape[0]) != n:
+        if arr.ndim == 0:
             raise ValueError(
-                f"Field {f!r} has sample-axis length "
-                f"{None if arr.ndim == 0 else arr.shape[0]}, expected {n}."
+                f"Field {f!r} has shape {arr.shape} (no sample axis), "
+                f"expected leading axis of length {n} to match field "
+                f"{first_name!r}."
+            )
+        if int(arr.shape[0]) != n:
+            raise ValueError(
+                f"Field {f!r} has shape {arr.shape} (sample-axis length "
+                f"{int(arr.shape[0])}), expected {n} to match field "
+                f"{first_name!r}."
             )
     return n
 

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -291,7 +291,40 @@ class Node(ABC):
     @property
     def inputs(self) -> Mapping[str, Any]:
         return self._inputs
-    
+
+
+def _index_sample(s: Any, i: int) -> Any:
+    """Index row ``i`` of a per-arg sample batch.
+
+    The input ``s`` may be a raw array (single-field broadcast samples
+    or legacy callers), a :class:`Record` (multi-field auto-wrap or
+    explicit Record source), or a :class:`NumericRecord` (the merged
+    ``EmpiricalDistribution`` returns ``NumericRecord`` with
+    stacked-along-leading-axis fields). The dispatch:
+
+    * Single-field ``Record`` → unwrap to the underlying field array's
+      row ``i``, so the inner call sees the same shape it would from a
+      single ``sample(dist)`` draw.
+    * Multi-field ``Record`` → fabricate a per-row :class:`NumericRecord`.
+    * Bare array → standard ``s[i]``.
+
+    Used by both ``_broadcast_enumerate_then_sample`` (for empirical-
+    enumerated rows and for the mixed sampled-rows path) and
+    ``_broadcast_sample`` (for plain MC sampling). Keeping the
+    implementation in one place avoids drift between the three
+    callsites.
+    """
+    # Local imports to avoid module-load circularity with
+    # ``record`` / ``_numeric_record``.
+    from .record import Record
+    from ._numeric_record import NumericRecord
+
+    if isinstance(s, Record):
+        if len(s.fields) == 1:
+            return s[s.fields[0]][i]
+        return NumericRecord({f: s[f][i] for f in s.fields})
+    return s[i]
+
 
 class WorkflowFunction(Node):
     """
@@ -1326,35 +1359,14 @@ class WorkflowFunction(Node):
                 # of per-field stacked arrays; pull row ``i`` per field
                 # so the inner call sees the same shape it would from a
                 # single ``sample(dist)`` draw.
-                from .record import Record
                 for name, dist, i in zip(emp_names, emp_dists, combo):
-                    s = dist.samples
-                    if isinstance(s, Record):
-                        if len(s.fields) == 1:
-                            call_values[name] = s[s.fields[0]][i]
-                        else:
-                            from ._numeric_record import NumericRecord
-                            call_values[name] = NumericRecord({
-                                f: s[f][i] for f in s.fields
-                            })
-                    else:
-                        call_values[name] = s[i]
+                    call_values[name] = _index_sample(dist.samples, i)
 
                 # Set sampled values for non-empirical distributions.
                 # ``sampled[name]`` may be a Record (auto-wrapped); use
                 # the same per-row indexing helper.
                 for name in sample_args:
-                    s = sampled[name]
-                    if isinstance(s, Record):
-                        if len(s.fields) == 1:
-                            call_values[name] = s[s.fields[0]][sample_idx]
-                        else:
-                            from ._numeric_record import NumericRecord
-                            call_values[name] = NumericRecord({
-                                f: s[f][sample_idx] for f in s.fields
-                            })
-                    else:
-                        call_values[name] = s[sample_idx]
+                    call_values[name] = _index_sample(sampled[name], sample_idx)
 
                 # Weight: empirical product weight divided evenly across reps
                 weights.append(emp_weight / reps_per_combo)
@@ -1388,24 +1400,6 @@ class WorkflowFunction(Node):
         """
         key = self._get_key()
         samples_per_arg = self._sample_broadcast_args(values, broadcast_args, n_broadcast_samples, key)
-
-        from .record import Record
-        from ._numeric_record import NumericRecord
-
-        def _index_sample(s, i):
-            """Index row ``i`` of a per-arg sample batch.
-
-            ``samples_per_arg`` may hold raw arrays (legacy) or
-            ``NumericRecord``-shaped batches (the merged
-            ``EmpiricalDistribution`` returns NumericRecord with
-            stacked-along-leading-axis fields). Single-field NumericRecord
-            unwraps; multi-field becomes a per-row NumericRecord.
-            """
-            if isinstance(s, Record):
-                if len(s.fields) == 1:
-                    return s[s.fields[0]][i]
-                return NumericRecord({f: s[f][i] for f in s.fields})
-            return s[i]
 
         call_value_list = []
         for i in range(n_broadcast_samples):

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -296,18 +296,31 @@ class Node(ABC):
 def _index_sample(s: Any, i: int) -> Any:
     """Index row ``i`` of a per-arg sample batch.
 
-    The input ``s`` may be a raw array (single-field broadcast samples
-    or legacy callers), a :class:`Record` (multi-field auto-wrap or
-    explicit Record source), or a :class:`NumericRecord` (the merged
-    ``EmpiricalDistribution`` returns ``NumericRecord`` with
-    stacked-along-leading-axis fields). The dispatch:
+    Parameters
+    ----------
+    s : Any
+        Either a bare array (single-field broadcast draws / legacy
+        callers), a :class:`Record` (multi-field auto-wrap or an
+        explicit Record source), or a :class:`NumericRecord` (the
+        unified ``EmpiricalDistribution`` — numeric arrays auto-wrap
+        as a single-field Record — returns a ``NumericRecord`` with
+        per-field axes stacked along the leading axis).
+    i : int
+        Row index along the leading axis.
 
-    * Single-field ``Record`` → unwrap to the underlying field array's
-      row ``i``, so the inner call sees the same shape it would from a
-      single ``sample(dist)`` draw.
-    * Multi-field ``Record`` → fabricate a per-row :class:`NumericRecord`.
-    * Bare array → standard ``s[i]``.
+    Returns
+    -------
+    Any
+        Same shape the inner call would see from a single
+        ``sample(dist)`` draw:
 
+        * Single-field ``Record`` → the underlying field array's row
+          ``i`` (unwrapped).
+        * Multi-field ``Record`` → a per-row :class:`NumericRecord`.
+        * Bare array → ``s[i]``.
+
+    Notes
+    -----
     Used by both ``_broadcast_enumerate_then_sample`` (for empirical-
     enumerated rows and for the mixed sampled-rows path) and
     ``_broadcast_sample`` (for plain MC sampling). Keeping the

--- a/tests/test_bootstrap_replicate.py
+++ b/tests/test_bootstrap_replicate.py
@@ -389,6 +389,25 @@ class TestRecordBootstrapReplicateDistribution:
         dist = RecordBootstrapReplicateDistribution(emp, name="x")
         assert dist.n == 20
 
+    def test_rejects_object_array_empirical(self):
+        """Generic (object-array) EmpiricalDistribution is rejected.
+
+        Numeric-array empiricals dispatch to RecordEmpiricalDistribution
+        via the factory ``__new__``, so any EmpiricalDistribution that
+        reaches RecordBootstrapReplicateDistribution.__init__ as a
+        generic instance is object-backed and can't be wrapped as a
+        Record. Confirm the explicit TypeError fires (instead of the
+        unhelpful _as_float_array(object_arr) failure that used to
+        bubble up).
+        """
+        from probpipe.core._empirical import RecordEmpiricalDistribution
+        emp = EmpiricalDistribution(["a", "b", "c"])
+        assert not isinstance(emp, RecordEmpiricalDistribution)
+        with pytest.raises(
+            TypeError, match="generic .object-array. EmpiricalDistribution",
+        ):
+            RecordBootstrapReplicateDistribution(emp)
+
     def test_obs_shape(self):
         dist = RecordBootstrapReplicateDistribution(jnp.ones((10, 3, 4)), name="x")
         assert dist.obs_shape == (3, 4)

--- a/tests/test_broadcast_distribution.py
+++ b/tests/test_broadcast_distribution.py
@@ -896,3 +896,72 @@ class TestCoerceOutput:
             field_name="f",
         )
         assert nr.source.operation == "inner"
+
+
+# ---------------------------------------------------------------------------
+# _index_sample helper (extracted from inline code in
+# _broadcast_enumerate_then_sample / _broadcast_sample so the three
+# call sites cant drift)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexSampleHelper:
+    """Direct unit tests for the module-level _index_sample helper.
+
+    Pins the dispatch contract (bare array vs. single-field Record vs.
+    multi-field Record). Integration tests through both
+    _broadcast_enumerate_then_sample and _broadcast_sample are covered
+    by the existing broadcast tests.
+    """
+
+    def test_bare_array(self):
+        """Plain array → standard s[i] indexing (gap C in the review)."""
+        from probpipe.core.node import _index_sample
+        s = jnp.arange(20.0).reshape(5, 4)
+        for i in range(5):
+            np.testing.assert_array_equal(
+                _index_sample(s, i), s[i],
+            )
+
+    def test_bare_array_1d(self):
+        from probpipe.core.node import _index_sample
+        s = jnp.arange(10.0)
+        assert float(_index_sample(s, 3)) == 3.0
+
+    def test_single_field_record_unwraps(self):
+        """Single-field Record → unwrap to the underlying field array."""
+        from probpipe import Record
+        from probpipe.core.node import _index_sample
+        s = Record(x=jnp.arange(15.0).reshape(5, 3))
+        for i in range(5):
+            row = _index_sample(s, i)
+            # Bare array, not a Record — single-field unwrap.
+            assert not hasattr(row, "fields")
+            np.testing.assert_array_equal(row, s["x"][i])
+
+    def test_multi_field_record_returns_per_row_numeric_record(self):
+        """Multi-field Record → fabricate a per-row NumericRecord."""
+        from probpipe import NumericRecord, Record
+        from probpipe.core.node import _index_sample
+        s = Record(
+            mu=jnp.arange(5.0),
+            sigma=jnp.arange(5.0) + 100.0,
+        )
+        row = _index_sample(s, 2)
+        assert isinstance(row, NumericRecord)
+        assert row.fields == ("mu", "sigma")
+        assert float(row["mu"]) == 2.0
+        assert float(row["sigma"]) == 102.0
+
+    def test_multi_field_record_with_nontrivial_event_shapes(self):
+        """Per-row NumericRecord preserves trailing event-shape axes."""
+        from probpipe import NumericRecord, Record
+        from probpipe.core.node import _index_sample
+        s = Record(
+            scalar=jnp.arange(4.0),
+            vec=jnp.arange(12.0).reshape(4, 3),
+        )
+        row = _index_sample(s, 1)
+        assert isinstance(row, NumericRecord)
+        assert float(row["scalar"]) == 1.0
+        np.testing.assert_array_equal(row["vec"], jnp.array([3.0, 4.0, 5.0]))

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -743,7 +743,6 @@ class TestProtocolConversion:
         Without the explicit raise, KDE construction would fail
         somewhere deep with a confusing dtype error.
         """
-        from probpipe import EmpiricalDistribution
         emp = EmpiricalDistribution(["a", "b", "c"])
         with pytest.raises(
             TypeError, match="generic .object-array. EmpiricalDistribution",

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -660,7 +660,7 @@ class TestProtocolConversion:
         )
 
     def test_multivariate_empirical_to_supports_log_prob(self):
-        """Multivariate RecordEmpiricalDistribution converts to KDE via SupportsLogProb."""
+        """Multivariate (single-field with d-dim event) RecordEmpirical → KDE."""
         from probpipe.distributions.kde import KDEDistribution
 
         samples = jax.random.normal(jax.random.PRNGKey(1), (300, 4))
@@ -671,6 +671,84 @@ class TestProtocolConversion:
         np.testing.assert_allclose(
             np.array(result._mean()), np.array(emp._mean()), atol=0.2,
         )
+
+    def test_multi_field_record_empirical_to_kde(self):
+        """Multi-field RecordEmpirical → KDE via flat_samples (n, total_dim).
+
+        Pre-fix this raised because ``_convert_to_kde`` fell through to
+        ``source._sample(key, (n,))`` which returned a NumericRecord;
+        ``KDEDistribution(NumericRecord)`` then tripped the multi-field
+        shape shim. The fix routes multi-field empiricals through
+        ``source.flat_samples`` (KDE accepts a flat (n, dim) matrix).
+        """
+        from probpipe import Record
+        from probpipe.distributions.kde import KDEDistribution
+
+        n = 200
+        rec = Record(
+            mu=jax.random.normal(jax.random.PRNGKey(2), (n,)),
+            log_sigma=jax.random.normal(jax.random.PRNGKey(3), (n,)),
+        )
+        emp = RecordEmpiricalDistribution(rec)
+        result = converter_registry.convert(emp, SupportsLogProb)
+        assert isinstance(result, KDEDistribution)
+        # KDE got the flat (n, 2) matrix.
+        assert result.n == n
+        # log_prob over a single 2-vector returns a scalar.
+        lp = result._log_prob(jnp.array([0.0, 0.0]))
+        assert lp.shape == ()
+
+    def test_single_field_record_empirical_to_kde_unchanged(self):
+        """Single-field path stays on the fast path (passes the field
+        array straight to KDE rather than going via ``flat_samples``).
+
+        Pinned so a future ``flat_samples``-everywhere refactor doesn't
+        silently change the single-field behaviour. The (n,) auto-wrap
+        case keeps its 0-D KDE event shape.
+        """
+        from probpipe.distributions.kde import KDEDistribution
+
+        samples = jax.random.normal(jax.random.PRNGKey(4), (150,))
+        emp = RecordEmpiricalDistribution(samples, name="theta")
+        result = converter_registry.convert(emp, SupportsLogProb)
+        assert isinstance(result, KDEDistribution)
+        # Scalar event — direct field passthrough, not flattened.
+        assert result.event_shape == ()
+
+    def test_weighted_single_field_empirical_to_kde_preserves_weights(self):
+        """Single-field empirical with non-uniform weights → KDE with
+        the same weights (gap A in the review)."""
+        from probpipe.distributions.kde import KDEDistribution
+
+        n = 80
+        samples = jax.random.normal(jax.random.PRNGKey(5), (n,))
+        weights = jnp.linspace(0.1, 1.0, n)
+        emp = RecordEmpiricalDistribution(samples, weights=weights, name="x")
+        result = converter_registry.convert(emp, SupportsLogProb)
+        assert isinstance(result, KDEDistribution)
+        # KDE preserves the source's normalised weights (the converter
+        # passes ``weights=source._w``; KDE may rebuild a Weights
+        # internally, but the normalised values must match).
+        np.testing.assert_allclose(
+            np.asarray(result._w.normalized),
+            np.asarray(emp._w.normalized),
+            atol=1e-6,
+        )
+        assert not result._w.is_uniform
+
+    def test_object_array_empirical_to_kde_rejected(self):
+        """Generic (object-array) EmpiricalDistribution → KDE raises
+        a clear TypeError (gap B in the review).
+
+        Without the explicit raise, KDE construction would fail
+        somewhere deep with a confusing dtype error.
+        """
+        from probpipe import EmpiricalDistribution
+        emp = EmpiricalDistribution(["a", "b", "c"])
+        with pytest.raises(
+            TypeError, match="generic .object-array. EmpiricalDistribution",
+        ):
+            converter_registry.convert(emp, SupportsLogProb)
 
     def test_check_protocol_already_satisfied(self):
         """check() returns EXACT when protocol is already satisfied."""

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -315,6 +315,59 @@ class TestEmpiricalDistribution:
         assert ed.n == 10
 
 
+class TestEmpiricalValidationMessages:
+    """Pin actionable error messages for ``RecordEmpiricalDistribution``
+    construction failures. The reviewer flagged that the 0-D-field
+    branch reported ``"sample-axis length None"``, which doesn't help
+    users debug. Each message must include the offending field name
+    and its actual ``arr.shape``.
+    """
+
+    def test_zero_dim_first_field_reports_shape(self):
+        """First field is 0-D → message names the field and shape."""
+        from probpipe import Record
+        rec = Record(x=jnp.array(1.0))
+        with pytest.raises(ValueError) as exc:
+            RecordEmpiricalDistribution(rec)
+        msg = str(exc.value)
+        assert "'x'" in msg
+        assert "shape ()" in msg
+
+    def test_zero_dim_later_field_reports_shape(self):
+        """A later field is 0-D → message names that field, its shape,
+        and the reference field."""
+        from probpipe import Record
+        rec = Record(x=jnp.zeros(5), y=jnp.array(2.0))
+        with pytest.raises(ValueError) as exc:
+            RecordEmpiricalDistribution(rec)
+        msg = str(exc.value)
+        assert "'y'" in msg
+        assert "shape ()" in msg
+        assert "'x'" in msg
+        assert "5" in msg
+
+    def test_mismatched_sample_axis_reports_both_fields(self):
+        """A later field has a different sample-axis length → message
+        names the field, its full shape, and the reference field."""
+        from probpipe import Record
+        rec = Record(x=jnp.zeros(5), y=jnp.zeros(7))
+        with pytest.raises(ValueError) as exc:
+            RecordEmpiricalDistribution(rec)
+        msg = str(exc.value)
+        assert "'y'" in msg
+        assert "(7,)" in msg
+        assert "'x'" in msg
+        # Reference n should appear.
+        assert "5" in msg
+
+    def test_zero_dim_numeric_array_reports_shape(self):
+        """``EmpiricalDistribution(jnp.array(1.0), name='x')`` is a 0-D
+        bare array — the auto-wrap path should reject with a clear
+        message that includes the actual shape."""
+        with pytest.raises(ValueError, match=r"shape \(\)"):
+            EmpiricalDistribution(jnp.array(1.0), name="x")
+
+
 class TestFlatSamples:
     """Tests for the ``flat_samples`` ``(n, dim)`` matrix accessor."""
 

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -272,8 +272,11 @@ class TestWithResampling:
         step2 = with_resampling(weighted_step, ess_threshold=0.5, seed=42)
         dists2 = iterate(step_fn=step2, initial=initial, inputs=[0.0, 0.0])
 
-        assert jnp.allclose(dists1[1].samples[dists1[1].samples.fields[0]], dists2[1].samples[dists2[1].samples.fields[0]])
-        assert jnp.allclose(dists1[2].samples, dists2[2].samples)
+        # Both assertions use explicit field-access — the auto-wrap field
+        # name is ``"x"`` (set on the initial ``EmpiricalDistribution``),
+        # not whatever the post-resampling internal default would be.
+        assert jnp.allclose(dists1[1].samples["x"], dists2[1].samples["x"])
+        assert jnp.allclose(dists1[2].samples["x"], dists2[2].samples["x"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Six small follow-up commits addressing arob5's post-merge review of PR-B (#155). Each commit lands the fix plus its targeted regression test where applicable. Independently revertable.

## Commits

1. **cleanup(empirical):** replace unreachable `RecordBootstrap` branch with explicit raise (finding 0.1) — `RecordBootstrapReplicateDistribution` now raises a clear `TypeError` for generic (object-array) `EmpiricalDistribution` sources instead of falling through to a confusing `_as_float_array` error.
2. **fix(converters):** `_convert_to_kde` handles multi-field `RecordEmpirical` via `flat_samples` (findings 0.2, 0.3, gap A, gap B) — multi-field `RecordEmpiricalDistribution` → `KDEDistribution` now routes through `flat_samples` (was broken). Adds tests for single-field unchanged path, multi-field new path, weight preservation, and explicit object-array rejection.
3. **refactor(node):** extract `_index_sample` helper for broadcast row-indexing (finding 0.4, gap C) — promotes inline Record/NumericRecord per-row indexing duplicated across `_broadcast_enumerate_then_sample` / `_broadcast_sample` to a shared module-level helper. Direct unit test plus integration coverage.
4. **test(transition):** unify field-access idiom in adjacent assertions (finding 0.5).
5. **fix(empirical):** include field name + shape in `_validate_record_samples` error messages (finding 0.6, gap E) — replaces the unhelpful "sample-axis length None" message with one naming the field and the actual shape. Audits sibling validators in `_wrap_numeric_array_as_record` for the same gap.
6. **docs(empirical):** cross-link `event_shape` / `obs_shape` between empirical and bootstrap classes (finding 0.7) — symmetric "See Also" sections so the single-field-only / multi-field-raises accessors point at each other.

## Test plan

- [x] Targeted suites (`test_bootstrap_replicate.py`, `test_distributions.py`, `test_converters.py`, `test_broadcast_distribution.py`, `test_transition.py`, `test_protocols.py`) all green
- [x] Full pytest: 2390 passed, 7 skipped, 0 failed
- [x] mkdocs strict (no docstring formatting changes that should affect builds; verify in CI)
