### PR TITLE
Debug(WorkflowFunction): WorkflowFunction call parameter parsing

### DIFF
--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -535,32 +535,25 @@ class WorkflowFunction(Node):
             return False
 
     def __call__(self, *args, **call_inputs):
-        # Bind positional args to parameter names using the wrapped function's
-        # signature so callers can use positional arguments naturally.
-        if args:
-            bound = self._sig.bind_partial(*args)
-            for name, value in bound.arguments.items():
-                if name in call_inputs:
-                    raise TypeError(
-                        f"{self._name}() got multiple values for argument '{name}'"
-                    )
-                call_inputs[name] = value
-
-        # If the wrapped function has a **kwargs parameter, sig.bind nests
-        # the extra keyword args under the parameter name.  Unpack them so
-        # they reach the function as top-level keyword arguments.
-        if self._has_var_keyword:
-            for p in self._sig.parameters.values():
-                if p.kind == inspect.Parameter.VAR_KEYWORD and p.name in call_inputs:
-                    extra = call_inputs.pop(p.name)
-                    call_inputs.update(extra)
-
         # Extract reserved call-time overrides (collision already prevented in __init__)
         n_broadcast_samples = call_inputs.pop("n_broadcast_samples", self._n_broadcast_samples)
         do_include_inputs = call_inputs.pop("include_inputs", self._include_inputs)
 
         if "seed" in call_inputs:
             self._key = jax.random.PRNGKey(call_inputs.pop("seed"))
+
+        # Bind user arguments through the wrapped function's real signature.
+        # ``bind_partial`` preserves module/default resolution below while
+        # still rejecting unexpected keywords and duplicate positional/keyword
+        # values with Python-call-compatible errors.
+        bound = self._sig.bind_partial(*args, **call_inputs)
+        call_inputs = {}
+        for name, value in bound.arguments.items():
+            param = self._sig.parameters[name]
+            if param.kind == inspect.Parameter.VAR_KEYWORD:
+                call_inputs.update(value)
+            else:
+                call_inputs[name] = value
 
         values = self._resolve_inputs(call_inputs)
         values = self._convert_distributions(values)

--- a/tests/test_broadcasting.py
+++ b/tests/test_broadcasting.py
@@ -149,6 +149,43 @@ class TestReservedParameterNames:
             WorkflowFunction(func=bad_fn, vectorize="loop")
 
 
+class TestWorkflowFunctionCallResolution:
+    def test_unexpected_keyword_raises(self):
+        def identity(x):
+            return x
+
+        w = WorkflowFunction(func=identity, vectorize="loop")
+
+        with pytest.raises(TypeError, match="unexpected keyword argument 'typo'"):
+            w(x=1.0, typo=2.0)
+
+    def test_var_keyword_name_is_not_unpacked(self):
+        seen = []
+
+        def identity(x, **kwargs):
+            seen.append(kwargs)
+            return x
+
+        w = WorkflowFunction(func=identity, vectorize="loop")
+        out = w(x=1.0, kwargs={"scale": 2.0})
+
+        assert float(out) == 1.0
+        assert seen == [{"kwargs": {"scale": 2.0}}]
+
+    def test_extra_keywords_still_reach_var_keyword(self):
+        seen = []
+
+        def identity(x, **kwargs):
+            seen.append(kwargs)
+            return x
+
+        w = WorkflowFunction(func=identity, vectorize="loop")
+        out = w(x=1.0, scale=2.0)
+
+        assert float(out) == 1.0
+        assert seen == [{"scale": 2.0}]
+
+
 class TestNoBroadcasting:
     """Cases where broadcasting should NOT happen."""
 


### PR DESCRIPTION
## Summary

Fix `WorkflowFunction.__call__` so user-supplied arguments are bound through the wrapped function's real Python signature.

## Bug

`WorkflowFunction` previously only used `inspect.Signature.bind_partial()` for positional arguments. Keyword arguments were passed into the custom input-resolution path without first being validated against the wrapped function signature.

As a result, unexpected keywords could be silently ignored:

```python
def f(x):
    return x

w = WorkflowFunction(func=f)
w(x=1, typo=2)  # previously returned 1 instead of raising TypeError
```

There was also a related `**kwargs` edge case. If the wrapped function accepted `**kwargs`, passing a keyword named the same as that var-keyword parameter was incorrectly unpacked instead of being treated as a normal extra keyword.

## Fix
The call path now extracts ProbPipe-specific call overrides first (`n_broadcast_samples`, `include_inputs`, and `seed`), then binds the remaining user arguments with:

```python
self._sig.bind_partial(*args, **call_inputs)
```

This preserves the existing module/default resolution behavior while restoring Python-compatible errors for unexpected keywords and duplicate arguments.

The bound **kwargs mapping is then flattened only when it comes from the actual `VAR_KEYWORD` parameter slot.

## Tests
Added regression coverage for:

- unexpected keywords raising `TypeError`
- preserving a keyword literally named `kwargs`
- still forwarding ordinary extra keywords into `**kwargs`
- existing positional/keyword duplicate behavior

Validated with:

```python
python -m pytest -p no:xdist -o addopts="" \
  tests/test_broadcasting.py::TestWorkflowFunctionCallResolution \
  tests/test_broadcasting.py::TestBroadcastingBasic::test_positional_args \
  tests/test_ops.py::TestWorkflowFunctionRouting::test_positional_and_keyword_duplicate_raises -q
```