### PR TITLE
refactor(core) [#196 PR-1]: Result-contract extraction

### DIFF
--- a/probpipe/core/_workflow_result.py
+++ b/probpipe/core/_workflow_result.py
@@ -1,0 +1,121 @@
+"""WorkflowFunction result-contract helpers.
+
+This private module owns the boundary rule that raw workflow returns
+become ``Record | RecordArray | Distribution`` values and receive
+provenance when appropriate.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Any, Literal
+
+import jax.numpy as jnp
+
+from ._broadcast_distributions import _make_stack
+from ._distribution_base import Distribution
+from ._numeric_record import NumericRecord, _is_numeric_leaf
+from .provenance import Provenance
+from .record import Record
+
+# Broadcast modes: how a value reached ``_coerce_output``. Named
+# constants so callsites use the same spelling and typos fail loudly.
+# ``BROADCAST_MARGINALISE`` is intentionally absent — the
+# Distribution-only path goes through the distribution-broadcast layer
+# and doesn't call ``_coerce_output`` at all; its marginal already
+# carries provenance.
+BroadcastMode = Literal["wrap", "stack", "nested"]
+BROADCAST_WRAP: BroadcastMode = "wrap"
+BROADCAST_STACK: BroadcastMode = "stack"
+BROADCAST_NESTED: BroadcastMode = "nested"
+
+
+def _wrap_as_record(value: Any, field_name: str) -> Any:
+    """Coerce a raw return into the Record | RecordArray | Distribution contract.
+
+    Uniform rule applied at the WorkflowFunction boundary:
+
+    - Already-structured values (``Record`` / ``RecordArray`` /
+      ``Distribution``) pass through unchanged — their domain field
+      names are preserved.
+    - ``dict`` (non-empty) → ``Record(dict(value))``: caller's keys
+      stay addressable as field names.
+    - Non-empty ``list`` / ``tuple`` → ``_make_stack``: assembles a
+      ``DistributionArray`` / ``RecordArray`` / ``NumericRecordArray``
+      matching the inner element type.
+    - Scalar numeric / ``jnp.ndarray`` → ``NumericRecord({field_name: value})``
+      with the function's own name as the single field name. Raw
+      numeric access round-trips via the single-field shim:
+      ``float(x)``, ``jnp.array(x)``, and (for callable-valued fields)
+      ``x(args)`` call-forwarding.
+    - Anything else (opaque Python object) → ``Record({field_name: value})``.
+    """
+    if isinstance(value, (Distribution, Record)):
+        return value
+    if isinstance(value, dict) and value:
+        return Record(dict(value))
+    if isinstance(value, (list, tuple)) and value:
+        try:
+            return _make_stack(list(value), n=len(value), field_name=field_name)
+        except (TypeError, ValueError):
+            pass
+    # Numeric scalar / array → NumericRecord with the function's
+    # name as the single field; the wrap adds no batch_shape of its
+    # own (batching comes from sweeps). ``_is_numeric_leaf`` excludes
+    # opaque duck-typed objects (``unittest.mock.MagicMock`` etc.)
+    # whose attribute probing would recurse inside ``jnp.asarray``.
+    if _is_numeric_leaf(value):
+        return NumericRecord({field_name: jnp.asarray(value)})
+    return Record({field_name: value})
+
+
+def _coerce_output(
+    value: Any,
+    *,
+    broadcast_mode: BroadcastMode,
+    provenance: Provenance | None,
+    field_name: str,
+) -> Any:
+    """Enforce the Record | RecordArray | Distribution output contract.
+
+    Parameters
+    ----------
+    value
+        The raw output produced by the function body or a broadcast
+        aggregator. For ``broadcast_mode != "wrap"`` this is always
+        already one of the three contract types.
+    broadcast_mode : {"wrap", "stack", "nested"}
+        How the value was produced:
+
+        * ``"wrap"`` — non-broadcast call; ``value`` is whatever the
+          user's function returned. Scalars / arrays become
+          ``NumericRecord({field_name: value})``; dict / list / tuple
+          promote via ``_wrap_as_record``; existing Record /
+          RecordArray / Distribution values pass through.
+        * ``"stack"`` — array-valued broadcast; ``value`` is a stacked
+          aggregate from ``_make_stack`` (``NumericRecordArray`` /
+          ``RecordArray`` / ``DistributionArray``).
+        * ``"nested"`` — array + Distribution broadcast; ``value`` is
+          a ``DistributionArray`` of per-row marginals.
+    provenance : Provenance or None
+        Provenance node to attach. ``None`` skips the attachment step.
+    field_name : str
+        Name used when wrapping bare scalar / array returns — always
+        the WorkflowFunction's own name so the single-field record
+        maps back to the op that produced it.
+
+    Returns
+    -------
+    Record | RecordArray | Distribution
+        The value, possibly wrapped, with ``.source`` attached when it
+        was empty. An already-sourced value keeps its existing source
+        (inner marginals produced by the broadcast layer carry their
+        own provenance; ``_coerce_output`` doesn't overwrite).
+    """
+    if broadcast_mode == BROADCAST_WRAP:
+        value = _wrap_as_record(value, field_name)
+    if provenance is not None and hasattr(value, "with_source"):
+        # Existing source, e.g. an inner marginal, keeps its provenance.
+        with suppress(RuntimeError):
+            value.with_source(provenance)
+    return value

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Any, get_type_hints
-from collections.abc import Callable, Mapping
 import inspect
 import logging
+import warnings
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from itertools import product as cartesian_product
 from types import MappingProxyType
-import warnings
+from typing import Any, get_type_hints
 
 import jax
 import jax.numpy as jnp
 
 try:
-    from prefect import task, flow
+    from prefect import flow, task
 except ImportError:
     task = flow = None
 
@@ -26,19 +26,19 @@ except ImportError:
     Digraph = None
 
 from .._utils import prod
-from ..custom_types import PRNGKey, Array
-from .distribution import (
-    NumericRecordDistribution,
-    BroadcastDistribution,
-    Distribution,
-    EmpiricalDistribution,
-)
+from ..converters import converter_registry
+from ..custom_types import Array, PRNGKey
+from . import _workflow_result
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
 from ._record_array import RecordArray, _RecordArrayView
 from ._record_distribution import _RecordDistributionView
-from .provenance import Provenance
-from . import _workflow_result as _workflow_result
+from .distribution import (
+    BroadcastDistribution,
+    Distribution,
+    EmpiricalDistribution,
+    NumericRecordDistribution,
+)
 from .protocols import (
     SupportsConditioning,
     SupportsCovariance,
@@ -51,6 +51,7 @@ from .protocols import (
     SupportsUnnormalizedLogProb,
     SupportsVariance,
 )
+from .provenance import Provenance
 
 # Protocol types that indicate a parameter expects a distribution object.
 # Used by _find_broadcast_args to avoid broadcasting over such parameters.
@@ -66,7 +67,6 @@ _DISTRIBUTION_PROTOCOLS: tuple[type, ...] = (
     SupportsRandomUnnormalizedLogProb,
     SupportsConditioning,
 )
-from ..converters import converter_registry
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +77,7 @@ logger = logging.getLogger(__name__)
 
 # Compatibility aliases for tests or downstream code that imported these
 # private helpers from ``probpipe.core.node`` before the extraction.
+# Will be removed in a follow-up issue after downstream updates.
 BroadcastMode = _workflow_result.BroadcastMode
 BROADCAST_WRAP = _workflow_result.BROADCAST_WRAP
 BROADCAST_STACK = _workflow_result.BROADCAST_STACK
@@ -230,8 +231,8 @@ def _index_sample(s: Any, i: int) -> Any:
     """
     # Local imports to avoid module-load circularity with
     # ``record`` / ``_numeric_record``.
-    from .record import Record
     from ._numeric_record import NumericRecord
+    from .record import Record
 
     if isinstance(s, Record):
         if len(s.fields) == 1:

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Literal, Mapping, get_type_hints
+from typing import Any, get_type_hints
+from collections.abc import Callable, Mapping
 import inspect
 import logging
 from concurrent.futures import ThreadPoolExecutor
@@ -11,7 +12,6 @@ import warnings
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 
 try:
     from prefect import task, flow
@@ -32,15 +32,13 @@ from .distribution import (
     BroadcastDistribution,
     Distribution,
     EmpiricalDistribution,
-    _make_marginal,
 )
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
-from ._numeric_record import NumericRecord, _is_numeric_leaf
 from ._record_array import RecordArray, _RecordArrayView
 from ._record_distribution import _RecordDistributionView
 from .provenance import Provenance
-from .record import Record
+from . import _workflow_result as _workflow_result
 from .protocols import (
     SupportsConditioning,
     SupportsCovariance,
@@ -77,111 +75,14 @@ logger = logging.getLogger(__name__)
 # Output-type coercion for WorkflowFunction returns (issue #130)
 # ---------------------------------------------------------------------------
 
-# Broadcast modes: how a value reached ``_coerce_output``. Named
-# constants so callsites use the same spelling and typos fail loudly.
-# ``BROADCAST_MARGINALISE`` is intentionally absent — the
-# Distribution-only path goes through
-# ``_broadcast_distributions_only`` and doesn't call
-# ``_coerce_output`` at all; its marginal already carries provenance.
-BroadcastMode = Literal["wrap", "stack", "nested"]
-BROADCAST_WRAP: BroadcastMode = "wrap"
-BROADCAST_STACK: BroadcastMode = "stack"
-BROADCAST_NESTED: BroadcastMode = "nested"
-
-
-def _wrap_as_record(value: Any, field_name: str) -> Any:
-    """Coerce a raw return into the Record | RecordArray | Distribution contract.
-
-    Uniform rule applied at the WorkflowFunction boundary:
-
-    - Already-structured values (``Record`` / ``RecordArray`` /
-      ``Distribution``) pass through unchanged — their domain field
-      names are preserved.
-    - ``dict`` (non-empty) → ``Record(dict(value))``: caller's keys
-      stay addressable as field names.
-    - Non-empty ``list`` / ``tuple`` → ``_make_stack``: assembles a
-      ``DistributionArray`` / ``RecordArray`` / ``NumericRecordArray``
-      matching the inner element type.
-    - Scalar numeric / ``jnp.ndarray`` → ``NumericRecord({field_name: value})``
-      with the function's own name as the single field name. Raw
-      numeric access round-trips via the single-field shim:
-      ``float(x)``, ``jnp.array(x)``, and (for callable-valued fields)
-      ``x(args)`` call-forwarding.
-    - Anything else (opaque Python object) → ``Record({field_name: value})``.
-    """
-    if isinstance(value, (Distribution, Record)):
-        return value
-    if isinstance(value, dict) and value:
-        return Record(dict(value))
-    if isinstance(value, (list, tuple)) and value:
-        try:
-            return _make_stack(list(value), n=len(value), field_name=field_name)
-        except (TypeError, ValueError):
-            pass
-    # Numeric scalar / array → NumericRecord with the function's
-    # name as the single field; the wrap adds no batch_shape of its
-    # own (batching comes from sweeps). ``_is_numeric_leaf`` excludes
-    # opaque duck-typed objects (``unittest.mock.MagicMock`` etc.)
-    # whose attribute probing would recurse inside ``jnp.asarray``.
-    if _is_numeric_leaf(value):
-        return NumericRecord({field_name: jnp.asarray(value)})
-    return Record({field_name: value})
-
-
-def _coerce_output(
-    value: Any,
-    *,
-    broadcast_mode: BroadcastMode,
-    provenance: Provenance | None,
-    field_name: str,
-) -> Any:
-    """Enforce the Record | RecordArray | Distribution output contract.
-
-    Parameters
-    ----------
-    value
-        The raw output produced by the function body or a broadcast
-        aggregator. For ``broadcast_mode != "wrap"`` this is always
-        already one of the three contract types.
-    broadcast_mode : {"wrap", "stack", "nested"}
-        How the value was produced:
-
-        * ``"wrap"`` — non-broadcast call; ``value`` is whatever the
-          user's function returned. Scalars / arrays become
-          ``NumericRecord({field_name: value})``; dict / list / tuple
-          promote via ``_wrap_as_record``; existing Record /
-          RecordArray / Distribution values pass through.
-        * ``"stack"`` — array-valued broadcast; ``value`` is a stacked
-          aggregate from ``_make_stack`` (``NumericRecordArray`` /
-          ``RecordArray`` / ``DistributionArray``).
-        * ``"nested"`` — array + Distribution broadcast; ``value`` is
-          a ``DistributionArray`` of per-row marginals.
-    provenance : Provenance or None
-        Provenance node to attach. ``None`` skips the attachment step.
-    field_name : str
-        Name used when wrapping bare scalar / array returns — always
-        the WorkflowFunction's own name so the single-field record
-        maps back to the op that produced it.
-
-    Returns
-    -------
-    Record | RecordArray | Distribution
-        The value, possibly wrapped, with ``.source`` attached when it
-        was empty. An already-sourced value keeps its existing source
-        (inner marginals produced by the broadcast layer carry their
-        own provenance; ``_coerce_output`` doesn't overwrite).
-    """
-    if broadcast_mode == BROADCAST_WRAP:
-        value = _wrap_as_record(value, field_name)
-    if provenance is not None and hasattr(value, "with_source"):
-        try:
-            value.with_source(provenance)
-        except RuntimeError:
-            # Value already has a source (e.g., an inner marginal that
-            # the broadcasting layer built with its own provenance).
-            # Leave the existing source in place.
-            pass
-    return value
+# Compatibility aliases for tests or downstream code that imported these
+# private helpers from ``probpipe.core.node`` before the extraction.
+BroadcastMode = _workflow_result.BroadcastMode
+BROADCAST_WRAP = _workflow_result.BROADCAST_WRAP
+BROADCAST_STACK = _workflow_result.BROADCAST_STACK
+BROADCAST_NESTED = _workflow_result.BROADCAST_NESTED
+_wrap_as_record = _workflow_result._wrap_as_record
+_coerce_output = _workflow_result._coerce_output
 
 __all__ = [
     "InputFrozenError",
@@ -285,7 +186,7 @@ class Node(ABC):
         self._inputs = MappingProxyType(inputs)
 
     @property
-    def child_nodes(self) -> Mapping[str, "Node"]:
+    def child_nodes(self) -> Mapping[str, Node]:
         return self._child_nodes
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
   { name = "Andrew Roberts",   email = "arober@bu.edu" },
   { name = "Yongho Lim",      email = "ylim2@bu.edu" },
   { name = "Can Erozer",      email = "caner@bu.edu" },
+  { name = "Jiaqiang Zhu",      email = "julian25@bu.edu" },
 ]  # See AUTHORS file for full list
 dependencies = [
   # sbijax 0.3.6 (latest) pins jaxlib==0.8.1, so we cap below 0.9 to keep


### PR DESCRIPTION
## Summary

This is the stage 1 of #196, i.e. result-contract extraction. Only small changes implemented, no functional changes. Fixed a small lint dept in `probpipe/core/node.py` (see below for detail). Also added my contact information in `pyproject.toml` file. No new tests introduced.

## What changed

1. Added `probpipe/core/_workflow_result.py` with `BroadcastMode`, `BROADCAST_*`, `_wrap_as_record`, and `_coerce_output`.
2. Removed the moved helper implementation from `probpipe/core/node.py`.
3. Cleaned imports made unused by the move: `Literal`, `np, _make_marginal`, `NumericRecord`, `_is_numeric_leaf, and top-level Record`.
4. Changed the code format in `probpipe/core/node.py` to conform to modern typing rules does not introduce any functional changes. Including: `from typing import Callable, Mapping` -> `from collections.abc import Callable, Mapping`. And `Mapping[str, "Node"]` -> `Mapping[str, Node]`
5. Added my contact information in `pyproject.toml`.