### PR TITLE
refactor(core) [OUTDATE]: new characterization tests for `WorkflowFunction` call

### DIFF
--- a/tests/test_workflow_call_resolution.py
+++ b/tests/test_workflow_call_resolution.py
@@ -4,6 +4,8 @@ These tests lock down the public-call boundary before WorkflowFunction
 internals are split into smaller private modules.
 """
 
+from __future__ import annotations
+
 import jax.numpy as jnp
 import pytest
 
@@ -11,77 +13,44 @@ from probpipe import BroadcastDistribution, Normal
 from probpipe.core.node import Module, Node, WorkflowFunction, workflow_method
 
 
-def test_positional_and_mixed_arguments_bind_like_python_calls():
+@pytest.fixture
+def add_func():
     def add(x, y):
         return x + y
 
-    wf = WorkflowFunction(func=add, vectorize="loop")
-
-    assert float(wf(jnp.asarray(1.0), jnp.asarray(2.0))) == 3.0
-    assert float(wf(jnp.asarray(1.0), y=jnp.asarray(2.0))) == 3.0
+    return add
 
 
-def test_duplicate_positional_and_keyword_argument_raises():
-    def add(x, y):
-        return x + y
+@pytest.fixture
+def identity_func():
+    def identity(x):
+        return x
 
-    wf = WorkflowFunction(func=add, vectorize="loop")
-
-    with pytest.raises(TypeError, match="multiple values"):
-        wf(jnp.asarray(1.0), x=jnp.asarray(2.0))
+    return identity
 
 
-def test_var_keyword_expands_extra_keywords():
+@pytest.fixture
+def kwargs_recorder():
     seen = []
 
     def identity(x, **kwargs):
         seen.append(kwargs)
         return x
 
-    wf = WorkflowFunction(func=identity, vectorize="loop")
-
-    assert float(wf(x=1.0, scale=2.0)) == 1.0
-    assert seen == [{"scale": 2.0}]
+    return identity, seen
 
 
-def test_literal_kwargs_argument_is_not_unpacked():
-    seen = []
-
-    def identity(x, **kwargs):
-        seen.append(kwargs)
-        return x
-
-    wf = WorkflowFunction(func=identity, vectorize="loop")
-
-    assert float(wf(x=1.0, kwargs={"scale": 2.0})) == 1.0
-    assert seen == [{"kwargs": {"scale": 2.0}}]
+@pytest.fixture
+def normal_dist():
+    return Normal(loc=0.0, scale=1.0, name="x")
 
 
-def test_bind_values_and_function_defaults_are_resolved_before_call():
+@pytest.fixture
+def affine_func():
     def affine(x, offset=10.0, scale=1.0):
         return (x + offset) * scale
 
-    default_wf = WorkflowFunction(func=affine, vectorize="loop")
-    bound_wf = WorkflowFunction(
-        func=affine,
-        vectorize="loop",
-        bind={"offset": 3.0},
-        scale=2.0,
-    )
-
-    assert float(default_wf(x=1.0)) == 11.0
-    assert float(bound_wf(x=1.0)) == 8.0
-    assert float(bound_wf(x=1.0, offset=4.0)) == 10.0
-
-
-def test_missing_required_input_raises_after_all_resolution_sources_fail():
-    def add(x, y):
-        return x + y
-
-    wf = WorkflowFunction(func=add, vectorize="loop")
-
-    with pytest.raises(TypeError, match="Missing required input 'y'"):
-        wf(x=1.0)
+    return affine
 
 
 class DataNode(Node):
@@ -91,66 +60,112 @@ class DataNode(Node):
 class CallResolutionModule(Module):
     @workflow_method
     def step(self, dep: DataNode, x, y=7.0):
-        assert dep is self.child_nodes["dep"]
         return x + y
 
 
-def test_module_inputs_dependencies_and_defaults_resolve_for_workflow_methods():
-    dep = DataNode()
-    module = CallResolutionModule(dep=dep, x=5.0)
+class TestArgumentBinding:
+    def test_positional_and_mixed_arguments_bind_like_python_calls(self, add_func):
+        wf = WorkflowFunction(func=add_func, vectorize="loop")
 
-    assert float(module.step()) == 12.0
-    assert float(module.step(y=2.0)) == 7.0
+        assert float(wf(jnp.asarray(1.0), jnp.asarray(2.0))) == 3.0
+        assert float(wf(jnp.asarray(1.0), y=jnp.asarray(2.0))) == 3.0
+
+    def test_duplicate_positional_and_keyword_argument_raises(self, add_func):
+        wf = WorkflowFunction(func=add_func, vectorize="loop")
+
+        with pytest.raises(TypeError, match="multiple values"):
+            wf(jnp.asarray(1.0), x=jnp.asarray(2.0))
+
+    def test_var_keyword_expands_extra_keywords(self, kwargs_recorder):
+        identity, seen = kwargs_recorder
+        wf = WorkflowFunction(func=identity, vectorize="loop")
+
+        assert float(wf(x=1.0, scale=2.0)) == 1.0
+        assert seen == [{"scale": 2.0}]
+
+    def test_literal_kwargs_argument_is_not_unpacked(self, kwargs_recorder):
+        identity, seen = kwargs_recorder
+        wf = WorkflowFunction(func=identity, vectorize="loop")
+
+        assert float(wf(x=1.0, kwargs={"scale": 2.0})) == 1.0
+        assert seen == [{"kwargs": {"scale": 2.0}}]
+
+    def test_bind_values_and_function_defaults_are_resolved_before_call(self, affine_func):
+        default_wf = WorkflowFunction(func=affine_func, vectorize="loop")
+        bound_wf = WorkflowFunction(
+            func=affine_func,
+            vectorize="loop",
+            bind={"offset": 3.0},
+            scale=2.0,
+        )
+
+        assert float(default_wf(x=1.0)) == 11.0
+        assert float(bound_wf(x=1.0)) == 8.0
+        assert float(bound_wf(x=1.0, offset=4.0)) == 10.0
+
+    def test_missing_required_input_raises_after_all_resolution_sources_fail(self, add_func):
+        wf = WorkflowFunction(func=add_func, vectorize="loop")
+
+        with pytest.raises(TypeError, match="Missing required input 'y'"):
+            wf(x=1.0)
 
 
-def test_module_wired_dependency_cannot_be_overridden_at_call_time():
-    module = CallResolutionModule(dep=DataNode(), x=5.0)
+class TestModuleResolution:
+    def test_module_inputs_dependencies_and_defaults_resolve_for_workflow_methods(self):
+        dep = DataNode()
+        module = CallResolutionModule(dep=dep, x=5.0)
 
-    with pytest.raises(TypeError, match="cannot be overridden"):
-        module.step(dep=DataNode())
+        assert module.child_nodes["dep"] is dep
+        assert float(module.step()) == 12.0
+        assert float(module.step(y=2.0)) == 7.0
 
+    def test_module_wired_dependency_cannot_be_overridden_at_call_time(self):
+        module = CallResolutionModule(dep=DataNode(), x=5.0)
 
-def test_dependency_typed_parameter_requires_node_instance():
-    def use_dep(dep: DataNode):
-        return 1.0
+        with pytest.raises(TypeError, match="cannot be overridden"):
+            module.step(dep=DataNode())
 
-    wf = WorkflowFunction(func=use_dep, vectorize="loop")
+    def test_dependency_typed_parameter_requires_node_instance(self):
+        def use_dep(dep: DataNode):
+            return 1.0
 
-    with pytest.raises(TypeError, match="expects dependency 'dep:"):
-        wf(dep=object())
+        wf = WorkflowFunction(func=use_dep, vectorize="loop")
 
-
-def test_reserved_call_time_overrides_control_broadcast_execution():
-    def identity(x):
-        return x
-
-    wf = WorkflowFunction(
-        func=identity,
-        n_broadcast_samples=20,
-        vectorize="loop",
-        seed=0,
-    )
-    dist = Normal(loc=0.0, scale=1.0, name="x")
-
-    result = wf(dist, n_broadcast_samples=6, include_inputs=True, seed=123)
-
-    assert isinstance(result, BroadcastDistribution)
-    assert result.n == 6
+        with pytest.raises(TypeError, match="expects dependency 'dep:"):
+            wf(dep=object())
 
 
-def test_seed_override_restarts_sampling_state_for_a_call():
-    def identity(x):
-        return x
+class TestReservedOverrides:
+    def test_reserved_call_time_overrides_control_broadcast_execution(
+        self,
+        identity_func,
+        normal_dist,
+    ):
+        wf = WorkflowFunction(
+            func=identity_func,
+            n_broadcast_samples=20,
+            vectorize="loop",
+            seed=114514,
+        )
 
-    wf = WorkflowFunction(
-        func=identity,
-        n_broadcast_samples=8,
-        vectorize="loop",
-        seed=0,
-    )
-    dist = Normal(loc=0.0, scale=1.0, name="x")
+        result = wf(normal_dist, n_broadcast_samples=6, include_inputs=True, seed=114514)
 
-    first = wf(dist, seed=42)
-    second = wf(dist, seed=42)
+        assert isinstance(result, BroadcastDistribution)
+        assert result.n == 6
 
-    assert jnp.allclose(first.samples, second.samples)
+    def test_seed_override_restarts_sampling_state_for_a_call(
+        self,
+        identity_func,
+        normal_dist,
+    ):
+        wf = WorkflowFunction(
+            func=identity_func,
+            n_broadcast_samples=8,
+            vectorize="loop",
+            seed=114514,
+        )
+
+        first = wf(normal_dist, seed=114514)
+        second = wf(normal_dist, seed=114514)
+
+        assert jnp.allclose(first.samples, second.samples)

--- a/tests/test_workflow_call_resolution.py
+++ b/tests/test_workflow_call_resolution.py
@@ -1,0 +1,156 @@
+"""Characterization tests for WorkflowFunction call resolution.
+
+These tests lock down the public-call boundary before WorkflowFunction
+internals are split into smaller private modules.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+from probpipe import BroadcastDistribution, Normal
+from probpipe.core.node import Module, Node, WorkflowFunction, workflow_method
+
+
+def test_positional_and_mixed_arguments_bind_like_python_calls():
+    def add(x, y):
+        return x + y
+
+    wf = WorkflowFunction(func=add, vectorize="loop")
+
+    assert float(wf(jnp.asarray(1.0), jnp.asarray(2.0))) == 3.0
+    assert float(wf(jnp.asarray(1.0), y=jnp.asarray(2.0))) == 3.0
+
+
+def test_duplicate_positional_and_keyword_argument_raises():
+    def add(x, y):
+        return x + y
+
+    wf = WorkflowFunction(func=add, vectorize="loop")
+
+    with pytest.raises(TypeError, match="multiple values"):
+        wf(jnp.asarray(1.0), x=jnp.asarray(2.0))
+
+
+def test_var_keyword_expands_extra_keywords():
+    seen = []
+
+    def identity(x, **kwargs):
+        seen.append(kwargs)
+        return x
+
+    wf = WorkflowFunction(func=identity, vectorize="loop")
+
+    assert float(wf(x=1.0, scale=2.0)) == 1.0
+    assert seen == [{"scale": 2.0}]
+
+
+def test_literal_kwargs_argument_is_not_unpacked():
+    seen = []
+
+    def identity(x, **kwargs):
+        seen.append(kwargs)
+        return x
+
+    wf = WorkflowFunction(func=identity, vectorize="loop")
+
+    assert float(wf(x=1.0, kwargs={"scale": 2.0})) == 1.0
+    assert seen == [{"kwargs": {"scale": 2.0}}]
+
+
+def test_bind_values_and_function_defaults_are_resolved_before_call():
+    def affine(x, offset=10.0, scale=1.0):
+        return (x + offset) * scale
+
+    default_wf = WorkflowFunction(func=affine, vectorize="loop")
+    bound_wf = WorkflowFunction(
+        func=affine,
+        vectorize="loop",
+        bind={"offset": 3.0},
+        scale=2.0,
+    )
+
+    assert float(default_wf(x=1.0)) == 11.0
+    assert float(bound_wf(x=1.0)) == 8.0
+    assert float(bound_wf(x=1.0, offset=4.0)) == 10.0
+
+
+def test_missing_required_input_raises_after_all_resolution_sources_fail():
+    def add(x, y):
+        return x + y
+
+    wf = WorkflowFunction(func=add, vectorize="loop")
+
+    with pytest.raises(TypeError, match="Missing required input 'y'"):
+        wf(x=1.0)
+
+
+class DataNode(Node):
+    pass
+
+
+class CallResolutionModule(Module):
+    @workflow_method
+    def step(self, dep: DataNode, x, y=7.0):
+        assert dep is self.child_nodes["dep"]
+        return x + y
+
+
+def test_module_inputs_dependencies_and_defaults_resolve_for_workflow_methods():
+    dep = DataNode()
+    module = CallResolutionModule(dep=dep, x=5.0)
+
+    assert float(module.step()) == 12.0
+    assert float(module.step(y=2.0)) == 7.0
+
+
+def test_module_wired_dependency_cannot_be_overridden_at_call_time():
+    module = CallResolutionModule(dep=DataNode(), x=5.0)
+
+    with pytest.raises(TypeError, match="cannot be overridden"):
+        module.step(dep=DataNode())
+
+
+def test_dependency_typed_parameter_requires_node_instance():
+    def use_dep(dep: DataNode):
+        return 1.0
+
+    wf = WorkflowFunction(func=use_dep, vectorize="loop")
+
+    with pytest.raises(TypeError, match="expects dependency 'dep:"):
+        wf(dep=object())
+
+
+def test_reserved_call_time_overrides_control_broadcast_execution():
+    def identity(x):
+        return x
+
+    wf = WorkflowFunction(
+        func=identity,
+        n_broadcast_samples=20,
+        vectorize="loop",
+        seed=0,
+    )
+    dist = Normal(loc=0.0, scale=1.0, name="x")
+
+    result = wf(dist, n_broadcast_samples=6, include_inputs=True, seed=123)
+
+    assert isinstance(result, BroadcastDistribution)
+    assert result.n == 6
+
+
+def test_seed_override_restarts_sampling_state_for_a_call():
+    def identity(x):
+        return x
+
+    wf = WorkflowFunction(
+        func=identity,
+        n_broadcast_samples=8,
+        vectorize="loop",
+        seed=0,
+    )
+    dist = Normal(loc=0.0, scale=1.0, name="x")
+
+    first = wf(dist, seed=42)
+    second = wf(dist, seed=42)
+
+    assert jnp.allclose(first.samples, second.samples)

