### PR TITLE
refactor(core) [#196 PR-2]: Execution extraction

### DIFF
--- a/probpipe/core/_workflow_execution.py
+++ b/probpipe/core/_workflow_execution.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Any, Literal, Protocol
+from typing import Any, Literal
 
 try:
     from prefect import flow, task
@@ -44,37 +44,20 @@ class WorkflowExecutionRequest:
     execution: WorkflowExecutionConfig
 
 
-class _WorkflowExecutor(Protocol):
-    def execute_many(self, request: WorkflowExecutionRequest) -> list[Any]:
-        """Execute the request and return results in call order."""
-        ...
-
-
-class _SequentialExecutor:
-    def execute_many(self, request: WorkflowExecutionRequest) -> list[Any]:
-        return [request.func(**values) for values in request.call_value_list]
-
-
-class _ThreadExecutor:
-    def execute_many(self, request: WorkflowExecutionRequest) -> list[Any]:
-        return execute_many_threaded(request)
-
-
-class _PrefectTaskExecutor:
-    def execute_many(self, request: WorkflowExecutionRequest) -> list[Any]:
-        return execute_many_prefect_task(request)
-
-
-class _PrefectFlowExecutor:
-    def execute_many(self, request: WorkflowExecutionRequest) -> list[Any]:
-        return execute_many_prefect_flow(request)
-
-
 def execute_many(request: WorkflowExecutionRequest) -> list[Any]:
     """Execute all call dictionaries using the configured dispatch mode."""
     if not request.call_value_list:
         return []
-    return _resolve_executor(request.execution).execute_many(request)
+
+    if request.execution.mode == "sequential":
+        return [request.func(**values) for values in request.call_value_list]
+    if request.execution.mode == "thread":
+        return execute_many_threaded(request)
+    if request.execution.mode == "prefect_task":
+        return execute_many_prefect_task(request)
+    if request.execution.mode == "prefect_flow":
+        return execute_many_prefect_flow(request)
+    raise ValueError(f"Unknown workflow execution mode: {request.execution.mode!r}")
 
 
 def execute_many_threaded(request: WorkflowExecutionRequest) -> list[Any]:
@@ -149,18 +132,6 @@ def execute_many_prefect_flow(request: WorkflowExecutionRequest) -> list[Any]:
         return map_task(request, task_name=f"{request.execution.name}_run")
 
     return mapped_flow()
-
-
-def _resolve_executor(execution: WorkflowExecutionConfig) -> _WorkflowExecutor:
-    if execution.mode == "sequential":
-        return _SequentialExecutor()
-    if execution.mode == "thread":
-        return _ThreadExecutor()
-    if execution.mode == "prefect_task":
-        return _PrefectTaskExecutor()
-    if execution.mode == "prefect_flow":
-        return _PrefectFlowExecutor()
-    raise ValueError(f"Unknown workflow execution mode: {execution.mode!r}")
 
 
 def _resolve_max_workers(parallel: bool | int) -> int | None:

--- a/probpipe/core/_workflow_execution.py
+++ b/probpipe/core/_workflow_execution.py
@@ -1,0 +1,195 @@
+"""WorkflowFunction execution dispatch helpers.
+
+This private module owns ordered execution of plain call dictionaries.
+It deliberately knows nothing about ProbPipe value semantics; callers
+assemble inputs and interpret outputs outside this module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol
+
+try:
+    from prefect import flow, task
+except ImportError:
+    task = flow = None
+
+WorkflowExecutionMode = Literal[
+    "sequential",
+    "thread",
+    "prefect_task",
+    "prefect_flow",
+]
+
+
+@dataclass(frozen=True)
+class WorkflowExecutionConfig:
+    """Resolved execution settings for ordered workflow calls."""
+
+    mode: WorkflowExecutionMode
+    parallel: bool | int = False
+    name: str = "workflow"
+    prefect_task_runner: Any | None = None
+
+
+@dataclass(frozen=True)
+class WorkflowExecutionRequest:
+    """A backend-neutral request to run a function over call dictionaries."""
+
+    func: Callable[..., Any]
+    call_value_list: list[dict[str, Any]]
+    execution: WorkflowExecutionConfig
+
+
+class _WorkflowExecutor(Protocol):
+    def execute_many(self, request: WorkflowExecutionRequest) -> list[Any]:
+        """Execute the request and return results in call order."""
+        ...
+
+
+class _SequentialExecutor:
+    def execute_many(self, request: WorkflowExecutionRequest) -> list[Any]:
+        return [request.func(**values) for values in request.call_value_list]
+
+
+class _ThreadExecutor:
+    def execute_many(self, request: WorkflowExecutionRequest) -> list[Any]:
+        return execute_many_threaded(request)
+
+
+class _PrefectTaskExecutor:
+    def execute_many(self, request: WorkflowExecutionRequest) -> list[Any]:
+        return execute_many_prefect_task(request)
+
+
+class _PrefectFlowExecutor:
+    def execute_many(self, request: WorkflowExecutionRequest) -> list[Any]:
+        return execute_many_prefect_flow(request)
+
+
+def execute_many(request: WorkflowExecutionRequest) -> list[Any]:
+    """Execute all call dictionaries using the configured dispatch mode."""
+    if not request.call_value_list:
+        return []
+    return _resolve_executor(request.execution).execute_many(request)
+
+
+def execute_many_threaded(request: WorkflowExecutionRequest) -> list[Any]:
+    """Execute call dictionaries through ``ThreadPoolExecutor``."""
+    if not request.call_value_list:
+        return []
+
+    max_workers = _resolve_max_workers(request.execution.parallel)
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        return list(pool.map(lambda kwargs: request.func(**kwargs), request.call_value_list))
+
+
+def map_task(
+    request: WorkflowExecutionRequest,
+    *,
+    task_name: str | None = None,
+) -> list[Any]:
+    """Create a Prefect task, map keyword arguments over calls, and resolve futures."""
+    if not request.call_value_list:
+        return []
+
+    _ensure_prefect_task_available()
+
+    func = request.func
+
+    @task(name=task_name or request.execution.name)
+    def run_func(**kwargs):
+        return func(**kwargs)
+
+    # The first row defines the mapped parameter columns. Prefect maps keyword
+    # columns, so Ray via Prefect relies on this rectangular kwargs shape.
+    keys = request.call_value_list[0].keys()
+    kwargs_by_param = {
+        key: [call_values[key] for call_values in request.call_value_list]
+        for key in keys
+    }
+    futures = run_func.map(**kwargs_by_param)
+    return [future.result() for future in futures]
+
+
+def execute_many_prefect_task(request: WorkflowExecutionRequest) -> list[Any]:
+    """Use Prefect ``task.map()`` inside a lightweight flow."""
+    if not request.call_value_list:
+        return []
+
+    _ensure_prefect_flow_available()
+    runner = request.execution.prefect_task_runner
+
+    @flow(
+        name=f"{request.execution.name}_map",
+        **({"task_runner": runner} if runner is not None else {}),
+    )
+    def _task_map_flow():
+        return map_task(request)
+
+    return _task_map_flow()
+
+
+def execute_many_prefect_flow(request: WorkflowExecutionRequest) -> list[Any]:
+    """Wrap a mapped task inside a named Prefect flow."""
+    if not request.call_value_list:
+        return []
+
+    _ensure_prefect_flow_available()
+    runner = request.execution.prefect_task_runner
+
+    @flow(
+        name=request.execution.name,
+        **({"task_runner": runner} if runner is not None else {}),
+    )
+    def mapped_flow():
+        return map_task(request, task_name=f"{request.execution.name}_run")
+
+    return mapped_flow()
+
+
+def _resolve_executor(execution: WorkflowExecutionConfig) -> _WorkflowExecutor:
+    if execution.mode == "sequential":
+        return _SequentialExecutor()
+    if execution.mode == "thread":
+        return _ThreadExecutor()
+    if execution.mode == "prefect_task":
+        return _PrefectTaskExecutor()
+    if execution.mode == "prefect_flow":
+        return _PrefectFlowExecutor()
+    raise ValueError(f"Unknown workflow execution mode: {execution.mode!r}")
+
+
+def _resolve_max_workers(parallel: bool | int) -> int | None:
+    if isinstance(parallel, int) and not isinstance(parallel, bool):
+        if parallel < 1:
+            raise ValueError(
+                f"self._parallel must be True, False, or a positive int; got {parallel!r}"
+            )
+        return parallel
+
+    if parallel is True:
+        return None
+
+    raise TypeError(
+        f"parallel must be True, False, or a positive int; got {parallel!r}"
+    )
+
+
+def _ensure_prefect_task_available() -> None:
+    if task is None:
+        raise RuntimeError(
+            "Prefect task execution was requested, but Prefect is not installed. "
+            "Install with: pip install probpipe[prefect]"
+        )
+
+
+def _ensure_prefect_flow_available() -> None:
+    if task is None or flow is None:
+        raise RuntimeError(
+            "Prefect task execution was requested, but Prefect is not installed. "
+            "Install with: pip install probpipe[prefect]"
+        )

--- a/probpipe/core/_workflow_execution.py
+++ b/probpipe/core/_workflow_execution.py
@@ -49,15 +49,17 @@ def execute_many(request: WorkflowExecutionRequest) -> list[Any]:
     if not request.call_value_list:
         return []
 
-    if request.execution.mode == "sequential":
-        return [request.func(**values) for values in request.call_value_list]
-    if request.execution.mode == "thread":
-        return execute_many_threaded(request)
-    if request.execution.mode == "prefect_task":
-        return execute_many_prefect_task(request)
-    if request.execution.mode == "prefect_flow":
-        return execute_many_prefect_flow(request)
-    raise ValueError(f"Unknown workflow execution mode: {request.execution.mode!r}")
+    match request.execution.mode:
+        case "sequential":
+            return [request.func(**values) for values in request.call_value_list]
+        case "thread":
+            return execute_many_threaded(request)
+        case "prefect_task":
+            return execute_many_prefect_task(request)
+        case "prefect_flow":
+            return execute_many_prefect_flow(request)
+        case unknown:
+            raise ValueError(f"Unknown workflow execution mode: {unknown!r}")
 
 
 def execute_many_threaded(request: WorkflowExecutionRequest) -> list[Any]:

--- a/probpipe/core/_workflow_execution.py
+++ b/probpipe/core/_workflow_execution.py
@@ -138,7 +138,7 @@ def _resolve_max_workers(parallel: bool | int) -> int | None:
     if isinstance(parallel, int) and not isinstance(parallel, bool):
         if parallel < 1:
             raise ValueError(
-                f"self._parallel must be True, False, or a positive int; got {parallel!r}"
+                f"parallel must be True, False, or a positive int; got {parallel!r}"
             )
         return parallel
 
@@ -153,7 +153,7 @@ def _resolve_max_workers(parallel: bool | int) -> int | None:
 def _ensure_prefect_task_available() -> None:
     if task is None:
         raise RuntimeError(
-            "Prefect task execution was requested, but Prefect is not installed. "
+            "Prefect task or flow execution was requested, but Prefect is not installed. "
             "Install with: pip install probpipe[prefect]"
         )
 
@@ -161,6 +161,6 @@ def _ensure_prefect_task_available() -> None:
 def _ensure_prefect_flow_available() -> None:
     if task is None or flow is None:
         raise RuntimeError(
-            "Prefect task execution was requested, but Prefect is not installed. "
+            "Prefect task or flow execution was requested, but Prefect is not installed. "
             "Install with: pip install probpipe[prefect]"
         )

--- a/probpipe/core/_workflow_execution.py
+++ b/probpipe/core/_workflow_execution.py
@@ -81,7 +81,7 @@ def map_task(
     if not request.call_value_list:
         return []
 
-    _ensure_prefect_task_available()
+    _ensure_prefect_available()
 
     func = request.func
 
@@ -105,7 +105,7 @@ def execute_many_prefect_task(request: WorkflowExecutionRequest) -> list[Any]:
     if not request.call_value_list:
         return []
 
-    _ensure_prefect_flow_available()
+    _ensure_prefect_available()
     runner = request.execution.prefect_task_runner
 
     @flow(
@@ -123,7 +123,7 @@ def execute_many_prefect_flow(request: WorkflowExecutionRequest) -> list[Any]:
     if not request.call_value_list:
         return []
 
-    _ensure_prefect_flow_available()
+    _ensure_prefect_available()
     runner = request.execution.prefect_task_runner
 
     @flow(
@@ -152,16 +152,8 @@ def _resolve_max_workers(parallel: bool | int) -> int | None:
     )
 
 
-def _ensure_prefect_task_available() -> None:
+def _ensure_prefect_available() -> None:
     if task is None:
-        raise RuntimeError(
-            "Prefect task or flow execution was requested, but Prefect is not installed. "
-            "Install with: pip install probpipe[prefect]"
-        )
-
-
-def _ensure_prefect_flow_available() -> None:
-    if task is None or flow is None:
         raise RuntimeError(
             "Prefect task or flow execution was requested, but Prefect is not installed. "
             "Install with: pip install probpipe[prefect]"

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -5,7 +5,6 @@ import logging
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
-from concurrent.futures import ThreadPoolExecutor
 from itertools import product as cartesian_product
 from types import MappingProxyType
 from typing import Any, get_type_hints
@@ -28,7 +27,7 @@ except ImportError:
 from .._utils import prod
 from ..converters import converter_registry
 from ..custom_types import Array, PRNGKey
-from . import _workflow_result
+from . import _workflow_execution, _workflow_result
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
 from ._record_array import RecordArray, _RecordArrayView
@@ -417,6 +416,48 @@ class WorkflowFunction(Node):
             return WorkflowKind.OFF
 
         return kind
+
+    def _make_execution_config(
+        self,
+        *,
+        mode: _workflow_execution.WorkflowExecutionMode | None = None,
+    ) -> _workflow_execution.WorkflowExecutionConfig:
+        """Build resolved execution metadata for loop-style call dispatch."""
+        if mode is None:
+            kind = self.effective_workflow_kind
+            if kind is WorkflowKind.TASK:
+                mode = "prefect_task"
+            elif kind is WorkflowKind.FLOW:
+                mode = "prefect_flow"
+            elif self._parallel is not False:
+                mode = "thread"
+            else:
+                mode = "sequential"
+
+        prefect_task_runner = (
+            prefect_config.resolve_task_runner()
+            if mode in ("prefect_task", "prefect_flow")
+            else None
+        )
+        return _workflow_execution.WorkflowExecutionConfig(
+            mode=mode,
+            parallel=self._parallel,
+            name=self._name,
+            prefect_task_runner=prefect_task_runner,
+        )
+
+    def _make_execution_request(
+        self,
+        call_value_list: list[dict[str, Any]],
+        *,
+        mode: _workflow_execution.WorkflowExecutionMode | None = None,
+    ) -> _workflow_execution.WorkflowExecutionRequest:
+        """Build a backend-neutral execution request without capturing ``self``."""
+        return _workflow_execution.WorkflowExecutionRequest(
+            func=self._func,
+            call_value_list=call_value_list,
+            execution=self._make_execution_config(mode=mode),
+        )
 
     def _is_dependency_param(self, name: str) -> bool:
         """
@@ -1353,100 +1394,48 @@ class WorkflowFunction(Node):
         )
 
     def _execute_many(self, call_value_list: list[dict[str, Any]]) -> list:
