### PR TITLE
chore(tests): Run full suite on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,19 @@ jobs:
           echo "$CHANGED"
 
           # If foundational files changed, run the full suite.
-          RUN_ALL=false
-          for f in $CHANGED; do
-            case "$f" in
-              pyproject.toml|setup.cfg|setup.py|tests/conftest.py|probpipe/__init__.py)
-                RUN_ALL=true ;;
-            esac
-          done
+          # Also force the full suite on direct pushes to main (post-merge
+          # safety net — targeted tests are for PRs only).
+          if [ "${{ github.event_name }}" = "push" ]; then
+            RUN_ALL=true
+          else
+            RUN_ALL=false
+            for f in $CHANGED; do
+              case "$f" in
+                pyproject.toml|setup.cfg|setup.py|tests/conftest.py|probpipe/__init__.py)
+                  RUN_ALL=true ;;
+              esac
+            done
+          fi
 
           if [ -z "$CHANGED" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Two related fixes:
- Force run_all=true on push events (merges to main) so the full test
  suite always runs as a post-merge safety net. Targeted selection is
  for PRs only.
- Only upload coverage to Codecov when run_all=true, so partial test
  runs don't show a false coverage regression against the full baseline.