### PR TITLE
PR-C.2: Reject batched parameters in TFP-backed constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,15 +40,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   )
   ```
 
-  **Preview of upcoming PR-C.2 breaking change:** in the next release,
-  `Normal(loc=jnp.zeros(5), scale=1.0, name="x")` (and similar
-  TFP-backed classes constructed with batched parameters) will raise
-  `ValueError` with a hint pointing at this factory. Migrate now to
-  avoid the breaking change. The factory is performance-equivalent
-  to the legacy form because it shares the TFP-batched backend under
+### Changed (breaking)
+
+- **TFP-backed distribution constructors reject batched parameters.**
+  `Normal(loc=jnp.zeros(5), scale=1.0, name="x")` (and the same
+  pattern for every other TFP-backed class — `Beta`, `Gamma`,
+  `MultivariateNormal`, `Pareto`, `TruncatedNormal`, `Binomial`, …)
+  now raises `ValueError` whenever the parameters imply a non-empty
+  TFP `batch_shape`. The framework hierarchy rule "one random
+  variable per `Distribution`" (CONTRIBUTING.md) is enforced at
+  construction time.
+
+  ```text
+  ValueError: Normal parameters imply batch_shape=(5,); wrap multiple
+  distributions in a DistributionArray instead. See
+  DistributionArray.from_batched_params(Normal, ...) (or the alias
+  Normal.from_batched_params(...)) for the factory.
+  ```
+
+  Migration: route through the
+  `DistributionArray.from_batched_params` factory (or its per-class
+  alias) added in the previous release. The factory is
+  performance-equivalent to the legacy form because the fused
+  `_TFPArrayBackend` wraps the same TFP-batched distribution under
   the hood.
 
-### Changed (breaking)
+  ```python
+  # Before (rejected)
+  n = Normal(loc=jnp.zeros(5), scale=1.0, name="x")
+
+  # After (recommended ergonomic form)
+  da = Normal.from_batched_params(loc=jnp.zeros(5), scale=1.0, name="x")
+
+  # After (universal entry point)
+  da = DistributionArray.from_batched_params(
+      Normal, loc=jnp.zeros(5), scale=1.0, name="x",
+  )
+  ```
+
+  Removed associated tests that exercised the legacy form's
+  per-element support checks: ``test_uniform_support_array_bounds``,
+  ``test_half_cauchy_support_array_bounds``,
+  ``test_pareto_support_array_bounds``,
+  ``test_truncated_normal_support_array_bounds``,
+  ``test_binomial_support_array_total_count``,
+  ``test_repr_with_batch_shape``. Per-element support checks belong
+  on `Constraint` directly; batched constructions migrate to
+  `DistributionArray.from_batched_params`.
+
+  Internal infrastructure that legitimately needs the batched form
+  (the `_TFPArrayBackend` fused-storage backend, the
+  `ProbPipeConverter` dispatch, sequential-joint sampling /
+  log_prob, `GaussianRandomFunction.predict`) opts into a private
+  bypass; user code is unaffected by the bypass and always sees the
+  rejection.
 
 - **Empirical / Bootstrap / Marginal class consolidation.** The
   generic-vs-numeric pair is collapsed into a generic ``[T]`` base

--- a/docs/examples/10_random_functions_and_emulators.ipynb
+++ b/docs/examples/10_random_functions_and_emulators.ipynb
@@ -1162,7 +1162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "oyph006j5t",
    "metadata": {
     "execution": {
@@ -1172,67 +1172,8 @@
      "shell.execute_reply": "2026-04-22T03:26:18.675731Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Prediction at x=0.3:\n",
-      "  type:      Normal\n",
-      "  mean:      0.6034\n",
-      "  source:    Provenance('random_function_predict', parents=[])\n",
-      "  operation: random_function_predict\n",
-      "  metadata:  {'model': 'FittedPolynomial', 'x': 0.3}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Shifted prediction:\n",
-      "  source: Provenance('shift', parents=[grf_prediction])\n",
-      "  ancestors: [Normal(name='grf_prediction', event_shape=(), batch_shape=(1,))]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Random function outputs are standard distributions — provenance works normally.\n",
-    "# Attach provenance to track where a prediction came from.\n",
-    "\n",
-    "x_query = jnp.array([[0.3]])\n",
-    "pred_at_query = model(x_query)\n",
-    "\n",
-    "# Attach provenance to record how this distribution was created\n",
-    "pred_at_query.with_source(Provenance(\n",
-    "    operation=\"random_function_predict\",\n",
-    "    parents=(),\n",
-    "    metadata={\"model\": type(model).__name__, \"x\": 0.3},\n",
-    "))\n",
-    "\n",
-    "print(f\"Prediction at x=0.3:\")\n",
-    "print(f\"  type:      {type(pred_at_query).__name__}\")\n",
-    "print(f\"  mean:      {float(jnp.asarray(mean(pred_at_query)).squeeze()):.4f}\")\n",
-    "print(f\"  source:    {pred_at_query.source}\")\n",
-    "print(f\"  operation: {pred_at_query.source.operation}\")\n",
-    "print(f\"  metadata:  {pred_at_query.source.metadata}\")\n",
-    "\n",
-    "# Provenance can chain through multiple operations\n",
-    "pred_shifted = Normal(\n",
-    "    loc=jnp.asarray(mean(pred_at_query)) + 1.0,\n",
-    "    scale=jnp.sqrt(jnp.asarray(variance(pred_at_query)).squeeze()),\n",
-    "    name=\"shifted_prediction\",\n",
-    ")\n",
-    "pred_shifted.with_source(Provenance(\n",
-    "    operation=\"shift\",\n",
-    "    parents=(pred_at_query,),\n",
-    "    metadata={\"shift\": 1.0},\n",
-    "))\n",
-    "\n",
-    "print(f\"\\nShifted prediction:\")\n",
-    "print(f\"  source: {pred_shifted.source}\")\n",
-    "print(f\"  ancestors: {provenance_ancestors(pred_shifted)}\")"
-   ]
+   "outputs": [],
+   "source": "# Random function outputs are standard distributions — provenance works normally.\n# Attach provenance to track where a prediction came from.\n\nx_query = jnp.array([[0.3]])\npred_at_query = model(x_query)\n\n# Attach provenance to record how this distribution was created\npred_at_query.with_source(Provenance(\n    operation=\"random_function_predict\",\n    parents=(),\n    metadata={\"model\": type(model).__name__, \"x\": 0.3},\n))\n\nprint(f\"Prediction at x=0.3:\")\nprint(f\"  type:      {type(pred_at_query).__name__}\")\nprint(f\"  mean:      {float(jnp.asarray(mean(pred_at_query)).squeeze()):.4f}\")\nprint(f\"  source:    {pred_at_query.source}\")\nprint(f\"  operation: {pred_at_query.source.operation}\")\nprint(f\"  metadata:  {pred_at_query.source.metadata}\")\n\n# Provenance can chain through multiple operations\npred_shifted = Normal(\n    loc=jnp.asarray(mean(pred_at_query)).squeeze() + 1.0,\n    scale=jnp.sqrt(jnp.asarray(variance(pred_at_query)).squeeze()),\n    name=\"shifted_prediction\",\n)\npred_shifted.with_source(Provenance(\n    operation=\"shift\",\n    parents=(pred_at_query,),\n    metadata={\"shift\": 1.0},\n))\n\nprint(f\"\\nShifted prediction:\")\nprint(f\"  source: {pred_shifted.source}\")\nprint(f\"  ancestors: {provenance_ancestors(pred_shifted)}\")"
   },
   {
    "cell_type": "markdown",

--- a/probpipe/converters/_probpipe.py
+++ b/probpipe/converters/_probpipe.py
@@ -637,7 +637,21 @@ class ProbPipeConverter(Converter):
             except (NotImplementedError, AttributeError):
                 pass
 
-        result = fn(source, key, **kwargs)
+        # Some converters (e.g., ``_convert_to_normal``) fabricate
+        # TFP-backed scalars from a source's ``_mean`` / ``_variance``.
+        # When the source's moments are ``(d,)``-shaped (a 1-d
+        # empirical with one observation, or a Normal whose source
+        # was tracked through a WF sweep), the implied ``batch_shape``
+        # is non-empty — which the rejection in
+        # ``TFPDistribution.__init__`` (added later in this PR) would
+        # otherwise refuse. The converter is library-internal infra,
+        # not user code, so we opt into the bypass for the dispatch.
+        # A proper fix (route to ``DistributionArray`` for batched
+        # moments) is a follow-up; for now we preserve current
+        # behaviour.
+        from ..distributions._tfp_base import _allow_batched_tfp_init
+        with _allow_batched_tfp_init():
+            result = fn(source, key, **kwargs)
 
         # Mark approximate if source is approximate or conversion used sampling
         if source.is_approximate or not isinstance(source, target_type):

--- a/probpipe/converters/_probpipe.py
+++ b/probpipe/converters/_probpipe.py
@@ -28,6 +28,7 @@ from ..core.distribution import (
     RecordEmpiricalDistribution,
 )
 from ..core.provenance import Provenance
+from ..distributions._tfp_base import _allow_batched_tfp_init
 from ._registry import ConversionInfo, ConversionMethod, Converter
 
 # Default sample count for moment-matching conversions
@@ -642,14 +643,11 @@ class ProbPipeConverter(Converter):
         # When the source's moments are ``(d,)``-shaped (a 1-d
         # empirical with one observation, or a Normal whose source
         # was tracked through a WF sweep), the implied ``batch_shape``
-        # is non-empty — which the rejection in
-        # ``TFPDistribution.__init__`` (added later in this PR) would
-        # otherwise refuse. The converter is library-internal infra,
-        # not user code, so we opt into the bypass for the dispatch.
-        # A proper fix (route to ``DistributionArray`` for batched
-        # moments) is a follow-up; for now we preserve current
-        # behaviour.
-        from ..distributions._tfp_base import _allow_batched_tfp_init
+        # is non-empty — which ``TFPDistribution.__init__``'s rejection
+        # would otherwise refuse. The converter is library-internal
+        # infra, not user code, so we opt into the bypass for the
+        # dispatch. A proper fix (route to ``DistributionArray`` for
+        # batched moments) is tracked as a follow-up.
         with _allow_batched_tfp_init():
             result = fn(source, key, **kwargs)
 

--- a/probpipe/core/_numeric_record_distribution.py
+++ b/probpipe/core/_numeric_record_distribution.py
@@ -33,7 +33,6 @@ from typing import Any, Callable
 from .._dtype import _as_float_array, _default_float_dtype
 from .._utils import prod
 from .protocols import (
-    SupportsExpectation,
     SupportsLogProb,
     SupportsMean,
     SupportsSampling,
@@ -270,9 +269,9 @@ class NumericRecordDistribution(RecordDistribution):
         inputs.  For raw arrays, flattens event dimensions preserving
         leading batch/sample dims.
         """
-        from .record import Record as _Values
+        from .record import Record
         from ._record_array import NumericRecordArray
-        if isinstance(value, (NumericRecordArray, _Values)):
+        if isinstance(value, (NumericRecordArray, Record)):
             return super().flatten_value(value)
         value = jnp.asarray(value)
         es = self.event_shape

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -316,7 +316,15 @@ class SequentialJointDistribution(RecordDistribution, SupportsSampling, Supports
             else:
                 sig = inspect.signature(comp)
                 call_kw = {p: structured[p] for p in sig.parameters if p in structured}
-                cond_dist = comp(**call_kw)
+                # User lambda receives batched parent values during
+                # log_prob; the rejection in TFPDistribution.__init__
+                # would refuse the resulting batched form. The
+                # log_prob path is the symmetric counterpart to the
+                # bypass already added on the sampling side
+                # (_sample_sequential).
+                from ._tfp_base import _allow_batched_tfp_init
+                with _allow_batched_tfp_init():
+                    cond_dist = comp(**call_kw)
                 lp = cond_dist._log_prob(val)
             total = lp if total is None else total + lp
 

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -8,6 +8,7 @@ that receive previously-sampled values and return a ``Distribution``
 from __future__ import annotations
 
 import inspect
+from collections.abc import Callable
 from types import MappingProxyType
 
 import jax
@@ -37,7 +38,8 @@ from ._tfp_base import _allow_batched_tfp_init
 
 
 def _resolve_callable_component(
-    comp: callable, namespace: dict[str, Array],
+    comp: Callable[..., NumericRecordDistribution],
+    namespace: dict[str, Array],
 ) -> NumericRecordDistribution:
     """Invoke a user-supplied component callable with the parent
     values it requested via its signature.

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -253,7 +253,17 @@ class SequentialJointDistribution(RecordDistribution, SupportsSampling, Supports
                 # the batch is already in the distribution's batch_shape.
                 sig = inspect.signature(comp)
                 call_kw = {p: sampled[p] for p in sig.parameters if p in sampled}
-                dist = comp(**call_kw)
+                # The user lambda typically writes
+                # ``Normal(loc=z, scale=...)`` with a batched ``z``.
+                # The rejection added later in this PR would refuse
+                # that direct construction; bypass it here because
+                # sequential-joint sampling deliberately constructs
+                # a TFP-batched form to vectorise the per-cell draw.
+                # The bypass is internal infra; user-facing rejection
+                # of ``Normal(loc=arr, ...)`` still applies elsewhere.
+                from ._tfp_base import _allow_batched_tfp_init
+                with _allow_batched_tfp_init():
+                    dist = comp(**call_kw)
                 sampled[cname] = dist._sample(subkey)
 
         return sampled

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -33,6 +33,27 @@ from ._joint_utils import (
     KeyPath,
     _parse_condition_args,
 )
+from ._tfp_base import _allow_batched_tfp_init
+
+
+def _resolve_callable_component(
+    comp: callable, namespace: dict[str, Array],
+) -> NumericRecordDistribution:
+    """Invoke a user-supplied component callable with the parent
+    values it requested via its signature.
+
+    Filters ``namespace`` by ``inspect.signature(comp)`` parameters,
+    then calls ``comp(**filtered)`` under the
+    :func:`_allow_batched_tfp_init` bypass — the user lambda
+    typically writes ``Normal(loc=parent, scale=...)`` with batched
+    parents, so the standard rejection of batched-parameter
+    constructors must not fire here. Internal infra; user-facing
+    construction of ``Normal(loc=arr, ...)`` is rejected as usual.
+    """
+    sig = inspect.signature(comp)
+    call_kw = {p: namespace[p] for p in sig.parameters if p in namespace}
+    with _allow_batched_tfp_init():
+        return comp(**call_kw)
 
 
 # ---------------------------------------------------------------------------
@@ -249,21 +270,9 @@ class SequentialJointDistribution(RecordDistribution, SupportsSampling, Supports
                 sampled[cname] = comp._sample(subkey, sample_shape)
             else:
                 # Conditional: callable receives batched parent samples,
-                # returning a batched distribution.  Sample with () since
+                # returning a batched distribution. Sample with () since
                 # the batch is already in the distribution's batch_shape.
-                sig = inspect.signature(comp)
-                call_kw = {p: sampled[p] for p in sig.parameters if p in sampled}
-                # The user lambda typically writes
-                # ``Normal(loc=z, scale=...)`` with a batched ``z``.
-                # The rejection added later in this PR would refuse
-                # that direct construction; bypass it here because
-                # sequential-joint sampling deliberately constructs
-                # a TFP-batched form to vectorise the per-cell draw.
-                # The bypass is internal infra; user-facing rejection
-                # of ``Normal(loc=arr, ...)`` still applies elsewhere.
-                from ._tfp_base import _allow_batched_tfp_init
-                with _allow_batched_tfp_init():
-                    dist = comp(**call_kw)
+                dist = _resolve_callable_component(comp, sampled)
                 sampled[cname] = dist._sample(subkey)
 
         return sampled
@@ -314,17 +323,7 @@ class SequentialJointDistribution(RecordDistribution, SupportsSampling, Supports
             if isinstance(comp, NumericRecordDistribution):
                 lp = comp._log_prob(val)
             else:
-                sig = inspect.signature(comp)
-                call_kw = {p: structured[p] for p in sig.parameters if p in structured}
-                # User lambda receives batched parent values during
-                # log_prob; the rejection in TFPDistribution.__init__
-                # would refuse the resulting batched form. The
-                # log_prob path is the symmetric counterpart to the
-                # bypass already added on the sampling side
-                # (_sample_sequential).
-                from ._tfp_base import _allow_batched_tfp_init
-                with _allow_batched_tfp_init():
-                    cond_dist = comp(**call_kw)
+                cond_dist = _resolve_callable_component(comp, structured)
                 lp = cond_dist._log_prob(val)
             total = lp if total is None else total + lp
 

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -108,11 +108,66 @@ class TFPDistribution(
     :class:`SupportsLogProb` (provides ``_prob``,
     ``_unnormalized_log_prob``, ``_unnormalized_prob`` defaults),
     :class:`SupportsMean`, and :class:`SupportsVariance`.
+
+    Rejects batched parameters
+    --------------------------
+    Per the framework hierarchy "one random variable per
+    ``Distribution``" rule (CONTRIBUTING.md), the constructor raises
+    :class:`ValueError` when the underlying ``tfd.Distribution`` has
+    a non-empty ``batch_shape``. Wrap multiple distributions in a
+    :class:`~probpipe.DistributionArray` instead — the migration
+    factory is :meth:`~probpipe.DistributionArray.from_batched_params`
+    (or the per-class alias :meth:`Distribution.from_batched_params`).
+
+    The check fires in ``__init__`` after ``super().__init__(name=name)``
+    completes, so concrete subclasses that set ``self._tfp_dist``
+    *before* calling ``super().__init__`` (the standard pattern used
+    by ``Normal``, ``Beta``, ``Gamma``, …) are validated. Subclasses
+    that set ``_tfp_dist`` *after* ``super().__init__`` (e.g.
+    :class:`~probpipe.distributions.kde.KDEDistribution`) are skipped
+    via the ``hasattr`` guard — those classes are responsible for
+    their own shape invariants and don't go through TFP's batched
+    parameter convention.
+
+    Internal infrastructure that legitimately needs the batched form
+    (the ``_TFPArrayBackend`` fused storage, converters, sequential
+    joints, GRF predictions) opts into the bypass via
+    :func:`_allow_batched_tfp_init`.
     """
 
     _tfp_dist: tfd.Distribution
     _sampling_cost: str = "low"
     _preferred_orchestration: str | None = None
+
+    def __init__(self, *, name: str) -> None:
+        """Final-stage initializer for TFP-backed distributions.
+
+        Concrete subclasses (``Normal``, ``Beta``, …) set
+        ``self._tfp_dist`` in their own ``__init__`` *before* calling
+        ``super().__init__(name=name)``, so by the time we get here
+        the TFP backend is fully constructed and we can validate its
+        ``batch_shape``.
+        """
+        super().__init__(name=name)
+        if _ALLOW_BATCHED_INIT:
+            return
+        # KDE-style subclasses set ``_tfp_dist`` *after* this call;
+        # skip the check rather than crash on a missing attribute.
+        # Such classes are responsible for their own shape invariants.
+        tfp_dist = getattr(self, "_tfp_dist", None)
+        if tfp_dist is None:
+            return
+        actual = tuple(tfp_dist.batch_shape)
+        if actual != ():
+            cls_name = type(self).__name__
+            raise ValueError(
+                f"{cls_name} parameters imply batch_shape={actual}; "
+                f"wrap multiple distributions in a DistributionArray "
+                f"instead. See "
+                f"DistributionArray.from_batched_params({cls_name}, ...) "
+                f"(or the alias {cls_name}.from_batched_params(...)) "
+                f"for the factory."
+            )
 
     # -- record_template auto-generation ------------------------------------
 
@@ -318,14 +373,15 @@ class _TFPArrayBackend:
             batched_params = normalised
         self._batched_params = batched_params
         # Construct the fused ProbPipe Distribution with the batched
-        # params. The backend exists *to* hold a batched form, so any
-        # downstream rejection of batched parameters at construction
-        # time must provide a bypass; this constructor is the
-        # canonical caller of that bypass.
-        self._batched_dist: TFPDistribution = dist_cls(
-            **batched_params,
-            name=f"{name}{_ARRAY_BACKEND_NAME_SUFFIX}",
-        )
+        # params. ``TFPDistribution.__init__`` rejects batched
+        # parameters for user code; the backend is internal infra that
+        # exists *to* hold a batched form, so it opts into the bypass
+        # via ``_allow_batched_tfp_init``.
+        with _allow_batched_tfp_init():
+            self._batched_dist: TFPDistribution = dist_cls(
+                **batched_params,
+                name=f"{name}{_ARRAY_BACKEND_NAME_SUFFIX}",
+            )
         # Final sanity check: TFP's inferred batch_shape must match
         # the caller's declaration. Catches the rare case where a
         # higher-rank param's *trailing* axes don't agree but the

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -534,10 +534,15 @@ class _TFPArrayBackend:
         instance._name = name
         instance._batch_shape = tuple(batch_shape)
         instance._batched_params = dict(zip(keys, children))
-        instance._batched_dist = dist_cls(
-            **instance._batched_params,
-            name=f"{name}{_ARRAY_BACKEND_NAME_SUFFIX}",
-        )
+        # Rebuild the wrapped distribution with the same internal
+        # bypass that ``__init__`` uses — the leaves are batched by
+        # construction, so user-facing rejection of batched params
+        # must not fire here.
+        with _allow_batched_tfp_init():
+            instance._batched_dist = dist_cls(
+                **instance._batched_params,
+                name=f"{name}{_ARRAY_BACKEND_NAME_SUFFIX}",
+            )
         return instance
 
 

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -7,7 +7,8 @@ distribution modules in ``distributions/``.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+import contextlib
+from typing import Any, Callable, Iterator
 
 import jax
 import jax.numpy as jnp
@@ -29,6 +30,62 @@ from ..core.protocols import (
 )
 from ..core.record import Record, RecordTemplate
 from ..custom_types import Array, ArrayLike, PRNGKey
+
+
+# ---------------------------------------------------------------------------
+# Internal bypass for the upcoming batched-parameters rejection
+# ---------------------------------------------------------------------------
+# The next commit in this PR (PR-C.2) adds a runtime check inside
+# ``TFPDistribution.__init__`` that raises ``ValueError`` whenever a
+# concrete subclass (``Normal``, ``Beta``, ``Gamma``, …) is constructed
+# with parameters whose ``tfd.Distribution.batch_shape`` is non-empty.
+# The framework hierarchy rule (CONTRIBUTING.md) is "one random
+# variable per ``Distribution``"; collections live in
+# ``DistributionArray``.
+#
+# Some library-internal call sites legitimately need the legacy
+# batched form — the fused-storage ``_TFPArrayBackend`` (PR-C.1)
+# wraps a TFP-batched dist; converters, sequential joints, and
+# random functions construct ``Normal(loc=batch_array, ...)`` from
+# arrays produced inside the WF sweep. These sites bypass the
+# upcoming rejection via the ``_allow_batched_tfp_init`` context
+# manager added here. User-facing callers never use the bypass.
+#
+# This commit ships only the scaffolding (flag + context manager).
+# The rejection itself lands later in the PR after every legitimate
+# internal site has been wrapped and every test that exercises the
+# legacy user-facing form has been migrated to
+# ``DistributionArray.from_batched_params``.
+
+_ALLOW_BATCHED_INIT: bool = False
+"""Module-level toggle consulted by the upcoming
+``TFPDistribution.__init__`` rejection. Default ``False`` enforces the
+"one RV per Distribution" rule for all user-facing construction;
+internal infra opts in with :func:`_allow_batched_tfp_init`."""
+
+
+@contextlib.contextmanager
+def _allow_batched_tfp_init() -> Iterator[None]:
+    """Context manager: allow TFP-backed constructors to accept
+    parameters whose implied ``batch_shape`` is non-empty.
+
+    Used by library-internal infrastructure that legitimately needs
+    to construct a TFP-batched form (e.g. :class:`_TFPArrayBackend`,
+    converters that produce batched-Normal forms during a WF sweep,
+    sequential-joint sampling whose lambda receives a batched
+    sample). User code never uses this.
+
+    The rejection it bypasses is added in a subsequent commit in this
+    PR; until then this context manager is a no-op functionally but
+    is referenced by the internal call sites that will need it.
+    """
+    global _ALLOW_BATCHED_INIT
+    previous = _ALLOW_BATCHED_INIT
+    _ALLOW_BATCHED_INIT = True
+    try:
+        yield
+    finally:
+        _ALLOW_BATCHED_INIT = previous
 
 
 class TFPDistribution(

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -289,11 +289,11 @@ wrapped batched ``TFPDistribution``. Centralised so
 
 
 def _construct_batched_dist(
-    dist_cls: type,
+    dist_cls: type[TFPDistribution],
     *,
     name: str,
     batched_params: dict[str, Any],
-) -> "TFPDistribution":
+) -> TFPDistribution:
     """Construct the fused batched distribution under the internal
     bypass, with the centralised ``__array_backend``-suffixed name.
 
@@ -330,7 +330,7 @@ class _TFPArrayBackend:
 
     Parameters
     ----------
-    dist_cls : type
+    dist_cls : type[TFPDistribution]
         The concrete ``TFPDistribution`` subclass (e.g., ``Normal``).
         Used to materialise per-cell scalars.
     name : str
@@ -347,7 +347,7 @@ class _TFPArrayBackend:
     def __init__(
         self,
         *,
-        dist_cls: type,
+        dist_cls: type[TFPDistribution],
         name: str,
         batch_shape: tuple[int, ...],
         batched_params: dict[str, Any],

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -8,6 +8,7 @@ distribution modules in ``distributions/``.
 from __future__ import annotations
 
 import contextlib
+import contextvars
 from typing import Any, Callable, Iterator
 
 import jax
@@ -33,35 +34,30 @@ from ..custom_types import Array, ArrayLike, PRNGKey
 
 
 # ---------------------------------------------------------------------------
-# Internal bypass for the upcoming batched-parameters rejection
+# Internal bypass for the batched-parameters rejection
 # ---------------------------------------------------------------------------
-# The next commit in this PR (PR-C.2) adds a runtime check inside
-# ``TFPDistribution.__init__`` that raises ``ValueError`` whenever a
-# concrete subclass (``Normal``, ``Beta``, ``Gamma``, …) is constructed
-# with parameters whose ``tfd.Distribution.batch_shape`` is non-empty.
-# The framework hierarchy rule (CONTRIBUTING.md) is "one random
-# variable per ``Distribution``"; collections live in
-# ``DistributionArray``.
+# ``TFPDistribution.__init__`` raises ``ValueError`` whenever a concrete
+# subclass (``Normal``, ``Beta``, ``Gamma``, …) is constructed with
+# parameters whose ``tfd.Distribution.batch_shape`` is non-empty,
+# enforcing the framework rule "one random variable per ``Distribution``"
+# (CONTRIBUTING.md); collections live in ``DistributionArray``.
 #
-# Some library-internal call sites legitimately need the legacy
-# batched form — the fused-storage ``_TFPArrayBackend`` (PR-C.1)
-# wraps a TFP-batched dist; converters, sequential joints, and
-# random functions construct ``Normal(loc=batch_array, ...)`` from
-# arrays produced inside the WF sweep. These sites bypass the
-# upcoming rejection via the ``_allow_batched_tfp_init`` context
-# manager added here. User-facing callers never use the bypass.
-#
-# This commit ships only the scaffolding (flag + context manager).
-# The rejection itself lands later in the PR after every legitimate
-# internal site has been wrapped and every test that exercises the
-# legacy user-facing form has been migrated to
-# ``DistributionArray.from_batched_params``.
+# Library-internal infrastructure that legitimately holds a batched
+# form — the fused-storage ``_TFPArrayBackend``, converters that
+# fabricate batched-Normal forms during a WF sweep, sequential-joint
+# user lambdas given batched parents, ``GaussianRandomFunction.predict``
+# — opts in via :func:`_allow_batched_tfp_init`. User-facing callers
+# never use the bypass.
 
-_ALLOW_BATCHED_INIT: bool = False
-"""Module-level toggle consulted by the upcoming
-``TFPDistribution.__init__`` rejection. Default ``False`` enforces the
-"one RV per Distribution" rule for all user-facing construction;
-internal infra opts in with :func:`_allow_batched_tfp_init`."""
+_BATCHED_INIT_BYPASS: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_BATCHED_INIT_BYPASS", default=False,
+)
+"""Per-context flag consulted by ``TFPDistribution.__init__``'s
+batched-parameters rejection. ``ContextVar`` over a module-level bool
+because the bypass should be scoped to the dynamic extent of the
+``with`` block — including across threads and ``asyncio`` tasks — so
+two concurrent constructions can't bleed into each other's bypass
+state."""
 
 
 @contextlib.contextmanager
@@ -73,19 +69,15 @@ def _allow_batched_tfp_init() -> Iterator[None]:
     to construct a TFP-batched form (e.g. :class:`_TFPArrayBackend`,
     converters that produce batched-Normal forms during a WF sweep,
     sequential-joint sampling whose lambda receives a batched
-    sample). User code never uses this.
-
-    The rejection it bypasses is added in a subsequent commit in this
-    PR; until then this context manager is a no-op functionally but
-    is referenced by the internal call sites that will need it.
+    sample). User code never uses this; intra-library tests that
+    emulate internal RandomFunction subclasses may import the
+    context manager directly.
     """
-    global _ALLOW_BATCHED_INIT
-    previous = _ALLOW_BATCHED_INIT
-    _ALLOW_BATCHED_INIT = True
+    token = _BATCHED_INIT_BYPASS.set(True)
     try:
         yield
     finally:
-        _ALLOW_BATCHED_INIT = previous
+        _BATCHED_INIT_BYPASS.reset(token)
 
 
 class TFPDistribution(
@@ -149,7 +141,7 @@ class TFPDistribution(
         ``batch_shape``.
         """
         super().__init__(name=name)
-        if _ALLOW_BATCHED_INIT:
+        if _BATCHED_INIT_BYPASS.get():
             return
         # KDE-style subclasses set ``_tfp_dist`` *after* this call;
         # skip the check rather than crash on a missing attribute.
@@ -296,6 +288,26 @@ wrapped batched ``TFPDistribution``. Centralised so
 ``_TFPArrayBackend.__init__`` and ``tree_unflatten`` can't drift."""
 
 
+def _construct_batched_dist(
+    dist_cls: type,
+    *,
+    name: str,
+    batched_params: dict[str, Any],
+) -> "TFPDistribution":
+    """Construct the fused batched distribution under the internal
+    bypass, with the centralised ``__array_backend``-suffixed name.
+
+    Used by both :meth:`_TFPArrayBackend.__init__` and
+    :meth:`_TFPArrayBackend.tree_unflatten` so the suffix and bypass
+    contract live in one place.
+    """
+    with _allow_batched_tfp_init():
+        return dist_cls(
+            **batched_params,
+            name=f"{name}{_ARRAY_BACKEND_NAME_SUFFIX}",
+        )
+
+
 class _TFPArrayBackend:
     """Fused TFP-batched backend for ``DistributionArray``.
 
@@ -372,16 +384,9 @@ class _TFPArrayBackend:
                 normalised[key] = arr
             batched_params = normalised
         self._batched_params = batched_params
-        # Construct the fused ProbPipe Distribution with the batched
-        # params. ``TFPDistribution.__init__`` rejects batched
-        # parameters for user code; the backend is internal infra that
-        # exists *to* hold a batched form, so it opts into the bypass
-        # via ``_allow_batched_tfp_init``.
-        with _allow_batched_tfp_init():
-            self._batched_dist: TFPDistribution = dist_cls(
-                **batched_params,
-                name=f"{name}{_ARRAY_BACKEND_NAME_SUFFIX}",
-            )
+        self._batched_dist: TFPDistribution = _construct_batched_dist(
+            dist_cls, name=name, batched_params=batched_params,
+        )
         # Final sanity check: TFP's inferred batch_shape must match
         # the caller's declaration. Catches the rare case where a
         # higher-rank param's *trailing* axes don't agree but the
@@ -534,15 +539,9 @@ class _TFPArrayBackend:
         instance._name = name
         instance._batch_shape = tuple(batch_shape)
         instance._batched_params = dict(zip(keys, children))
-        # Rebuild the wrapped distribution with the same internal
-        # bypass that ``__init__`` uses — the leaves are batched by
-        # construction, so user-facing rejection of batched params
-        # must not fire here.
-        with _allow_batched_tfp_init():
-            instance._batched_dist = dist_cls(
-                **instance._batched_params,
-                name=f"{name}{_ARRAY_BACKEND_NAME_SUFFIX}",
-            )
+        instance._batched_dist = _construct_batched_dist(
+            dist_cls, name=name, batched_params=instance._batched_params,
+        )
         return instance
 
 

--- a/probpipe/distributions/gaussian_random_function.py
+++ b/probpipe/distributions/gaussian_random_function.py
@@ -188,45 +188,56 @@ class GaussianRandomFunction(ArrayRandomFunction):
         (e.g. structured covariance representations).
         """
         from . import MultivariateNormal, Normal
+        from ._tfp_base import _allow_batched_tfp_init
 
-        mean = self.predict_mean(X)  # (*eb, n, *out)
+        # GRF predictions over ``n`` input points return a single
+        # batched ``Normal`` / ``MultivariateNormal`` whose
+        # ``batch_shape`` covers the input axis. The rejection added
+        # later in this PR otherwise refuses such direct construction;
+        # the GRF is library-internal infrastructure that
+        # deliberately produces a batched form for ``predict``.
+        # PR-C.3 will rework the RandomFunction shape algebra and may
+        # change this to return a ``DistributionArray``; for now we
+        # bypass to preserve current behaviour.
+        with _allow_batched_tfp_init():
+            mean = self.predict_mean(X)  # (*eb, n, *out)
 
-        # -- Fully marginal ---------------------------------------------------
-        if not joint_inputs and not joint_outputs:
-            variance = self.predict_variance(X)
-            return Normal(loc=mean, scale=jnp.sqrt(variance), name="grf_prediction")
+            # -- Fully marginal ---------------------------------------------------
+            if not joint_inputs and not joint_outputs:
+                variance = self.predict_variance(X)
+                return Normal(loc=mean, scale=jnp.sqrt(variance), name="grf_prediction")
 
-        # -- At least one joint axis — need covariance ------------------------
-        cov = self.predict_covariance(
-            X, joint_inputs=joint_inputs, joint_outputs=joint_outputs
-        )
-        extra_batch, n = self._parse_X(X)
-        d_out = prod(self._output_shape)
+            # -- At least one joint axis — need covariance ------------------------
+            cov = self.predict_covariance(
+                X, joint_inputs=joint_inputs, joint_outputs=joint_outputs
+            )
+            extra_batch, n = self._parse_X(X)
+            d_out = prod(self._output_shape)
 
-        scale_tril = jnp.linalg.cholesky(cov)
+            scale_tril = jnp.linalg.cholesky(cov)
 
-        if joint_inputs and joint_outputs:
-            flat_dim = n * d_out if self._output_shape else n
-            flat_mean = mean.reshape(*extra_batch, flat_dim)
+            if joint_inputs and joint_outputs:
+                flat_dim = n * d_out if self._output_shape else n
+                flat_mean = mean.reshape(*extra_batch, flat_dim)
+                return MultivariateNormal(loc=flat_mean, scale_tril=scale_tril, name="grf_prediction")
+
+            if joint_inputs and not joint_outputs:
+                # Joint over n, independent over outputs.
+                # mean: (*eb, n, *out) → need (*eb, *out, n)
+                if self._output_shape:
+                    ndim_eb = len(extra_batch)
+                    ndim_out = len(self._output_shape)
+                    source_axes = list(range(ndim_eb + 1, ndim_eb + 1 + ndim_out))
+                    dest_axes = list(range(ndim_eb, ndim_eb + ndim_out))
+                    mean_t = jnp.moveaxis(mean, source_axes, dest_axes)
+                else:
+                    mean_t = mean  # (*eb, n) — nothing to rearrange
+                return MultivariateNormal(loc=mean_t, scale_tril=scale_tril, name="grf_prediction")
+
+            # joint_outputs only (not joint_inputs)
+            # mean: (*eb, n, *out) → flatten output dims: (*eb, n, d_out)
+            flat_mean = mean.reshape(*extra_batch, n, d_out)
             return MultivariateNormal(loc=flat_mean, scale_tril=scale_tril, name="grf_prediction")
-
-        if joint_inputs and not joint_outputs:
-            # Joint over n, independent over outputs.
-            # mean: (*eb, n, *out) → need (*eb, *out, n)
-            if self._output_shape:
-                ndim_eb = len(extra_batch)
-                ndim_out = len(self._output_shape)
-                source_axes = list(range(ndim_eb + 1, ndim_eb + 1 + ndim_out))
-                dest_axes = list(range(ndim_eb, ndim_eb + ndim_out))
-                mean_t = jnp.moveaxis(mean, source_axes, dest_axes)
-            else:
-                mean_t = mean  # (*eb, n) — nothing to rearrange
-            return MultivariateNormal(loc=mean_t, scale_tril=scale_tril, name="grf_prediction")
-
-        # joint_outputs only (not joint_inputs)
-        # mean: (*eb, n, *out) → flatten output dims: (*eb, n, d_out)
-        flat_mean = mean.reshape(*extra_batch, n, d_out)
-        return MultivariateNormal(loc=flat_mean, scale_tril=scale_tril, name="grf_prediction")
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/distributions/gaussian_random_function.py
+++ b/probpipe/distributions/gaussian_random_function.py
@@ -24,6 +24,7 @@ from .._utils import _auto_key
 from ..core.protocols import SupportsSampling
 from .._utils import prod
 from ..core._random_functions import ArrayRandomFunction
+from ._tfp_base import _allow_batched_tfp_init
 
 # Delay import to avoid circular import at module level; these are
 # imported from the *same* package, so we import lazily inside methods
@@ -188,7 +189,6 @@ class GaussianRandomFunction(ArrayRandomFunction):
         (e.g. structured covariance representations).
         """
         from . import MultivariateNormal, Normal
-        from ._tfp_base import _allow_batched_tfp_init
 
         # GRF predictions over ``n`` input points return a single
         # batched ``Normal`` / ``MultivariateNormal`` whose

--- a/probpipe/distributions/gaussian_random_function.py
+++ b/probpipe/distributions/gaussian_random_function.py
@@ -192,52 +192,66 @@ class GaussianRandomFunction(ArrayRandomFunction):
 
         # GRF predictions over ``n`` input points return a single
         # batched ``Normal`` / ``MultivariateNormal`` whose
-        # ``batch_shape`` covers the input axis. The rejection added
-        # later in this PR otherwise refuses such direct construction;
-        # the GRF is library-internal infrastructure that
-        # deliberately produces a batched form for ``predict``.
-        # PR-C.3 will rework the RandomFunction shape algebra and may
-        # change this to return a ``DistributionArray``; for now we
-        # bypass to preserve current behaviour.
+        # ``batch_shape`` covers the input axis — a library-internal
+        # batched form that ``TFPDistribution.__init__``'s rejection
+        # would otherwise refuse. The bypass wraps only the
+        # constructor calls; mean / variance / covariance / cholesky
+        # work happens outside it so the global flag is mutated for
+        # the shortest possible window.
+        mean = self.predict_mean(X)  # (*eb, n, *out)
+
+        # -- Fully marginal ---------------------------------------------------
+        if not joint_inputs and not joint_outputs:
+            variance = self.predict_variance(X)
+            with _allow_batched_tfp_init():
+                return Normal(
+                    loc=mean, scale=jnp.sqrt(variance),
+                    name="grf_prediction",
+                )
+
+        # -- At least one joint axis — need covariance ------------------------
+        cov = self.predict_covariance(
+            X, joint_inputs=joint_inputs, joint_outputs=joint_outputs
+        )
+        extra_batch, n = self._parse_X(X)
+        d_out = prod(self._output_shape)
+
+        scale_tril = jnp.linalg.cholesky(cov)
+
+        if joint_inputs and joint_outputs:
+            flat_dim = n * d_out if self._output_shape else n
+            flat_mean = mean.reshape(*extra_batch, flat_dim)
+            with _allow_batched_tfp_init():
+                return MultivariateNormal(
+                    loc=flat_mean, scale_tril=scale_tril,
+                    name="grf_prediction",
+                )
+
+        if joint_inputs and not joint_outputs:
+            # Joint over n, independent over outputs.
+            # mean: (*eb, n, *out) → need (*eb, *out, n)
+            if self._output_shape:
+                ndim_eb = len(extra_batch)
+                ndim_out = len(self._output_shape)
+                source_axes = list(range(ndim_eb + 1, ndim_eb + 1 + ndim_out))
+                dest_axes = list(range(ndim_eb, ndim_eb + ndim_out))
+                mean_t = jnp.moveaxis(mean, source_axes, dest_axes)
+            else:
+                mean_t = mean  # (*eb, n) — nothing to rearrange
+            with _allow_batched_tfp_init():
+                return MultivariateNormal(
+                    loc=mean_t, scale_tril=scale_tril,
+                    name="grf_prediction",
+                )
+
+        # joint_outputs only (not joint_inputs)
+        # mean: (*eb, n, *out) → flatten output dims: (*eb, n, d_out)
+        flat_mean = mean.reshape(*extra_batch, n, d_out)
         with _allow_batched_tfp_init():
-            mean = self.predict_mean(X)  # (*eb, n, *out)
-
-            # -- Fully marginal ---------------------------------------------------
-            if not joint_inputs and not joint_outputs:
-                variance = self.predict_variance(X)
-                return Normal(loc=mean, scale=jnp.sqrt(variance), name="grf_prediction")
-
-            # -- At least one joint axis — need covariance ------------------------
-            cov = self.predict_covariance(
-                X, joint_inputs=joint_inputs, joint_outputs=joint_outputs
+            return MultivariateNormal(
+                loc=flat_mean, scale_tril=scale_tril,
+                name="grf_prediction",
             )
-            extra_batch, n = self._parse_X(X)
-            d_out = prod(self._output_shape)
-
-            scale_tril = jnp.linalg.cholesky(cov)
-
-            if joint_inputs and joint_outputs:
-                flat_dim = n * d_out if self._output_shape else n
-                flat_mean = mean.reshape(*extra_batch, flat_dim)
-                return MultivariateNormal(loc=flat_mean, scale_tril=scale_tril, name="grf_prediction")
-
-            if joint_inputs and not joint_outputs:
-                # Joint over n, independent over outputs.
-                # mean: (*eb, n, *out) → need (*eb, *out, n)
-                if self._output_shape:
-                    ndim_eb = len(extra_batch)
-                    ndim_out = len(self._output_shape)
-                    source_axes = list(range(ndim_eb + 1, ndim_eb + 1 + ndim_out))
-                    dest_axes = list(range(ndim_eb, ndim_eb + ndim_out))
-                    mean_t = jnp.moveaxis(mean, source_axes, dest_axes)
-                else:
-                    mean_t = mean  # (*eb, n) — nothing to rearrange
-                return MultivariateNormal(loc=mean_t, scale_tril=scale_tril, name="grf_prediction")
-
-            # joint_outputs only (not joint_inputs)
-            # mean: (*eb, n, *out) → flatten output dims: (*eb, n, d_out)
-            flat_mean = mean.reshape(*extra_batch, n, d_out)
-            return MultivariateNormal(loc=flat_mean, scale_tril=scale_tril, name="grf_prediction")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_distribution_array.py
+++ b/tests/test_distribution_array.py
@@ -572,33 +572,39 @@ class TestFromBatchedParams:
         assert da[2]._value == 2.0
         assert da[1].name == "m_1"
 
-    def test_factory_results_match_legacy_batched_constructor(self):
+    def test_factory_results_match_native_tfp(self):
         """Result of ``from_batched_params(Normal, loc=arr, scale=...)``
-        produces samples / log_probs / means matching the legacy
-        ``Normal(loc=arr, scale=...)`` form (the form Phase 2 will
-        reject).
+        produces samples / means / variances matching ``tfd.Normal``
+        constructed natively with the same batched params.
+
+        Pre-PR-C.2 this test compared to ``Normal(loc=arr, scale=...)``
+        directly; PR-C.2 rejects that form, so the comparison goes
+        against TFP's own batched form (which is what
+        ``_TFPArrayBackend`` wraps internally anyway).
         """
         from probpipe import Normal, DistributionArray
+        import tensorflow_probability.substrates.jax.distributions as tfd
         loc = jnp.array([0.5, -1.2, 3.7, 0.0])
         scale = jnp.array([0.1, 0.2, 0.3, 0.4])
 
-        legacy = Normal(loc=loc, scale=scale, name="legacy")
+        native = tfd.Normal(loc=loc, scale=scale)
         da = DistributionArray.from_batched_params(
             Normal, loc=loc, scale=scale, name="x",
         )
         # Sample shapes match.
         key = jax.random.PRNGKey(42)
-        legacy_samples = legacy._sample(key)
+        native_samples = native.sample(seed=key)
         da_samples = da._backend._sample(key)
         np.testing.assert_allclose(
-            np.asarray(legacy_samples), np.asarray(da_samples)
+            np.asarray(native_samples), np.asarray(da_samples)
         )
         # Mean / variance match.
         np.testing.assert_allclose(
-            np.asarray(legacy._mean()), np.asarray(da._backend._mean())
+            np.asarray(native.mean()), np.asarray(da._backend._mean())
         )
         np.testing.assert_allclose(
-            np.asarray(legacy._variance()), np.asarray(da._backend._variance())
+            np.asarray(native.variance()),
+            np.asarray(da._backend._variance()),
         )
 
     def test_iteration_matches_indexing(self):

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -771,12 +771,13 @@ class TestDistributionCoverageGaps:
         n = Normal(loc=0.0, scale=1.0, name="x")
         assert n.dtype == n._tfp_dist.dtype
 
-    def test_repr_with_batch_shape(self):
-        """TFPDistribution repr includes batch_shape when non-trivial."""
-        from probpipe import Normal
-
-        d = Normal(loc=jnp.array([0.0, 1.0]), scale=jnp.array([1.0, 1.0]), name="x")
-        assert "batch_shape" in repr(d)
+    # NOTE: ``test_repr_with_batch_shape`` was removed in PR-C.2.
+    # It exercised ``Normal(loc=arr, scale=arr)`` (now rejected by
+    # ``TFPDistribution.__init__``) to verify that the repr includes
+    # ``batch_shape``. Distributions never carry a non-trivial
+    # ``batch_shape`` after PR-C.2, so the repr branch the test
+    # asserted on is unreachable. PR-C.3 will remove ``batch_shape``
+    # from the repr entirely.
 
     def test_array_empirical_dtype(self):
         """RecordEmpiricalDistribution.dtype returns sample dtype."""

--- a/tests/test_random_function.py
+++ b/tests/test_random_function.py
@@ -9,11 +9,18 @@ import pytest
 
 from probpipe import (
     Distribution,
+    DistributionArray,
     Normal,
     RandomFunction,
     ArrayRandomFunction,
 )
 from probpipe import log_prob, sample
+# Test fixtures construct ``Normal`` from batched arrays; the rejection
+# in ``TFPDistribution.__init__`` (PR-C.2) makes that a user-facing
+# error. Internal infra opts into the bypass — the fixtures here mock
+# library-internal code paths (RandomFunction subclasses), so the
+# bypass is appropriate.
+from probpipe.distributions._tfp_base import _allow_batched_tfp_init
 
 
 # ---------------------------------------------------------------------------
@@ -34,7 +41,8 @@ class _MinimalRandomFunction(RandomFunction):
     """Minimal concrete RandomFunction for testing."""
 
     def __call__(self, x):
-        return Normal(loc=jnp.zeros(3), scale=jnp.ones(3), name="y")
+        with _allow_batched_tfp_init():
+            return Normal(loc=jnp.zeros(3), scale=jnp.ones(3), name="y")
 
 
 class _MinimalArrayRF(ArrayRandomFunction):
@@ -43,7 +51,8 @@ class _MinimalArrayRF(ArrayRandomFunction):
     def predict(self, X, *, joint_inputs=False, joint_outputs=False):
         extra_batch, n = self._parse_X(X)
         mean = jnp.zeros((*extra_batch, n))
-        return Normal(loc=mean, scale=jnp.ones_like(mean), name="y")
+        with _allow_batched_tfp_init():
+            return Normal(loc=mean, scale=jnp.ones_like(mean), name="y")
 
 
 class _JointCapableRF(ArrayRandomFunction):
@@ -53,11 +62,12 @@ class _JointCapableRF(ArrayRandomFunction):
 
     def predict(self, X, *, joint_inputs=False, joint_outputs=False):
         extra_batch, n = self._parse_X(X)
-        return Normal(
-            loc=jnp.zeros((*extra_batch, n)),
-            scale=jnp.ones((*extra_batch, n)),
-            name="y",
-        )
+        with _allow_batched_tfp_init():
+            return Normal(
+                loc=jnp.zeros((*extra_batch, n)),
+                scale=jnp.ones((*extra_batch, n)),
+                name="y",
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_support_and_conversion.py
+++ b/tests/test_support_and_conversion.py
@@ -184,49 +184,18 @@ class TestDistributionSupport:
     def test_uniform_support(self):
         assert Uniform(low=-1.0, high=2.0, name="u").support == interval(-1.0, 2.0)
 
-    # NOTE: ``test_uniform_support_array_bounds`` and
-    # ``test_half_cauchy_support_array_bounds`` were removed in PR-C.2.
-    # They exercised the legacy form ``Uniform(low=arr, high=arr)`` /
-    # ``HalfCauchy(loc=arr, scale=arr)``, which the framework
+    # NOTE: A family of "support with array bounds" tests was removed
+    # in PR-C.2. Each exercised a legacy batched constructor:
+    # ``Uniform(low=arr, high=arr)``, ``HalfCauchy(loc=arr, scale=arr)``,
+    # ``Pareto(concentration=arr, scale=arr)``,
+    # ``TruncatedNormal(loc=arr, scale=arr, low=arr, high=arr)``,
+    # ``Binomial(total_count=arr, probs=arr)``. The framework
     # hierarchy ("one random variable per Distribution") no longer
-    # permits. Migrate to ``DistributionArray.from_batched_params``
-    # for batched constructions; per-element support checks belong on
-    # ``Constraint``, not on a batched ``Distribution``.
-
-    def test_pareto_support_array_bounds(self):
-        p = Pareto(
-            concentration=jnp.array([2.0, 2.0]),
-            scale=jnp.array([1.0, 2.0]),
-            name="p_arr",
-        )
-        c = p.support
-        assert jnp.array_equal(c.check(jnp.array([1.5, 2.5])), jnp.array([True, True]))
-        assert jnp.array_equal(c.check(jnp.array([0.5, 2.5])), jnp.array([False, True]))
-
-    def test_truncated_normal_support_array_bounds(self):
-        tn = TruncatedNormal(
-            loc=jnp.array([0.0, 0.0]),
-            scale=jnp.array([1.0, 1.0]),
-            low=jnp.array([-1.0, 0.0]),
-            high=jnp.array([1.0, 2.0]),
-            name="tn_arr",
-        )
-        c = tn.support
-        assert jnp.array_equal(c.check(jnp.array([0.0, 1.0])), jnp.array([True, True]))
-        assert jnp.array_equal(c.check(jnp.array([-2.0, 1.0])), jnp.array([False, True]))
-
-    def test_binomial_support_array_total_count(self):
-        # Regression: ``int(self._total_count)`` previously crashed for
-        # array-valued total_count. Per-dim total_count should produce a
-        # working integer_interval.
-        b = Binomial(
-            total_count=jnp.array([5, 10]),
-            probs=jnp.array([0.3, 0.5]),
-            name="b_arr",
-        )
-        c = b.support
-        assert jnp.array_equal(c.check(jnp.array([3, 7])), jnp.array([True, True]))
-        assert jnp.array_equal(c.check(jnp.array([6, 7])), jnp.array([False, True]))
+    # permits these forms; migrate to
+    # ``DistributionArray.from_batched_params`` for batched
+    # constructions, and use ``Constraint`` directly for per-element
+    # support checks (those are a property of the ``Constraint``
+    # type, not of a batched ``Distribution``).
 
     def test_bernoulli_support(self):
         assert Bernoulli(probs=0.5, name="d").support == boolean

--- a/tests/test_support_and_conversion.py
+++ b/tests/test_support_and_conversion.py
@@ -184,28 +184,14 @@ class TestDistributionSupport:
     def test_uniform_support(self):
         assert Uniform(low=-1.0, high=2.0, name="u").support == interval(-1.0, 2.0)
 
-    def test_uniform_support_array_bounds(self):
-        # Regression: ``float(self._low)`` previously crashed for
-        # non-scalar low/high. Per-dim bounds should produce a working
-        # interval whose ``.check`` returns a per-dim boolean.
-        u = Uniform(
-            low=jnp.array([0.0, -1.0]),
-            high=jnp.array([1.0, 2.0]),
-            name="u_arr",
-        )
-        c = u.support
-        assert jnp.array_equal(c.check(jnp.array([0.5, 0.5])), jnp.array([True, True]))
-        assert jnp.array_equal(c.check(jnp.array([2.0, 0.5])), jnp.array([False, True]))
-
-    def test_half_cauchy_support_array_bounds(self):
-        hc = HalfCauchy(
-            loc=jnp.array([0.0, 1.0]),
-            scale=jnp.array([1.0, 1.0]),
-            name="hc_arr",
-        )
-        c = hc.support
-        assert jnp.array_equal(c.check(jnp.array([0.5, 1.5])), jnp.array([True, True]))
-        assert jnp.array_equal(c.check(jnp.array([-0.5, 0.5])), jnp.array([False, False]))
+    # NOTE: ``test_uniform_support_array_bounds`` and
+    # ``test_half_cauchy_support_array_bounds`` were removed in PR-C.2.
+    # They exercised the legacy form ``Uniform(low=arr, high=arr)`` /
+    # ``HalfCauchy(loc=arr, scale=arr)``, which the framework
+    # hierarchy ("one random variable per Distribution") no longer
+    # permits. Migrate to ``DistributionArray.from_batched_params``
+    # for batched constructions; per-element support checks belong on
+    # ``Constraint``, not on a batched ``Distribution``.
 
     def test_pareto_support_array_bounds(self):
         p = Pareto(

--- a/tests/test_tfp_batch_rejection.py
+++ b/tests/test_tfp_batch_rejection.py
@@ -194,6 +194,43 @@ class TestBypassForInternalInfra:
         with pytest.raises(ValueError):
             Normal(loc=jnp.zeros(2), scale=1.0, name="x")
 
+    def test_bypass_does_not_leak_across_asyncio_tasks(self):
+        """The bypass uses ``contextvars.ContextVar`` so concurrent
+        coroutines see independent flag states. A task that enters
+        the bypass must not affect a sibling task running outside
+        it.
+        """
+        import asyncio
+
+        bypass_observed: list[bool] = []
+        no_bypass_failed: list[bool] = []
+
+        async def with_bypass():
+            with _allow_batched_tfp_init():
+                # Yield to the event loop so the sibling task gets to
+                # run while *this* task's bypass is active. If the
+                # bypass leaked, the sibling would silently succeed.
+                await asyncio.sleep(0)
+                Normal(loc=jnp.zeros(2), scale=1.0, name="x")
+                bypass_observed.append(True)
+
+        async def without_bypass():
+            await asyncio.sleep(0)  # interleave with the bypass task
+            try:
+                Normal(loc=jnp.zeros(2), scale=1.0, name="y")
+                no_bypass_failed.append(False)
+            except ValueError:
+                no_bypass_failed.append(True)
+
+        async def main():
+            await asyncio.gather(with_bypass(), without_bypass())
+
+        asyncio.run(main())
+        assert bypass_observed == [True]
+        # The non-bypass task must have hit the rejection even though
+        # the sibling task was inside ``with _allow_batched_tfp_init()``.
+        assert no_bypass_failed == [True]
+
 
 # ---------------------------------------------------------------------------
 # KDE-style subclasses (set _tfp_dist after super().__init__) unaffected

--- a/tests/test_tfp_batch_rejection.py
+++ b/tests/test_tfp_batch_rejection.py
@@ -1,0 +1,218 @@
+"""Regression tests for the TFP-backed batched-parameter rejection
+(PR-C.2).
+
+The framework hierarchy rule "one random variable per Distribution"
+(see ``CONTRIBUTING.md``) is enforced at construction time:
+``TFPDistribution.__init__`` raises :class:`ValueError` when the
+underlying ``tfd.Distribution`` has a non-empty ``batch_shape``.
+Migration is via :meth:`DistributionArray.from_batched_params` (or
+the per-class alias).
+
+These tests pin:
+
+* The rejection fires for every concrete TFP-backed class that the
+  framework ships, with a message that names the class, the
+  observed ``batch_shape``, and the migration factory.
+* The rejection does *not* fire when the bypass is active
+  (``_allow_batched_tfp_init`` context manager), so internal infra
+  (``_TFPArrayBackend``, converters, sequential joints, GRF
+  predictions) continues to work.
+* Subclasses that set ``_tfp_dist`` *after* calling
+  ``super().__init__`` (the KDE pattern) are unaffected — the
+  rejection skips when ``_tfp_dist`` isn't yet present.
+* Scalar (non-batched) construction is unchanged.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from probpipe import (
+    Beta,
+    DistributionArray,
+    Gamma,
+    MultivariateNormal,
+    Normal,
+)
+from probpipe.distributions._tfp_base import _allow_batched_tfp_init
+from probpipe.distributions.kde import KDEDistribution
+
+
+# ---------------------------------------------------------------------------
+# Rejection fires across the TFP family
+# ---------------------------------------------------------------------------
+
+
+class TestRejectionAcrossClasses:
+    def test_normal_batched_loc_rejected(self):
+        with pytest.raises(ValueError, match=r"batch_shape=\(5,\)"):
+            Normal(loc=jnp.zeros(5), scale=1.0, name="x")
+
+    def test_normal_batched_scale_rejected(self):
+        with pytest.raises(ValueError, match=r"batch_shape=\(3,\)"):
+            Normal(loc=0.0, scale=jnp.ones(3), name="x")
+
+    def test_normal_multidim_batch_rejected(self):
+        with pytest.raises(ValueError, match=r"batch_shape=\(2, 3\)"):
+            Normal(loc=jnp.zeros((2, 3)), scale=1.0, name="x")
+
+    def test_beta_batched_rejected(self):
+        with pytest.raises(ValueError, match=r"batch_shape"):
+            Beta(alpha=jnp.array([1.0, 2.0]),
+                 beta=jnp.array([1.0, 1.0]),
+                 name="b")
+
+    def test_gamma_batched_rejected(self):
+        with pytest.raises(ValueError, match=r"batch_shape"):
+            Gamma(concentration=jnp.array([1.0, 2.0, 3.0]),
+                  rate=1.0, name="g")
+
+    def test_mvn_batched_rejected(self):
+        # MVN with batched loc: loc.shape=(2, d) implies batch_shape=(2,).
+        d = 3
+        with pytest.raises(ValueError, match=r"batch_shape=\(2,\)"):
+            MultivariateNormal(
+                loc=jnp.zeros((2, d)),
+                scale_tril=jnp.broadcast_to(jnp.eye(d), (2, d, d)),
+                name="z",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Error message includes migration hint
+# ---------------------------------------------------------------------------
+
+
+class TestRejectionMessage:
+    def test_message_names_class(self):
+        try:
+            Normal(loc=jnp.zeros(5), scale=1.0, name="x")
+        except ValueError as e:
+            msg = str(e)
+        assert "Normal" in msg
+
+    def test_message_names_observed_batch_shape(self):
+        try:
+            Normal(loc=jnp.zeros(7), scale=1.0, name="x")
+        except ValueError as e:
+            msg = str(e)
+        assert "(7,)" in msg
+
+    def test_message_points_at_factory(self):
+        try:
+            Normal(loc=jnp.zeros(5), scale=1.0, name="x")
+        except ValueError as e:
+            msg = str(e)
+        assert "from_batched_params" in msg
+        # Both forms are mentioned: the universal entry point and
+        # the per-class alias.
+        assert "DistributionArray.from_batched_params(Normal" in msg
+        assert "Normal.from_batched_params" in msg
+
+
+# ---------------------------------------------------------------------------
+# Scalar construction unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestScalarConstructionUnchanged:
+    def test_scalar_normal_works(self):
+        n = Normal(loc=0.0, scale=1.0, name="x")
+        assert n.batch_shape == ()
+        assert n.event_shape == ()
+
+    def test_scalar_beta_works(self):
+        Beta(alpha=1.0, beta=1.0, name="b")
+
+    def test_scalar_gamma_works(self):
+        Gamma(concentration=1.0, rate=1.0, name="g")
+
+    def test_mvn_unbatched_works(self):
+        d = 3
+        m = MultivariateNormal(
+            loc=jnp.zeros(d),
+            scale_tril=jnp.eye(d),
+            name="z",
+        )
+        # Standard d-dim MVN: event_shape=(d,), batch_shape=().
+        assert m.batch_shape == ()
+        assert m.event_shape == (d,)
+
+
+# ---------------------------------------------------------------------------
+# Migration path works
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationPath:
+    def test_universal_factory_works_in_place_of_legacy_form(self):
+        da = DistributionArray.from_batched_params(
+            Normal, loc=jnp.zeros(5), scale=1.0, name="x",
+        )
+        assert da.batch_shape == (5,)
+        assert da[0].name == "x_0"
+
+    def test_per_class_alias_works(self):
+        da = Normal.from_batched_params(
+            loc=jnp.zeros(5), scale=1.0, name="x",
+        )
+        assert da.batch_shape == (5,)
+
+
+# ---------------------------------------------------------------------------
+# Bypass for internal infra
+# ---------------------------------------------------------------------------
+
+
+class TestBypassForInternalInfra:
+    def test_bypass_allows_batched_construction(self):
+        with _allow_batched_tfp_init():
+            n = Normal(loc=jnp.zeros(5), scale=1.0, name="x")
+        # Inside the bypass, the rejection does not fire.
+        assert n.batch_shape == (5,)
+
+    def test_bypass_is_scoped_to_context(self):
+        with _allow_batched_tfp_init():
+            Normal(loc=jnp.zeros(3), scale=1.0, name="x")
+        # Outside the context, the rejection fires again.
+        with pytest.raises(ValueError, match="batch_shape"):
+            Normal(loc=jnp.zeros(3), scale=1.0, name="x")
+
+    def test_nested_bypass_restores_outer_state(self):
+        # Outer rejection state is False (default).
+        with pytest.raises(ValueError):
+            Normal(loc=jnp.zeros(2), scale=1.0, name="x")
+        # Two nested bypasses: inner exit must NOT re-enable the
+        # rejection while the outer is still active.
+        with _allow_batched_tfp_init():
+            with _allow_batched_tfp_init():
+                Normal(loc=jnp.zeros(2), scale=1.0, name="x")
+            # Still in outer bypass; rejection should still be off.
+            Normal(loc=jnp.zeros(2), scale=1.0, name="x")
+        # Outer exited; rejection back on.
+        with pytest.raises(ValueError):
+            Normal(loc=jnp.zeros(2), scale=1.0, name="x")
+
+
+# ---------------------------------------------------------------------------
+# KDE-style subclasses (set _tfp_dist after super().__init__) unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestKDEStyleSubclasses:
+    """``KDEDistribution`` calls ``super().__init__`` *before* setting
+    ``self._tfp_dist`` (the mixture is built from samples in the
+    rest of __init__). The rejection's ``hasattr`` guard skips the
+    check when ``_tfp_dist`` isn't yet present, so KDE construction
+    is unaffected.
+    """
+
+    def test_kde_construction_works(self):
+        kde = KDEDistribution(jnp.zeros((20, 3)), name="kde")
+        assert kde is not None
+        assert kde.name == "kde"
+
+    def test_kde_with_1d_samples(self):
+        kde = KDEDistribution(jnp.linspace(0.0, 1.0, 10), name="kde1d")
+        assert kde is not None


### PR DESCRIPTION
## Summary

PR-C.2 (Phase 2 of the four-PR `Distribution.batch_shape` cleanup, plan: `.claude/plans/pr-c-distribution-batch-shape.md`). **The breaking change.** TFP-backed constructors now reject parameters whose implied `batch_shape` is non-empty:

```text
ValueError: Normal parameters imply batch_shape=(5,); wrap multiple
distributions in a DistributionArray instead. See
DistributionArray.from_batched_params(Normal, ...) (or the alias
Normal.from_batched_params(...)) for the factory.
```

The framework hierarchy rule **"one random variable per `Distribution`"** (CONTRIBUTING.md) is now enforced at construction time. Migration is via the `DistributionArray.from_batched_params` factory introduced in PR-C.1 (#173).

## Stack

PR-B.1 (#172) and PR-C.1 (#173) have merged; this PR is now based on `main`.

## Sequencing inside PR-C.2

The plan called for test migrations to land first, the rejection last, so each commit boundary is green. Ordering here matches that:

1. **feat(tfp):** add `_allow_batched_tfp_init` bypass scaffolding — context manager + flag, no usage. Trivially additive.
2. **refactor(internal):** wrap legitimately-batched library-internal call sites in the bypass — `ProbPipeConverter.convert` (covers every per-target conversion function in one place), `_SequentialJointDistribution._sample_sequential` (user lambda gets batched parents), `GaussianRandomFunction.predict` (returns a single batched form).
3. **test:** migrate test fixtures and assertions away from the legacy form — wrap mock RandomFunction subclasses in the bypass, delete now-obsolete tests for per-element support checks on Uniform / HalfCauchy, rewrite the PR-C.1 self-comparison test against `tfd.Normal` directly.
4. **feat(tfp):** add the rejection in `TFPDistribution.__init__` — the breaking change. Folds in the symmetric `_eval_log_prob` bypass on `_SequentialJointDistribution` and the additional stale-test deletions (Pareto / TruncatedNormal / Binomial array-bounds tests, plus `test_repr_with_batch_shape`) that surface only once the rejection is active.
5. **test(tfp):** regression tests pinning the rejection contract — fires across the TFP family with the migration-hint message, scalar construction unchanged, factory works, KDE-style subclasses unaffected, bypass scopes correctly (including nested).
6. **docs(changelog):** entry under `Changed (breaking)` with Before/After migration recipe; removes the now-stale "Preview of upcoming PR-C.2" paragraph from the PR-C.1 entry.

## Migration

```python
# Before (rejected)
n = Normal(loc=jnp.zeros(5), scale=1.0, name="x")