-        """
-        Execute the wrapped function for every dict in *call_value_list* and
-        return the results in the same order.
-
-        Dispatch strategy:
-          - workflow_kind="task"  → Prefect task.map() (single mapped task)
-          - workflow_kind="flow"  → Prefect: one wrapping flow with task.map()
-          - parallel=True/int    → concurrent.futures.ThreadPoolExecutor
-          - otherwise            → sequential list comprehension
-        """
+        """Compatibility wrapper around ``_workflow_execution.execute_many``."""
         if not call_value_list:
             return []
-
-        kind = self.effective_workflow_kind
-        if kind is WorkflowKind.TASK:
-            return self._execute_many_prefect_task(call_value_list)
-
-        if kind is WorkflowKind.FLOW:
-            return self._execute_many_prefect_flow(call_value_list)
-
-        if self._parallel is not False:
-            return self._execute_many_threaded(call_value_list)
-
-        return [self._func(**v) for v in call_value_list]
+        request = self._make_execution_request(call_value_list)
+        return _workflow_execution.execute_many(request)
 
     def _execute_many_threaded(self, call_value_list: list[dict[str, Any]]) -> list:
-        max_workers = None  # ThreadPoolExecutor default for parallel=True
-
-        if isinstance(self._parallel, int) and not isinstance(self._parallel, bool):
-            if self._parallel < 1:
-                raise ValueError(
-                    f"self._parallel must be True, False, or a positive int; got {self._parallel!r}"
-                )
-            max_workers = self._parallel
-
-        elif self._parallel is not True:
-            raise TypeError(
-                f"parallel must be True, False, or a positive int; got {self._parallel!r}"
-            )
-
-        with ThreadPoolExecutor(max_workers=max_workers) as pool:
-            return list(pool.map(lambda kwargs: self._func(**kwargs), call_value_list))
-
-    def _map_task(self, call_value_list: list[dict[str, Any]], task_name: str | None = None) -> list:
-        """Create a Prefect task wrapping self._func, .map() over all calls, and resolve."""
+        """Compatibility wrapper around threaded workflow execution."""
         if not call_value_list:
             return []