--- a/tests/test_workflow_distribution_normalization.py
+++ b/tests/test_workflow_distribution_normalization.py
@@ -1,0 +1,114 @@
+"""Characterization tests for WorkflowFunction distribution normalization."""
+
+import jax.numpy as jnp
+import numpy as np
+import tensorflow_probability.substrates.jax.distributions as tfd
+
+from probpipe import (
+    DistributionArray,
+    EmpiricalDistribution,
+    Normal,
+    NumericRecordArray,
+)
+from probpipe.core.node import WorkflowFunction
+from probpipe.core.protocols import SupportsLogProb
+
+
+def test_concrete_distribution_hint_converts_external_distribution():
+    seen = []
+
+    def mean_of_normal(dist: Normal):
+        seen.append(dist)
+        return dist._mean()
+
+    wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
+    external = tfd.Normal(loc=2.0, scale=0.5)
+
+    result = wf(dist=external)
+
+    assert isinstance(seen[0], Normal)
+    assert float(result) == 2.0
+
+
+def test_protocol_hint_converts_distribution_that_lacks_protocol():
+    seen = []
+    empirical = EmpiricalDistribution(
+        jnp.asarray([[0.0], [1.0], [2.0]]),
+        name="x",
+    )
+
+    def log_prob_at_zero(dist: SupportsLogProb):
+        seen.append(dist)
+        return dist._log_prob(jnp.asarray([0.0]))
+
+    wf = WorkflowFunction(func=log_prob_at_zero, vectorize="loop")
+
+    result = wf(dist=empirical)
+
+    assert seen[0] is not empirical
+    assert isinstance(seen[0], SupportsLogProb)
+    assert jnp.isfinite(jnp.asarray(result)).all()
+
+
+def test_zero_dimensional_distribution_array_unwraps_to_scalar_component():
+    seen = []
+
+    def mean_of_normal(dist: Normal):
+        seen.append(dist)
+        return dist._mean()
+
+    da = DistributionArray.from_batched_params(
+        Normal,
+        batch_shape=(),
+        loc=jnp.asarray(3.0),
+        scale=jnp.asarray(1.0),
+        name="zero_d",
+    )
+    wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
+
+    result = wf(dist=da)
+
+    assert isinstance(seen[0], Normal)
+    assert float(result) == 3.0
+
+
+def test_size_one_distribution_array_remains_a_sweep():
+    def mean_of_normal(dist: Normal):
+        return dist._mean()
+
+    da = DistributionArray.from_batched_params(
+        Normal,
+        batch_shape=(1,),
+        loc=jnp.asarray([3.0]),
+        scale=jnp.asarray([1.0]),
+        name="one_cell",
+    )
+    wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
+
+    result = wf(dist=da)
+
+    assert isinstance(result, NumericRecordArray)
+    assert result.batch_shape == (1,)
+    np.testing.assert_allclose(result["mean_of_normal"], jnp.asarray([3.0]))
+
+
+def test_unhinted_external_distribution_converts_then_broadcasts():
+    seen_shapes = []
+
+    def double(x):
+        seen_shapes.append(jnp.asarray(x).shape)
+        return x * 2.0
+
+    wf = WorkflowFunction(
+        func=double,
+        n_broadcast_samples=8,
+        vectorize="loop",
+        seed=0,
+    )
+    external = tfd.Normal(loc=1.0, scale=0.1)
+
+    result = wf(external)
+
+    assert result.n == 8
+    assert seen_shapes == [()] * 8
+    np.testing.assert_allclose(float(jnp.mean(result.samples)), 2.0, atol=0.25)

