### PR TITLE
PR-C.1: SupportsArrayBackend protocol + from_batched_params factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`SupportsArrayBackend` capability protocol** (`probpipe.SupportsArrayBackend`)
+  declares that a `Distribution` subclass can produce a fused storage
+  backend for `DistributionArray`. Implemented by every TFP-backed
+  concrete class (`Normal`, `Beta`, `Gamma`, `MultivariateNormal`,
+  `Dirichlet`, …) via inheritance from `TFPDistribution`. Distribution
+  classes that don't implement the protocol still work in a
+  `DistributionArray` via the literal-array fallback path.
+
+- **`DistributionArray.from_batched_params(dist_cls, *, name, batch_shape=None, **batched_params)`**
+  factory + ergonomic per-class alias **`Distribution.from_batched_params(*, name, batch_shape=None, **batched_params)`**.
+  Constructs a `DistributionArray` of homogeneous components,
+  dispatching on `SupportsArrayBackend`: TFP-backed classes get a
+  fused TFP-batched backend; other classes fall back to one
+  `dist_cls` instance per cell. Per-cell names auto-suffix
+  `f"{name}_{flat_index}"`. `batch_shape` is inferred from broadcast
+  of array-valued params; classes with heterogeneous per-param event
+  ranks (`MultivariateNormal`, `Dirichlet`) require explicit
+  `batch_shape=...`.
+
+  ```python
+  # Recommended ergonomic form
+  da = Normal.from_batched_params(loc=jnp.zeros(5), scale=1.0, name="x")
+  da.batch_shape       # (5,)
+  da[2].name           # "x_2"
+
+  # Equivalent universal form
+  da = DistributionArray.from_batched_params(
+      Normal, loc=jnp.zeros(5), scale=1.0, name="x",
+  )
+  ```
+
+  **Preview of upcoming PR-C.2 breaking change:** in the next release,
+  `Normal(loc=jnp.zeros(5), scale=1.0, name="x")` (and similar
+  TFP-backed classes constructed with batched parameters) will raise
+  `ValueError` with a hint pointing at this factory. Migrate now to
+  avoid the breaking change. The factory is performance-equivalent
+  to the legacy form because it shares the TFP-batched backend under
+  the hood.
+
 ### Changed (breaking)
 
 - **Empirical / Bootstrap / Marginal class consolidation.** The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,17 @@ full public API surface.
    dispatch time.  Protocols are dynamically included on composite
    distributions (`ProductDistribution`, `TransformedDistribution`)
    based on component capabilities.