+        request = self._make_execution_request(call_value_list, mode="thread")
+        return _workflow_execution.execute_many_threaded(request)
 
-        if task is None:
-            raise RuntimeError(
-                "Prefect task execution was requested, but Prefect is not installed. "
-                "Install with: pip install probpipe[prefect]"
-            )
-
-        func = self._func
-
-        @task(name=task_name or self._name)
-        def run_func(**kwargs):
-            return func(**kwargs)
-
-        keys = call_value_list[0].keys()
-        kwargs_by_param = {k: [d[k] for d in call_value_list] for k in keys}
-        futures = run_func.map(**kwargs_by_param)
-        return [future.result() for future in futures]
+    def _map_task(self, call_value_list: list[dict[str, Any]], task_name: str | None = None) -> list:
+        """Compatibility wrapper around Prefect task mapping."""
+        if not call_value_list:
+            return []
+        request = _workflow_execution.WorkflowExecutionRequest(
+            func=self._func,
+            call_value_list=call_value_list,
+            execution=_workflow_execution.WorkflowExecutionConfig(
+                mode="prefect_task",
+                parallel=self._parallel,
+                name=self._name,
+            ),
+        )
+        return _workflow_execution.map_task(request, task_name=task_name)
 
     def _execute_many_prefect_task(self, call_value_list: list[dict[str, Any]]) -> list:
-        """Use Prefect task.map() inside a lightweight flow.
-
-        Prefect 3.x requires ``task.map()`` to be called within a flow
-        context.  This mode creates a minimal wrapper flow so the mapped
-        task runs are tracked but not grouped under a named flow.
-        """
-        outer = self
-        runner = prefect_config.resolve_task_runner()
-
-        @flow(name=f"{self._name}_map",
-              **({"task_runner": runner} if runner is not None else {}))
-        def _task_map_flow():
-            return outer._map_task(call_value_list)
-
-        return _task_map_flow()
+        """Compatibility wrapper around Prefect task execution."""
+        if not call_value_list:
+            return []
+        request = self._make_execution_request(call_value_list, mode="prefect_task")
+        return _workflow_execution.execute_many_prefect_task(request)
 
     def _execute_many_prefect_flow(self, call_value_list: list[dict[str, Any]]) -> list:
-        """Wrap a mapped task inside a named Prefect flow."""
-        outer = self
-        runner = prefect_config.resolve_task_runner()
+        """Compatibility wrapper around Prefect flow execution."""
+        if not call_value_list:
+            return []
+        request = self._make_execution_request(call_value_list, mode="prefect_flow")
+        return _workflow_execution.execute_many_prefect_flow(request)
 
-        @flow(name=self._name,
-              **({"task_runner": runner} if runner is not None else {}))
-        def mapped_flow():
-            return outer._map_task(call_value_list, task_name=f"{outer._name}_run")
-
-        return mapped_flow()
- 
 
 class Module(Node):
     """

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -1400,6 +1400,10 @@ class WorkflowFunction(Node):
         request = self._make_execution_request(call_value_list)
         return _workflow_execution.execute_many(request)
 
+    # Cleanup note (#196): these mode-specific wrappers are retained for
+    # private-call compatibility during the staged execution extraction.
+    # Future cleanup can move tests/callers to ``_workflow_execution`` and
+    # remove the wrappers below.
     def _execute_many_threaded(self, call_value_list: list[dict[str, Any]]) -> list:
         """Compatibility wrapper around threaded workflow execution."""
         if not call_value_list:

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -1409,8 +1409,6 @@ class WorkflowFunction(Node):
 
     def _map_task(self, call_value_list: list[dict[str, Any]], task_name: str | None = None) -> list:
         """Compatibility wrapper around Prefect task mapping."""
-        if not call_value_list:
-            return []
         request = _workflow_execution.WorkflowExecutionRequest(
             func=self._func,
             call_value_list=call_value_list,

--- a/tests/core/test_workflow_parallel.py
+++ b/tests/core/test_workflow_parallel.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
 import pytest
 
+import probpipe.core._workflow_execution as execution_mod
 import probpipe.core.node as node_mod
 from probpipe.core.config import WorkflowKind
 from probpipe.core.node import WorkflowFunction
@@ -9,8 +14,12 @@ def add_one(x):
     return x + 1
 
 
+def add_xy(x, y):
+    return x + y
+
+
 class RecordingExecutor:
-    instances = []
+    instances: ClassVar[list[RecordingExecutor]] = []
 
     def __init__(self, max_workers=None):
         self.max_workers = max_workers
@@ -37,8 +46,12 @@ class FakeFuture:
 
 
 class FakeMappedTask:
-    def __init__(self, fn):
+    created_names: ClassVar[list[str | None]] = []
+
+    def __init__(self, fn, name):
         self.fn = fn
+        self.name = name
+        self.__class__.created_names.append(name)
 
     def map(self, **kwargs_by_param):
         count = len(next(iter(kwargs_by_param.values())))
@@ -49,103 +62,252 @@ class FakeMappedTask:
         return futures
 
 
+class RecordingFlow:
+    calls: ClassVar[list[dict[str, object]]] = []
+
+
 def fake_task(name=None):
     def decorator(fn):
-        return FakeMappedTask(fn)
+        return FakeMappedTask(fn, name)
 
     return decorator
 
 
+def fake_flow(name=None, **flow_kwargs):
+    def decorator(fn):
+        def wrapper():
+            RecordingFlow.calls.append({"name": name, "kwargs": flow_kwargs})
+            return fn()
+
+        return wrapper
+
+    return decorator
+
+
+def make_request(
+    *,
+    mode="sequential",
+    parallel=False,
+    calls=None,
+    func=add_one,
+    name="add_one",
+    prefect_task_runner=None,
+):
+    return execution_mod.WorkflowExecutionRequest(
+        func=func,
+        call_value_list=calls if calls is not None else [{"x": 1}, {"x": 2}],
+        execution=execution_mod.WorkflowExecutionConfig(
+            mode=mode,
+            parallel=parallel,
+            name=name,
+            prefect_task_runner=prefect_task_runner,
+        ),
+    )
+
+
 @pytest.fixture(autouse=True)
-def _reset_executor_instances():
+def _reset_fakes():
     RecordingExecutor.instances.clear()
+    FakeMappedTask.created_names.clear()
+    RecordingFlow.calls.clear()
     yield
     RecordingExecutor.instances.clear()
+    FakeMappedTask.created_names.clear()
+    RecordingFlow.calls.clear()
 
 
-def test_execute_many_parallel_false_runs_sequentially():
-    wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=False)
+class TestExecutionRequestShape:
+    def test_workflow_function_request_contains_plain_function(self, monkeypatch):
+        seen = {}
 
-    assert wf._execute_many([{"x": 1}, {"x": 2}]) == [2, 3]
+        def fake_execute_many(request):
+            seen["request"] = request
+            return [request.func(**request.call_value_list[0])]
 
+        monkeypatch.setattr(execution_mod, "execute_many", fake_execute_many)
+        wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=False)
 
-def test_execute_many_parallel_true_uses_executor_default_workers(monkeypatch):
-    monkeypatch.setattr(node_mod, "ThreadPoolExecutor", RecordingExecutor)
-
-    wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=True)
-
-    assert wf._execute_many([{"x": 1}, {"x": 2}]) == [2, 3]
-    assert len(RecordingExecutor.instances) == 1
-    assert RecordingExecutor.instances[0].max_workers is None
-
-
-def test_execute_many_parallel_int_uses_explicit_worker_count(monkeypatch):
-    monkeypatch.setattr(node_mod, "ThreadPoolExecutor", RecordingExecutor)
-
-    wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=3)
-
-    assert wf._execute_many([{"x": 1}, {"x": 2}]) == [2, 3]
-    assert len(RecordingExecutor.instances) == 1
-    assert RecordingExecutor.instances[0].max_workers == 3
+        assert wf._execute_many([{"x": 1}]) == [2]
+        assert seen["request"].func is add_one
+        assert not isinstance(seen["request"].func, WorkflowFunction)
+        assert seen["request"].execution.mode == "sequential"
 
 
-def test_execute_many_parallel_true_empty_input_returns_empty_without_executor(monkeypatch):
-    monkeypatch.setattr(node_mod, "ThreadPoolExecutor", RecordingExecutor)
+class TestSequentialExecution:
+    def test_execute_many_parallel_false_runs_sequentially(self):
+        request = make_request(mode="sequential", parallel=False)
 
-    wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=True)
+        assert execution_mod.execute_many(request) == [2, 3]
+        assert RecordingExecutor.instances == []
 
-    assert wf._execute_many([]) == []
-    assert RecordingExecutor.instances == []
+    def test_execute_many_empty_input_returns_empty_without_executor(self, monkeypatch):
+        monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
+        request = make_request(mode="thread", parallel=True, calls=[])
 
-
-def test_execute_many_rejects_non_positive_parallel_int():
-    wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=0)
-
-    with pytest.raises(ValueError, match="positive int"):
-        wf._execute_many([{"x": 1}])
-
-
-def test_execute_many_rejects_invalid_parallel_value():
-    wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=None)
-
-    with pytest.raises(TypeError, match="positive int"):
-        wf._execute_many([{"x": 1}])
+        assert execution_mod.execute_many(request) == []
+        assert RecordingExecutor.instances == []
 
 
-def test_execute_many_dispatches_task_and_flow_without_running_prefect(monkeypatch):
-    monkeypatch.setattr(node_mod, "task", object())
+class TestThreadExecution:
+    def test_execute_many_parallel_true_uses_executor_default_workers(self, monkeypatch):
+        monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
+        request = make_request(mode="thread", parallel=True)
 
-    task_wf = WorkflowFunction(func=add_one, workflow_kind=WorkflowKind.TASK, vectorize="loop")
-    flow_wf = WorkflowFunction(func=add_one, workflow_kind=WorkflowKind.FLOW, vectorize="loop")
+        assert execution_mod.execute_many(request) == [2, 3]
+        assert len(RecordingExecutor.instances) == 1
+        assert RecordingExecutor.instances[0].max_workers is None
 
-    monkeypatch.setattr(task_wf, "_execute_many_prefect_task", lambda values: ("task", values))
-    monkeypatch.setattr(flow_wf, "_execute_many_prefect_flow", lambda values: ("flow", values))
+    def test_execute_many_parallel_int_uses_explicit_worker_count(self, monkeypatch):
+        monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
+        request = make_request(mode="thread", parallel=3)
 
-    calls = [{"x": 1}]
-    assert task_wf._execute_many(calls) == ("task", calls)
-    assert flow_wf._execute_many(calls) == ("flow", calls)
+        assert execution_mod.execute_many(request) == [2, 3]
+        assert len(RecordingExecutor.instances) == 1
+        assert RecordingExecutor.instances[0].max_workers == 3
 
+    @pytest.mark.parametrize("parallel", [0, -1])
+    def test_execute_many_rejects_non_positive_parallel_int(self, parallel):
+        request = make_request(mode="thread", parallel=parallel)
 
-def test_map_task_empty_input_returns_empty_before_prefect_guard(monkeypatch):
-    monkeypatch.setattr(node_mod, "task", None)
+        with pytest.raises(ValueError, match="positive int"):
+            execution_mod.execute_many(request)
 
-    wf = WorkflowFunction(func=add_one, vectorize="loop")
+    def test_execute_many_rejects_invalid_parallel_value(self):
+        request = make_request(mode="thread", parallel=None)
 
-    assert wf._map_task([]) == []
-
-
-def test_map_task_raises_clear_error_when_prefect_missing(monkeypatch):
-    monkeypatch.setattr(node_mod, "task", None)
-
-    wf = WorkflowFunction(func=add_one, vectorize="loop")
-
-    with pytest.raises(RuntimeError, match="Prefect task execution was requested"):
-        wf._map_task([{"x": 1}])
+        with pytest.raises(TypeError, match="positive int"):
+            execution_mod.execute_many(request)
 
 
-def test_map_task_maps_keyword_arguments_and_resolves_futures(monkeypatch):
-    monkeypatch.setattr(node_mod, "task", fake_task)
+class TestPrefectMapping:
+    def test_map_task_empty_input_returns_empty_before_prefect_guard(self, monkeypatch):
+        monkeypatch.setattr(execution_mod, "task", None)
+        monkeypatch.setattr(execution_mod, "flow", None)
+        request = make_request(mode="prefect_task", calls=[])
 
-    wf = WorkflowFunction(func=add_one, vectorize="loop")
+        assert execution_mod.map_task(request) == []
 
-    assert wf._map_task([{"x": 1}, {"x": 2}], task_name="add-one") == [2, 3]
+    def test_map_task_raises_clear_error_when_prefect_missing(self, monkeypatch):
+        monkeypatch.setattr(execution_mod, "task", None)
+        monkeypatch.setattr(execution_mod, "flow", None)
+        request = make_request(mode="prefect_task")
+
+        with pytest.raises(RuntimeError, match="Prefect task execution was requested"):
+            execution_mod.map_task(request)
+
+    def test_map_task_maps_keyword_arguments_and_resolves_futures(self, monkeypatch):
+        monkeypatch.setattr(execution_mod, "task", fake_task)
+        monkeypatch.setattr(execution_mod, "flow", None)
+        request = make_request(
+            mode="prefect_task",
+            calls=[{"x": 1, "y": 2}, {"x": 3, "y": 4}],
+            func=add_xy,
+        )
+
+        assert execution_mod.map_task(request, task_name="add-xy") == [3, 7]
+        assert FakeMappedTask.created_names == ["add-xy"]
+
+    def test_prefect_task_executor_uses_flow_wrapper_and_runner(self, monkeypatch):
+        runner = object()
+        monkeypatch.setattr(execution_mod, "task", fake_task)
+        monkeypatch.setattr(execution_mod, "flow", fake_flow)
+        request = make_request(
+            mode="prefect_task",
+            prefect_task_runner=runner,
+            name="plus_one",
+        )
+
+        assert execution_mod.execute_many(request) == [2, 3]
+        assert RecordingFlow.calls == [
+            {"name": "plus_one_map", "kwargs": {"task_runner": runner}},
+        ]
+        assert FakeMappedTask.created_names == ["plus_one"]
+
+    def test_prefect_flow_executor_uses_named_flow_and_task_name(self, monkeypatch):
+        runner = object()
+        monkeypatch.setattr(execution_mod, "task", fake_task)
+        monkeypatch.setattr(execution_mod, "flow", fake_flow)
+        request = make_request(
+            mode="prefect_flow",
+            prefect_task_runner=runner,
+            name="plus_one",
+        )
+
+        assert execution_mod.execute_many(request) == [2, 3]
+        assert RecordingFlow.calls == [
+            {"name": "plus_one", "kwargs": {"task_runner": runner}},
+        ]
+        assert FakeMappedTask.created_names == ["plus_one_run"]
+
+
+class TestWorkflowFunctionCompatibility:
+    def test_execute_many_wrapper_preserves_private_call_behavior(self):
+        wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=False)
+
+        assert wf._execute_many([{"x": 1}, {"x": 2}]) == [2, 3]
+
+    def test_private_wrappers_return_empty_before_building_request(self, monkeypatch):
+        wf = WorkflowFunction(func=add_one, workflow_kind=WorkflowKind.TASK, vectorize="loop")
+
+        def fail_request(*args, **kwargs):
+            raise AssertionError("empty calls should not build an execution request")
+
+        monkeypatch.setattr(wf, "_make_execution_request", fail_request)
+
+        assert wf._execute_many([]) == []
+        assert wf._execute_many_threaded([]) == []
+        assert wf._map_task([]) == []
+        assert wf._execute_many_prefect_task([]) == []
+        assert wf._execute_many_prefect_flow([]) == []
+
+    def test_execute_many_wrapper_resolves_task_and_flow_modes(self, monkeypatch):
+        seen_modes = []
+
+        def fake_execute_many(request):
+            seen_modes.append(request.execution.mode)
+            return ("ok", request.call_value_list)
+
+        monkeypatch.setattr(node_mod, "task", object())
+        monkeypatch.setattr(execution_mod, "execute_many", fake_execute_many)
+        task_wf = WorkflowFunction(
+            func=add_one,
+            workflow_kind=WorkflowKind.TASK,
+            vectorize="loop",
+        )
+        flow_wf = WorkflowFunction(
+            func=add_one,
+            workflow_kind=WorkflowKind.FLOW,
+            vectorize="loop",
+        )
+
+        calls = [{"x": 1}]
+        assert task_wf._execute_many(calls) == ("ok", calls)
+        assert flow_wf._execute_many(calls) == ("ok", calls)
+        assert seen_modes == ["prefect_task", "prefect_flow"]
+
+    def test_threaded_wrapper_delegates_to_execution_module(self, monkeypatch):
+        monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
+        wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=2)
+
+        assert wf._execute_many_threaded([{"x": 1}, {"x": 2}]) == [2, 3]
+        assert RecordingExecutor.instances[0].max_workers == 2
+
+    def test_map_task_wrapper_delegates_to_execution_module(self, monkeypatch):
+        monkeypatch.setattr(execution_mod, "task", fake_task)
+        monkeypatch.setattr(execution_mod, "flow", None)
+        wf = WorkflowFunction(func=add_one, vectorize="loop")
+
+        assert wf._map_task([{"x": 1}, {"x": 2}], task_name="add-one") == [2, 3]
+        assert FakeMappedTask.created_names == ["add-one"]
+
+    def test_map_task_wrapper_does_not_resolve_task_runner(self, monkeypatch):
+        monkeypatch.setattr(execution_mod, "task", fake_task)
+        monkeypatch.setattr(execution_mod, "flow", None)
+
+        def fail_resolve_task_runner():
+            raise AssertionError("direct _map_task should not resolve a task runner")
+
+        monkeypatch.setattr(node_mod.prefect_config, "resolve_task_runner", fail_resolve_task_runner)
+        wf = WorkflowFunction(func=add_one, vectorize="loop")
+
+        assert wf._map_task([{"x": 1}], task_name="add-one") == [2]

--- a/tests/core/test_workflow_parallel.py
+++ b/tests/core/test_workflow_parallel.py
@@ -192,7 +192,7 @@ class TestPrefectMapping:
         monkeypatch.setattr(execution_mod, "flow", None)
         request = make_request(mode="prefect_task")
 
-        with pytest.raises(RuntimeError, match="Prefect task execution was requested"):
+        with pytest.raises(RuntimeError, match=r"Prefect task.*execution was requested"):
             execution_mod.map_task(request)
 
     def test_map_task_maps_keyword_arguments_and_resolves_futures(self, monkeypatch):
@@ -245,6 +245,16 @@ class TestWorkflowFunctionCompatibility:
         wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=False)
 
         assert wf._execute_many([{"x": 1}, {"x": 2}]) == [2, 3]
+
+    def test_make_execution_config_resolves_truthy_parallel_to_thread(self):
+        wf = WorkflowFunction(
+            func=add_one,
+            vectorize="loop",
+            workflow_kind=WorkflowKind.OFF,
+            parallel=True,
+        )
+
+        assert wf._make_execution_config().mode == "thread"
 
     def test_private_wrappers_return_empty_before_building_request(self, monkeypatch):
         wf = WorkflowFunction(func=add_one, workflow_kind=WorkflowKind.TASK, vectorize="loop")


### PR DESCRIPTION
This is the stage 2 of #196. 

Changes:

1. The following files have been added: `probpipe/core/_workflow_execution.py`, containing `WorkflowExecutionConfig`, `WorkflowExecutionRequest`, `execute_many(request)`, and the `sequential/thread/Prefect` executor.

2. `probpipe/core/node.py` retains `effective_workflow_kind` and adds `_make_execution_config()` and `_make_execution_request()`. The original `_execute_many*` and `_map_task` have become compatibility wrappers. (P.S. This was intentionally designed to pass pytests. Will become clear during the future clean-up PR.)

3. `tests/test_workflow_parallel.py` has been rewritten in groups of `Test*`, directly overriding the execution module and retaining compatibility tests for the `WorkflowFunction` private wrapper.