--- a/tests/test_workflow_distribution_normalization.py
+++ b/tests/test_workflow_distribution_normalization.py
@@ -1,114 +1,137 @@
 """Characterization tests for WorkflowFunction distribution normalization."""
 
+from __future__ import annotations
+
 import jax.numpy as jnp
 import numpy as np
+import pytest
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from probpipe import (
     DistributionArray,
     EmpiricalDistribution,
+    KDEDistribution,
     Normal,
     NumericRecordArray,
+    log_prob,
+    mean,
 )
 from probpipe.core.node import WorkflowFunction
 from probpipe.core.protocols import SupportsLogProb
 
 
-def test_concrete_distribution_hint_converts_external_distribution():
-    seen = []
-
-    def mean_of_normal(dist: Normal):
-        seen.append(dist)
-        return dist._mean()
-
-    wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
-    external = tfd.Normal(loc=2.0, scale=0.5)
-
-    result = wf(dist=external)
-
-    assert isinstance(seen[0], Normal)
-    assert float(result) == 2.0
+@pytest.fixture
+def normal_external():
+    return tfd.Normal(loc=2.0, scale=0.5)
 
 
-def test_protocol_hint_converts_distribution_that_lacks_protocol():
-    seen = []
-    empirical = EmpiricalDistribution(
+@pytest.fixture
+def empirical_dist():
+    return EmpiricalDistribution(
         jnp.asarray([[0.0], [1.0], [2.0]]),
         name="x",
     )
 
-    def log_prob_at_zero(dist: SupportsLogProb):
-        seen.append(dist)
-        return dist._log_prob(jnp.asarray([0.0]))
 
-    wf = WorkflowFunction(func=log_prob_at_zero, vectorize="loop")
-
-    result = wf(dist=empirical)
-
-    assert seen[0] is not empirical
-    assert isinstance(seen[0], SupportsLogProb)
-    assert jnp.isfinite(jnp.asarray(result)).all()
-
-
-def test_zero_dimensional_distribution_array_unwraps_to_scalar_component():
+@pytest.fixture
+def mean_recorder():
     seen = []
 
     def mean_of_normal(dist: Normal):
         seen.append(dist)
-        return dist._mean()
+        return mean(dist)
 
-    da = DistributionArray.from_batched_params(
-        Normal,
-        batch_shape=(),
-        loc=jnp.asarray(3.0),
-        scale=jnp.asarray(1.0),
-        name="zero_d",
-    )
-    wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
-
-    result = wf(dist=da)
-
-    assert isinstance(seen[0], Normal)
-    assert float(result) == 3.0
+    return mean_of_normal, seen
 
 
-def test_size_one_distribution_array_remains_a_sweep():
-    def mean_of_normal(dist: Normal):
-        return dist._mean()
+class TestHintedDistributionConversion:
+    def test_concrete_distribution_hint_converts_external_distribution(
+        self,
+        mean_recorder,
+        normal_external,
+    ):
+        mean_of_normal, seen = mean_recorder
+        wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
 
-    da = DistributionArray.from_batched_params(
-        Normal,
-        batch_shape=(1,),
-        loc=jnp.asarray([3.0]),
-        scale=jnp.asarray([1.0]),
-        name="one_cell",
-    )
-    wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
+        result = wf(dist=normal_external)
 
-    result = wf(dist=da)
+        assert isinstance(seen[0], Normal)
+        assert float(result) == 2.0
 
-    assert isinstance(result, NumericRecordArray)
-    assert result.batch_shape == (1,)
-    np.testing.assert_allclose(result["mean_of_normal"], jnp.asarray([3.0]))
+    def test_protocol_hint_converts_distribution_that_lacks_protocol(self, empirical_dist):
+        seen = []
+
+        def log_prob_at_zero(dist: SupportsLogProb):
+            seen.append(dist)
+            return log_prob(dist, jnp.asarray([0.0]))
+
+        wf = WorkflowFunction(func=log_prob_at_zero, vectorize="loop")
+
+        result = wf(dist=empirical_dist)
+
+        assert seen[0] is not empirical_dist
+        assert isinstance(seen[0], KDEDistribution)
+        assert isinstance(seen[0], SupportsLogProb)
+        assert jnp.isfinite(jnp.asarray(result)).all()
 
 
-def test_unhinted_external_distribution_converts_then_broadcasts():
-    seen_shapes = []
+class TestDistributionArrayHandling:
+    def test_zero_dimensional_distribution_array_unwraps_to_scalar_component(
+        self,
+        mean_recorder,
+    ):
+        mean_of_normal, seen = mean_recorder
+        da = DistributionArray.from_batched_params(
+            Normal,
+            batch_shape=(),
+            loc=jnp.asarray(3.0),
+            scale=jnp.asarray(1.0),
+            name="zero_d",
+        )
+        wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
 
-    def double(x):
-        seen_shapes.append(jnp.asarray(x).shape)
-        return x * 2.0
+        result = wf(dist=da)
 
-    wf = WorkflowFunction(
-        func=double,
-        n_broadcast_samples=8,
-        vectorize="loop",
-        seed=0,
-    )
-    external = tfd.Normal(loc=1.0, scale=0.1)
+        assert isinstance(seen[0], Normal)
+        assert float(result) == 3.0
 
-    result = wf(external)
+    def test_size_one_distribution_array_remains_a_sweep(self, mean_recorder):
+        mean_of_normal, _ = mean_recorder
+        da = DistributionArray.from_batched_params(
+            Normal,
+            batch_shape=(1,),
+            loc=jnp.asarray([3.0]),
+            scale=jnp.asarray([1.0]),
+            name="one_cell",
+        )
+        wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
 
-    assert result.n == 8
-    assert seen_shapes == [()] * 8
-    np.testing.assert_allclose(float(jnp.mean(result.samples)), 2.0, atol=0.25)
+        result = wf(dist=da)
+
+        assert isinstance(result, NumericRecordArray)
+        assert result.batch_shape == (1,)
+        np.testing.assert_allclose(result[result.fields[0]], jnp.asarray([3.0]))
+
+
+class TestUnhintedExternalDistribution:
+    def test_unhinted_external_distribution_converts_then_broadcasts(self):
+        seen_values = []
+
+        def double(x):
+            value = jnp.asarray(x)
+            seen_values.append(value)
+            return value * 2.0
+
+        wf = WorkflowFunction(
+            func=double,
+            n_broadcast_samples=8,
+            vectorize="loop",
+            seed=114514,
+        )
+        external = tfd.Normal(loc=1.0, scale=0.1)
+
+        result = wf(external)
+
+        assert result.n == 8
+        assert [value.shape for value in seen_values] == [()] * 8
+        np.testing.assert_allclose(result.samples, 2.0 * jnp.stack(seen_values), atol=0.0)


### PR DESCRIPTION
This is the PR 0 stage of #196 , following the plan in #194.

Adding 2 new characterization tests in `tests`. No functional changes.

- `tests/test_workflow_call_resolution.py`: Covers positional binding, `**kwargs`, bind/default/missing input, module dependency/input resolution, dependency type validation, reserved call-time overrides, and seed override.
- `tests/test_workflow_distribution_normalization.py`: Covers TFP external distribution transformation, protocol hint transformation, 0-d `DistributionArray` unwrap, size-1 sweep, and unhinted external distribution broadcast.

Result: all passed.