+
+   Most protocols are *instance-level*: the contract is "this
+   `Distribution` instance can do X" and the runtime check is
+   `isinstance(my_dist, SupportsX)`. A small number are *class-level*:
+   `SupportsArrayBackend` declares `_make_array_backend` as a
+   `@classmethod`, so the contract is "this class can produce a
+   batched form" and the runtime check is on the class itself
+   (`isinstance(MyDistribution, SupportsArrayBackend)`). New
+   protocols default to instance-level; reach for class-level only
+   when the capability is genuinely a class concern (e.g., a fused-
+   storage factory that doesn't depend on per-instance state).
 4. **Private method convention** — protocols define `_method()` (e.g.,
    `_sample`, `_log_prob`, `_mean`). The public API is via ops:
    `sample(dist)`, not `dist.sample()`.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -30,11 +30,18 @@ _make_array_backend
 
 Most `Supports*` protocols are instance-level capabilities (does
 `isinstance(my_dist, SupportsSampling)` hold?). `SupportsArrayBackend`
-is the exception: its method is a `@classmethod`, so the runtime check
-is on the **class** (`isinstance(MyDistribution, SupportsArrayBackend)`),
-not on instances. The corresponding *backend* interface that
-`_make_array_backend` returns (`_DistributionArrayBackend`) is private
-to the library — user code never imports or constructs it.
+is the exception: its method is a `@classmethod`, so the contract
+lives at class scope. Always check
+`isinstance(MyDistribution, SupportsArrayBackend)` (i.e. on the
+class object). `isinstance(an_instance, SupportsArrayBackend)`
+returns `True` too — instances inherit class attributes, and
+`runtime_checkable` just looks for the named attribute — but the
+result is misleading because the protocol's contract is the class
+declaring `_make_array_backend`, not the instance.
+
+The corresponding *backend* interface that `_make_array_backend`
+returns (`_DistributionArrayBackend`) is private to the library —
+user code never imports or constructs it.
 
 ### 1.2 Ops (public API)
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -16,15 +16,25 @@ It is intended for contributors and AI assistants working on the codebase.
 Protocol classes are named `Supports<Capability>` in CamelCase:
 
 ```python
-SupportsSampling, SupportsLogProb, SupportsMean, SupportsConditioning
+SupportsSampling, SupportsLogProb, SupportsMean, SupportsConditioning,
+SupportsArrayBackend
 ```
 
 Protocol methods use a **single leading underscore** to distinguish the
 primitive implementation from the public op:
 
 ```python
-_sample, _log_prob, _mean, _variance, _cov, _condition_on, _expectation
+_sample, _log_prob, _mean, _variance, _cov, _condition_on, _expectation,
+_make_array_backend
 ```
+
+Most `Supports*` protocols are instance-level capabilities (does
+`isinstance(my_dist, SupportsSampling)` hold?). `SupportsArrayBackend`
+is the exception: its method is a `@classmethod`, so the runtime check
+is on the **class** (`isinstance(MyDistribution, SupportsArrayBackend)`),
+not on instances. The corresponding *backend* interface that
+`_make_array_backend` returns (`_DistributionArrayBackend`) is private
+to the library — user code never imports or constructs it.
 
 ### 1.2 Ops (public API)
 

--- a/docs/api/distributions.md
+++ b/docs/api/distributions.md
@@ -34,6 +34,8 @@
 
 ::: probpipe.core._broadcast_distributions.BroadcastDistribution
 
+::: probpipe.core._distribution_array.DistributionArray
+
 ## Continuous
 
 ::: probpipe.Normal

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -33,3 +33,12 @@ to distinguish the primitive implementation from the public
 
 ::: probpipe.core.protocols.SupportsConditioning
 
+## Array backend
+
+`SupportsArrayBackend` is the only **class-level** protocol in ProbPipe — its
+declared method (`_make_array_backend`) is a `@classmethod`, so the runtime
+check is `isinstance(MyDistribution, SupportsArrayBackend)` against the class
+itself.
+
+::: probpipe.core.protocols.SupportsArrayBackend
+

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -142,6 +142,7 @@ from probpipe.core.protocols import (
     SupportsRandomLogProb,
     SupportsRandomUnnormalizedLogProb,
     SupportsConditioning,
+    SupportsArrayBackend,
 )
 from probpipe.converters import (
     converter_registry,
@@ -262,6 +263,7 @@ __all__ = [
     "SupportsRandomLogProb",
     "SupportsRandomUnnormalizedLogProb",
     "SupportsConditioning",
+    "SupportsArrayBackend",
     # Transition / iteration
     "iterate",
     "with_conversion",

--- a/probpipe/_array_utils.py
+++ b/probpipe/_array_utils.py
@@ -374,3 +374,38 @@ def _ensure_batch_matrix(x: ArrayLike, num_rows: int | None = None, num_cols: in
         raise ValueError(f"_ensure_batch_matrix: Required {num_cols} rows. Got {arr.shape[2]}.")
 
     return arr.copy() if copy else arr
+
+def _slice_leading_axes(value: Any, multi_index: tuple[int, ...]) -> Any:
+    """Index the leading ``len(multi_index)`` axes of ``value`` at the given
+    multi-d index. Scalars and lower-rank values pass through unchanged.
+
+    Used by ``DistributionArray.from_batched_params`` (literal-array
+    fallback) and by ``_TFPArrayBackend.cell`` to slice batched
+    parameter arrays per cell. The trailing event axes (if any) are
+    preserved in the slice — for ``MultivariateNormal`` with ``loc``
+    of shape ``(batch, d)`` and ``multi_index=(i,)``, returns
+    ``loc[i]`` of shape ``(d,)``.
+
+    Parameters
+    ----------
+    value : Any
+        Either a scalar / 0-D-or-lower-rank JAX-array (broadcast
+        across every cell) or an array whose leading
+        ``len(multi_index)`` axes match the batch shape.
+    multi_index : tuple of int
+        Per-axis position to extract. Empty tuple is a no-op.
+
+    Returns
+    -------
+    Any
+        The value indexed at ``multi_index`` along its leading axes,
+        or the original ``value`` unchanged when it has lower rank
+        than ``len(multi_index)`` (i.e., it broadcasts across the
+        batch).
+    """
+    if not multi_index:
+        return value
+    arr = jnp.asarray(value)
+    if arr.ndim < len(multi_index):
+        return value
+    return arr[multi_index]

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -201,9 +201,10 @@ class DistributionArray[T](Distribution[T]):
     ) -> "DistributionArray":
         """Construct a ``DistributionArray`` of homogeneous components.
 
-        Companion to the future-deprecated TFP-batched-parameters
-        constructor: ``Normal(loc=jnp.zeros(5), scale=1.0, name="x")``
-        will raise in PR-C.2; the migration is::
+        The recommended way to build a ``DistributionArray`` whose
+        cells are all instances of the same class — most often a
+        TFP-backed family like ``Normal`` — without manually
+        constructing each cell::
 
             DistributionArray.from_batched_params(
                 Normal, loc=jnp.zeros(5), scale=1.0, name="x",

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -42,10 +42,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import jax.numpy as jnp
 import numpy as np
 
+from .._array_utils import _slice_leading_axes
 from .._utils import prod
 from ._distribution_base import Distribution
+from .protocols import SupportsArrayBackend
 
 if TYPE_CHECKING:
     from .protocols import _DistributionArrayBackend
@@ -162,9 +165,8 @@ class DistributionArray[T](Distribution[T]):
                 )
         self._components: tuple[Distribution, ...] | None = components
         self._batch_shape = batch_shape
-        # ``_backend`` is set only by the ``_from_backend`` factory
-        # (commit 3 of PR-C.1). The literal-array path leaves it
-        # ``None`` and continues to use ``_components`` as the
+        # Set only by :meth:`_from_backend`. The literal-array path
+        # leaves it ``None`` and uses ``_components`` as the
         # storage-of-truth.
         self._backend: "_DistributionArrayBackend | None" = None
         if name is None:
@@ -262,7 +264,7 @@ class DistributionArray[T](Distribution[T]):
             da[0].name           # "z_0"
         """
         inferred_shape = _infer_batch_shape(batched_params, batch_shape)
-        if hasattr(dist_cls, "_make_array_backend"):
+        if isinstance(dist_cls, SupportsArrayBackend):
             backend = dist_cls._make_array_backend(
                 name=name,
                 batch_shape=inferred_shape,
@@ -302,7 +304,8 @@ class DistributionArray[T](Distribution[T]):
             )
             multi_t = tuple(int(x) for x in multi)
             cell_params = {
-                k: _slice_at(v, multi_t) for k, v in batched_params.items()
+                k: _slice_leading_axes(v, multi_t)
+                for k, v in batched_params.items()
             }
             components.append(
                 dist_cls(name=f"{name}_{flat}", **cell_params)
@@ -330,7 +333,7 @@ class DistributionArray[T](Distribution[T]):
         materialised lazily on first access via :attr:`components`.
 
         Private — public construction goes through
-        :meth:`from_batched_params` (commit 4).
+        :meth:`from_batched_params`.
 
         Parameters
         ----------
@@ -524,12 +527,11 @@ def _infer_batch_shape(
     """
     if declared is not None:
         return tuple(int(x) for x in declared)
-    import jax.numpy as jnp
     shapes = []
     for value in batched_params.values():
         try:
             arr = jnp.asarray(value)
-        except Exception:
+        except (TypeError, ValueError):
             continue
         if arr.ndim > 0:
             shapes.append(arr.shape)
@@ -547,7 +549,7 @@ def _infer_batch_shape(
     # d, d)``), the broadcast attempt fails — punt to the caller.
     try:
         bs = jnp.broadcast_shapes(*shapes)
-    except (ValueError, Exception) as err:  # noqa: BLE001 — JAX raises ValueError; be safe across versions
+    except ValueError as err:
         raise ValueError(
             "from_batched_params: cannot infer batch_shape from the "
             f"given parameter shapes {shapes}. This typically happens "
@@ -557,22 +559,6 @@ def _infer_batch_shape(
             "explicitly."
         ) from err
     return tuple(int(x) for x in bs)
-
-
-def _slice_at(value, multi_index: tuple[int, ...]):
-    """Index leading ``len(multi_index)`` axes of ``value`` at the given
-    multi-d index. Scalars / lower-rank values are passed through.
-
-    Mirrors :func:`probpipe.distributions._tfp_base._slice_param_at`
-    for the literal-array fallback path.
-    """
-    if not multi_index:
-        return value
-    import jax.numpy as jnp
-    arr = jnp.asarray(value)
-    if arr.ndim < len(multi_index):
-        return value
-    return arr[multi_index]
 
 
 def _make_distribution_array(

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -178,6 +178,137 @@ class DistributionArray[T](Distribution[T]):
             getattr(c, "is_approximate", False) for c in components
         )
 
+    # -- public batched-construction factory --------------------------------
+
+    @classmethod
+    def from_batched_params(
+        cls,
+        dist_cls: type,
+        *,
+        name: str,
+        batch_shape: tuple[int, ...] | None = None,
+        **batched_params,
+    ) -> "DistributionArray":
+        """Construct a ``DistributionArray`` of homogeneous components.
+
+        Companion to the future-deprecated TFP-batched-parameters
+        constructor: ``Normal(loc=jnp.zeros(5), scale=1.0, name="x")``
+        will raise in PR-C.2; the migration is::
+
+            DistributionArray.from_batched_params(
+                Normal, loc=jnp.zeros(5), scale=1.0, name="x",
+            )
+
+        When ``dist_cls`` implements
+        :class:`~probpipe.core.protocols.SupportsArrayBackend` (every
+        TFP-backed concrete class does — ``Normal``, ``Beta``,
+        ``Gamma``, ``MultivariateNormal``, …), the factory dispatches
+        onto the backend's fused-storage path: a single batched
+        TFP backend owns the parameters; cells are materialised lazily
+        on demand. Otherwise the factory falls back to the
+        literal-array path: one ``dist_cls`` instance per cell with
+        per-cell parameters auto-sliced and names auto-suffixed
+        ``f"{name}_{flat_index}"``.
+
+        Parameters
+        ----------
+        dist_cls : type
+            A ``Distribution`` subclass. The factory does not
+            instantiate ``dist_cls`` directly when the protocol path
+            is taken; per-cell scalars are produced by the backend.
+        name : str
+            Base name; per-cell scalars are named
+            ``f"{name}_{flat_index}"`` (row-major over
+            ``batch_shape``).
+        batch_shape : tuple of int, optional
+            Leading shape of the batched parameters. Inferred from
+            ``batched_params`` (broadcast shape of array-valued
+            entries) when omitted.
+        **batched_params
+            Constructor kwargs for ``dist_cls`` with leading
+            ``batch_shape`` already applied. Scalars are broadcast
+            across every cell.
+
+        Returns
+        -------
+        DistributionArray
+            Backend-delegated when ``dist_cls`` implements
+            ``SupportsArrayBackend``; literal-array fallback otherwise.
+
+        Raises
+        ------
+        ValueError
+            If ``batch_shape`` cannot be inferred (no array-valued
+            params) and the caller did not pass it explicitly.
+
+        Examples
+        --------
+        Backend-delegated TFP path::
+
+            da = DistributionArray.from_batched_params(
+                Normal, loc=jnp.zeros(5), scale=1.0, name="x",
+            )
+            da.batch_shape       # (5,)
+            da[0].name           # "x_0"
+            da[0].loc            # 0.0
+            da._backend          # _TFPArrayBackend(...)
+
+        Literal-array fallback (any class without the protocol)::
+
+            da = DistributionArray.from_batched_params(
+                MyCustomDist, param=jnp.arange(4), name="z",
+            )
+            da._backend          # None — fallback path
+            da[0].name           # "z_0"
+        """
+        inferred_shape = _infer_batch_shape(batched_params, batch_shape)
+        if hasattr(dist_cls, "_make_array_backend"):
+            backend = dist_cls._make_array_backend(
+                name=name,
+                batch_shape=inferred_shape,
+                **batched_params,
+            )
+            return cls._from_backend(backend, name=name)
+        return cls._from_literal_components(
+            dist_cls,
+            name=name,
+            batch_shape=inferred_shape,
+            batched_params=batched_params,
+        )
+
+    @classmethod
+    def _from_literal_components(
+        cls,
+        dist_cls: type,
+        *,
+        name: str,
+        batch_shape: tuple[int, ...],
+        batched_params: dict,
+    ) -> "DistributionArray":
+        """Build by constructing one ``dist_cls`` instance per cell.
+
+        Used by :meth:`from_batched_params` for any ``dist_cls`` that
+        does not implement
+        :class:`~probpipe.core.protocols.SupportsArrayBackend`.
+        Per-cell parameters are sliced from ``batched_params`` at the
+        flat row-major index; cell names auto-suffix as
+        ``f"{name}_{flat}"``.
+        """
+        components = []
+        n = prod(batch_shape)
+        for flat in range(n):
+            multi = (
+                np.unravel_index(flat, batch_shape) if batch_shape else ()
+            )
+            multi_t = tuple(int(x) for x in multi)
+            cell_params = {
+                k: _slice_at(v, multi_t) for k, v in batched_params.items()
+            }
+            components.append(
+                dist_cls(name=f"{name}_{flat}", **cell_params)
+            )
+        return cls(components, batch_shape=batch_shape, name=name)
+
     # -- backend-delegated constructor --------------------------------------
 
     @classmethod
@@ -374,6 +505,74 @@ class DistributionArray[T](Distribution[T]):
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
+
+
+def _infer_batch_shape(
+    batched_params: dict, declared: tuple[int, ...] | None,
+) -> tuple[int, ...]:
+    """Return the broadcast shape of array-valued entries in
+    ``batched_params``, or ``declared`` if explicitly supplied.
+
+    Used by :meth:`DistributionArray.from_batched_params` when the
+    caller doesn't pass ``batch_shape`` explicitly. Walks the values,
+    treating scalars / 0-D arrays as broadcast-across-batch and
+    everything else by its leading shape (since trailing axes may be
+    event-shape, e.g. MVN's ``loc`` is ``(*batch, d)`` — but for
+    inference we use the full broadcast shape across non-scalar
+    params, which equals the batch leading prefix when scalars are
+    excluded).
+    """
+    if declared is not None:
+        return tuple(int(x) for x in declared)
+    import jax.numpy as jnp
+    shapes = []
+    for value in batched_params.values():
+        try:
+            arr = jnp.asarray(value)
+        except Exception:
+            continue
+        if arr.ndim > 0:
+            shapes.append(arr.shape)
+    if not shapes:
+        raise ValueError(
+            "from_batched_params: cannot infer batch_shape — no "
+            "array-valued parameters were passed (all are scalar). "
+            "Pass batch_shape=... explicitly, or use the regular "
+            "Distribution constructor for a single instance."
+        )
+    # The broadcast shape across non-scalar params is the batch prefix
+    # only when all params share the same event_shape. For families
+    # with differing per-param event ranks (e.g. ``MultivariateNormal``
+    # with ``loc.shape=(*batch, d)`` and ``scale_tril.shape=(*batch,
+    # d, d)``), the broadcast attempt fails — punt to the caller.
+    try:
+        bs = jnp.broadcast_shapes(*shapes)
+    except (ValueError, Exception) as err:  # noqa: BLE001 — JAX raises ValueError; be safe across versions
+        raise ValueError(
+            "from_batched_params: cannot infer batch_shape from the "
+            f"given parameter shapes {shapes}. This typically happens "
+            "for distributions with non-trivial event_shape (e.g. "
+            "MultivariateNormal, Dirichlet) where each parameter has "
+            "a different number of event axes. Pass batch_shape=... "
+            "explicitly."
+        ) from err
+    return tuple(int(x) for x in bs)
+
+
+def _slice_at(value, multi_index: tuple[int, ...]):
+    """Index leading ``len(multi_index)`` axes of ``value`` at the given
+    multi-d index. Scalars / lower-rank values are passed through.
+
+    Mirrors :func:`probpipe.distributions._tfp_base._slice_param_at`
+    for the literal-array fallback path.
+    """
+    if not multi_index:
+        return value
+    import jax.numpy as jnp
+    arr = jnp.asarray(value)
+    if arr.ndim < len(multi_index):
+        return value
+    return arr[multi_index]
 
 
 def _make_distribution_array(

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -357,7 +357,12 @@ class DistributionArray[T](Distribution[T]):
         if name is None:
             name = "distribution_array"
         Distribution.__init__(instance, name=name)
-        instance._approximate = False
+        # Approximation status flows from the backend. TFP-backed
+        # arrays are exact; a future Record-backend (over a
+        # ``RecordEmpiricalDistribution``) will report
+        # ``is_approximate=True`` on its own samples and the array
+        # picks that up here.
+        instance._approximate = bool(getattr(backend, "is_approximate", False))
         return instance
 
     # -- structure -----------------------------------------------------------
@@ -491,11 +496,22 @@ class DistributionArray[T](Distribution[T]):
 
         ``__getitem__`` is a leading-axis indexer (partial slicing); this
         method bypasses it for the sweep layer, which unravels its own
-        flat index across multiple array inputs.
+        flat index across multiple array inputs and always passes
+        non-negative integers. Negatives are rejected here — both
+        backend and literal paths behave identically. User-facing
+        ``da[-1]`` wraps via ``__getitem__`` before this method is
+        called.
         """
+        i_int = int(i)
+        n = self.n
+        if not 0 <= i_int < n:
+            raise IndexError(
+                f"_flat_component: index {i_int} out of range for "
+                f"DistributionArray with n={n} cells."
+            )
         if self._backend is not None:
-            return self._backend.cell(i)
-        return self._components[i]
+            return self._backend.cell(i_int)
+        return self._components[i_int]
 
     def __repr__(self) -> str:
         backed = " backend=True" if self._backend is not None else ""

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -119,6 +119,14 @@ class DistributionArray[T](Distribution[T]):
       than rejecting at construction.
     """
 
+    # Storage slots. ``_components`` is ``None`` for backend-delegated
+    # arrays until :attr:`components` materialises the eager tuple
+    # lazily; the literal-array constructor sets it directly.
+    # ``_backend`` is ``None`` for the literal path and set by
+    # :meth:`_from_backend`.
+    _components: "tuple[Distribution, ...] | None"
+    _backend: "_DistributionArrayBackend | None"
+
     def __init__(
         self,
         components,
@@ -163,12 +171,12 @@ class DistributionArray[T](Distribution[T]):
                     f"{prod(batch_shape)} components but got "
                     f"{len(components)}."
                 )
-        self._components: tuple[Distribution, ...] | None = components
+        self._components = components
         self._batch_shape = batch_shape
         # Set only by :meth:`_from_backend`. The literal-array path
         # leaves it ``None`` and uses ``_components`` as the
         # storage-of-truth.
-        self._backend: "_DistributionArrayBackend | None" = None
+        self._backend = None
         if name is None:
             name = "distribution_array"
         super().__init__(name=name)

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -40,10 +40,15 @@ to pull out the i-th element of a **batch** → ``DistributionArray``.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from .._utils import prod
 from ._distribution_base import Distribution
+
+if TYPE_CHECKING:
+    from .protocols import _DistributionArrayBackend
 
 __all__ = ["DistributionArray"]
 
@@ -155,8 +160,13 @@ class DistributionArray[T](Distribution[T]):
                     f"{prod(batch_shape)} components but got "
                     f"{len(components)}."
                 )
-        self._components = components
+        self._components: tuple[Distribution, ...] | None = components
         self._batch_shape = batch_shape
+        # ``_backend`` is set only by the ``_from_backend`` factory
+        # (commit 3 of PR-C.1). The literal-array path leaves it
+        # ``None`` and continues to use ``_components`` as the
+        # storage-of-truth.
+        self._backend: "_DistributionArrayBackend | None" = None
         if name is None:
             name = "distribution_array"
         super().__init__(name=name)
@@ -168,17 +178,80 @@ class DistributionArray[T](Distribution[T]):
             getattr(c, "is_approximate", False) for c in components
         )
 
+    # -- backend-delegated constructor --------------------------------------
+
+    @classmethod
+    def _from_backend(
+        cls,
+        backend: "_DistributionArrayBackend",
+        *,
+        name: str | None = None,
+    ) -> "DistributionArray":
+        """Construct a backend-delegated ``DistributionArray``.
+
+        Storage refactor entry point: when a homogeneous batched form
+        is available (e.g., via
+        :meth:`~probpipe.core.protocols.SupportsArrayBackend._make_array_backend`),
+        the array stores the backend rather than a tuple of eagerly
+        materialised components. Per-cell access (``__getitem__`` /
+        ``_flat_component`` / iteration) goes through
+        ``backend.cell(...)``; the literal ``_components`` tuple is
+        materialised lazily on first access via :attr:`components`.
+
+        Private — public construction goes through
+        :meth:`from_batched_params` (commit 4).
+
+        Parameters
+        ----------
+        backend : _DistributionArrayBackend
+            Storage backend produced by a ``SupportsArrayBackend``
+            distribution class. Carries ``batch_shape``,
+            ``event_shape``, and ``cell(index)`` plus whichever ops
+            the underlying distribution class supports.
+        name : str, optional
+            Name for provenance / introspection. Defaults to
+            ``"distribution_array"``.
+        """
+        instance = cls.__new__(cls)
+        # Bypass __init__ entirely — backend-delegated arrays have no
+        # eager component list. Initialise fields the same way
+        # __init__ would, but without per-component validation (the
+        # backend already vouched for shape consistency).
+        instance._components = None
+        instance._batch_shape = tuple(backend.batch_shape)
+        instance._backend = backend
+        if name is None:
+            name = "distribution_array"
+        Distribution.__init__(instance, name=name)
+        instance._approximate = False
+        return instance
+
     # -- structure -----------------------------------------------------------
 
     @property
     def n(self) -> int:
         """Total number of components (``prod(batch_shape)``)."""
-        return len(self._components)
+        return prod(self._batch_shape)
 
     @property
     def components(self) -> tuple[Distribution, ...]:
         """Flat tuple of component distributions, in row-major order
-        across the leading ``batch_shape``."""
+        across the leading ``batch_shape``.
+
+        For backend-delegated arrays the tuple is materialised lazily
+        on first access via ``backend.cell(i)`` for each flat index
+        and cached. Cells are still freshly constructed inside
+        ``cell()`` (no de-duplication), so successive ``components``
+        accesses return the same cached tuple but indexing via
+        :meth:`__getitem__` / :meth:`_flat_component` always returns a
+        fresh scalar.
+        """
+        if self._components is None:
+            assert self._backend is not None  # invariant
+            n = prod(self._batch_shape)
+            self._components = tuple(
+                self._backend.cell(i) for i in range(n)
+            )
         return self._components
 
     @property
@@ -196,6 +269,8 @@ class DistributionArray[T](Distribution[T]):
     @property
     def event_shape(self) -> tuple[int, ...]:
         """Shared ``event_shape`` across components."""
+        if self._backend is not None:
+            return tuple(self._backend.event_shape)
         return getattr(self._components[0], "event_shape", ())
 
     # -- container protocol --------------------------------------------------
@@ -244,12 +319,17 @@ class DistributionArray[T](Distribution[T]):
                 int(k) % dim for k, dim in zip(key_tuple, bshape)
             )
             flat = int(np.ravel_multi_index(indices, bshape))
+            if self._backend is not None:
+                return self._backend.cell(flat)
             return self._components[flat]
 
         # General path: object-array view for slice / mixed-key
         # support. Only materialised when slices are actually used,
-        # and only for the axes that involve them.
-        components_nd = np.asarray(self._components, dtype=object).reshape(bshape)
+        # and only for the axes that involve them. Backend-delegated
+        # arrays materialise their components on this path too — slice
+        # indexing is rare and a one-time materialisation cost is
+        # acceptable.
+        components_nd = np.asarray(self.components, dtype=object).reshape(bshape)
         sliced = components_nd[key_tuple]
         if isinstance(sliced, Distribution):
             return sliced
@@ -268,6 +348,8 @@ class DistributionArray[T](Distribution[T]):
         )
 
     def __iter__(self):
+        if self._backend is not None:
+            return (self._backend.cell(i) for i in range(self.n))
         return iter(self._components)
 
     def _flat_component(self, i: int) -> Distribution:
@@ -277,12 +359,15 @@ class DistributionArray[T](Distribution[T]):
         method bypasses it for the sweep layer, which unravels its own
         flat index across multiple array inputs.
         """
+        if self._backend is not None:
+            return self._backend.cell(i)
         return self._components[i]
 
     def __repr__(self) -> str:
+        backed = " backend=True" if self._backend is not None else ""
         return (
             f"DistributionArray(n={self.n}, "
-            f"event_shape={self.event_shape})"
+            f"event_shape={self.event_shape}{backed})"
         )
 
 

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from xarray import DataTree
 
+    from ._distribution_array import DistributionArray
     from .record import RecordTemplate
 
 import jax
@@ -175,7 +176,7 @@ class Distribution[T](ABC):
         name: str,
         batch_shape: tuple[int, ...] | None = None,
         **batched_params,
-    ) -> Any:
+    ) -> "DistributionArray":
         """Class-method alias for :meth:`DistributionArray.from_batched_params`.
 
         Lets users write the ergonomic per-class form::

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -166,6 +166,46 @@ class Distribution[T](ABC):
         )
         return clone
 
+    # -- batched-construction alias ----------------------------------------
+
+    @classmethod
+    def from_batched_params(
+        cls,
+        *,
+        name: str,
+        batch_shape: tuple[int, ...] | None = None,
+        **batched_params,
+    ) -> Any:
+        """Class-method alias for :meth:`DistributionArray.from_batched_params`.
+
+        Lets users write the ergonomic per-class form::
+
+            Normal.from_batched_params(loc=jnp.zeros(5), scale=1.0, name="x")
+
+        instead of the universal entry point::
+
+            DistributionArray.from_batched_params(
+                Normal, loc=jnp.zeros(5), scale=1.0, name="x",
+            )
+
+        Both produce the same ``DistributionArray`` — the alias is a
+        thin classmethod that calls the universal factory with
+        ``cls`` bound. Subclasses inherit the alias automatically;
+        no per-family override is needed.
+
+        See :meth:`DistributionArray.from_batched_params` for the full
+        contract (dispatch on
+        :class:`~probpipe.core.protocols.SupportsArrayBackend`,
+        ``batch_shape`` inference, per-cell name suffixing).
+        """
+        # Local import: ``DistributionArray`` lives in the same
+        # subpackage and importing at module top would create a cycle
+        # (DistributionArray inherits from Distribution).
+        from ._distribution_array import DistributionArray
+        return DistributionArray.from_batched_params(
+            cls, name=name, batch_shape=batch_shape, **batched_params,
+        )
+
     # -- repr ---------------------------------------------------------------
 
     def __repr__(self) -> str:

--- a/probpipe/core/protocols.py
+++ b/probpipe/core/protocols.py
@@ -50,11 +50,21 @@ Concrete classes that want default MC implementations can use the
 from __future__ import annotations
 
 import functools
-from typing import Any, Callable, ClassVar, Protocol, runtime_checkable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Protocol,
+    runtime_checkable,
+)
 
 import jax.numpy as jnp
 
 from ..custom_types import Array, PRNGKey
+
+if TYPE_CHECKING:
+    from ._distribution_base import Distribution
 
 
 # ---------------------------------------------------------------------------
@@ -340,8 +350,7 @@ class _DistributionArrayBackend(Protocol):
     present.
 
     ``cell(index)`` materialises a fresh **scalar** ``Distribution``
-    for the cell at ``index`` (post-Phase-2: scalar means
-    parameters that don't imply ``batch_shape != ()``). Used by
+    (i.e. ``batch_shape == ()``) for the cell at ``index``. Used by
     ``DistributionArray.__getitem__`` and by the WF sweep when
     cell-level dispatch is needed.
     """
@@ -352,7 +361,7 @@ class _DistributionArrayBackend(Protocol):
     @property
     def event_shape(self) -> tuple[int, ...]: ...
 
-    def cell(self, index: int | tuple[int, ...]) -> Any:
+    def cell(self, index: int | tuple[int, ...]) -> "Distribution":
         """Fabricate a scalar ``Distribution`` for the cell at ``index``."""
         ...
 
@@ -374,9 +383,12 @@ class SupportsArrayBackend(Protocol):
 
     The protocol attaches to the **class**, not to instances. The
     runtime check is ``isinstance(MyDistribution, SupportsArrayBackend)``
-    (i.e. the class itself implements ``_make_array_backend``); calling
-    ``isinstance(an_instance, SupportsArrayBackend)`` is meaningless
-    because the protocol method is a classmethod.
+    (i.e. the class itself implements ``_make_array_backend``).
+    ``isinstance(an_instance, SupportsArrayBackend)`` returns
+    ``True`` too — instances inherit class attributes, and
+    ``runtime_checkable`` just looks for the named attribute — but
+    the result is misleading because the contract is at class
+    scope.
 
     The protocol is internal to the library; user code never calls
     ``_make_array_backend`` directly. ``DistributionArray`` is the

--- a/probpipe/core/protocols.py
+++ b/probpipe/core/protocols.py
@@ -34,6 +34,10 @@ Protocol hierarchy
         ↑ inherits
     SupportsLogProb           provides _unnormalized_log_prob via _log_prob
 
+    SupportsArrayBackend      classmethod-level capability; declares that a
+                              ``Distribution`` subclass can produce a fused
+                              storage backend for ``DistributionArray``
+
 The moment protocols (SupportsMean, SupportsVariance, SupportsCovariance)
 are independent of SupportsExpectation.  The ops layer falls back to
 MC estimation via SupportsExpectation when the exact protocol is absent.
@@ -303,6 +307,133 @@ class SupportsConditioning(Protocol):
     def _condition_on(self, observed: Any, /, **kwargs: Any) -> Any: ...
 
 
+# ---------------------------------------------------------------------------
+# Array backend (fused storage for DistributionArray)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class _DistributionArrayBackend(Protocol):
+    """Internal storage backend that ``DistributionArray`` consumes.
+
+    A backend owns the *batched* parameters of a homogeneous
+    ``DistributionArray`` and delivers vectorised ops directly — TFP's
+    native batch axis, a single ``RecordEmpiricalDistribution`` with a
+    leading batch dim, etc. It is **not** a :class:`Distribution`; it
+    has no ``name`` / ``provenance`` and lives only as the contract
+    between a distribution class's
+    :meth:`SupportsArrayBackend._make_array_backend` and the array
+    consumer.
+
+    Backends are private to the library. User code never imports or
+    constructs them; they exist solely so a
+    :class:`~probpipe.DistributionArray` can fuse storage instead of
+    materialising one ``Distribution`` per cell.
+
+    Required surface
+    ----------------
+    Every backend exposes ``batch_shape``, ``event_shape``, ``cell``,
+    and the ``_sample``/``_log_prob``/``_mean``/``_variance``/``_cov``
+    methods that mirror whichever moment / density protocols the
+    underlying distribution class supports. ``DistributionArray``
+    introspects via ``isinstance`` and forwards to whichever ones are
+    present.
+
+    ``cell(index)`` materialises a fresh **scalar** ``Distribution``
+    for the cell at ``index`` (post-Phase-2: scalar means
+    parameters that don't imply ``batch_shape != ()``). Used by
+    ``DistributionArray.__getitem__`` and by the WF sweep when
+    cell-level dispatch is needed.
+    """
+
+    @property
+    def batch_shape(self) -> tuple[int, ...]: ...
+
+    @property
+    def event_shape(self) -> tuple[int, ...]: ...
+
+    def cell(self, index: int | tuple[int, ...]) -> Any:
+        """Fabricate a scalar ``Distribution`` for the cell at ``index``."""
+        ...
+
+
+@runtime_checkable
+class SupportsArrayBackend(Protocol):
+    """Distribution class that supports efficient batched construction.
+
+    Used by :meth:`DistributionArray.from_batched_params` to fuse
+    storage when the caller's components are homogeneous instances of
+    the same class. Implementations construct an internal
+    :class:`_DistributionArrayBackend` that owns the batched parameters
+    and the vectorised ops; ``DistributionArray`` becomes a thin
+    consumer.
+
+    Distribution classes that don't implement this protocol still work
+    in a ``DistributionArray`` via the literal-array fallback (one
+    ``Distribution`` instance per cell) — slower but correct.
+
+    The protocol attaches to the **class**, not to instances. The
+    runtime check is ``isinstance(MyDistribution, SupportsArrayBackend)``
+    (i.e. the class itself implements ``_make_array_backend``); calling
+    ``isinstance(an_instance, SupportsArrayBackend)`` is meaningless
+    because the protocol method is a classmethod.
+
+    The protocol is internal to the library; user code never calls
+    ``_make_array_backend`` directly. ``DistributionArray`` is the
+    sole consumer.
+
+    Examples
+    --------
+    A distribution class declares the capability by implementing the
+    classmethod::
+
+        class MyDistribution(Distribution[T]):
+            @classmethod
+            def _make_array_backend(
+                cls,
+                *,
+                name: str,
+                batch_shape: tuple[int, ...],
+                **batched_params,
+            ) -> _DistributionArrayBackend:
+                return _MyArrayBackend(
+                    cls=cls, name=name, batch_shape=batch_shape,
+                    **batched_params,
+                )
+    """
+
+    @classmethod
+    def _make_array_backend(
+        cls,
+        *,
+        name: str,
+        batch_shape: tuple[int, ...],
+        **batched_params: Any,
+    ) -> _DistributionArrayBackend:
+        """Construct an array backend for this class.
+
+        Parameters
+        ----------
+        name : str
+            Base name; per-cell distributions auto-suffix as
+            ``f"{name}_{i}"``.
+        batch_shape : tuple of int
+            The leading shape of the batched parameters. The backend
+            stores parameters with this shape prepended to each
+            ``cls(**kwargs)``-style argument.
+        **batched_params
+            Same keys as ``cls(**kwargs)`` would take, but with
+            ``batch_shape`` prepended to each array argument.
+
+        Returns
+        -------
+        _DistributionArrayBackend
+            Backend instance owning the batched parameters and
+            delivering vectorised ops.
+        """
+        ...
+
+
 def protocols_supported_by_all(
     leaves: list, candidates: tuple[type, ...],
 ) -> tuple[type, ...]:
@@ -331,5 +462,6 @@ __all__ = [
     "SupportsRandomLogProb",
     "SupportsRandomUnnormalizedLogProb",
     "SupportsConditioning",
+    "SupportsArrayBackend",
     "protocols_supported_by_all",
 ]

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 from typing import Any, Callable
 
 import jax.numpy as jnp
+import numpy as np
 import tensorflow_probability.substrates.jax.distributions as tfd
 
+from .._utils import prod
+from ..core._distribution_base import Distribution
 from ..core.distribution import (
     NumericRecordDistribution,
     _mc_expectation,
@@ -22,6 +25,7 @@ from ..core.protocols import (
     SupportsMean,
     SupportsSampling,
     SupportsVariance,
+    _DistributionArrayBackend,
 )
 from ..core.record import Record, RecordTemplate
 from ..custom_types import Array, ArrayLike, PRNGKey
@@ -139,3 +143,224 @@ class TFPDistribution(
             self, f, key=key, num_evaluations=num_evaluations,
             return_dist=return_dist,
         )
+
+    # -- SupportsArrayBackend (fused storage for DistributionArray) ----------
+
+    @classmethod
+    def _make_array_backend(
+        cls,
+        *,
+        name: str,
+        batch_shape: tuple[int, ...],
+        **batched_params: Any,
+    ) -> "_TFPArrayBackend":
+        """Construct a fused TFP-batched backend for ``DistributionArray``.
+
+        Inherited automatically by every concrete TFP-backed distribution
+        (``Normal``, ``Beta``, ``Gamma``, ``MultivariateNormal``, …); the
+        same code path covers the whole family because the wrapped TFP
+        constructor handles the per-class param-name mapping.
+
+        See :class:`probpipe.core.protocols.SupportsArrayBackend` for the
+        protocol contract. Phase 1 of PR-C — additive only; nothing yet
+        forces users through this path.
+        """
+        return _TFPArrayBackend(
+            dist_cls=cls,
+            name=name,
+            batch_shape=tuple(batch_shape),
+            batched_params=dict(batched_params),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fused storage backend for DistributionArray
+# ---------------------------------------------------------------------------
+
+
+class _TFPArrayBackend:
+    """Fused TFP-batched backend for ``DistributionArray``.
+
+    Owns one ``tfd.Distribution`` instance with TFP's native
+    ``batch_shape != ()`` plus the constructor params used to make it,
+    so per-cell materialisation (``cell(i)``) can construct a fresh
+    *scalar* :class:`Distribution` with the row-``i`` slice of each
+    param.
+
+    Implementation strategy: the backend wraps a *single* ProbPipe
+    ``Distribution`` instance constructed with the batched params
+    (legal in Phase 1 — Phase 2 will need a bypass for the un-batched
+    assertion this class introduces). Vectorised ops forward to that
+    wrapped instance's TFP backend; ``cell(i)`` slices the params and
+    runs the ordinary scalar constructor with a suffixed name.
+
+    Not a :class:`Distribution` itself — the backend exists only as
+    the contract between :meth:`TFPDistribution._make_array_backend`
+    and :class:`~probpipe.DistributionArray`. See
+    :class:`probpipe.core.protocols._DistributionArrayBackend`.
+
+    Parameters
+    ----------
+    dist_cls : type
+        The concrete ``TFPDistribution`` subclass (e.g., ``Normal``).
+        Used to materialise per-cell scalars.
+    name : str
+        Base name. Per-cell scalars auto-suffix as ``f"{name}_{flat}"``
+        where ``flat`` is the row-major flat index over ``batch_shape``.
+    batch_shape : tuple of int
+        Leading shape of the batched parameters.
+    batched_params : dict[str, Any]
+        Constructor kwargs for ``dist_cls`` with leading ``batch_shape``
+        already applied. Scalars are passed through unchanged in
+        ``cell(i)`` (broadcast across all cells).
+    """
+
+    def __init__(
+        self,
+        *,
+        dist_cls: type,
+        name: str,
+        batch_shape: tuple[int, ...],
+        batched_params: dict[str, Any],
+    ) -> None:
+        self._dist_cls = dist_cls
+        self._name = name
+        self._batch_shape = tuple(batch_shape)
+        self._batched_params = batched_params
+        # Construct the fused ProbPipe Distribution with the batched
+        # params. This is legal in Phase 1; Phase 2's un-batched
+        # assertion will need a private bypass here (the backend's
+        # whole purpose is to hold a batched form).
+        self._batched_dist: TFPDistribution = dist_cls(
+            **batched_params,
+            name=f"{name}__array_backend",
+        )
+        # Sanity check: the constructed TFP dist's batch_shape should
+        # match what the caller said. Mismatches usually mean the
+        # caller's params don't actually broadcast to ``batch_shape``.
+        actual = tuple(self._batched_dist._tfp_dist.batch_shape)
+        if actual != self._batch_shape:
+            raise ValueError(
+                f"_TFPArrayBackend: declared batch_shape={self._batch_shape} "
+                f"but {dist_cls.__name__} with the given batched_params "
+                f"produced TFP batch_shape={actual}. Check that every "
+                f"batched parameter broadcasts to batch_shape."
+            )
+
+    # -- shape ---------------------------------------------------------------
+
+    @property
+    def batch_shape(self) -> tuple[int, ...]:
+        return self._batch_shape
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        return tuple(self._batched_dist._tfp_dist.event_shape)
+
+    @property
+    def dtype(self) -> jnp.dtype:
+        return self._batched_dist._tfp_dist.dtype
+
+    # -- per-cell materialisation -------------------------------------------
+
+    def cell(self, index: int | tuple[int, ...]) -> Distribution:
+        """Fabricate a fresh scalar :class:`Distribution` for cell ``index``.
+
+        ``index`` may be a flat ``int`` (interpreted row-major over
+        ``batch_shape``) or a ``tuple[int, ...]`` of axis-aligned
+        indices. The returned distribution is fully scalar
+        (``batch_shape == ()``) — no caching; each call re-runs the
+        ordinary ``dist_cls(**scalar_params, name=...)`` constructor.
+        """
+        multi = self._normalize_index(index)
+        flat = int(np.ravel_multi_index(multi, self._batch_shape)) if self._batch_shape else 0
+        scalar_params = {
+            key: _slice_param_at(value, multi)
+            for key, value in self._batched_params.items()
+        }
+        return self._dist_cls(
+            **scalar_params,
+            name=f"{self._name}_{flat}",
+        )
+
+    def _normalize_index(
+        self, index: int | tuple[int, ...]
+    ) -> tuple[int, ...]:
+        bshape = self._batch_shape
+        if isinstance(index, (int, np.integer)) or hasattr(index, "__index__"):
+            i = int(index)
+            if not bshape:
+                if i != 0:
+                    raise IndexError(
+                        f"_TFPArrayBackend.cell: scalar backend has only one "
+                        f"cell; got index={i}."
+                    )
+                return ()
+            if len(bshape) == 1:
+                if not 0 <= i < bshape[0]:
+                    raise IndexError(
+                        f"_TFPArrayBackend.cell: index {i} out of range for "
+                        f"batch_shape={bshape}."
+                    )
+                return (i,)
+            return tuple(int(x) for x in np.unravel_index(i, bshape))
+        idx = tuple(int(x) for x in index)
+        if len(idx) != len(bshape):
+            raise IndexError(
+                f"_TFPArrayBackend.cell: index {idx} has rank {len(idx)} "
+                f"but batch_shape={bshape} has rank {len(bshape)}."
+            )
+        for i, dim in zip(idx, bshape):
+            if not 0 <= i < dim:
+                raise IndexError(
+                    f"_TFPArrayBackend.cell: index {idx} out of range for "
+                    f"batch_shape={bshape}."
+                )
+        return idx
+
+    # -- vectorised ops (forward to the wrapped batched distribution) -------
+
+    def _sample(
+        self,
+        key: PRNGKey,
+        sample_shape: tuple[int, ...] = (),
+    ) -> Array:
+        return self._batched_dist._sample(key, sample_shape)
+
+    def _log_prob(self, value: ArrayLike) -> Array:
+        return self._batched_dist._log_prob(value)
+
+    def _mean(self) -> Array:
+        return self._batched_dist._mean()
+
+    def _variance(self) -> Array:
+        return self._batched_dist._variance()
+
+    def _cov(self) -> Array:
+        return self._batched_dist._cov()
+
+    def __repr__(self) -> str:
+        return (
+            f"_TFPArrayBackend({self._dist_cls.__name__}, "
+            f"batch_shape={self._batch_shape}, name={self._name!r})"
+        )
+
+
+def _slice_param_at(
+    value: Any, multi_index: tuple[int, ...]
+) -> Any:
+    """Index the leading ``len(multi_index)`` axes of ``value`` at ``multi_index``.
+
+    A scalar / lower-rank value (broadcast across every cell of the
+    batch) is passed through unchanged. The trailing event axes (if
+    any) are preserved in the slice — e.g., for ``MultivariateNormal``
+    with ``loc`` of shape ``(batch, d)`` and ``multi_index=(i,)``,
+    returns ``loc[i]`` of shape ``(d,)``.
+    """
+    if not multi_index:
+        return value
+    arr = jnp.asarray(value)
+    if arr.ndim < len(multi_index):
+        # Lower-rank — value is broadcast across the batch axes.
+        return value
+    return arr[multi_index]

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -178,6 +178,12 @@ class TFPDistribution(
 # ---------------------------------------------------------------------------
 
 
+_ARRAY_BACKEND_NAME_SUFFIX = "__array_backend"
+"""Suffix appended to a backend's base ``name`` when constructing the
+wrapped batched ``TFPDistribution``. Centralised so
+``_TFPArrayBackend.__init__`` and ``tree_unflatten`` can't drift."""
+
+
 class _TFPArrayBackend:
     """Fused TFP-batched backend for ``DistributionArray``.
 
@@ -225,38 +231,34 @@ class _TFPArrayBackend:
         self._dist_cls = dist_cls
         self._name = name
         self._batch_shape = tuple(batch_shape)
-        # Pre-flight shape check + scalar broadcast.
-        #
-        # Validate every higher-rank param's leading axes against the
-        # declared ``batch_shape`` *before* construction. Raises a
-        # message that names the offending parameter and references
-        # ``batch_shape`` — clearer than letting TFP raise a generic
-        # "Arguments ... must have compatible shapes" further down
-        # the call stack. Then broadcast any 0-D scalars to
-        # ``batch_shape`` so callers can mix scalars with arrays —
+        # Single pass: validate every higher-rank param's leading
+        # axes against the declared ``batch_shape``, broadcasting
+        # 0-D scalars up to ``batch_shape`` so callers can mix
+        # scalars with arrays —
         # ``from_batched_params(Normal, loc=0.0, scale=1.0,
-        # batch_shape=(5,))`` constructs five identical Normals.
+        # batch_shape=(5,))`` constructs five identical Normals. The
+        # leading-axes check raises with a per-parameter message
+        # before TFP gets to raise its generic "Arguments ... must
+        # have compatible shapes".
         if self._batch_shape:
-            for key, value in batched_params.items():
-                arr = jnp.asarray(value)
-                if arr.ndim < len(self._batch_shape):
-                    continue
-                leading = arr.shape[: len(self._batch_shape)]
-                if leading != self._batch_shape:
-                    raise ValueError(
-                        f"_TFPArrayBackend: declared "
-                        f"batch_shape={self._batch_shape} but parameter "
-                        f"{key!r} has leading shape {leading}; the two "
-                        f"must match. Check that every batched parameter "
-                        f"broadcasts to batch_shape."
-                    )
-            broadcasted = {}
+            normalised: dict[str, Any] = {}
             for key, value in batched_params.items():
                 arr = jnp.asarray(value)
                 if arr.ndim == 0:
                     arr = jnp.broadcast_to(arr, self._batch_shape)
-                broadcasted[key] = arr
-            batched_params = broadcasted
+                elif arr.ndim >= len(self._batch_shape):
+                    leading = arr.shape[: len(self._batch_shape)]
+                    if leading != self._batch_shape:
+                        raise ValueError(
+                            f"_TFPArrayBackend: declared "
+                            f"batch_shape={self._batch_shape} but "
+                            f"parameter {key!r} has leading shape "
+                            f"{leading}; the two must match. Check "
+                            f"that every batched parameter broadcasts "
+                            f"to batch_shape."
+                        )
+                normalised[key] = arr
+            batched_params = normalised
         self._batched_params = batched_params
         # Construct the fused ProbPipe Distribution with the batched
         # params. The backend exists *to* hold a batched form, so any
@@ -265,12 +267,14 @@ class _TFPArrayBackend:
         # canonical caller of that bypass.
         self._batched_dist: TFPDistribution = dist_cls(
             **batched_params,
-            name=f"{name}__array_backend",
+            name=f"{name}{_ARRAY_BACKEND_NAME_SUFFIX}",
         )
-        # Sanity check: the constructed TFP dist's batch_shape should
-        # match what the caller said. Mismatches usually mean the
-        # caller's params don't actually broadcast to ``batch_shape``.
-        actual = tuple(self._batched_dist._tfp_dist.batch_shape)
+        # Final sanity check: TFP's inferred batch_shape must match
+        # the caller's declaration. Catches the rare case where a
+        # higher-rank param's *trailing* axes don't agree but the
+        # leading-axes check above passed (e.g., MVN where ``loc`` /
+        # ``scale_tril`` event ranks differ).
+        actual = self._batched_dist.batch_shape
         if actual != self._batch_shape:
             raise ValueError(
                 f"_TFPArrayBackend: declared batch_shape={self._batch_shape} "
@@ -287,11 +291,11 @@ class _TFPArrayBackend:
 
     @property
     def event_shape(self) -> tuple[int, ...]:
-        return tuple(self._batched_dist._tfp_dist.event_shape)
+        return self._batched_dist.event_shape
 
     @property
     def dtype(self) -> jnp.dtype:
-        return self._batched_dist._tfp_dist.dtype
+        return self._batched_dist.dtype
 
     # -- per-cell materialisation -------------------------------------------
 
@@ -303,9 +307,13 @@ class _TFPArrayBackend:
         indices. The returned distribution is fully scalar
         (``batch_shape == ()``) — no caching; each call re-runs the
         ordinary ``dist_cls(**scalar_params, name=...)`` constructor.
+
+        ``batch_shape`` is non-empty by construction (
+        :func:`DistributionArray._infer_batch_shape` rejects scalar-
+        only param sets), so we never have to handle a degenerate
+        zero-axis backend here.
         """
-        multi = self._normalize_index(index)
-        flat = int(np.ravel_multi_index(multi, self._batch_shape)) if self._batch_shape else 0
+        multi, flat = self._normalize_index(index)
         scalar_params = {
             key: _slice_leading_axes(value, multi)
             for key, value in self._batched_params.items()
@@ -317,38 +325,37 @@ class _TFPArrayBackend:
 
     def _normalize_index(
         self, index: int | tuple[int, ...]
-    ) -> tuple[int, ...]:
+    ) -> tuple[tuple[int, ...], int]:
+        """Return ``(multi_index, flat_index)`` for the given input.
+
+        Lets :meth:`cell` slice with the multi-d index *and* name the
+        result with the flat index in one pass, without round-tripping
+        through ``np.ravel_multi_index`` / ``np.unravel_index`` for
+        the common 1-D case. Out-of-range indices raise ``IndexError``
+        via NumPy; rank mismatches are caught here with a clearer
+        message than NumPy's default.
+        """
         bshape = self._batch_shape
         if isinstance(index, (int, np.integer)) or hasattr(index, "__index__"):
             i = int(index)
-            if not bshape:
-                if i != 0:
-                    raise IndexError(
-                        f"_TFPArrayBackend.cell: scalar backend has only one "
-                        f"cell; got index={i}."
-                    )
-                return ()
             if len(bshape) == 1:
                 if not 0 <= i < bshape[0]:
                     raise IndexError(
-                        f"_TFPArrayBackend.cell: index {i} out of range for "
-                        f"batch_shape={bshape}."
+                        f"_TFPArrayBackend.cell: index {i} out of range "
+                        f"for batch_shape={bshape}."
                     )
-                return (i,)
-            return tuple(int(x) for x in np.unravel_index(i, bshape))
+                return (i,), i
+            multi = tuple(int(x) for x in np.unravel_index(i, bshape))
+            return multi, i
         idx = tuple(int(x) for x in index)
         if len(idx) != len(bshape):
             raise IndexError(
-                f"_TFPArrayBackend.cell: index {idx} has rank {len(idx)} "
-                f"but batch_shape={bshape} has rank {len(bshape)}."
+                f"_TFPArrayBackend.cell: index {idx} has rank "
+                f"{len(idx)} but batch_shape={bshape} has rank "
+                f"{len(bshape)}."
             )
-        for i, dim in zip(idx, bshape):
-            if not 0 <= i < dim:
-                raise IndexError(
-                    f"_TFPArrayBackend.cell: index {idx} out of range for "
-                    f"batch_shape={bshape}."
-                )
-        return idx
+        flat = int(np.ravel_multi_index(idx, bshape))
+        return idx, flat
 
     # -- vectorised ops (forward to the wrapped batched distribution) -------
 
@@ -416,7 +423,7 @@ class _TFPArrayBackend:
         instance._batched_params = dict(zip(keys, children))
         instance._batched_dist = dist_cls(
             **instance._batched_params,
-            name=f"{name}__array_backend",
+            name=f"{name}{_ARRAY_BACKEND_NAME_SUFFIX}",
         )
         return instance
 

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import tensorflow_probability.substrates.jax.distributions as tfd
 
+from .._array_utils import _slice_leading_axes
 from .._utils import prod
 from ..core._distribution_base import Distribution
 from ..core.distribution import (
@@ -162,8 +164,8 @@ class TFPDistribution(
         constructor handles the per-class param-name mapping.
 
         See :class:`probpipe.core.protocols.SupportsArrayBackend` for the
-        protocol contract. Phase 1 of PR-C — additive only; nothing yet
-        forces users through this path.
+        protocol contract. Additive — ``DistributionArray.from_batched_params``
+        is the only consumer; user code never calls this directly.
         """
         return _TFPArrayBackend(
             dist_cls=cls,
@@ -188,11 +190,10 @@ class _TFPArrayBackend:
     param.
 
     Implementation strategy: the backend wraps a *single* ProbPipe
-    ``Distribution`` instance constructed with the batched params
-    (legal in Phase 1 — Phase 2 will need a bypass for the un-batched
-    assertion this class introduces). Vectorised ops forward to that
-    wrapped instance's TFP backend; ``cell(i)`` slices the params and
-    runs the ordinary scalar constructor with a suffixed name.
+    ``Distribution`` instance constructed with the batched params.
+    Vectorised ops forward to that wrapped instance's TFP backend;
+    ``cell(i)`` slices the params and runs the ordinary scalar
+    constructor with a suffixed name.
 
     Not a :class:`Distribution` itself — the backend exists only as
     the contract between :meth:`TFPDistribution._make_array_backend`
@@ -228,9 +229,10 @@ class _TFPArrayBackend:
         self._batch_shape = tuple(batch_shape)
         self._batched_params = batched_params
         # Construct the fused ProbPipe Distribution with the batched
-        # params. This is legal in Phase 1; Phase 2's un-batched
-        # assertion will need a private bypass here (the backend's
-        # whole purpose is to hold a batched form).
+        # params. The backend exists *to* hold a batched form, so any
+        # downstream rejection of batched parameters at construction
+        # time must provide a bypass; this constructor is the
+        # canonical caller of that bypass.
         self._batched_dist: TFPDistribution = dist_cls(
             **batched_params,
             name=f"{name}__array_backend",
@@ -275,7 +277,7 @@ class _TFPArrayBackend:
         multi = self._normalize_index(index)
         flat = int(np.ravel_multi_index(multi, self._batch_shape)) if self._batch_shape else 0
         scalar_params = {
-            key: _slice_param_at(value, multi)
+            key: _slice_leading_axes(value, multi)
             for key, value in self._batched_params.items()
         }
         return self._dist_cls(
@@ -345,22 +347,48 @@ class _TFPArrayBackend:
             f"batch_shape={self._batch_shape}, name={self._name!r})"
         )
 
+    # -- JAX pytree registration --------------------------------------------
 
-def _slice_param_at(
-    value: Any, multi_index: tuple[int, ...]
-) -> Any:
-    """Index the leading ``len(multi_index)`` axes of ``value`` at ``multi_index``.
+    def tree_flatten(self):
+        """Split the backend into JAX-traceable children + static aux.
 
-    A scalar / lower-rank value (broadcast across every cell of the
-    batch) is passed through unchanged. The trailing event axes (if
-    any) are preserved in the slice — e.g., for ``MultivariateNormal``
-    with ``loc`` of shape ``(batch, d)`` and ``multi_index=(i,)``,
-    returns ``loc[i]`` of shape ``(d,)``.
-    """
-    if not multi_index:
-        return value
-    arr = jnp.asarray(value)
-    if arr.ndim < len(multi_index):
-        # Lower-rank — value is broadcast across the batch axes.
-        return value
-    return arr[multi_index]
+        Children are the batched parameter values (the JAX-array
+        leaves the user passed); aux carries everything needed to
+        reconstruct the backend (the distribution class, the cell
+        name, the declared ``batch_shape``, and the parameter keys
+        in iteration order). The wrapped ``_batched_dist`` is
+        reconstructed inside ``tree_unflatten`` from the params, so
+        successive ``jit`` / ``vmap`` traces stay consistent.
+        """
+        keys = tuple(self._batched_params.keys())
+        children = tuple(self._batched_params[k] for k in keys)
+        aux = (self._dist_cls, self._name, self._batch_shape, keys)
+        return children, aux
+
+    @classmethod
+    def tree_unflatten(cls, aux, children) -> "_TFPArrayBackend":
+        """Reconstruct the backend without re-running the
+        ``__init__`` shape sanity check.
+
+        ``tree_map`` and ``vmap`` both invoke ``tree_unflatten`` with
+        leaf shapes that may not match the originally-declared
+        ``batch_shape`` (e.g., a fresh leading axis stacked by
+        ``tree_map``, an abstract per-cell shape inside a ``vmap``
+        trace). The aux is informational and preserved for the
+        round-trip; the wrapped ``_batched_dist`` is rebuilt directly
+        from the leaves.
+        """
+        dist_cls, name, batch_shape, keys = aux
+        instance = cls.__new__(cls)
+        instance._dist_cls = dist_cls
+        instance._name = name
+        instance._batch_shape = tuple(batch_shape)
+        instance._batched_params = dict(zip(keys, children))
+        instance._batched_dist = dist_cls(
+            **instance._batched_params,
+            name=f"{name}__array_backend",
+        )
+        return instance
+
+
+jax.tree_util.register_pytree_node_class(_TFPArrayBackend)

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -15,7 +15,6 @@ import numpy as np
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from .._array_utils import _slice_leading_axes
-from .._utils import prod
 from ..core._distribution_base import Distribution
 from ..core.distribution import (
     NumericRecordDistribution,
@@ -27,7 +26,6 @@ from ..core.protocols import (
     SupportsMean,
     SupportsSampling,
     SupportsVariance,
-    _DistributionArrayBackend,
 )
 from ..core.record import Record, RecordTemplate
 from ..custom_types import Array, ArrayLike, PRNGKey

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -225,6 +225,38 @@ class _TFPArrayBackend:
         self._dist_cls = dist_cls
         self._name = name
         self._batch_shape = tuple(batch_shape)
+        # Pre-flight shape check + scalar broadcast.
+        #
+        # Validate every higher-rank param's leading axes against the
+        # declared ``batch_shape`` *before* construction. Raises a
+        # message that names the offending parameter and references
+        # ``batch_shape`` — clearer than letting TFP raise a generic
+        # "Arguments ... must have compatible shapes" further down
+        # the call stack. Then broadcast any 0-D scalars to
+        # ``batch_shape`` so callers can mix scalars with arrays —
+        # ``from_batched_params(Normal, loc=0.0, scale=1.0,
+        # batch_shape=(5,))`` constructs five identical Normals.
+        if self._batch_shape:
+            for key, value in batched_params.items():
+                arr = jnp.asarray(value)
+                if arr.ndim < len(self._batch_shape):
+                    continue
+                leading = arr.shape[: len(self._batch_shape)]
+                if leading != self._batch_shape:
+                    raise ValueError(
+                        f"_TFPArrayBackend: declared "
+                        f"batch_shape={self._batch_shape} but parameter "
+                        f"{key!r} has leading shape {leading}; the two "
+                        f"must match. Check that every batched parameter "
+                        f"broadcasts to batch_shape."
+                    )
+            broadcasted = {}
+            for key, value in batched_params.items():
+                arr = jnp.asarray(value)
+                if arr.ndim == 0:
+                    arr = jnp.broadcast_to(arr, self._batch_shape)
+                broadcasted[key] = arr
+            batched_params = broadcasted
         self._batched_params = batched_params
         # Construct the fused ProbPipe Distribution with the batched
         # params. The backend exists *to* hold a batched form, so any

--- a/tests/test_distribution_array.py
+++ b/tests/test_distribution_array.py
@@ -295,3 +295,136 @@ class TestProvenance:
         da.with_source(Provenance("sweep", parents=(parent,)))
         assert da.source.operation == "sweep"
         assert da.source.parents == (parent,)
+
+
+# ---------------------------------------------------------------------------
+# Backend-delegated storage (PR-C.1 commit 3)
+# ---------------------------------------------------------------------------
+
+
+class TestBackendDelegatedStorage:
+    """Tests for the ``_from_backend`` private constructor + lazy
+    component materialisation. The factory entry point
+    (``from_batched_params``) lands in commit 4; this commit pins the
+    storage refactor in isolation.
+    """
+
+    def _make_backend(self, n=5):
+        from probpipe import Normal
+        return Normal._make_array_backend(
+            name="x",
+            batch_shape=(n,),
+            loc=jnp.arange(float(n)),
+            scale=jnp.ones(n),
+        )
+
+    def test_from_backend_returns_distribution_array(self):
+        from probpipe import DistributionArray
+        backend = self._make_backend(n=5)
+        da = DistributionArray._from_backend(backend, name="batched_x")
+        assert isinstance(da, DistributionArray)
+        assert da._backend is backend
+        assert da.batch_shape == (5,)
+        assert da.event_shape == ()
+        assert da.n == 5
+        assert len(da) == 5
+        assert da.name == "batched_x"
+
+    def test_from_backend_does_not_materialise_components_eagerly(self):
+        from probpipe import DistributionArray
+        backend = self._make_backend(n=5)
+        da = DistributionArray._from_backend(backend, name="x")
+        # Components stay None until first .components access; the
+        # storage refactor's whole point is lazy materialisation.
+        assert da._components is None
+
+    def test_indexing_routes_through_backend_cell(self):
+        from probpipe import DistributionArray, Normal
+        backend = self._make_backend(n=5)
+        da = DistributionArray._from_backend(backend, name="x")
+        # Each int access fabricates fresh; identity differs.
+        a = da[2]
+        b = da[2]
+        assert isinstance(a, Normal)
+        assert a is not b
+        # Per-cell params correctly sliced.
+        assert float(a.loc) == 2.0
+        # Components stayed None — int indexing doesn't materialise the
+        # eager tuple.
+        assert da._components is None
+
+    def test_flat_component_routes_through_backend_cell(self):
+        from probpipe import DistributionArray, Normal
+        backend = self._make_backend(n=4)
+        da = DistributionArray._from_backend(backend, name="x")
+        for i in range(4):
+            cell = da._flat_component(i)
+            assert isinstance(cell, Normal)
+            assert float(cell.loc) == float(i)
+        assert da._components is None  # still lazy
+
+    def test_iteration_lazy_via_backend(self):
+        from probpipe import DistributionArray, Normal
+        backend = self._make_backend(n=4)
+        da = DistributionArray._from_backend(backend, name="x")
+        cells = list(da)
+        assert len(cells) == 4
+        for i, cell in enumerate(cells):
+            assert isinstance(cell, Normal)
+            assert float(cell.loc) == float(i)
+        # Iteration via backend.cell does NOT cache into _components;
+        # only .components does that.
+        assert da._components is None
+
+    def test_components_property_materialises_lazily_and_caches(self):
+        from probpipe import DistributionArray
+        backend = self._make_backend(n=3)
+        da = DistributionArray._from_backend(backend, name="x")
+        c1 = da.components
+        c2 = da.components
+        assert isinstance(c1, tuple)
+        assert len(c1) == 3
+        # Cached: same tuple identity returned.
+        assert c1 is c2
+        # And now _components is populated.
+        assert da._components is c1
+
+    def test_slice_indexing_materialises_components(self):
+        from probpipe import DistributionArray
+        backend = self._make_backend(n=5)
+        da = DistributionArray._from_backend(backend, name="x")
+        sub = da[1:4]
+        # Slicing forces materialisation (rare path).
+        assert da._components is not None
+        assert isinstance(sub, DistributionArray)
+        assert sub.n == 3
+
+    def test_repr_indicates_backend_mode(self):
+        from probpipe import DistributionArray
+        backend = self._make_backend(n=3)
+        backed = DistributionArray._from_backend(backend, name="x")
+        assert "backend=True" in repr(backed)
+
+    def test_literal_path_unchanged(self):
+        """Construction via the explicit components list still works
+        identically — no _backend, eager _components tuple."""
+        from probpipe import DistributionArray, Normal
+        comps = [Normal(loc=float(i), scale=1.0, name=f"c_{i}") for i in range(3)]
+        da = DistributionArray(comps, name="literal")
+        assert da._backend is None
+        assert da._components == tuple(comps)
+        assert da[1] is comps[1]
+        assert da.components is da._components
+
+    def test_multi_d_batch_shape_via_backend(self):
+        from probpipe import DistributionArray, Normal
+        loc = jnp.arange(6.0).reshape(2, 3)
+        backend = Normal._make_array_backend(
+            name="g", batch_shape=(2, 3), loc=loc, scale=1.0,
+        )
+        da = DistributionArray._from_backend(backend, name="g")
+        assert da.batch_shape == (2, 3)
+        assert da.n == 6
+        # Row-major flat index 4 -> (1, 1) -> loc=4.0
+        assert float(da[1, 1].loc) == 4.0
+        assert float(da._flat_component(4).loc) == 4.0

--- a/tests/test_distribution_array.py
+++ b/tests/test_distribution_array.py
@@ -428,3 +428,184 @@ class TestBackendDelegatedStorage:
         # Row-major flat index 4 -> (1, 1) -> loc=4.0
         assert float(da[1, 1].loc) == 4.0
         assert float(da._flat_component(4).loc) == 4.0
+
+
+# ---------------------------------------------------------------------------
+# from_batched_params factory (PR-C.1 commit 4)
+# ---------------------------------------------------------------------------
+
+
+class TestFromBatchedParams:
+    """Public entry point that dispatches on ``SupportsArrayBackend``."""
+
+    def test_normal_uses_tfp_backend(self):
+        from probpipe import Normal, DistributionArray
+        from probpipe.distributions._tfp_base import _TFPArrayBackend
+        da = DistributionArray.from_batched_params(
+            Normal, loc=jnp.arange(5.0), scale=1.0, name="x",
+        )
+        assert isinstance(da, DistributionArray)
+        assert isinstance(da._backend, _TFPArrayBackend)
+        assert da.batch_shape == (5,)
+        assert da.event_shape == ()
+        assert da.n == 5
+
+    def test_per_cell_name_auto_suffix(self):
+        from probpipe import Normal, DistributionArray
+        da = DistributionArray.from_batched_params(
+            Normal, loc=jnp.arange(3.0), scale=jnp.ones(3), name="weights",
+        )
+        assert da[0].name == "weights_0"
+        assert da[1].name == "weights_1"
+        assert da[2].name == "weights_2"
+
+    def test_per_cell_params_correctly_sliced(self):
+        from probpipe import Normal, DistributionArray
+        da = DistributionArray.from_batched_params(
+            Normal, loc=jnp.arange(4.0), scale=jnp.linspace(0.1, 0.4, 4),
+            name="x",
+        )
+        for i in range(4):
+            cell = da[i]
+            assert float(cell.loc) == float(i)
+            assert float(cell.scale) == pytest.approx(0.1 + 0.1 * i, abs=1e-6)
+
+    def test_scalar_param_broadcasts_through_cells(self):
+        from probpipe import Normal, DistributionArray
+        da = DistributionArray.from_batched_params(
+            Normal, loc=jnp.zeros(3), scale=2.5, name="x",
+        )
+        for i in range(3):
+            assert float(da[i].scale) == 2.5
+
+    def test_inferred_batch_shape_uses_broadcast(self):
+        from probpipe import Normal, DistributionArray
+        # Both arrays imply batch_shape=(4,) — broadcast convention.
+        da = DistributionArray.from_batched_params(
+            Normal, loc=jnp.arange(4.0), scale=jnp.ones(4), name="x",
+        )
+        assert da.batch_shape == (4,)
+
+    def test_explicit_batch_shape_honored(self):
+        from probpipe import Normal, DistributionArray
+        da = DistributionArray.from_batched_params(
+            Normal,
+            batch_shape=(2, 3),
+            loc=jnp.arange(6.0).reshape(2, 3),
+            scale=1.0,
+            name="g",
+        )
+        assert da.batch_shape == (2, 3)
+        assert da.n == 6
+        # Row-major: (1, 2) -> flat 5 -> loc=5.0, name="g_5".
+        assert float(da[1, 2].loc) == 5.0
+        assert da[1, 2].name == "g_5"
+
+    def test_no_array_params_requires_explicit_batch_shape(self):
+        from probpipe import Normal, DistributionArray
+        with pytest.raises(ValueError, match="batch_shape"):
+            DistributionArray.from_batched_params(
+                Normal, loc=0.0, scale=1.0, name="x",
+            )
+
+    def test_multivariate_normal_via_factory(self):
+        """MVN-style classes need explicit ``batch_shape`` because
+        their per-param event ranks differ (``loc`` is
+        ``(*batch, d)``, ``scale_tril`` is ``(*batch, d, d)``)."""
+        from probpipe import MultivariateNormal, DistributionArray
+        from probpipe.distributions._tfp_base import _TFPArrayBackend
+        d = 3
+        da = DistributionArray.from_batched_params(
+            MultivariateNormal,
+            batch_shape=(2,),
+            loc=jnp.zeros((2, d)),
+            scale_tril=jnp.broadcast_to(jnp.eye(d), (2, d, d)),
+            name="z",
+        )
+        assert isinstance(da._backend, _TFPArrayBackend)
+        assert da.batch_shape == (2,)
+        assert da.event_shape == (d,)
+        assert da[0].event_shape == (d,)
+
+    def test_inference_punts_on_event_rank_mismatch(self):
+        """Without explicit ``batch_shape``, MVN-style heterogeneous
+        event-rank params raise a clear ``ValueError``."""
+        from probpipe import MultivariateNormal, DistributionArray
+        d = 3
+        with pytest.raises(ValueError, match="batch_shape"):
+            DistributionArray.from_batched_params(
+                MultivariateNormal,
+                loc=jnp.zeros((2, d)),
+                scale_tril=jnp.broadcast_to(jnp.eye(d), (2, d, d)),
+                name="z",
+            )
+
+    def test_non_protocol_class_falls_back_to_literal(self):
+        """A Distribution subclass that doesn't implement
+        ``SupportsArrayBackend`` gets the literal-array fallback path:
+        eager construction, no backend.
+        """
+        from probpipe import DistributionArray
+        from probpipe.core._distribution_base import Distribution
+
+        class MyDist(Distribution):
+            def __init__(self, value, *, name):
+                self._value = float(value)
+                super().__init__(name=name)
+
+            @property
+            def event_shape(self):
+                return ()
+
+            @property
+            def batch_shape(self):
+                return ()
+
+        da = DistributionArray.from_batched_params(
+            MyDist, value=jnp.arange(3.0), name="m",
+        )
+        # Fallback path: literal components, no backend.
+        assert da._backend is None
+        assert da._components is not None
+        assert isinstance(da[0], MyDist)
+        assert da[0]._value == 0.0
+        assert da[2]._value == 2.0
+        assert da[1].name == "m_1"
+
+    def test_factory_results_match_legacy_batched_constructor(self):
+        """Result of ``from_batched_params(Normal, loc=arr, scale=...)``
+        produces samples / log_probs / means matching the legacy
+        ``Normal(loc=arr, scale=...)`` form (the form Phase 2 will
+        reject).
+        """
+        from probpipe import Normal, DistributionArray
+        loc = jnp.array([0.5, -1.2, 3.7, 0.0])
+        scale = jnp.array([0.1, 0.2, 0.3, 0.4])
+
+        legacy = Normal(loc=loc, scale=scale, name="legacy")
+        da = DistributionArray.from_batched_params(
+            Normal, loc=loc, scale=scale, name="x",
+        )
+        # Sample shapes match.
+        key = jax.random.PRNGKey(42)
+        legacy_samples = legacy._sample(key)
+        da_samples = da._backend._sample(key)
+        np.testing.assert_allclose(
+            np.asarray(legacy_samples), np.asarray(da_samples)
+        )
+        # Mean / variance match.
+        np.testing.assert_allclose(
+            np.asarray(legacy._mean()), np.asarray(da._backend._mean())
+        )
+        np.testing.assert_allclose(
+            np.asarray(legacy._variance()), np.asarray(da._backend._variance())
+        )
+
+    def test_iteration_matches_indexing(self):
+        from probpipe import Normal, DistributionArray
+        da = DistributionArray.from_batched_params(
+            Normal, loc=jnp.arange(4.0), scale=jnp.ones(4), name="x",
+        )
+        for i, cell in enumerate(da):
+            assert float(cell.loc) == float(da[i].loc)
+            assert cell.name == da[i].name

--- a/tests/test_distribution_array.py
+++ b/tests/test_distribution_array.py
@@ -609,3 +609,92 @@ class TestFromBatchedParams:
         for i, cell in enumerate(da):
             assert float(cell.loc) == float(da[i].loc)
             assert cell.name == da[i].name
+
+
+# ---------------------------------------------------------------------------
+# Distribution.from_batched_params alias (PR-C.1 commit 5)
+# ---------------------------------------------------------------------------
+
+
+class TestDistributionFromBatchedParamsAlias:
+    """Ergonomic per-class alias on Distribution[T]."""
+
+    def test_alias_dispatches_to_distribution_array_factory(self):
+        from probpipe import Normal, DistributionArray
+        from probpipe.distributions._tfp_base import _TFPArrayBackend
+
+        da = Normal.from_batched_params(
+            loc=jnp.arange(5.0), scale=1.0, name="x",
+        )
+        assert isinstance(da, DistributionArray)
+        assert isinstance(da._backend, _TFPArrayBackend)
+        assert da.batch_shape == (5,)
+        assert da[0].name == "x_0"
+
+    def test_alias_matches_classmethod_call(self):
+        from probpipe import Normal, DistributionArray
+        loc = jnp.arange(4.0)
+        scale = jnp.linspace(0.1, 0.4, 4)
+
+        via_alias = Normal.from_batched_params(
+            loc=loc, scale=scale, name="x",
+        )
+        via_factory = DistributionArray.from_batched_params(
+            Normal, loc=loc, scale=scale, name="x",
+        )
+        # Same backend type, same per-cell parameters / names.
+        assert type(via_alias._backend) is type(via_factory._backend)
+        for i in range(4):
+            a = via_alias[i]
+            f = via_factory[i]
+            assert a.name == f.name
+            assert float(a.loc) == float(f.loc)
+            assert float(a.scale) == float(f.scale)
+
+    def test_alias_inherited_by_all_distribution_subclasses(self):
+        from probpipe.core._distribution_base import Distribution
+        from probpipe import (
+            Normal, Beta, Gamma, MultivariateNormal,
+            EmpiricalDistribution,
+        )
+        # Every Distribution subclass inherits the alias.
+        for cls in (Distribution, Normal, Beta, Gamma,
+                    MultivariateNormal, EmpiricalDistribution):
+            assert hasattr(cls, "from_batched_params")
+            assert callable(cls.from_batched_params)
+
+    def test_alias_with_explicit_batch_shape(self):
+        from probpipe import MultivariateNormal
+        d = 3
+        da = MultivariateNormal.from_batched_params(
+            batch_shape=(2,),
+            loc=jnp.zeros((2, d)),
+            scale_tril=jnp.broadcast_to(jnp.eye(d), (2, d, d)),
+            name="z",
+        )
+        assert da.batch_shape == (2,)
+        assert da.event_shape == (d,)
+
+    def test_alias_falls_back_for_non_protocol_class(self):
+        """The alias inherits the factory's protocol-vs-fallback
+        dispatch, so non-protocol Distribution subclasses also get the
+        literal-array fallback when invoking the alias."""
+        from probpipe.core._distribution_base import Distribution
+
+        class MyDist(Distribution):
+            def __init__(self, value, *, name):
+                self._value = float(value)
+                super().__init__(name=name)
+
+            @property
+            def event_shape(self):
+                return ()
+
+            @property
+            def batch_shape(self):
+                return ()
+
+        da = MyDist.from_batched_params(value=jnp.arange(3.0), name="m")
+        assert da._backend is None
+        assert isinstance(da[0], MyDist)
+        assert da[1].name == "m_1"

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -725,23 +725,19 @@ class TestSupportsArrayBackendProtocolSurface:
         # Backend-interface stays private — leading underscore, not exported.
         assert "_DistributionArrayBackend" not in proto_mod.__all__
 
-    def test_no_existing_distribution_implements_protocol_yet(self):
-        """Until commit 2 lands ``_make_array_backend`` on
-        ``TFPDistribution``, no shipped class implements the protocol.
+    def test_tfp_distributions_implement_protocol(self):
+        """Every concrete TFP-backed distribution inherits
+        ``_make_array_backend`` from ``TFPDistribution``.
 
-        Pins the additive-only contract: commit 1 introduces the
-        protocol surface in isolation. The check is on the **class**
-        (the protocol method is a classmethod), not on instances.
+        The protocol method is a classmethod, so the check is on the
+        class itself: ``hasattr(Normal, "_make_array_backend")``. Pins
+        the post-commit-2 contract — non-TFP distributions still don't
+        implement it and stay on the literal-array fallback path.
         """
-        from probpipe.core.protocols import SupportsArrayBackend
-
-        # The protocol is defined classmethod-level; ``isinstance`` on
-        # a class checks whether the class itself has the attribute.
-        # No shipped class has ``_make_array_backend`` after commit 1.
         for cls in (Normal, Beta, Gamma, MultivariateNormal):
-            assert not hasattr(cls, "_make_array_backend"), (
-                f"{cls.__name__}._make_array_backend already exists; "
-                f"PR-C.1 commit 1 should only ship the protocol surface."
+            assert hasattr(cls, "_make_array_backend"), (
+                f"{cls.__name__} should inherit _make_array_backend "
+                f"from TFPDistribution after PR-C.1 commit 2."
             )
 
     def test_backend_protocol_minimum_surface(self):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -690,3 +690,68 @@ class TestProtocolsSupportedByAll:
         from probpipe.core.protocols import protocols_supported_by_all
         result = protocols_supported_by_all([], (SupportsLogProb, SupportsMean))
         assert result == (SupportsLogProb, SupportsMean)
+
+
+# ---------------------------------------------------------------------------
+# SupportsArrayBackend protocol surface
+# ---------------------------------------------------------------------------
+
+
+class TestSupportsArrayBackendProtocolSurface:
+    """Structural checks on :class:`SupportsArrayBackend`.
+
+    Commit 1 of PR-C.1 only adds the protocol; concrete TFP / Record
+    implementations land in later commits, and the existing
+    ``Distribution`` subclasses don't yet implement
+    ``_make_array_backend``. These tests pin the protocol's *shape*
+    (importable, runtime-checkable, classmethod-level) so later
+    commits can layer on the implementations without regressing the
+    contract.
+    """
+
+    def test_protocol_is_importable(self):
+        from probpipe.core.protocols import (
+            SupportsArrayBackend,
+            _DistributionArrayBackend,
+        )
+
+        assert SupportsArrayBackend is not None
+        assert _DistributionArrayBackend is not None
+
+    def test_protocol_in_public_all(self):
+        from probpipe.core import protocols as proto_mod
+
+        assert "SupportsArrayBackend" in proto_mod.__all__
+        # Backend-interface stays private — leading underscore, not exported.
+        assert "_DistributionArrayBackend" not in proto_mod.__all__
+
+    def test_no_existing_distribution_implements_protocol_yet(self):
+        """Until commit 2 lands ``_make_array_backend`` on
+        ``TFPDistribution``, no shipped class implements the protocol.
+
+        Pins the additive-only contract: commit 1 introduces the
+        protocol surface in isolation. The check is on the **class**
+        (the protocol method is a classmethod), not on instances.
+        """
+        from probpipe.core.protocols import SupportsArrayBackend
+
+        # The protocol is defined classmethod-level; ``isinstance`` on
+        # a class checks whether the class itself has the attribute.
+        # No shipped class has ``_make_array_backend`` after commit 1.
+        for cls in (Normal, Beta, Gamma, MultivariateNormal):
+            assert not hasattr(cls, "_make_array_backend"), (
+                f"{cls.__name__}._make_array_backend already exists; "
+                f"PR-C.1 commit 1 should only ship the protocol surface."
+            )
+
+    def test_backend_protocol_minimum_surface(self):
+        """``_DistributionArrayBackend`` Protocol declares the agreed
+        minimum surface."""
+        from probpipe.core.protocols import _DistributionArrayBackend
+
+        # Protocol attributes via __annotations__ / methods via vars.
+        members = set(dir(_DistributionArrayBackend))
+        for required in ("batch_shape", "event_shape", "cell"):
+            assert required in members, (
+                f"_DistributionArrayBackend missing required attr {required!r}"
+            )

--- a/tests/test_tfp_array_backend.py
+++ b/tests/test_tfp_array_backend.py
@@ -1,0 +1,305 @@
+"""Tests for ``_TFPArrayBackend`` (PR-C.1 commit 2).
+
+The backend is the fused-storage substrate that
+:class:`~probpipe.DistributionArray` will dispatch onto in commits 3-4.
+These tests pin the backend's behaviour in isolation:
+
+* Per-cell materialisation (``cell(i)``) returns fresh scalar
+  distributions with sliced parameters.
+* Vectorised ops (``_sample`` / ``_log_prob`` / ``_mean`` / ``_variance``)
+  are numerically equivalent to constructing the same TFP-batched
+  distribution directly.
+* Multi-d ``batch_shape`` works with both flat-int and tuple indexing.
+* Scalar parameters that broadcast across the batch are passed through
+  ``cell(i)`` unchanged.
+* Mismatched ``batch_shape`` declarations are rejected.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tensorflow_probability.substrates.jax.distributions as tfd
+
+from probpipe import Beta, Gamma, MultivariateNormal, Normal
+from probpipe.distributions._tfp_base import _TFPArrayBackend
+
+
+# ---------------------------------------------------------------------------
+# Construction + minimum surface
+# ---------------------------------------------------------------------------
+
+
+class TestMakeArrayBackendConstruction:
+    def test_normal_returns_tfp_array_backend(self):
+        backend = Normal._make_array_backend(
+            name="x",
+            batch_shape=(5,),
+            loc=jnp.arange(5.0),
+            scale=1.0,
+        )
+        assert isinstance(backend, _TFPArrayBackend)
+        assert backend.batch_shape == (5,)
+        assert backend.event_shape == ()
+
+    def test_beta_inherits_make_array_backend(self):
+        backend = Beta._make_array_backend(
+            name="b",
+            batch_shape=(3,),
+            alpha=jnp.array([1.0, 2.0, 3.0]),
+            beta=jnp.array([1.0, 1.0, 1.0]),
+        )
+        assert isinstance(backend, _TFPArrayBackend)
+        assert backend.batch_shape == (3,)
+
+    def test_gamma_inherits_make_array_backend(self):
+        backend = Gamma._make_array_backend(
+            name="g",
+            batch_shape=(4,),
+            concentration=jnp.array([1.0, 2.0, 3.0, 4.0]),
+            rate=1.0,
+        )
+        assert isinstance(backend, _TFPArrayBackend)
+        assert backend.batch_shape == (4,)
+
+    def test_mvn_inherits_make_array_backend(self):
+        d = 3
+        backend = MultivariateNormal._make_array_backend(
+            name="z",
+            batch_shape=(2,),
+            loc=jnp.zeros((2, d)),
+            scale_tril=jnp.broadcast_to(jnp.eye(d), (2, d, d)),
+        )
+        assert isinstance(backend, _TFPArrayBackend)
+        assert backend.batch_shape == (2,)
+        assert backend.event_shape == (d,)
+
+    def test_required_minimum_surface(self):
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(2,), loc=jnp.zeros(2), scale=1.0,
+        )
+        for attr in (
+            "batch_shape", "event_shape", "cell",
+            "_sample", "_log_prob", "_mean", "_variance", "_cov",
+        ):
+            assert hasattr(backend, attr), (
+                f"_TFPArrayBackend missing required attr {attr!r}"
+            )
+
+    def test_mismatched_batch_shape_rejected(self):
+        """Declaring ``batch_shape=(5,)`` with params that broadcast to
+        ``(3,)`` raises ``ValueError`` at backend construction."""
+        with pytest.raises(ValueError, match="batch_shape"):
+            Normal._make_array_backend(
+                name="x",
+                batch_shape=(5,),
+                loc=jnp.zeros(3),  # actually batch_shape=(3,)
+                scale=1.0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Per-cell materialisation
+# ---------------------------------------------------------------------------
+
+
+class TestCellMaterialisation:
+    def test_cell_returns_fresh_scalar_normal(self):
+        loc = jnp.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(5,), loc=loc, scale=1.0,
+        )
+        cell0 = backend.cell(0)
+        cell2 = backend.cell(2)
+        assert isinstance(cell0, Normal)
+        assert isinstance(cell2, Normal)
+        # Distinct fresh instances per call.
+        assert backend.cell(0) is not backend.cell(0)
+        # Per-cell parameters are correctly sliced.
+        assert float(cell0.loc) == 0.0
+        assert float(cell2.loc) == 2.0
+        # Per-cell scalar `scale` is broadcast through unchanged.
+        assert float(cell0.scale) == 1.0
+        assert float(cell2.scale) == 1.0
+
+    def test_cell_name_auto_suffixes(self):
+        backend = Normal._make_array_backend(
+            name="weights", batch_shape=(3,),
+            loc=jnp.zeros(3), scale=jnp.ones(3),
+        )
+        for i in range(3):
+            assert backend.cell(i).name == f"weights_{i}"
+
+    def test_cell_returns_unbatched_distribution(self):
+        """Cells materialise as scalar distributions
+        (``tfd batch_shape == ()``)."""
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(4,),
+            loc=jnp.arange(4.0), scale=jnp.ones(4),
+        )
+        for i in range(4):
+            cell = backend.cell(i)
+            assert tuple(cell._tfp_dist.batch_shape) == ()
+
+    def test_cell_negative_index_rejected(self):
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(3,), loc=jnp.zeros(3), scale=1.0,
+        )
+        with pytest.raises(IndexError):
+            backend.cell(-1)
+        with pytest.raises(IndexError):
+            backend.cell(3)
+
+    def test_cell_with_mvn_preserves_event_axis(self):
+        d = 3
+        loc = jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        scale_tril = jnp.broadcast_to(jnp.eye(d), (2, d, d))
+        backend = MultivariateNormal._make_array_backend(
+            name="z", batch_shape=(2,), loc=loc, scale_tril=scale_tril,
+        )
+        cell0 = backend.cell(0)
+        cell1 = backend.cell(1)
+        np.testing.assert_allclose(np.asarray(cell0.loc), [1.0, 2.0, 3.0])
+        np.testing.assert_allclose(np.asarray(cell1.loc), [4.0, 5.0, 6.0])
+        # event_shape preserved on the per-cell scalar.
+        assert cell0.event_shape == (d,)
+
+
+# ---------------------------------------------------------------------------
+# Multi-d batching
+# ---------------------------------------------------------------------------
+
+
+class TestMultiDimensionalBatch:
+    def test_int_index_maps_to_row_major_position(self):
+        """Flat ``int`` indices unravel row-major over ``batch_shape``."""
+        loc = jnp.array([[10.0, 11.0, 12.0],
+                         [20.0, 21.0, 22.0]])
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(2, 3), loc=loc, scale=1.0,
+        )
+        # Row-major: index 0 -> (0, 0), index 4 -> (1, 1), index 5 -> (1, 2).
+        assert float(backend.cell(0).loc) == 10.0
+        assert float(backend.cell(4).loc) == 21.0
+        assert float(backend.cell(5).loc) == 22.0
+
+    def test_tuple_index_axis_aligned(self):
+        loc = jnp.array([[10.0, 11.0, 12.0],
+                         [20.0, 21.0, 22.0]])
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(2, 3), loc=loc, scale=1.0,
+        )
+        assert float(backend.cell((0, 0)).loc) == 10.0
+        assert float(backend.cell((1, 2)).loc) == 22.0
+
+    def test_int_and_tuple_indices_match(self):
+        loc = jnp.arange(12.0).reshape(3, 4)
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(3, 4), loc=loc, scale=1.0,
+        )
+        for flat in range(12):
+            multi = np.unravel_index(flat, (3, 4))
+            assert float(backend.cell(flat).loc) == float(
+                backend.cell(tuple(int(x) for x in multi)).loc
+            )
+
+    def test_tuple_wrong_rank_rejected(self):
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(2, 3),
+            loc=jnp.zeros((2, 3)), scale=1.0,
+        )
+        with pytest.raises(IndexError):
+            backend.cell((0,))
+
+
+# ---------------------------------------------------------------------------
+# Vectorised ops match TFP-batched native
+# ---------------------------------------------------------------------------
+
+
+class TestBatchedOpsMatchTFPNative:
+    def _make_pair(self, loc, scale):
+        backend = Normal._make_array_backend(
+            name="x",
+            batch_shape=tuple(jnp.broadcast_shapes(
+                jnp.asarray(loc).shape, jnp.asarray(scale).shape,
+            )),
+            loc=loc,
+            scale=scale,
+        )
+        tfp_native = tfd.Normal(loc=jnp.asarray(loc),
+                                scale=jnp.asarray(scale))
+        return backend, tfp_native
+
+    def test_sample_shape_matches_native(self):
+        backend, native = self._make_pair(jnp.arange(5.0), 1.0)
+        key = jax.random.PRNGKey(0)
+        b_samples = backend._sample(key)
+        n_samples = native.sample(seed=key)
+        assert b_samples.shape == n_samples.shape == (5,)
+
+    def test_sample_with_sample_shape_matches_native(self):
+        backend, native = self._make_pair(jnp.arange(3.0), jnp.ones(3))
+        key = jax.random.PRNGKey(7)
+        b_samples = backend._sample(key, sample_shape=(10,))
+        n_samples = native.sample(seed=key, sample_shape=(10,))
+        np.testing.assert_allclose(np.asarray(b_samples), np.asarray(n_samples))
+
+    def test_log_prob_matches_native(self):
+        backend, native = self._make_pair(jnp.arange(4.0), 1.5)
+        x = jnp.array([0.5, 1.0, 2.5, 3.5])
+        np.testing.assert_allclose(
+            np.asarray(backend._log_prob(x)),
+            np.asarray(native.log_prob(x)),
+            rtol=1e-6,
+        )
+
+    def test_mean_variance_match_native(self):
+        backend, native = self._make_pair(jnp.array([1.0, 2.0, 3.0]),
+                                          jnp.array([0.1, 0.2, 0.3]))
+        np.testing.assert_allclose(
+            np.asarray(backend._mean()), np.asarray(native.mean()),
+        )
+        np.testing.assert_allclose(
+            np.asarray(backend._variance()), np.asarray(native.variance()),
+        )
+
+    def test_multi_d_batch_sample_shape(self):
+        loc = jnp.zeros((2, 3))
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(2, 3), loc=loc, scale=1.0,
+        )
+        samples = backend._sample(jax.random.PRNGKey(0))
+        assert samples.shape == (2, 3)
+
+
+# ---------------------------------------------------------------------------
+# Scalar broadcast in cell()
+# ---------------------------------------------------------------------------
+
+
+class TestScalarBroadcast:
+    def test_scalar_param_passes_through_cell(self):
+        """A param given as a Python float / 0-D array (broadcast across
+        every cell) is preserved unchanged in ``cell(i)``."""
+        backend = Normal._make_array_backend(
+            name="x",
+            batch_shape=(4,),
+            loc=jnp.arange(4.0),
+            scale=2.5,  # scalar
+        )
+        for i in range(4):
+            cell = backend.cell(i)
+            assert float(cell.scale) == 2.5
+
+    def test_zero_d_jax_array_param_passes_through(self):
+        backend = Normal._make_array_backend(
+            name="x",
+            batch_shape=(3,),
+            loc=jnp.arange(3.0),
+            scale=jnp.array(0.5),
+        )
+        for i in range(3):
+            assert float(backend.cell(i).scale) == 0.5

--- a/tests/test_tfp_array_backend.py
+++ b/tests/test_tfp_array_backend.py
@@ -303,3 +303,91 @@ class TestScalarBroadcast:
         )
         for i in range(3):
             assert float(backend.cell(i).scale) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# JAX pytree registration
+# ---------------------------------------------------------------------------
+
+
+class TestPytreeRegistration:
+    """``_TFPArrayBackend`` is registered as a JAX pytree node so it
+    can flow through ``jit`` / ``vmap`` / ``tree_map``.
+
+    Children are the batched parameter values (the JAX-array leaves
+    the user passed); aux carries the distribution class, name,
+    declared ``batch_shape``, and parameter keys. Reconstruction
+    rebuilds the wrapped ``_batched_dist`` from the parameter dict.
+    """
+
+    def _backend(self):
+        return Normal._make_array_backend(
+            name="x", batch_shape=(5,),
+            loc=jnp.arange(5.0), scale=1.0,
+        )
+
+    def test_flatten_yields_batched_params_in_insertion_order(self):
+        backend = self._backend()
+        leaves, treedef = jax.tree_util.tree_flatten(backend)
+        # Two children: ``loc`` (array) then ``scale`` (scalar) —
+        # insertion order from ``Normal._make_array_backend``.
+        assert len(leaves) == 2
+        assert hasattr(leaves[0], "shape") and leaves[0].shape == (5,)
+        assert leaves[1] == 1.0
+
+    def test_round_trip_preserves_behaviour(self):
+        backend = self._backend()
+        leaves, treedef = jax.tree_util.tree_flatten(backend)
+        rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+        assert isinstance(rebuilt, _TFPArrayBackend)
+        assert rebuilt.batch_shape == backend.batch_shape
+        # Behavioural equivalence: same mean, same per-cell scalar.
+        np.testing.assert_allclose(
+            np.asarray(rebuilt._mean()), np.asarray(backend._mean())
+        )
+        assert float(rebuilt.cell(2).loc) == float(backend.cell(2).loc)
+
+    def test_jit_through_backend(self):
+        """A ``jit``-compiled function that consumes the backend
+        traces cleanly: the backend is a valid pytree node, so JAX
+        threads its leaves through the compilation."""
+        @jax.jit
+        def fn(b):
+            return b._mean()
+
+        backend = self._backend()
+        out = fn(backend)
+        np.testing.assert_allclose(
+            np.asarray(out), np.arange(5.0)
+        )
+
+    def test_tree_map_replaces_leaves(self):
+        """``tree_map`` over the backend rebuilds it with transformed
+        leaves; the surrounding aux is preserved."""
+        backend = self._backend()
+        scaled = jax.tree_util.tree_map(lambda x: jnp.asarray(x) * 2.0, backend)
+        assert isinstance(scaled, _TFPArrayBackend)
+        assert scaled.batch_shape == backend.batch_shape
+        # ``loc`` doubled, ``scale`` doubled; per-cell mean = 2 * loc.
+        np.testing.assert_allclose(
+            np.asarray(scaled._mean()), 2.0 * np.arange(5.0)
+        )
+
+    def test_vmap_over_leading_batch(self):
+        """vmap-able through ``tree_map`` lifting a fresh axis on each
+        leaf, then calling the backend's vectorised op under the lift."""
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(3,),
+            loc=jnp.zeros(3), scale=jnp.ones(3),
+        )
+        # Stack two backends along a new leading axis via tree_map.
+        stacked = jax.tree_util.tree_map(
+            lambda x: jnp.stack([jnp.asarray(x), jnp.asarray(x) + 10.0]),
+            backend,
+        )
+        # vmap pulls the new axis out and runs ``_mean`` per slice.
+        means = jax.vmap(lambda b: b._mean())(stacked)
+        # Two slices: original (zeros) and shifted by 10.
+        np.testing.assert_allclose(
+            np.asarray(means), np.array([[0.0, 0.0, 0.0], [10.0, 10.0, 10.0]])
+        )

--- a/tests/test_tfp_array_backend.py
+++ b/tests/test_tfp_array_backend.py
@@ -329,11 +329,13 @@ class TestPytreeRegistration:
     def test_flatten_yields_batched_params_in_insertion_order(self):
         backend = self._backend()
         leaves, treedef = jax.tree_util.tree_flatten(backend)
-        # Two children: ``loc`` (array) then ``scale`` (scalar) —
-        # insertion order from ``Normal._make_array_backend``.
+        # Two children: ``loc`` then ``scale`` — insertion order from
+        # ``Normal._make_array_backend``. Both end up as ``(5,)``-
+        # shaped arrays after the constructor's scalar broadcast.
         assert len(leaves) == 2
         assert hasattr(leaves[0], "shape") and leaves[0].shape == (5,)
-        assert leaves[1] == 1.0
+        assert hasattr(leaves[1], "shape") and leaves[1].shape == (5,)
+        np.testing.assert_allclose(np.asarray(leaves[1]), np.ones(5))
 
     def test_round_trip_preserves_behaviour(self):
         backend = self._backend()
@@ -391,3 +393,132 @@ class TestPytreeRegistration:
         np.testing.assert_allclose(
             np.asarray(means), np.array([[0.0, 0.0, 0.0], [10.0, 10.0, 10.0]])
         )
+
+
+# ---------------------------------------------------------------------------
+# Scalar parameter broadcasting (review finding C4)
+# ---------------------------------------------------------------------------
+
+
+class TestScalarParamBroadcasting:
+    """Scalar parameters paired with an explicit ``batch_shape``
+    broadcast across every cell. Without this, the sanity check on
+    ``_TFPArrayBackend.__init__`` rejects the configuration with a
+    cryptic shape-mismatch error.
+    """
+
+    def test_all_scalar_params_with_explicit_shape(self):
+        """All-scalar params + ``batch_shape=(5,)`` produces five
+        identical Normals."""
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(5,), loc=0.0, scale=1.0,
+        )
+        assert backend.batch_shape == (5,)
+        for i in range(5):
+            cell = backend.cell(i)
+            assert float(cell.loc) == 0.0
+            assert float(cell.scale) == 1.0
+
+    def test_scalar_loc_array_scale(self):
+        """``loc`` scalar + ``scale`` array broadcasts ``loc`` to
+        match the batch axis."""
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(3,),
+            loc=0.0, scale=jnp.array([0.1, 0.2, 0.3]),
+        )
+        for i in range(3):
+            cell = backend.cell(i)
+            assert float(cell.loc) == 0.0
+
+    def test_multi_d_batch_with_scalar_params(self):
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(2, 3), loc=0.0, scale=1.0,
+        )
+        assert backend.batch_shape == (2, 3)
+        for i in range(6):
+            assert float(backend.cell(i).loc) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Backend-derived approximation status (review finding C2)
+# ---------------------------------------------------------------------------
+
+
+class TestBackendApproximate:
+    """``_from_backend`` propagates ``is_approximate`` from the
+    backend rather than hardcoding ``False``. This is forward-
+    compatible with a future ``_RecordArrayBackend`` over an
+    empirical source whose samples are an approximation.
+    """
+
+    def test_tfp_backend_is_exact(self):
+        """The shipping ``_TFPArrayBackend`` has no
+        ``is_approximate`` attribute, so the ``DistributionArray``
+        defaults to exact (``False``)."""
+        from probpipe import DistributionArray
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(3,), loc=jnp.zeros(3), scale=1.0,
+        )
+        da = DistributionArray._from_backend(backend, name="x")
+        assert da.is_approximate is False
+
+    def test_approximate_backend_propagates(self):
+        """A backend reporting ``is_approximate=True`` flows through
+        to the assembled DistributionArray."""
+        from probpipe import DistributionArray
+
+        class _ApproxBackend:
+            batch_shape = (3,)
+            event_shape = ()
+            is_approximate = True
+
+            def cell(self, i):
+                return Normal(loc=0.0, scale=1.0, name=f"x_{i}")
+
+        da = DistributionArray._from_backend(_ApproxBackend(), name="x")
+        assert da.is_approximate is True
+
+
+# ---------------------------------------------------------------------------
+# Negative-index alignment (review finding C5)
+# ---------------------------------------------------------------------------
+
+
+class TestFlatComponentNegativeRejection:
+    """``_flat_component`` rejects negatives in *both* the backend
+    and literal-array paths. ``__getitem__`` wraps user-facing
+    ``da[-1]`` before any flat-index call site sees it, so internal
+    sweep code (which already only passes non-negatives) and
+    direct ``_flat_component(-1)`` calls behave consistently.
+    """
+
+    def test_backed_path_rejects_negative(self):
+        from probpipe import DistributionArray
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(3,),
+            loc=jnp.zeros(3), scale=1.0,
+        )
+        da = DistributionArray._from_backend(backend, name="x")
+        with pytest.raises(IndexError):
+            da._flat_component(-1)
+
+    def test_literal_path_rejects_negative(self):
+        """The literal path used to silently allow Python tuple
+        wraparound; align with the backed path."""
+        from probpipe import DistributionArray
+        comps = [Normal(loc=float(i), scale=1.0, name=f"c_{i}")
+                 for i in range(3)]
+        da = DistributionArray(comps, name="x")
+        with pytest.raises(IndexError):
+            da._flat_component(-1)
+
+    def test_user_facing_da_minus_one_still_works(self):
+        """``da[-1]`` continues to work via ``__getitem__`` wrap."""
+        from probpipe import DistributionArray
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(3,),
+            loc=jnp.array([10.0, 20.0, 30.0]), scale=1.0,
+        )
+        da = DistributionArray._from_backend(backend, name="x")
+        assert float(da[-1].loc) == 30.0
+        assert float(da[-2].loc) == 20.0