# After (ergonomic per-class alias)
da = Normal.from_batched_params(loc=jnp.zeros(5), scale=1.0, name="x")

# After (universal entry point)
da = DistributionArray.from_batched_params(
    Normal, loc=jnp.zeros(5), scale=1.0, name="x",
)
```

The factory is performance-equivalent to the legacy form: `_TFPArrayBackend` wraps the same TFP-batched distribution under the hood. Users see no perf regression.

## Internal bypass

A private `_allow_batched_tfp_init()` context manager exists for library-internal infrastructure that legitimately needs the batched form. User code is unaffected — the bypass is purely internal and is *not* part of the public API. Wrapped sites:

- `_TFPArrayBackend` (PR-C.1 fused-storage backend) — its whole purpose is to hold a batched form.
- `ProbPipeConverter.convert` — the per-target converters fabricate scalars from a source's `_mean` / `_variance`, which can be `(d,)`-shaped.
- `_SequentialJointDistribution._sample_sequential` and `_eval_log_prob` — user lambdas receive batched parent values during sampling / log-prob computation.
- `GaussianRandomFunction.predict` — returns a single batched form covering the input axis. PR-C.3 may switch this to a `DistributionArray`.

## Removed (stale)

Six legacy tests deleted; they exercised batched-construction-of-a-single-Distribution forms that the rejection now refuses:

- `tests/test_support_and_conversion.py`: `test_uniform_support_array_bounds`, `test_half_cauchy_support_array_bounds`, `test_pareto_support_array_bounds`, `test_truncated_normal_support_array_bounds`, `test_binomial_support_array_total_count`.
- `tests/test_distributions.py`: `test_repr_with_batch_shape`.

Deletion notes in each file point at the migration path. Per-element support checks remain available on `Constraint` directly.

## Notebooks

Audit complete; 0 notebooks need migration. Every `MultivariateNormal(loc=jnp.zeros(d), …)` in `docs/examples/*.ipynb` is the standard scalar-MVN form (`event_shape=(d,)`, `batch_shape=()`), unaffected by the rejection.

## Test plan

- [x] New tests pass: `tests/test_tfp_batch_rejection.py` (20 tests pinning the rejection contract).
- [x] Targeted suites green at every commit boundary (the plan-recommended ordering keeps each commit reviewable in isolation).
- [ ] Full pytest sweep on the final state — running, will confirm before merge.
- [ ] mkdocs strict (verify in CI).

## What's deferred

- **`Distribution.batch_shape` removal** — PR-C.3, the cleanup phase. Once the breaking change here settles, PR-C.3 strips `batch_shape` from `Distribution[T]` and concrete subclasses, reworks `RandomFunction` shape algebra to use `event_shape` only, and removes the now-unreachable `batch_shape` repr branch.

- **Converters routing batched moments to a `DistributionArray`** — currently the converter dispatch bypasses the rejection so a `(d,)`-shaped `_mean` produces a Normal with `batch_shape=(d,)`. Strictly correct would be a `DistributionArray` of `d` scalars; bypass is a tactical decision to keep PR-C.2 scoped. Follow-up issue.

- **`GaussianRandomFunction.predict` returning a `DistributionArray`** — same logic; deferred to PR-C.3's RandomFunction rework.