--- a/tests/test_tfp_array_backend.py
+++ b/tests/test_tfp_array_backend.py
@@ -115,14 +115,32 @@ class TestCellMaterialisation:
         cell2 = backend.cell(2)
         assert isinstance(cell0, Normal)
         assert isinstance(cell2, Normal)
-        # Distinct fresh instances per call.
-        assert backend.cell(0) is not backend.cell(0)
         # Per-cell parameters are correctly sliced.
         assert float(cell0.loc) == 0.0
         assert float(cell2.loc) == 2.0
         # Per-cell scalar `scale` is broadcast through unchanged.
         assert float(cell0.scale) == 1.0
         assert float(cell2.scale) == 1.0
+
+    def test_cell_value_correctness_independent_of_call(self):
+        """Each ``cell(i)`` call returns a distribution that holds
+        exactly its own per-cell parameters — even when called
+        repeatedly with different indices.
+
+        Pins observable behaviour rather than instance identity:
+        a future caching optimisation could legitimately deduplicate
+        but must not corrupt per-cell values.
+        """
+        loc = jnp.array([10.0, 20.0, 30.0])
+        backend = Normal._make_array_backend(
+            name="x", batch_shape=(3,), loc=loc, scale=1.0,
+        )
+        a = backend.cell(0)
+        b = backend.cell(2)
+        c = backend.cell(0)
+        assert float(a.loc) == 10.0
+        assert float(b.loc) == 30.0
+        assert float(c.loc) == 10.0  # second cell(0) still gets loc[0]
 
     def test_cell_name_auto_suffixes(self):
         backend = Normal._make_array_backend(


### PR DESCRIPTION
## Summary

PR-C.1 (Phase 1 of the four-PR `Distribution.batch_shape` cleanup, plan: `.claude/plans/pr-c-distribution-batch-shape.md`). **Additive only — no breaking change.** Introduces the migration path that PR-C.2 will rely on when TFP-backed constructors begin rejecting batched parameters.

Key piece: distributions own their own array logic via the new `SupportsArrayBackend` capability protocol. `DistributionArray` becomes a thin consumer that detects the protocol and delegates to whatever backend the class returns. Same pattern as the rest of the protocol family (`SupportsSampling`, `SupportsLogProb`, …) — capability declared on the distribution side, dispatched by the consumer.

This is cleaner than putting backend-specific knowledge in `DistributionArray` subclasses: each distribution family owns its batching story; new families (user distributions, joints, future `RandomMeasure[T]`) integrate by implementing one classmethod; no `DistributionArray` subclass proliferation; no special WF-sweep hook needed.

## Stack

This PR is stacked on top of **#172 (PR-B.1)**. Base is `dev/pr-b-loose-ends`; once #172 merges, GitHub will auto-rebase this onto `main`.

## Commits

1. **feat(protocols):** `SupportsArrayBackend` + `_DistributionArrayBackend` protocols — capability + the produced-backend interface. No implementations yet.
2. **feat(tfp):** `_TFPArrayBackend` + `TFPDistribution._make_array_backend` — every concrete TFP-backed distribution (`Normal`, `Beta`, `Gamma`, `MultivariateNormal`, `Dirichlet`, …) inherits the protocol.
3. **refactor(distribution-array):** `_backend` slot + `_from_backend` private classmethod + lazy cell materialisation. Literal-array path unchanged.
4. **feat(distribution-array):** `from_batched_params` classmethod with protocol dispatch — backend path for `SupportsArrayBackend` classes; literal-array fallback otherwise. Per-cell name auto-suffix; `batch_shape` inferred from broadcast of array params; `MultivariateNormal`-style heterogeneous event ranks require explicit `batch_shape`.
5. **feat(distribution):** `Distribution.from_batched_params` class-method alias — `Normal.from_batched_params(loc=..., scale=..., name="x")` for free.
6. **docs(changelog):** documents the new surface; previews the upcoming PR-C.2 breaking change.

## Migration path (preview of PR-C.2)

```python
# Today (still works)
n = Normal(loc=jnp.zeros(5), scale=1.0, name="x")
n.batch_shape  # (5,)

# After PR-C.2 lands, the above raises with a hint pointing at:
da = DistributionArray.from_batched_params(
    Normal, loc=jnp.zeros(5), scale=1.0, name="x",
)
# Or the ergonomic per-class alias:
da = Normal.from_batched_params(loc=jnp.zeros(5), scale=1.0, name="x")

da.batch_shape  # (5,)
da[2].name      # "x_2"
da[2].loc       # 2.0
da._backend     # _TFPArrayBackend(Normal, batch_shape=(5,), name='x')
```

The factory is performance-equivalent to the legacy form because `_TFPArrayBackend` wraps the same TFP-batched distribution under the hood.

## Test plan

- [x] New tests pass: `tests/test_protocols.py::TestSupportsArrayBackendProtocolSurface` (4), `tests/test_tfp_array_backend.py` (24), `tests/test_distribution_array.py::TestBackendDelegatedStorage` (10) + `TestFromBatchedParams` (12) + `TestDistributionFromBatchedParamsAlias` (5)
- [x] Full pytest: 2443 passed, 7 skipped, 0 failed
- [ ] mkdocs strict (verify in CI)

## What's deferred

- **Vectorised dispatch via the WF sweep.** Backed `DistributionArray`s expose the backend's vectorised `_sample` / `_log_prob` / `_mean` / `_variance` / `_cov`, but the WF sweep still routes through `_flat_component(i)` for cell-by-cell dispatch. The lazy-materialisation benefit on construction is real today; the vectorised-ops benefit is a clean follow-up commit (small, can land in PR-C.1.1 or PR-C.2). This is documented as a known optimisation, not a regression.
- **`_RecordArrayBackend`** for `RecordEmpiricalDistribution` / `RecordBootstrapReplicateDistribution` — the perf-preservation argument is strongest for TFP, so the Record backend is deferred to a follow-up issue. The `from_batched_params(RecordEmpiricalDistribution, ...)` path goes through the literal-array fallback today.
- **Per-family `Normal.batched(...)` shortcuts** — the `Distribution.from_batched_params` alias already gives `Normal.from_batched_params(...)` for free. Defer if users ask.
