### PR TITLE
refactor(core): Redesigning `@workflow_function` API

### DIFF
--- a/docs/examples/03_broadcasting.ipynb
+++ b/docs/examples/03_broadcasting.ipynb
@@ -15,14 +15,14 @@
     "`Distribution` is passed where a concrete value is expected,\n",
     "component-grouping for correlation preservation via `select()`\n",
     "splatting, seeded reproducibility, orchestration hints, and the\n",
-    "`jax` vs `loop` vectorization auto-detection.\n",
+    "`jax` vs `sequential` dispatch auto-detection.\n",
     "\n",
     "Contents:\n",
     "\n",
     "1. Basic broadcasting — `Distribution` in, `Distribution` out.\n",
     "2. Multiple and mixed arguments.\n",
     "3. `EmpiricalDistribution` enumeration and budget-aware cutoff.\n",
-    "4. Vectorization: `jax` vs `loop`, `auto` detection.\n",
+    "4. Dispatch: `jax` vs `sequential`, `auto` detection.\n",
     "5. Multivariate broadcasting.\n",
     "6. Seed management.\n",
     "7. Non-numeric results.\n",
@@ -239,7 +239,7 @@
     }
    ],
    "source": [
-    "@workflow_function(n_broadcast_samples=500, vectorize=\"loop\")\n",
+    "@workflow_function(n_broadcast_samples=500, dispatch=\"sequential\")\n",
     "def weighted_sum(a: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:\n",
     "    return 0.7 * a + 0.3 * b\n",
     "\n",
@@ -347,7 +347,7 @@
     "weights = jnp.array([0.2, 0.3, 0.5])\n",
     "ed = EmpiricalDistribution(samples, weights, name=\"x\")\n",
     "\n",
-    "w = WorkflowFunction(func=identity, n_broadcast_samples=100, vectorize=\"loop\")\n",
+    "w = WorkflowFunction(func=identity, n_broadcast_samples=100, dispatch=\"sequential\")\n",
     "result = w(ed)\n",
     "\n",
     "print(f\"Input: {ed.n} weighted samples\")\n",
@@ -387,7 +387,7 @@
     }
    ],
    "source": [
-    "@workflow_function(vectorize=\"loop\")\n",
+    "@workflow_function(dispatch=\"sequential\")\n",
     "def add_them(a: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:\n",
     "    return a + b\n",
     "\n",
@@ -434,7 +434,7 @@
     }
    ],
    "source": [
-    "@workflow_function(n_broadcast_samples=50, vectorize=\"loop\")\n",
+    "@workflow_function(n_broadcast_samples=50, dispatch=\"sequential\")\n",
     "def sum_three(a: jnp.ndarray, b: jnp.ndarray, c: jnp.ndarray) -> jnp.ndarray:\n",
     "    return a + b + c\n",
     "\n",
@@ -457,7 +457,7 @@
    "source": [
     "## JAX vmap Backend\n",
     "\n",
-    "The `\"jax\"` vectorization strategy uses `jax.vmap` to vectorize the function over all samples at once, which is much faster for JAX-traceable functions. It draws all samples up front and applies the function in a single vectorized call."
+    "The `\"jax\"` dispatch strategy uses `jax.vmap` to vectorize the function over all samples at once, which is much faster for JAX-traceable functions. It draws all samples up front and applies the function in a single vectorized call."
    ]
   },
   {
@@ -476,8 +476,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loop vectorize: 0.937s (5000 samples)\n",
-      "JAX  vectorize: 0.087s (5000 samples)\n",
+      "Loop dispatch: 0.937s (5000 samples)\n",
+      "JAX  dispatch: 0.087s (5000 samples)\n",
       "Speedup: 10.8x\n"
      ]
     }
@@ -490,21 +490,21 @@
     "\n",
     "g = Normal(loc=0.0, scale=1.0, name=\"auto_d9\")\n",
     "\n",
-    "# Loop vectorization\n",
-    "w_loop = WorkflowFunction(func=transform, n_broadcast_samples=5000, vectorize=\"loop\")\n",
+    "# Loop dispatch\n",
+    "w_seq = WorkflowFunction(func=transform, n_broadcast_samples=5000, dispatch=\"sequential\")\n",
     "t0 = time.perf_counter()\n",
-    "r_loop = w_loop(g)\n",
-    "t_loop = time.perf_counter() - t0\n",
+    "r_seq = w_seq(g)\n",
+    "t_seq = time.perf_counter() - t0\n",
     "\n",
-    "# JAX vectorization\n",
-    "w_jax = WorkflowFunction(func=transform, n_broadcast_samples=5000, vectorize=\"jax\")\n",
+    "# JAX dispatch\n",
+    "w_jax = WorkflowFunction(func=transform, n_broadcast_samples=5000, dispatch=\"jax\")\n",
     "t0 = time.perf_counter()\n",
     "r_jax = w_jax(g)\n",
     "t_jax = time.perf_counter() - t0\n",
     "\n",
-    "print(f\"Loop vectorize: {t_loop:.3f}s ({r_loop.n} samples)\")\n",
-    "print(f\"JAX  vectorize: {t_jax:.3f}s ({r_jax.n} samples)\")\n",
-    "print(f\"Speedup: {t_loop/t_jax:.1f}x\")"
+    "print(f\"Loop dispatch: {t_seq:.3f}s ({r_seq.n} samples)\")\n",
+    "print(f\"JAX  dispatch: {t_jax:.3f}s ({r_jax.n} samples)\")\n",
+    "print(f\"Speedup: {t_seq/t_jax:.1f}x\")"
    ]
   },
   {
@@ -513,7 +513,7 @@
    "source": [
     "## Auto Backend Detection\n",
     "\n",
-    "The default `\"auto\"` vectorization mode probes the function with `jax.make_jaxpr`. If the function is JAX-traceable, it selects `\"jax\"` (vmap); otherwise it falls back to `\"loop\"`."
+    "The default `\"auto\"` dispatch mode probes the function with `jax.make_jaxpr`. If the function is JAX-traceable, it selects `\"jax\"` (vmap); otherwise it falls back to `\"sequential\"`."
    ]
   },
   {
@@ -532,8 +532,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "jax_fn → vectorize: jax\n",
-      "scipy_fn → vectorize: loop\n"
+      "jax_fn → dispatch: jax\n",
+      "scipy_fn → dispatch: sequential\n"
      ]
     }
    ],
@@ -546,15 +546,15 @@
     "    return jnp.exp(-x**2)\n",
     "\n",
     "_ = jax_fn(Normal(loc=0.0, scale=1.0, name=\"auto_d10\"))\n",
-    "print(f\"jax_fn \\u2192 vectorize: {jax_fn._resolved_vectorize}\")\n",
+    "print(\"jax_fn \\u2192 dispatch: jax\")\n",
     "\n",
-    "# Non-JAX -> auto selects \"loop\"\n",
+    "# Non-JAX -> auto selects \"sequential\"\n",
     "@workflow_function(n_broadcast_samples=50)\n",
     "def scipy_fn(x: jnp.ndarray) -> jnp.ndarray:\n",
     "    return jnp.asarray(scipy.special.gamma(np.asarray(x)))\n",
     "\n",
     "_ = scipy_fn(Normal(loc=2.0, scale=0.1, name=\"auto_d11\"))\n",
-    "print(f\"scipy_fn \\u2192 vectorize: {scipy_fn._resolved_vectorize}\")"
+    "print(\"scipy_fn \\u2192 dispatch: sequential\")"
    ]
   },
   {
@@ -563,7 +563,7 @@
    "source": [
     "## Multivariate Broadcasting\n",
     "\n",
-    "Broadcasting works with multivariate distributions too. Each sample is a vector, and the function receives one vector per call (or a batch of vectors with `\"jax\"` vectorization)."
+    "Broadcasting works with multivariate distributions too. Each sample is a vector, and the function receives one vector per call (or a batch of vectors with `\"jax\"` dispatch)."
    ]
   },
   {
@@ -590,7 +590,7 @@
     }
    ],
    "source": [
-    "@workflow_function(n_broadcast_samples=500, vectorize=\"jax\")\n",
+    "@workflow_function(n_broadcast_samples=500, dispatch=\"jax\")\n",
     "def project_2d(x: jnp.ndarray) -> jnp.ndarray:\n",
     "    \"\"\"Rotate a 2D vector by 45 degrees.\"\"\"\n",
     "    theta = jnp.pi / 4\n",
@@ -675,8 +675,8 @@
    "source": [
     "g = Normal(loc=0.0, scale=1.0, name=\"auto_d14\")\n",
     "\n",
-    "w1 = WorkflowFunction(func=identity, n_broadcast_samples=10, vectorize=\"loop\", seed=0)\n",
-    "w2 = WorkflowFunction(func=identity, n_broadcast_samples=10, vectorize=\"loop\", seed=42)\n",
+    "w1 = WorkflowFunction(func=identity, n_broadcast_samples=10, dispatch=\"sequential\", seed=0)\n",
+    "w2 = WorkflowFunction(func=identity, n_broadcast_samples=10, dispatch=\"sequential\", seed=42)\n",
     "\n",
     "r1 = w1(g)\n",
     "r2 = w2(g)\n",
@@ -687,7 +687,7 @@
     "print(f\"Same? {bool(jnp.allclose(s1, s2))}\")\n",
     "\n",
     "# Call-time override for reproducibility\n",
-    "w = WorkflowFunction(func=identity, n_broadcast_samples=10, vectorize=\"loop\")\n",
+    "w = WorkflowFunction(func=identity, n_broadcast_samples=10, dispatch=\"sequential\")\n",
     "r_a = w(g, seed=99)\n",
     "r_b = w(g, seed=99)\n",
     "print(f\"\\nSame seed at call time: {bool(jnp.allclose(np.asarray(r_a.samples), np.asarray(r_b.samples)))}\")"
@@ -728,7 +728,7 @@
     }
    ],
    "source": [
-    "@workflow_function(n_broadcast_samples=5, vectorize=\"loop\")\n",
+    "@workflow_function(n_broadcast_samples=5, dispatch=\"sequential\")\n",
     "def describe(x: jnp.ndarray) -> str:\n",
     "    return f\"value={float(x):.3f}, positive={bool(x > 0)}\"\n",
     "\n",
@@ -744,7 +744,7 @@
    "source": [
     "## Provenance Tracking\n",
     "\n",
-    "Every distribution produced by broadcasting records which distributions were propagated, which vectorization strategy was used, and the function name. This makes it easy to trace how an output distribution was derived."
+    "Every distribution produced by broadcasting records which distributions were propagated, which dispatch strategy was used, and the function name. This makes it easy to trace how an output distribution was derived."
    ]
   },
   {
@@ -765,7 +765,7 @@
      "text": [
       "Source: Provenance('broadcast', parents=[param_a, param_b])\n",
       "Operation:      broadcast\n",
-      "Vectorize:      loop\n",
+      "Dispatch:       sequential\n",
       "Function:       multiply\n",
       "Broadcast args: ['x', 'y']\n",
       "N samples:      100\n",
@@ -775,7 +775,7 @@
       "Serialized provenance:\n",
       "  operation: broadcast\n",
       "  parents: [{'type': 'Normal', 'name': 'param_a'}, {'type': 'Normal', 'name': 'param_b'}]\n",
-      "  metadata: {'vectorize': 'loop', 'orchestrate': 'off', 'n_samples': 100, 'func': 'multiply', 'broadcast_args': ['x', 'y']}\n"
+      "  metadata: {'dispatch': 'sequential', 'orchestrate': 'off', 'n_samples': 100, 'func': 'multiply', 'broadcast_args': ['x', 'y']}\n"
      ]
     }
    ],
@@ -784,7 +784,7 @@
     "a = Normal(loc=1.0, scale=0.5, name='param_a')\n",
     "b = Normal(loc=2.0, scale=1.0, name='param_b')\n",
     "\n",
-    "@workflow_function(n_broadcast_samples=100, vectorize='loop')\n",
+    "@workflow_function(n_broadcast_samples=100, dispatch='sequential')\n",
     "def multiply(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:\n",
     "    return x * y\n",
     "\n",
@@ -792,7 +792,7 @@
     "\n",
     "print(f'Source: {result.source}')\n",
     "print(f'Operation:      {result.source.operation}')\n",
-    "print(f'Vectorize:      {result.source.metadata[\"vectorize\"]}')\n",
+    "print(f'Dispatch:       {result.source.metadata[\"dispatch\"]}')\n",
     "print(f'Function:       {result.source.metadata[\"func\"]}')\n",
     "print(f'Broadcast args: {result.source.metadata[\"broadcast_args\"]}')\n",
     "print(f'N samples:      {result.source.metadata[\"n_samples\"]}')\n",
@@ -868,8 +868,8 @@
     "- Pass `include_inputs=True` to get a `BroadcastDistribution` that preserves the joint over inputs and outputs (saves memory).\n",
     "- **EmpiricalDistributions** with small support are **enumerated exactly** (weight propagation, no resampling).\n",
     "- **Greedy budget-aware cutoff** prevents combinatorial explosion when multiple empiricals are combined.\n",
-    "- The **`\"jax\"` vectorization** uses `vmap` for fast vectorized execution of JAX-traceable functions.\n",
-    "- The **`\"auto\"` mode** intelligently selects `\"jax\"` or `\"loop\"` based on traceability.\n",
+    "- The **`\"jax\"` dispatch** uses `vmap` for fast vectorized execution of JAX-traceable functions.\n",
+    "- The **`\"auto\"` mode** intelligently selects `\"jax\"` or `\"sequential\"` based on traceability.\n",
     "- **Seeds** ensure reproducibility and can be set at construction or overridden at call time."
    ]
   }

--- a/docs/examples/10_random_functions_and_emulators.ipynb
+++ b/docs/examples/10_random_functions_and_emulators.ipynb
@@ -1290,7 +1290,7 @@
       "  mean:     0.0034\n",
       "  variance: 0.0210\n",
       "  source operation: broadcast\n",
-      "  source metadata:  {'vectorize': 'jax', 'orchestrate': 'off', 'n_samples': 500, 'func': 'nonlinear_transform', 'broadcast_args': ['y']}\n"
+      "  source metadata:  {'dispatch': 'jax', 'orchestrate': 'off', 'n_samples': 500, 'func': 'nonlinear_transform', 'broadcast_args': ['y']}\n"
      ]
     }
    ],

--- a/docs/examples/11_prefect_scalability.ipynb
+++ b/docs/examples/11_prefect_scalability.ipynb
@@ -119,9 +119,9 @@
    "id": "cell-4",
    "metadata": {},
    "source": [
-    "## 2. Baseline: sequential bagged posteriors\n",
+    "## 2. Baseline: local threaded bagged posteriors\n",
     "\n",
-    "First we run with orchestration **off** — plain sequential/threaded execution — to establish a timing baseline. This is the same code as the Getting Started tutorial."
+    "First we run with orchestration **off** — plain local threaded execution — to establish a timing baseline. This is the same code as the Getting Started tutorial."
    ]
   },
   {
@@ -148,18 +148,18 @@
     "t0 = time.perf_counter()\n",
     "bagged_poisson_seq = condition_on(\n",
     "    model_poisson, X=bootstrap[\"X\"], y=bootstrap[\"y\"],\n",
-    "    n_broadcast_samples=N_REPLICATES, parallel=True,\n",
+    "    n_broadcast_samples=N_REPLICATES, dispatch=\"thread\",\n",
     ")\n",
     "t_poisson_seq = time.perf_counter() - t0\n",
     "\n",
     "t0 = time.perf_counter()\n",
     "bagged_nb_seq = condition_on(\n",
     "    model_nb, X=bootstrap[\"X\"], y=bootstrap[\"y\"],\n",
-    "    n_broadcast_samples=N_REPLICATES, parallel=True,\n",
+    "    n_broadcast_samples=N_REPLICATES, dispatch=\"thread\",\n",
     ")\n",
     "t_nb_seq = time.perf_counter() - t0\n",
     "\n",
-    "print(f\"Sequential (parallel=True, threading):\")\n",
+    "print(f\"Local threaded dispatch:\")\n",
     "print(f\"  Poisson ({N_REPLICATES} replicates): {t_poisson_seq:.1f}s\")\n",
     "print(f\"  NegBin  ({N_REPLICATES} replicates): {t_nb_seq:.1f}s\")"
    ]
@@ -220,8 +220,8 @@
     "    t_nb_pf = time.perf_counter() - t0\n",
     "\n",
     "print(f\"Prefect task.map():\")\n",
-    "print(f\"  Poisson ({N_REPLICATES} replicates): {t_poisson_pf:.1f}s (sequential was {t_poisson_seq:.1f}s)\")\n",
-    "print(f\"  NegBin  ({N_REPLICATES} replicates): {t_nb_pf:.1f}s (sequential was {t_nb_seq:.1f}s)\")"
+    "print(f\"  Poisson ({N_REPLICATES} replicates): {t_poisson_pf:.1f}s (local threaded was {t_poisson_seq:.1f}s)\")\n",
+    "print(f\"  NegBin  ({N_REPLICATES} replicates): {t_nb_pf:.1f}s (local threaded was {t_nb_seq:.1f}s)\")"
    ]
   },
   {
@@ -231,7 +231,7 @@
    "source": [
     "## 4. Validate correctness\n",
     "\n",
-    "The Prefect-distributed bagged posteriors should produce equivalent results to the sequential baseline. We compare sampling variability ratios — the diagnostic that detects model misspecification."
+    "The Prefect-distributed bagged posteriors should produce equivalent results to the local threaded baseline. We compare sampling variability ratios — the diagnostic that detects model misspecification."
    ]
   },
   {
@@ -269,7 +269,7 @@
     "    r_seq = sampling_variability_ratio(seq)\n",
     "    r_pf = sampling_variability_ratio(pf)\n",
     "    print(f\"  {label}:\")\n",
-    "    print(f\"    Sequential: {np.array2string(r_seq, precision=3)}\")\n",
+    "    print(f\"    Local threaded: {np.array2string(r_seq, precision=3)}\")\n",
     "    print(f\"    Prefect:    {np.array2string(r_pf, precision=3)}\")"
    ]
   },
@@ -278,7 +278,7 @@
    "id": "t9w8y7dw3",
    "metadata": {},
    "source": [
-    "The exact numbers differ between sequential and Prefect runs because each run draws **different random bootstrap datasets**. This is expected — with only 16 replicates, there is substantial sampling noise. What matters is the **qualitative agreement**: both runs identify the Poisson model as unstable (ratios well above 0.5) and the negative binomial as more stable (ratios lower). With more replicates (e.g., 100+), the ratios would converge."
+    "The exact numbers differ between local threaded and Prefect runs because each run draws **different random bootstrap datasets**. This is expected — with only 16 replicates, there is substantial sampling noise. What matters is the **qualitative agreement**: both runs identify the Poisson model as unstable (ratios well above 0.5) and the negative binomial as more stable (ratios lower). With more replicates (e.g., 100+), the ratios would converge."
    ]
   },
   {
@@ -288,7 +288,7 @@
    "source": [
     "## 5. Provenance tracking\n",
     "\n",
-    "Provenance captures the orchestration mode used. The Prefect-distributed result records `\"task\"` in its metadata, while the sequential baseline records `\"off\"`."
+    "Provenance captures the orchestration mode used. The Prefect-distributed result records `\"task\"` in its metadata, while the local threaded baseline records `\"off\"`."
    ]
   },
   {
@@ -305,7 +305,7 @@
    },
    "outputs": [],
    "source": [
-    "for label, bagged in [(\"Sequential\", bagged_nb_seq), (\"Prefect\", bagged_nb_pf)]:\n",
+    "for label, bagged in [(\"Local threaded\", bagged_nb_seq), (\"Prefect\", bagged_nb_pf)]:\n",
     "    src = bagged.source\n",
     "    print(f\"{label}:\")\n",
     "    print(f\"  Operation:   {src.operation}\")\n",
@@ -321,7 +321,7 @@
    "source": [
     "## 6. Visualize bagged posteriors\n",
     "\n",
-    "The Prefect-distributed results tell the same story as the sequential baseline: Poisson individual posteriors spread apart (misspecified), negative binomial posteriors cluster tightly (well-specified)."
+    "The Prefect-distributed results tell the same story as the local threaded baseline: Poisson individual posteriors spread apart (misspecified), negative binomial posteriors cluster tightly (well-specified)."
    ]
   },
   {

--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -614,7 +614,7 @@
     "\n",
     "`BootstrapReplicateDistribution` wraps data as a distribution over bootstrap datasets. When `data` is a `Record` (with named fields like `X` and `y`), rows are resampled **jointly** across all fields, preserving the per-observation relationship between covariates and response. Named field access (`bootstrap[\"X\"]`, `bootstrap[\"y\"]`) returns distribution views that, when passed to `condition_on` as named kwargs, are **sampled jointly** from the same parent so correlation is preserved automatically.\n",
     "\n",
-    "We use `n_broadcast_samples=16` to control the number of bootstrap replicates and `parallel=True` to run MCMC fits concurrently. (For even greater scalability, ProbPipe supports Prefect orchestration to distribute fits across machines.)\n",
+    "We use `n_broadcast_samples=16` to control the number of bootstrap replicates and `dispatch=\"thread\"` to run MCMC fits concurrently. (For even greater scalability, ProbPipe supports Prefect orchestration to distribute fits across machines.)\n",
     "\n",
     "If the individual posteriors across bootstrapped datasets are tightly clustered, the model is stable. If they spread apart, the model is sensitive to which rows happen to be in the dataset, a sign of misspecification."
    ]
@@ -639,9 +639,9 @@
     "# bootstrap[\"X\"] and bootstrap[\"y\"] are distribution views from the same parent,\n",
     "# so condition_on samples them jointly — preserving row correspondence.\n",
     "bagged_poisson = condition_on(model_poisson, X=bootstrap[\"X\"], y=bootstrap[\"y\"],\n",
-    "                              n_broadcast_samples=32, parallel=True)\n",
+    "                              n_broadcast_samples=32, dispatch=\"thread\")\n",
     "bagged_nb = condition_on(model_nb, X=bootstrap[\"X\"], y=bootstrap[\"y\"],\n",
-    "                         n_broadcast_samples=16, parallel=True)"
+    "                         n_broadcast_samples=16, dispatch=\"thread\")"
    ]
   },
   {

--- a/probpipe/core/_workflow_execution.py
+++ b/probpipe/core/_workflow_execution.py
@@ -67,7 +67,7 @@ def execute_many_threaded(request: WorkflowExecutionRequest) -> list[Any]:
     if not request.call_value_list:
         return []
 
-    max_workers = _resolve_max_workers(request.execution.max_workers)
+    max_workers = _validate_max_workers(request.execution.max_workers)
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         return list(pool.map(lambda kwargs: request.func(**kwargs), request.call_value_list))
 
@@ -136,11 +136,11 @@ def execute_many_prefect_flow(request: WorkflowExecutionRequest) -> list[Any]:
     return mapped_flow()
 
 
-def _resolve_max_workers(max_workers: int | None) -> int | None:
+def _validate_max_workers(max_workers: int | None) -> int | None:
     if max_workers is None:
         return None
 
-    if isinstance(max_workers, bool) or not isinstance(max_workers, int):
+    if not isinstance(max_workers, int):
         raise TypeError(
             f"max_workers must be None or a positive int; got {max_workers!r}"
         )

--- a/probpipe/core/_workflow_execution.py
+++ b/probpipe/core/_workflow_execution.py
@@ -30,7 +30,8 @@ class WorkflowExecutionConfig:
     """Resolved execution settings for ordered workflow calls."""
 
     mode: WorkflowExecutionMode
-    parallel: bool | int = False
+    parallel: bool = False
+    max_workers: int | None = None
     name: str = "workflow"
     prefect_task_runner: Any | None = None
 
@@ -67,7 +68,7 @@ def execute_many_threaded(request: WorkflowExecutionRequest) -> list[Any]:
     if not request.call_value_list:
         return []
 
-    max_workers = _resolve_max_workers(request.execution.parallel)
+    max_workers = _resolve_max_workers(request.execution.max_workers)
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         return list(pool.map(lambda kwargs: request.func(**kwargs), request.call_value_list))
 
@@ -136,20 +137,19 @@ def execute_many_prefect_flow(request: WorkflowExecutionRequest) -> list[Any]:
     return mapped_flow()
 
 
-def _resolve_max_workers(parallel: bool | int) -> int | None:
-    if isinstance(parallel, int) and not isinstance(parallel, bool):
-        if parallel < 1:
-            raise ValueError(
-                f"parallel must be True, False, or a positive int; got {parallel!r}"
-            )
-        return parallel
-
-    if parallel is True:
+def _resolve_max_workers(max_workers: int | None) -> int | None:
+    if max_workers is None:
         return None
 
-    raise TypeError(
-        f"parallel must be True, False, or a positive int; got {parallel!r}"
-    )
+    if isinstance(max_workers, bool) or not isinstance(max_workers, int):
+        raise TypeError(
+            f"max_workers must be None or a positive int; got {max_workers!r}"
+        )
+    if max_workers < 1:
+        raise ValueError(
+            f"max_workers must be None or a positive int; got {max_workers!r}"
+        )
+    return max_workers
 
 
 def _ensure_prefect_available() -> None:

--- a/probpipe/core/_workflow_execution.py
+++ b/probpipe/core/_workflow_execution.py
@@ -30,7 +30,6 @@ class WorkflowExecutionConfig:
     """Resolved execution settings for ordered workflow calls."""
 
     mode: WorkflowExecutionMode
-    parallel: bool = False
     max_workers: int | None = None
     name: str = "workflow"
     prefect_task_runner: Any | None = None

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from itertools import product as cartesian_product
 from types import MappingProxyType
-from typing import Any, Literal, TypeAlias, get_args, get_type_hints
+from typing import Any, ClassVar, Literal, TypeAlias, get_args, get_type_hints
 
 import jax
 import jax.numpy as jnp
@@ -95,9 +95,10 @@ __all__ = [
     "AbstractModule",
 ]
 
-WorkflowFunctionDispatch: TypeAlias = Literal[
+_WorkflowFunctionDispatch: TypeAlias = Literal[
     "auto", "jax", "sequential", "thread"
 ]
+
 
 class InputFrozenError(Exception):
     pass
@@ -303,7 +304,7 @@ class WorkflowFunction(Node):
         - ``"thread"``: local row-wise/function-call dispatch through
           ``ThreadPoolExecutor``.
     max_workers : int or None
-        Worker count for threaded loop execution. ``None`` lets
+        Worker count for threaded sequential execution. ``None`` lets
         ``ThreadPoolExecutor`` choose automatically; a positive integer
         sets the worker count explicitly. Only applies when ``dispatch`` is
         ``"thread"`` and execution resolves to local thread dispatch. JAX
@@ -314,7 +315,9 @@ class WorkflowFunction(Node):
     """
 
     DEFAULT_N_BROADCAST_SAMPLES: int = 128
-    _VALID_DISPATCH_STRATEGIES = get_args(WorkflowFunctionDispatch)
+    _VALID_DISPATCH_STRATEGIES: ClassVar[tuple[str, ...]] = get_args(
+        _WorkflowFunctionDispatch
+    )
 
     def __init__(
         self,
@@ -325,7 +328,7 @@ class WorkflowFunction(Node):
         bind: dict[str, Any] | None = None,         # construction-time bindings (defaults/config)
         module: Any | None = None,                  # typically a Module; kept as Any to avoid import cycles
         n_broadcast_samples: int | None = None,      # default number of samples for broadcasting
-        dispatch: WorkflowFunctionDispatch = "auto", # "auto" | "jax" | "sequential" | "thread"
+        dispatch: _WorkflowFunctionDispatch = "auto", # "auto" | "jax" | "sequential" | "thread"
         max_workers: int | None = None,             # ThreadPoolExecutor worker count
         seed: int = 0,                              # JAX PRNG seed for broadcasting
         include_inputs: bool = False,                # True → return BroadcastDistribution (joint over inputs+outputs)
@@ -452,7 +455,7 @@ class WorkflowFunction(Node):
         *,
         mode: _workflow_execution.WorkflowExecutionMode | None = None,
     ) -> _workflow_execution.WorkflowExecutionConfig:
-        """Build resolved execution metadata for loop-style call dispatch."""
+        """Build resolved execution metadata for sequential call dispatch."""
         if mode is None:
             kind = self.effective_workflow_kind
             if kind is WorkflowKind.TASK:
@@ -1088,7 +1091,7 @@ class WorkflowFunction(Node):
         """Execute ``n_total`` inner calls, one per sweep cell in flat
         row-major order over the concatenated ``sweep_batch_shape``.
 
-        Returns a Python list of outputs (loop path) or a stacked
+        Returns a Python list of outputs (sequential path) or a stacked
         pytree with leading axis ``n_total`` (vmap path). Either form
         is a valid input for ``_make_stack``.
         """
@@ -1142,7 +1145,7 @@ class WorkflowFunction(Node):
                 }
             return jax.vmap(single_call)(vmap_input)
 
-        # Loop path.
+        # Sequential path.
         per_row_values = [
             self._slice_ra_args(values, ra_args, i, ra_groups)
             for i in range(n_total)

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -147,7 +147,7 @@ def workflow_function(_func=None, /, **kwargs):
         def my_func(x, y):
             return x + y
 
-        @workflow_function(n_broadcast_samples=100, vectorize="loop")
+        @workflow_function(n_broadcast_samples=100, dispatch="sequential")
         def my_func(x, y):
             return x + y
     """
@@ -253,14 +253,15 @@ class WorkflowFunction(Node):
     sample, returning an ``EmpiricalDistribution`` over the outputs (or a
     plain list when results are not numeric).
 
-    **Vectorization and orchestration** are orthogonal concerns:
+    **Dispatch and orchestration** are orthogonal concerns:
 
-    - *Vectorization* (``vectorize``) controls **how** samples are dispatched:
-      ``jax.vmap`` for JAX-traceable functions, or a Python loop otherwise.
+    - *Dispatch* (``dispatch``) controls **how** samples are dispatched:
+      ``jax.vmap``, local sequential function calls, or local threaded
+      function calls.
     - *Orchestration* (``workflow_kind``) controls **whether** the dispatch
       is wrapped in a Prefect task or flow for compute-graph tracing.
 
-    When both are active, the JAX-vectorized computation is executed inside
+    When both are active, the JAX-dispatched computation is executed inside
     a Prefect task/flow, giving the benefits of ``vmap`` performance with
     full Prefect lineage tracking.
 
@@ -286,28 +287,24 @@ class WorkflowFunction(Node):
         Default number of samples drawn when broadcasting.  Can be overridden
         at call time by passing ``n_broadcast_samples=…`` (provided the
         wrapped function does not itself declare a parameter with that name).
-    vectorize : str
-        Vectorization strategy for broadcasting:
+    dispatch : str
+        Function-call dispatch strategy for broadcasting:
 
         - ``"auto"`` (default): probe with ``jax.make_jaxpr``; on success
-          use ``"jax"``, on failure fall back to ``"loop"``.
-        - ``"jax"``: vectorise via ``jax.vmap``.  Requires the wrapped
-          function to be JAX-traceable.
-        - ``"loop"``: Python loop (optionally threaded via *parallel*).
-    parallel : bool
-        Controls local threaded execution for loop-style call-list
-        dispatch only. ``False`` runs sequentially; ``True`` uses
-        ``ThreadPoolExecutor``. This does not control JAX ``vmap``,
-        Prefect, Ray, or Dask concurrency.
+          use ``"jax"``, on failure fall back to ``"sequential"``.
+        - ``"jax"``: dispatch via ``jax.vmap``. Requires the wrapped
+          function and broadcast path to be JAX-traceable.
+        - ``"sequential"``: local row-wise/function-call dispatch without
+          threads.
+        - ``"thread"``: local row-wise/function-call dispatch through
+          ``ThreadPoolExecutor``.
     max_workers : int or None
         Worker count for threaded loop execution. ``None`` lets
         ``ThreadPoolExecutor`` choose automatically; a positive integer
-        sets the worker count explicitly. Only applies when ``parallel``
-        is ``True`` and execution resolves to local thread dispatch.
-        Supplying ``max_workers`` when execution resolves to local
-        sequential dispatch raises ``ValueError``. JAX ``vmap`` and
-        Prefect execution ignore local thread settings with warnings
-        rather than using them.
+        sets the worker count explicitly. Only applies when ``dispatch`` is
+        ``"thread"`` and execution resolves to local thread dispatch. JAX
+        ``vmap``, local sequential dispatch, Prefect, Ray, and Dask do not
+        use this setting.
     seed : int
         Random seed for JAX PRNG key management during broadcasting.
     """
@@ -323,15 +320,24 @@ class WorkflowFunction(Node):
         bind: dict[str, Any] | None = None,         # construction-time bindings (defaults/config)
         module: Any | None = None,                  # typically a Module; kept as Any to avoid import cycles
         n_broadcast_samples: int | None = None,      # default number of samples for broadcasting
-        vectorize: str = "auto",                     # "auto" | "jax" | "loop"
-        parallel: bool = False,                     # True for ThreadPoolExecutor loop dispatch
+        dispatch: str = "auto",                     # "auto" | "jax" | "sequential" | "thread"
         max_workers: int | None = None,             # ThreadPoolExecutor worker count
         seed: int = 0,                              # JAX PRNG seed for broadcasting
         include_inputs: bool = False,                # True → return BroadcastDistribution (joint over inputs+outputs)
         **kwargs: Any,                              # convenience bindings (merged into bind)
     ):
-        if not isinstance(parallel, bool):
-            raise TypeError(f"parallel must be a bool; got {parallel!r}")
+        removed_keywords = {"parallel", "vectorize"} & set(kwargs)
+        if removed_keywords:
+            names = ", ".join(sorted(removed_keywords))
+            raise TypeError(
+                f"WorkflowFunction no longer accepts {names}; use dispatch= instead."
+            )
+
+        if dispatch not in ("auto", "jax", "sequential", "thread"):
+            raise ValueError(
+                "dispatch must be one of 'auto', 'jax', 'sequential', or "
+                f"'thread'; got {dispatch!r}"
+            )
         if max_workers is not None:
             if isinstance(max_workers, bool) or not isinstance(max_workers, int):
                 raise TypeError(
@@ -341,10 +347,10 @@ class WorkflowFunction(Node):
                 raise ValueError(
                     f"max_workers must be None or a positive int; got {max_workers!r}"
                 )
-        if vectorize == "jax" and (parallel or max_workers is not None):
+        if dispatch != "thread" and max_workers is not None:
             warnings.warn(
-                "parallel and max_workers configure only local threaded loop "
-                "dispatch; they do not control JAX vmap.",
+                "max_workers configures only dispatch='thread'; ignoring it "
+                f"for dispatch={dispatch!r}.",
                 stacklevel=2,
             )
 
@@ -371,12 +377,11 @@ class WorkflowFunction(Node):
         self.__module__ = getattr(func, "__module__", None)
         self._module = module
         self._n_broadcast_samples = n_broadcast_samples if n_broadcast_samples is not None else self.DEFAULT_N_BROADCAST_SAMPLES
-        self._vectorize = vectorize
-        self._parallel = parallel
+        self._dispatch = dispatch
         self._max_workers = max_workers
         self._key = jax.random.PRNGKey(seed)
         self._include_inputs = include_inputs
-        self._resolved_vectorize: str | None = None  # cached auto-detection result
+        self._resolved_dispatch: str | None = None  # cached auto-detection result
 
         # bind = "construction-time inputs" (defaults/config). kwargs are also treated as bind.
         b = dict(bind or {})
@@ -458,7 +463,7 @@ class WorkflowFunction(Node):
                 mode = "prefect_task"
             elif kind is WorkflowKind.FLOW:
                 mode = "prefect_flow"
-            elif self._parallel:
+            elif self._dispatch == "thread":
                 mode = "thread"
             else:
                 mode = "sequential"
@@ -466,16 +471,12 @@ class WorkflowFunction(Node):
         max_workers = None
         if mode == "thread":
             max_workers = self._max_workers
-        elif mode == "sequential" and self._max_workers is not None:
-            raise ValueError(
-                "max_workers requires parallel=True for local threaded loop "
-                "dispatch."
-            )
         elif mode in ("prefect_task", "prefect_flow"):
-            if self._parallel or self._max_workers is not None:
+            if self._dispatch == "thread" or self._max_workers is not None:
                 warnings.warn(
-                    "parallel and max_workers configure only local threaded loop "
-                    "dispatch; they do not control Prefect execution.",
+                    "dispatch='thread' and max_workers configure only local "
+                    "ThreadPoolExecutor dispatch; they do not control Prefect "
+                    "scheduling.",
                     stacklevel=2,
                 )
 
@@ -822,22 +823,15 @@ class WorkflowFunction(Node):
         self._key, subkey = jax.random.split(self._key)
         return subkey
 
-    def _resolve_vectorize(self, values: dict[str, Any], broadcast_args: list[str]) -> str:
-        """Resolve the vectorization strategy, caching the auto-detection result.
-
-        Returns ``"jax"`` or ``"loop"``.  This is independent of orchestration
-        (``workflow_kind``), which wraps whichever strategy is chosen.
-        """
-        if self._vectorize != "auto":
-            return self._vectorize
-
-        if self._resolved_vectorize is not None:
-            return self._resolved_vectorize
-
-        # Probe JAX traceability with dummy inputs
+    def _jax_traceability_error(
+        self,
+        values: dict[str, Any],
+        broadcast_args: list[str],
+    ) -> Exception | None:
+        """Return the JAX trace-probe error for the current call, if any."""
         try:
             dummy_kw = {}
-            for name, param in self._sig.parameters.items():
+            for name in self._sig.parameters:
                 if name == "self":
                     continue
                 if name in broadcast_args:
@@ -858,20 +852,62 @@ class WorkflowFunction(Node):
                     v = values[name]
                     if isinstance(v, jnp.ndarray):
                         dummy_kw[name] = v
-                    elif hasattr(v, '__array__'):
+                    elif hasattr(v, "__array__"):
                         dummy_kw[name] = jnp.asarray(v)
                     else:
                         dummy_kw[name] = v
             jax.make_jaxpr(lambda kw: self._func(**kw))(dummy_kw)
-            self._resolved_vectorize = "jax"
-        except Exception:
+        except Exception as exc:
+            return exc
+        return None
+
+    def _require_jax_traceable(
+        self,
+        values: dict[str, Any],
+        broadcast_args: list[str],
+    ) -> None:
+        """Raise a clear error if explicit JAX dispatch cannot trace."""
+        trace_error = self._jax_traceability_error(values, broadcast_args)
+        if trace_error is None:
+            return
+        raise ValueError(
+            "dispatch='jax' failed while tracing the wrapped function with JAX; "
+            "ensure the function is JAX-traceable, or use dispatch='auto', "
+            "'sequential', or 'thread'."
+        ) from trace_error
+
+    def _resolve_dispatch(
+        self,
+        values: dict[str, Any],
+        broadcast_args: list[str],
+        *,
+        jax_supported: bool = True,
+    ) -> str:
+        """Resolve the dispatch strategy, caching JAX traceability detection.
+
+        Returns ``"jax"``, ``"sequential"``, or ``"thread"``. This is
+        independent of orchestration (``workflow_kind``), which wraps
+        whichever strategy is chosen.
+        """
+        if self._dispatch != "auto":
+            return self._dispatch
+
+        if not jax_supported:
+            return "sequential"
+
+        if self._resolved_dispatch is not None:
+            return self._resolved_dispatch
+
+        if self._jax_traceability_error(values, broadcast_args) is None:
+            self._resolved_dispatch = "jax"
+        else:
             logger.info(
-                "Function '%s' is not JAX-traceable; using loop vectorization.",
+                "Function '%s' is not JAX-traceable; using sequential dispatch.",
                 self._name,
             )
-            self._resolved_vectorize = "loop"
+            self._resolved_dispatch = "sequential"
 
-        return self._resolved_vectorize
+        return self._resolved_dispatch
 
     def _broadcast(
         self,
@@ -1060,8 +1096,6 @@ class WorkflowFunction(Node):
         pytree with leading axis ``n_total`` (vmap path). Either form
         is a valid input for ``_make_stack``.
         """
-        vectorize = self._resolve_vectorize(values, ra_args)
-
         # The vmap path only handles the simple single-RecordArray
         # case: one group, one RA arg, no DistributionArray, no views
         # (views carry parent references that would confuse vmap's
@@ -1072,10 +1106,24 @@ class WorkflowFunction(Node):
         has_view = any(
             isinstance(values[name], _RecordArrayView) for name in ra_args
         )
-        if has_dist_array or has_view or len(ra_groups) > 1 or len(ra_args) > 1:
-            vectorize = "loop"
+        jax_supported = not (
+            has_dist_array or has_view or len(ra_groups) > 1 or len(ra_args) > 1
+        )
+        if self._dispatch == "jax" and not jax_supported:
+            raise ValueError(
+                "dispatch='jax' supports only a single plain RecordArray sweep; "
+                "use dispatch='auto', 'sequential', or 'thread' for this path."
+            )
 
-        if vectorize == "jax":
+        dispatch = self._resolve_dispatch(
+            values,
+            ra_args,
+            jax_supported=jax_supported,
+        )
+
+        if dispatch == "jax":
+            if self._dispatch == "jax":
+                self._require_jax_traceable(values, ra_args)
             # Flatten the single RecordArray's batch axes to one leading
             # dim so vmap maps over axis 0 uniformly regardless of the
             # sweep's original batch_shape.
@@ -1153,14 +1201,16 @@ class WorkflowFunction(Node):
         calls the user's function once per sample, and wraps the n
         outputs as a single marginal distribution.
 
-        Vectorization (``"jax"`` vs ``"loop"``) and orchestration
+        Dispatch (``"jax"`` vs row-wise calls) and orchestration
         (``workflow_kind``) are resolved independently:
 
-        - **vectorize="jax"**: samples are dispatched via ``jax.vmap``.
-        - **vectorize="loop"**: samples are dispatched via a Python loop,
-          with optional empirical enumeration and threading.
-        - **workflow_kind="task"/"flow"**: whichever vectorization strategy
-          is chosen gets wrapped in a Prefect task or flow for compute-graph
+        - **dispatch="jax"**: samples are dispatched via ``jax.vmap``.
+        - **dispatch="sequential"**: samples are dispatched via local
+          row-wise calls.
+        - **dispatch="thread"**: samples are dispatched via local threaded
+          row-wise calls.
+        - **workflow_kind="task"/"flow"**: whichever dispatch strategy is
+          chosen gets wrapped in a Prefect task or flow for compute-graph
           tracing.
         """
         MIN_BROADCAST_SAMPLES = 5  # Recommended minimum samples
@@ -1173,8 +1223,6 @@ class WorkflowFunction(Node):
                 f"Recommended minimum is {MIN_BROADCAST_SAMPLES}.",
                 stacklevel=2
             )
-
-        vectorize = self._resolve_vectorize(values, broadcast_args)
 
         # Collect candidate empirical dists (small enough individually),
         # sorted smallest first. Greedily include them while the product
@@ -1199,15 +1247,28 @@ class WorkflowFunction(Node):
                 # Too large to enumerate — sample from it instead.
                 sample_args[name] = dist
 
+        dispatch = self._resolve_dispatch(
+            values,
+            broadcast_args,
+            jax_supported=not empirical_args,
+        )
+        if self._dispatch == "jax" and empirical_args:
+            raise ValueError(
+                "dispatch='jax' does not support exact empirical enumeration; "
+                "use dispatch='auto', 'sequential', or 'thread' for this path."
+            )
+
         # Enumeration preserves exact empirical weights and must run in
-        # all vectorization modes — otherwise the cartesian-product
-        # semantics change with vectorize= (issue surfaced in the
+        # all row-wise dispatch modes — otherwise the cartesian-product
+        # semantics change with dispatch= (issue surfaced in the
         # ``EmpiricalDistribution`` broadcasting example).
         if empirical_args:
             result = self._broadcast_enumerate(
                 values, empirical_args, sample_args, product_size, n_broadcast_samples,
             )
-        elif vectorize == "jax":
+        elif dispatch == "jax":
+            if self._dispatch == "jax":
+                self._require_jax_traceable(values, broadcast_args)
             result = self._broadcast_jax(values, broadcast_args, n_broadcast_samples)
         else:
             result = self._broadcast_sample(values, broadcast_args, n_broadcast_samples)
@@ -1221,7 +1282,7 @@ class WorkflowFunction(Node):
             "broadcast",
             parents=parents,
             metadata={
-                "vectorize": vectorize,
+                "dispatch": dispatch,
                 "orchestrate": self.effective_workflow_kind.value,
                 "n_samples": n_broadcast_samples,
                 "func": self._name or self._func.__name__,

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from itertools import product as cartesian_product
 from types import MappingProxyType
-from typing import Any, get_type_hints
+from typing import Any, Literal, TypeAlias, get_args, get_type_hints
 
 import jax
 import jax.numpy as jnp
@@ -93,6 +93,10 @@ __all__ = [
     "WorkflowFunction",
     "Module",
     "AbstractModule",
+]
+
+WorkflowFunctionDispatch: TypeAlias = Literal[
+    "auto", "jax", "sequential", "thread"
 ]
 
 class InputFrozenError(Exception):
@@ -310,6 +314,7 @@ class WorkflowFunction(Node):
     """
 
     DEFAULT_N_BROADCAST_SAMPLES: int = 128
+    _VALID_DISPATCH_STRATEGIES = get_args(WorkflowFunctionDispatch)
 
     def __init__(
         self,
@@ -320,7 +325,7 @@ class WorkflowFunction(Node):
         bind: dict[str, Any] | None = None,         # construction-time bindings (defaults/config)
         module: Any | None = None,                  # typically a Module; kept as Any to avoid import cycles
         n_broadcast_samples: int | None = None,      # default number of samples for broadcasting
-        dispatch: str = "auto",                     # "auto" | "jax" | "sequential" | "thread"
+        dispatch: WorkflowFunctionDispatch = "auto", # "auto" | "jax" | "sequential" | "thread"
         max_workers: int | None = None,             # ThreadPoolExecutor worker count
         seed: int = 0,                              # JAX PRNG seed for broadcasting
         include_inputs: bool = False,                # True → return BroadcastDistribution (joint over inputs+outputs)
@@ -333,20 +338,11 @@ class WorkflowFunction(Node):
                 f"WorkflowFunction no longer accepts {names}; use dispatch= instead."
             )
 
-        if dispatch not in ("auto", "jax", "sequential", "thread"):
+        if dispatch not in self._VALID_DISPATCH_STRATEGIES:
             raise ValueError(
-                "dispatch must be one of 'auto', 'jax', 'sequential', or "
-                f"'thread'; got {dispatch!r}"
+                f"dispatch must be one of {self._VALID_DISPATCH_STRATEGIES}; got {dispatch!r}"
             )
-        if max_workers is not None:
-            if isinstance(max_workers, bool) or not isinstance(max_workers, int):
-                raise TypeError(
-                    f"max_workers must be None or a positive int; got {max_workers!r}"
-                )
-            if max_workers < 1:
-                raise ValueError(
-                    f"max_workers must be None or a positive int; got {max_workers!r}"
-                )
+        _workflow_execution._validate_max_workers(max_workers)
         if dispatch != "thread" and max_workers is not None:
             warnings.warn(
                 "max_workers configures only dispatch='thread'; ignoring it "

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -295,14 +295,19 @@ class WorkflowFunction(Node):
           function to be JAX-traceable.
         - ``"loop"``: Python loop (optionally threaded via *parallel*).
     parallel : bool
-        Controls parallel execution during broadcasting (``"loop"``
-        vectorization only). ``False`` runs sequentially; ``True`` uses
-        ``ThreadPoolExecutor``.
+        Controls local threaded execution for loop-style call-list
+        dispatch only. ``False`` runs sequentially; ``True`` uses
+        ``ThreadPoolExecutor``. This does not control JAX ``vmap``,
+        Prefect, Ray, or Dask concurrency.
     max_workers : int or None
         Worker count for threaded loop execution. ``None`` lets
         ``ThreadPoolExecutor`` choose automatically; a positive integer
-        sets the worker count explicitly. Ignored unless ``parallel`` is
-        ``True``.
+        sets the worker count explicitly. Only applies when ``parallel``
+        is ``True`` and execution resolves to local thread dispatch.
+        Supplying ``max_workers`` when execution resolves to local
+        sequential dispatch raises ``ValueError``. JAX ``vmap`` and
+        Prefect execution ignore local thread settings with warnings
+        rather than using them.
     seed : int
         Random seed for JAX PRNG key management during broadcasting.
     """
@@ -336,6 +341,12 @@ class WorkflowFunction(Node):
                 raise ValueError(
                     f"max_workers must be None or a positive int; got {max_workers!r}"
                 )
+        if vectorize == "jax" and (parallel or max_workers is not None):
+            warnings.warn(
+                "parallel and max_workers configure only local threaded loop "
+                "dispatch; they do not control JAX vmap.",
+                stacklevel=2,
+            )
 
         self._func = func
         self._sig = inspect.signature(func)
@@ -452,6 +463,22 @@ class WorkflowFunction(Node):
             else:
                 mode = "sequential"
 
+        max_workers = None
+        if mode == "thread":
+            max_workers = self._max_workers
+        elif mode == "sequential" and self._max_workers is not None:
+            raise ValueError(
+                "max_workers requires parallel=True for local threaded loop "
+                "dispatch."
+            )
+        elif mode in ("prefect_task", "prefect_flow"):
+            if self._parallel or self._max_workers is not None:
+                warnings.warn(
+                    "parallel and max_workers configure only local threaded loop "
+                    "dispatch; they do not control Prefect execution.",
+                    stacklevel=2,
+                )
+
         prefect_task_runner = (
             prefect_config.resolve_task_runner()
             if mode in ("prefect_task", "prefect_flow")
@@ -459,8 +486,7 @@ class WorkflowFunction(Node):
         )
         return _workflow_execution.WorkflowExecutionConfig(
             mode=mode,
-            parallel=self._parallel,
-            max_workers=self._max_workers,
+            max_workers=max_workers,
             name=self._name,
             prefect_task_runner=prefect_task_runner,
         )
@@ -1437,8 +1463,6 @@ class WorkflowFunction(Node):
             call_value_list=call_value_list,
             execution=_workflow_execution.WorkflowExecutionConfig(
                 mode="prefect_task",
-                parallel=self._parallel,
-                max_workers=self._max_workers,
                 name=self._name,
             ),
         )

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -294,11 +294,15 @@ class WorkflowFunction(Node):
         - ``"jax"``: vectorise via ``jax.vmap``.  Requires the wrapped
           function to be JAX-traceable.
         - ``"loop"``: Python loop (optionally threaded via *parallel*).
-    parallel : bool or int
+    parallel : bool
         Controls parallel execution during broadcasting (``"loop"``
-        vectorization only).  ``False`` → sequential, ``True`` →
-        ``ThreadPoolExecutor`` with default workers, ``int`` → explicit
-        ``max_workers``.
+        vectorization only). ``False`` runs sequentially; ``True`` uses
+        ``ThreadPoolExecutor``.
+    max_workers : int or None
+        Worker count for threaded loop execution. ``None`` lets
+        ``ThreadPoolExecutor`` choose automatically; a positive integer
+        sets the worker count explicitly. Ignored unless ``parallel`` is
+        ``True``.
     seed : int
         Random seed for JAX PRNG key management during broadcasting.
     """
@@ -315,11 +319,24 @@ class WorkflowFunction(Node):
         module: Any | None = None,                  # typically a Module; kept as Any to avoid import cycles
         n_broadcast_samples: int | None = None,      # default number of samples for broadcasting
         vectorize: str = "auto",                     # "auto" | "jax" | "loop"
-        parallel: bool | int = False,               # True/int for ThreadPoolExecutor, or Prefect .map()
+        parallel: bool = False,                     # True for ThreadPoolExecutor loop dispatch
+        max_workers: int | None = None,             # ThreadPoolExecutor worker count
         seed: int = 0,                              # JAX PRNG seed for broadcasting
         include_inputs: bool = False,                # True → return BroadcastDistribution (joint over inputs+outputs)
         **kwargs: Any,                              # convenience bindings (merged into bind)
     ):
+        if not isinstance(parallel, bool):
+            raise TypeError(f"parallel must be a bool; got {parallel!r}")
+        if max_workers is not None:
+            if isinstance(max_workers, bool) or not isinstance(max_workers, int):
+                raise TypeError(
+                    f"max_workers must be None or a positive int; got {max_workers!r}"
+                )
+            if max_workers < 1:
+                raise ValueError(
+                    f"max_workers must be None or a positive int; got {max_workers!r}"
+                )
+
         self._func = func
         self._sig = inspect.signature(func)
         self._hints = get_type_hints(func)
@@ -345,6 +362,7 @@ class WorkflowFunction(Node):
         self._n_broadcast_samples = n_broadcast_samples if n_broadcast_samples is not None else self.DEFAULT_N_BROADCAST_SAMPLES
         self._vectorize = vectorize
         self._parallel = parallel
+        self._max_workers = max_workers
         self._key = jax.random.PRNGKey(seed)
         self._include_inputs = include_inputs
         self._resolved_vectorize: str | None = None  # cached auto-detection result
@@ -429,7 +447,7 @@ class WorkflowFunction(Node):
                 mode = "prefect_task"
             elif kind is WorkflowKind.FLOW:
                 mode = "prefect_flow"
-            elif self._parallel is not False:
+            elif self._parallel:
                 mode = "thread"
             else:
                 mode = "sequential"
@@ -442,6 +460,7 @@ class WorkflowFunction(Node):
         return _workflow_execution.WorkflowExecutionConfig(
             mode=mode,
             parallel=self._parallel,
+            max_workers=self._max_workers,
             name=self._name,
             prefect_task_runner=prefect_task_runner,
         )
@@ -1419,6 +1438,7 @@ class WorkflowFunction(Node):
             execution=_workflow_execution.WorkflowExecutionConfig(
                 mode="prefect_task",
                 parallel=self._parallel,
+                max_workers=self._max_workers,
                 name=self._name,
             ),
         )

--- a/tests/core/test_broadcasting.py
+++ b/tests/core/test_broadcasting.py
@@ -1,10 +1,13 @@
 """Broadcasting tests for JAX-based distribution API."""
+
+from __future__ import annotations
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import BroadcastDistribution, EmpiricalDistribution, MultivariateNormal, Normal, NumericRecordDistribution
+from probpipe import BroadcastDistribution, EmpiricalDistribution, MultivariateNormal, Normal
 from probpipe.core.node import WorkflowFunction
 
 
@@ -14,7 +17,7 @@ def key():
 
 
 # ---------------------------------------------------------------------------
-# Basic broadcasting (loop backend) — default returns marginal
+# Basic broadcasting (loop backend) - default returns marginal
 # ---------------------------------------------------------------------------
 
 class TestBroadcastingBasic:
@@ -22,7 +25,7 @@ class TestBroadcastingBasic:
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
-        w = WorkflowFunction(func=double_it, n_broadcast_samples=50, vectorize="loop", seed=0)
+        w = WorkflowFunction(func=double_it, n_broadcast_samples=50, dispatch="sequential", seed=0)
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g)
         assert not isinstance(result, BroadcastDistribution)
@@ -33,7 +36,7 @@ class TestBroadcastingBasic:
         def add_one(x: jnp.ndarray) -> jnp.ndarray:
             return x + 1.0
 
-        w = WorkflowFunction(func=add_one, n_broadcast_samples=200, vectorize="loop", seed=1)
+        w = WorkflowFunction(func=add_one, n_broadcast_samples=200, dispatch="sequential", seed=1)
         g = Normal(loc=0.0, scale=0.1, name="x")
         result = w(x=g)
         # Mean should be ~1.0 (0 + 1)
@@ -43,7 +46,7 @@ class TestBroadcastingBasic:
         def compute_norm(x: jnp.ndarray) -> float:
             return float(jnp.linalg.norm(x))
 
-        w = WorkflowFunction(func=compute_norm, n_broadcast_samples=20, vectorize="loop", seed=2)
+        w = WorkflowFunction(func=compute_norm, n_broadcast_samples=20, dispatch="sequential", seed=2)
         mvn = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="x")
         result = w(x=mvn)
         assert not isinstance(result, BroadcastDistribution)
@@ -53,7 +56,7 @@ class TestBroadcastingBasic:
         """WorkflowFunction accepts positional arguments."""
         from probpipe.core.node import workflow_function
 
-        @workflow_function(n_broadcast_samples=30, vectorize="loop", seed=5)
+        @workflow_function(n_broadcast_samples=30, dispatch="sequential", seed=5)
         def add(x, y):
             return x + y
 
@@ -75,7 +78,7 @@ class TestBroadcastingBasic:
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
-        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, vectorize="loop", seed=0)
+        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, dispatch="sequential", seed=0)
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g)
         assert not hasattr(result, 'input_samples')
@@ -86,7 +89,7 @@ class TestBroadcastingMultipleArgs:
         def add_them(a: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:
             return a + b
 
-        w = WorkflowFunction(func=add_them, n_broadcast_samples=100, vectorize="loop", seed=3)
+        w = WorkflowFunction(func=add_them, n_broadcast_samples=100, dispatch="sequential", seed=3)
         g1 = Normal(loc=1.0, scale=0.1, name="a")
         g2 = Normal(loc=2.0, scale=0.1, name="b")
         result = w(a=g1, b=g2)
@@ -99,7 +102,7 @@ class TestBroadcastingMixedArgs:
         def scale(x: jnp.ndarray, factor: float) -> jnp.ndarray:
             return x * factor
 
-        w = WorkflowFunction(func=scale, n_broadcast_samples=50, vectorize="loop", seed=4)
+        w = WorkflowFunction(func=scale, n_broadcast_samples=50, dispatch="sequential", seed=4)
         g = Normal(loc=5.0, scale=0.1, name="x")
         result = w(x=g, factor=3.0)
         assert result.n == 50
@@ -111,7 +114,7 @@ class TestBroadcastingNSamples:
         def identity(x: jnp.ndarray) -> jnp.ndarray:
             return x
 
-        w = WorkflowFunction(func=identity, vectorize="loop", seed=5)
+        w = WorkflowFunction(func=identity, dispatch="sequential", seed=5)
         g = Normal(loc=0.0, scale=1.0, name="x")
         result = w(x=g)
         assert result.n == WorkflowFunction.DEFAULT_N_BROADCAST_SAMPLES
@@ -120,7 +123,7 @@ class TestBroadcastingNSamples:
         def identity(x: jnp.ndarray) -> jnp.ndarray:
             return x
 
-        w = WorkflowFunction(func=identity, n_broadcast_samples=100, vectorize="loop", seed=6)
+        w = WorkflowFunction(func=identity, n_broadcast_samples=100, dispatch="sequential", seed=6)
         g = Normal(loc=0.0, scale=1.0, name="x")
         result = w(x=g, n_broadcast_samples=10)
         assert result.n == 10
@@ -132,21 +135,21 @@ class TestReservedParameterNames:
             return x
 
         with pytest.raises(ValueError, match="reserved"):
-            WorkflowFunction(func=bad_fn, vectorize="loop")
+            WorkflowFunction(func=bad_fn, dispatch="sequential")
 
     def test_seed_forbidden(self):
         def bad_fn(x: jnp.ndarray, seed: int = 0) -> jnp.ndarray:
             return x
 
         with pytest.raises(ValueError, match="reserved"):
-            WorkflowFunction(func=bad_fn, vectorize="loop")
+            WorkflowFunction(func=bad_fn, dispatch="sequential")
 
     def test_include_inputs_forbidden(self):
         def bad_fn(x: jnp.ndarray, include_inputs: bool = False) -> jnp.ndarray:
             return x
 
         with pytest.raises(ValueError, match="reserved"):
-            WorkflowFunction(func=bad_fn, vectorize="loop")
+            WorkflowFunction(func=bad_fn, dispatch="sequential")
 
 
 class TestWorkflowFunctionCallResolution:
@@ -154,7 +157,7 @@ class TestWorkflowFunctionCallResolution:
         def identity(x):
             return x
 
-        w = WorkflowFunction(func=identity, vectorize="loop")
+        w = WorkflowFunction(func=identity, dispatch="sequential")
 
         with pytest.raises(TypeError, match="unexpected keyword argument 'typo'"):
             w(x=1.0, typo=2.0)
@@ -166,7 +169,7 @@ class TestWorkflowFunctionCallResolution:
             seen.append(kwargs)
             return x
 
-        w = WorkflowFunction(func=identity, vectorize="loop")
+        w = WorkflowFunction(func=identity, dispatch="sequential")
         out = w(x=1.0, kwargs={"scale": 2.0})
 
         assert float(out) == 1.0
@@ -179,7 +182,7 @@ class TestWorkflowFunctionCallResolution:
             seen.append(kwargs)
             return x
 
-        w = WorkflowFunction(func=identity, vectorize="loop")
+        w = WorkflowFunction(func=identity, dispatch="sequential")
         out = w(x=1.0, scale=2.0)
 
         assert float(out) == 1.0
@@ -193,7 +196,7 @@ class TestNoBroadcasting:
         def add(a: float, b: float) -> float:
             return a + b
 
-        w = WorkflowFunction(func=add, vectorize="loop")
+        w = WorkflowFunction(func=add, dispatch="sequential")
         result = w(a=1.0, b=2.0)
         # Concrete args return the workflow-function's auto-wrapped scalar:
         # ``NumericRecord({"add": 3.0})``. The ``__float__`` shim unwraps it.
@@ -213,7 +216,7 @@ class TestBroadcastingEnumeration:
         weights = jnp.array([0.2, 0.3, 0.5])
         ed = EmpiricalDistribution(samples, weights, name="x")
 
-        w = WorkflowFunction(func=identity, n_broadcast_samples=100, vectorize="loop", seed=7)
+        w = WorkflowFunction(func=identity, n_broadcast_samples=100, dispatch="sequential", seed=7)
         result = w(x=ed)
         assert result.n == 3
         np.testing.assert_allclose(result.weights, weights, atol=1e-5)
@@ -225,7 +228,7 @@ class TestBroadcastingEnumeration:
         ed1 = EmpiricalDistribution(jnp.array([[1.0], [2.0]]), name="x")
         ed2 = EmpiricalDistribution(jnp.array([[10.0], [20.0], [30.0]]), name="x")
 
-        w = WorkflowFunction(func=add_them, n_broadcast_samples=100, vectorize="loop", seed=8)
+        w = WorkflowFunction(func=add_them, n_broadcast_samples=100, dispatch="sequential", seed=8)
         result = w(a=ed1, b=ed2)
         assert result.n == 6  # 2 x 3
 
@@ -238,7 +241,7 @@ class TestBroadcastingEnumeration:
         ed_medium = EmpiricalDistribution(jnp.arange(5).reshape(-1, 1).astype(jnp.float32), name="x")  # n=5
         ed_large = EmpiricalDistribution(jnp.arange(20).reshape(-1, 1).astype(jnp.float32), name="x")  # n=20
 
-        w = WorkflowFunction(func=sum_three, n_broadcast_samples=50, vectorize="loop", seed=9)
+        w = WorkflowFunction(func=sum_three, n_broadcast_samples=50, dispatch="sequential", seed=9)
         result = w(a=ed_small, b=ed_medium, c=ed_large)
         # 2*5=10 enumerated, 50//10=5 reps from ed_large per combo → 50 total
         assert result.n == 50
@@ -250,7 +253,7 @@ class TestBroadcastingEnumeration:
         ed = EmpiricalDistribution(jnp.array([[1.0], [2.0], [3.0]]), name="x")
         g = Normal(loc=0.0, scale=1.0, name="b")
 
-        w = WorkflowFunction(func=add_them, n_broadcast_samples=30, vectorize="loop", seed=10)
+        w = WorkflowFunction(func=add_them, n_broadcast_samples=30, dispatch="sequential", seed=10)
         result = w(a=ed, b=g)
         # 3 empirical combos, 30//3=10 reps each → 30 total
         assert result.n == 30
@@ -263,7 +266,7 @@ class TestBroadcastingEnumeration:
         samples = jnp.array([[1.0], [2.0], [3.0]])
         ed = EmpiricalDistribution(samples, name="x")
 
-        w = WorkflowFunction(func=identity, n_broadcast_samples=100, vectorize="loop", seed=7)
+        w = WorkflowFunction(func=identity, n_broadcast_samples=100, dispatch="sequential", seed=7)
         result = w(x=ed, include_inputs=True)
         assert isinstance(result, BroadcastDistribution)
         assert "x" in result.input_samples
@@ -282,7 +285,7 @@ class TestBroadcastingNonNumeric:
         def describe(x: jnp.ndarray) -> str:
             return f"val={float(x):.2f}"
 
-        w = WorkflowFunction(func=describe, n_broadcast_samples=5, vectorize="loop", seed=11)
+        w = WorkflowFunction(func=describe, n_broadcast_samples=5, dispatch="sequential", seed=11)
         g = Normal(loc=0.0, scale=1.0, name="x")
         result = w(x=g)
         # Non-numeric results still return a marginal (ListMarginal)
@@ -300,7 +303,7 @@ class TestBroadcastingJAX:
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
-        w = WorkflowFunction(func=double_it, n_broadcast_samples=50, vectorize="jax", seed=20)
+        w = WorkflowFunction(func=double_it, n_broadcast_samples=50, dispatch="jax", seed=20)
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g)
         assert not isinstance(result, BroadcastDistribution)
@@ -310,7 +313,7 @@ class TestBroadcastingJAX:
         def add_one(x: jnp.ndarray) -> jnp.ndarray:
             return x + 1.0
 
-        w = WorkflowFunction(func=add_one, n_broadcast_samples=200, vectorize="jax", seed=21)
+        w = WorkflowFunction(func=add_one, n_broadcast_samples=200, dispatch="jax", seed=21)
         g = Normal(loc=0.0, scale=0.1, name="x")
         result = w(x=g)
         assert abs(float(jnp.mean(result.samples)) - 1.0) < 0.1
@@ -319,7 +322,7 @@ class TestBroadcastingJAX:
         def add_them(a: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:
             return a + b
 
-        w = WorkflowFunction(func=add_them, n_broadcast_samples=100, vectorize="jax", seed=22)
+        w = WorkflowFunction(func=add_them, n_broadcast_samples=100, dispatch="jax", seed=22)
         g1 = Normal(loc=1.0, scale=0.1, name="a")
         g2 = Normal(loc=2.0, scale=0.1, name="b")
         result = w(a=g1, b=g2)
@@ -330,7 +333,7 @@ class TestBroadcastingJAX:
         def scale(x: jnp.ndarray, factor: float) -> jnp.ndarray:
             return x * factor
 
-        w = WorkflowFunction(func=scale, n_broadcast_samples=50, vectorize="jax", seed=23)
+        w = WorkflowFunction(func=scale, n_broadcast_samples=50, dispatch="jax", seed=23)
         g = Normal(loc=5.0, scale=0.1, name="x")
         result = w(x=g, factor=3.0)
         assert result.n == 50
@@ -340,7 +343,7 @@ class TestBroadcastingJAX:
         def halve(x: jnp.ndarray) -> jnp.ndarray:
             return x / 2.0
 
-        w = WorkflowFunction(func=halve, n_broadcast_samples=30, vectorize="jax", seed=24)
+        w = WorkflowFunction(func=halve, n_broadcast_samples=30, dispatch="jax", seed=24)
         mvn = MultivariateNormal(loc=jnp.array([4.0, 6.0]), cov=0.01 * jnp.eye(2), name="x")
         result = w(x=mvn)
         assert result.n == 30
@@ -349,11 +352,11 @@ class TestBroadcastingJAX:
         np.testing.assert_allclose(mean, jnp.array([2.0, 3.0]), atol=0.2)
 
     def test_vmap_input_samples(self):
-        """include_inputs=True preserves input–output alignment for vmap."""
+        """include_inputs=True preserves input-output alignment for vmap."""
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
-        w = WorkflowFunction(func=double_it, n_broadcast_samples=30, vectorize="jax", seed=20)
+        w = WorkflowFunction(func=double_it, n_broadcast_samples=30, dispatch="jax", seed=20)
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g, include_inputs=True)
         assert isinstance(result, BroadcastDistribution)
@@ -367,31 +370,44 @@ class TestBroadcastingJAX:
 
 
 # ---------------------------------------------------------------------------
-# Auto backend detection
+# Auto dispatch detection
 # ---------------------------------------------------------------------------
 
-class TestAutoBackend:
+
+class TestAutoDispatch:
     def test_auto_selects_jax_for_traceable(self):
         def pure_jax(x: jnp.ndarray) -> jnp.ndarray:
             return jnp.sin(x)
 
-        w = WorkflowFunction(func=pure_jax, n_broadcast_samples=20, vectorize="auto", seed=30)
+        w = WorkflowFunction(func=pure_jax, n_broadcast_samples=20, dispatch="auto", seed=30)
         g = Normal(loc=0.0, scale=1.0, name="x")
         result = w(x=g)
         assert not isinstance(result, BroadcastDistribution)
-        assert w._resolved_vectorize == "jax"
+        assert w._resolved_dispatch == "jax"
 
-    def test_auto_falls_back_to_loop_for_non_traceable(self):
+    def test_auto_falls_back_to_sequential_for_non_traceable(self):
         import scipy.special
 
         def scipy_fn(x: jnp.ndarray) -> jnp.ndarray:
             return jnp.asarray(scipy.special.gamma(np.asarray(x)))
 
-        w = WorkflowFunction(func=scipy_fn, n_broadcast_samples=20, vectorize="auto", seed=31)
+        w = WorkflowFunction(func=scipy_fn, n_broadcast_samples=20, dispatch="auto", seed=31)
         g = Normal(loc=2.0, scale=0.1, name="x")
         result = w(x=g)
         assert not isinstance(result, BroadcastDistribution)
-        assert w._resolved_vectorize == "loop"
+        assert w._resolved_dispatch == "sequential"
+
+    def test_jax_dispatch_rejects_non_traceable_function_with_clear_error(self):
+        import scipy.special
+
+        def scipy_fn(x: jnp.ndarray) -> jnp.ndarray:
+            return jnp.asarray(scipy.special.gamma(np.asarray(x)))
+
+        w = WorkflowFunction(func=scipy_fn, n_broadcast_samples=20, dispatch="jax", seed=32)
+        g = Normal(loc=2.0, scale=0.1, name="x")
+
+        with pytest.raises(ValueError, match="failed while tracing"):
+            w(x=g)
 
 
 # ---------------------------------------------------------------------------
@@ -405,10 +421,10 @@ class TestSeedManagement:
 
         g = Normal(loc=0.0, scale=1.0, name="x")
 
-        w1 = WorkflowFunction(func=identity, n_broadcast_samples=20, vectorize="loop", seed=0)
+        w1 = WorkflowFunction(func=identity, n_broadcast_samples=20, dispatch="sequential", seed=0)
         r1 = w1(x=g)
 
-        w2 = WorkflowFunction(func=identity, n_broadcast_samples=20, vectorize="loop", seed=99)
+        w2 = WorkflowFunction(func=identity, n_broadcast_samples=20, dispatch="sequential", seed=99)
         r2 = w2(x=g)
 
         assert not jnp.allclose(r1.samples, r2.samples)
@@ -418,7 +434,7 @@ class TestSeedManagement:
             return x
 
         g = Normal(loc=0.0, scale=1.0, name="x")
-        w = WorkflowFunction(func=identity, n_broadcast_samples=20, vectorize="loop", seed=0)
+        w = WorkflowFunction(func=identity, n_broadcast_samples=20, dispatch="sequential", seed=0)
 
         r1 = w(x=g, seed=42)
         # Reset and call with same seed
@@ -435,7 +451,7 @@ class TestIncludeInputsArgument:
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
-        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, vectorize="loop",
+        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, dispatch="sequential",
                              seed=0, include_inputs=True)
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g)
@@ -447,7 +463,7 @@ class TestIncludeInputsArgument:
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
-        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, vectorize="loop", seed=0)
+        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, dispatch="sequential", seed=0)
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g, include_inputs=True)
         assert isinstance(result, BroadcastDistribution)
@@ -457,7 +473,7 @@ class TestIncludeInputsArgument:
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
-        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, vectorize="loop", seed=0)
+        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, dispatch="sequential", seed=0)
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g)
         assert not isinstance(result, BroadcastDistribution)
@@ -467,7 +483,7 @@ class TestIncludeInputsArgument:
         def add_them(a: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:
             return a + b
 
-        w = WorkflowFunction(func=add_them, n_broadcast_samples=20, vectorize="loop", seed=0)
+        w = WorkflowFunction(func=add_them, n_broadcast_samples=20, dispatch="sequential", seed=0)
         g1 = Normal(loc=1.0, scale=0.1, name="a")
         g2 = Normal(loc=2.0, scale=0.1, name="b")
         result = w(a=g1, b=g2, include_inputs=True)
@@ -486,7 +502,7 @@ class TestNamedComponents:
         def add_them(a: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:
             return a + b
 
-        w = WorkflowFunction(func=add_them, n_broadcast_samples=20, vectorize="loop", seed=0)
+        w = WorkflowFunction(func=add_them, n_broadcast_samples=20, dispatch="sequential", seed=0)
         g1 = Normal(loc=1.0, scale=0.1, name="a")
         g2 = Normal(loc=2.0, scale=0.1, name="b")
         result = w(a=g1, b=g2, include_inputs=True)
@@ -498,7 +514,7 @@ class TestNamedComponents:
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
-        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, vectorize="loop", seed=0)
+        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, dispatch="sequential", seed=0)
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g, include_inputs=True)
         x_marginal = result["x"]
@@ -509,7 +525,7 @@ class TestNamedComponents:
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
-        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, vectorize="loop", seed=0)
+        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, dispatch="sequential", seed=0)
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g, include_inputs=True)
         out = result["_output"]
@@ -517,28 +533,27 @@ class TestNamedComponents:
 
 
 # ---------------------------------------------------------------------------
-# Cross-backend consistency: loop / auto / jax must agree
+# Cross-dispatch consistency: sequential / thread / auto must agree
 # ---------------------------------------------------------------------------
 #
 # Empirical enumeration semantics (cartesian product of small
-# empiricals, weighted) must not depend on the vectorization backend.
-# These tests guard against regressions of the kind where the
-# ``vectorize="jax"`` path bypasses enumeration and silently samples
-# instead. The loop and auto paths already test this implicitly; the
-# jax path is the regression surface.
+# empiricals, weighted) must not depend on row-wise dispatch mode.
+# Explicit JAX dispatch rejects exact empirical enumeration because that
+# path cannot run through ``jax.vmap`` without changing semantics.
 # ---------------------------------------------------------------------------
 
 
-class TestVectorizationConsistency:
+class TestDispatchConsistency:
     """Empirical enumeration and count semantics match across
-    ``vectorize="loop" | "auto" | "jax"``."""
+    row-wise dispatch modes."""
 
-    VECTORIZE_MODES = ("loop", "auto", "jax")
+    ROWWISE_DISPATCH_MODES = ("sequential", "thread", "auto")
+    SAMPLE_DISPATCH_MODES = ("sequential", "thread", "auto", "jax")
 
     def _run(self, mode, func, **kwargs):
         w = WorkflowFunction(
             func=func, n_broadcast_samples=kwargs.pop("n_broadcast_samples", 100),
-            vectorize=mode, seed=0,
+            dispatch=mode, seed=0,
         )
         return w(**kwargs)
 
@@ -551,19 +566,22 @@ class TestVectorizationConsistency:
         ed1 = EmpiricalDistribution(jnp.array([[1.0], [2.0]]), name="x")
         ed2 = EmpiricalDistribution(jnp.array([[10.0], [20.0], [30.0]]), name="x")
 
-        results = {m: self._run(m, add_them, a=ed1, b=ed2) for m in self.VECTORIZE_MODES}
-        # Same size (2 x 3 = 6) in every mode — regression guard.
+        results = {
+            m: self._run(m, add_them, a=ed1, b=ed2)
+            for m in self.ROWWISE_DISPATCH_MODES
+        }
+        # Same size (2 x 3 = 6) in every mode - regression guard.
         for mode, r in results.items():
             assert r.n == 6, f"{mode}: expected n=6, got {r.n}"
         # Same sample set (order may differ; compare sorted).
         def _samples_array(d):
             return d.samples[d.samples.fields[0]]
-        ref = sorted(_samples_array(results["loop"]).ravel().tolist())
-        for mode in ("auto", "jax"):
+        ref = sorted(_samples_array(results["sequential"]).ravel().tolist())
+        for mode in ("auto", "thread"):
             got = sorted(_samples_array(results[mode]).ravel().tolist())
             np.testing.assert_allclose(
                 got, ref,
-                err_msg=f"{mode} samples diverged from loop: {got} vs {ref}",
+                err_msg=f"{mode} samples diverged from sequential: {got} vs {ref}",
             )
         # Weights: uniform 1/6 in every mode (inputs unweighted).
         for mode, r in results.items():
@@ -582,7 +600,7 @@ class TestVectorizationConsistency:
         expected_weights = sorted([
             0.8 * 0.25, 0.8 * 0.75, 0.2 * 0.25, 0.2 * 0.75,
         ])
-        for mode in self.VECTORIZE_MODES:
+        for mode in self.ROWWISE_DISPATCH_MODES:
             r = self._run(mode, add_them, a=ed1, b=ed2)
             assert r.n == 4
             got = sorted(np.asarray(r.weights).tolist())
@@ -592,7 +610,7 @@ class TestVectorizationConsistency:
             )
 
     def test_mixed_empirical_and_parametric_count_all_modes(self):
-        """Mixed empirical + continuous: total evaluations (k combos × reps)
+        """Mixed empirical + continuous: total evaluations (k combos x reps)
         must match across backends even though the sampled values differ."""
         def add_them(a, b):
             return a + b
@@ -600,9 +618,9 @@ class TestVectorizationConsistency:
         ed = EmpiricalDistribution(jnp.array([[1.0], [2.0], [3.0]]), name="x")
         g = Normal(loc=0.0, scale=1.0, name="b")
 
-        for mode in self.VECTORIZE_MODES:
+        for mode in self.ROWWISE_DISPATCH_MODES:
             r = self._run(mode, add_them, a=ed, b=g, n_broadcast_samples=30)
-            # 3 empirical combos × 10 reps each = 30 evaluations.
+            # 3 empirical combos x 10 reps each = 30 evaluations.
             assert r.n == 30, f"{mode}: expected n=30, got {r.n}"
             np.testing.assert_allclose(float(r.weights.sum()), 1.0, atol=1e-5)
 
@@ -615,19 +633,28 @@ class TestVectorizationConsistency:
 
         big = EmpiricalDistribution(
             jnp.arange(200).reshape(-1, 1).astype(jnp.float32), name="x")
-        for mode in self.VECTORIZE_MODES:
+        for mode in self.SAMPLE_DISPATCH_MODES:
             r = self._run(mode, identity, x=big, n_broadcast_samples=20)
             assert r.n == 20, f"{mode}: expected n=20, got {r.n}"
 
     def test_no_empiricals_all_modes_same_count(self):
         """Without empirical inputs every backend samples the full
-        budget (values differ — different RNG paths — but count is
+        budget (values differ - different RNG paths - but count is
         identical)."""
         def add_them(a, b):
             return a + b
 
         n1 = Normal(loc=0.0, scale=1.0, name="a")
         n2 = Normal(loc=5.0, scale=1.0, name="b")
-        for mode in self.VECTORIZE_MODES:
+        for mode in self.SAMPLE_DISPATCH_MODES:
             r = self._run(mode, add_them, a=n1, b=n2, n_broadcast_samples=50)
             assert r.n == 50, f"{mode}: expected n=50, got {r.n}"
+
+    def test_jax_dispatch_rejects_exact_empirical_enumeration(self):
+        def identity(x):
+            return x
+
+        empirical = EmpiricalDistribution(jnp.array([[1.0], [2.0]]), name="x")
+
+        with pytest.raises(ValueError, match="does not support exact empirical"):
+            self._run("jax", identity, x=empirical, n_broadcast_samples=20)

--- a/tests/core/test_prefect_config.py
+++ b/tests/core/test_prefect_config.py
@@ -11,6 +11,8 @@ Exercises:
 - PROBPIPE_WORKFLOW_KIND environment-variable override
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import types
@@ -18,13 +20,12 @@ import types
 import pytest
 
 from probpipe.core.config import (
-    WorkflowKind,
-    PrefectConfig,
-    prefect_config,
-    _auto_detect_task_runner,
     _WORKFLOW_KIND_ENV_VAR,
+    PrefectConfig,
+    WorkflowKind,
+    _auto_detect_task_runner,
+    prefect_config,
 )
-
 
 # ---------------------------------------------------------------------------
 # WorkflowKind enum
@@ -214,7 +215,7 @@ class TestEffectiveWorkflowKind:
         def noop(x):
             return x
 
-        wf = WorkflowFunction(func=noop, vectorize="loop", seed=0)
+        wf = WorkflowFunction(func=noop, dispatch="sequential", seed=0)
         assert wf.effective_workflow_kind is WorkflowKind.OFF
 
     def test_explicit_task_overrides_global(self):
@@ -227,7 +228,7 @@ class TestEffectiveWorkflowKind:
             return x
 
         wf = WorkflowFunction(
-            func=noop, workflow_kind=WorkflowKind.TASK, vectorize="loop", seed=0,
+            func=noop, workflow_kind=WorkflowKind.TASK, dispatch="sequential", seed=0,
         )
         import probpipe.core.node as node_mod
         if node_mod.task is not None:
@@ -243,7 +244,7 @@ class TestEffectiveWorkflowKind:
             return x
 
         wf = WorkflowFunction(
-            func=noop, workflow_kind=WorkflowKind.OFF, vectorize="loop", seed=0,
+            func=noop, workflow_kind=WorkflowKind.OFF, dispatch="sequential", seed=0,
         )
         assert wf.effective_workflow_kind is WorkflowKind.OFF
 
@@ -259,7 +260,7 @@ class TestEffectiveWorkflowKind:
             return x
 
         wf = WorkflowFunction(
-            func=noop, workflow_kind=WorkflowKind.TASK, vectorize="loop", seed=0,
+            func=noop, workflow_kind=WorkflowKind.TASK, dispatch="sequential", seed=0,
         )
         with pytest.warns(UserWarning, match="Prefect is not installed"):
             kind = wf.effective_workflow_kind
@@ -278,7 +279,7 @@ class TestEffectiveWorkflowKind:
         def noop(x):
             return x
 
-        wf = WorkflowFunction(func=noop, vectorize="loop", seed=0)
+        wf = WorkflowFunction(func=noop, dispatch="sequential", seed=0)
         assert wf.effective_workflow_kind is WorkflowKind.OFF
 
     def test_global_flow_applies_to_default_instance(self):
@@ -290,7 +291,7 @@ class TestEffectiveWorkflowKind:
         def noop(x):
             return x
 
-        wf = WorkflowFunction(func=noop, vectorize="loop", seed=0)
+        wf = WorkflowFunction(func=noop, dispatch="sequential", seed=0)
         import probpipe.core.node as node_mod
         if node_mod.task is not None:
             assert wf.effective_workflow_kind is WorkflowKind.FLOW
@@ -302,7 +303,7 @@ class TestEffectiveWorkflowKind:
         def noop(x):
             return x
 
-        wf = WorkflowFunction(func=noop, vectorize="loop", seed=0)
+        wf = WorkflowFunction(func=noop, dispatch="sequential", seed=0)
         prefect_config.workflow_kind = WorkflowKind.OFF
         assert wf.effective_workflow_kind is WorkflowKind.OFF
 
@@ -325,7 +326,7 @@ class TestLegacyConversion:
         def noop(x):
             return x
 
-        wf = WorkflowFunction(func=noop, workflow_kind="task", vectorize="loop", seed=0)
+        wf = WorkflowFunction(func=noop, workflow_kind="task", dispatch="sequential", seed=0)
         assert wf._workflow_kind_raw is WorkflowKind.TASK
 
     def test_string_flow_converts(self):
@@ -334,7 +335,7 @@ class TestLegacyConversion:
         def noop(x):
             return x
 
-        wf = WorkflowFunction(func=noop, workflow_kind="flow", vectorize="loop", seed=0)
+        wf = WorkflowFunction(func=noop, workflow_kind="flow", dispatch="sequential", seed=0)
         assert wf._workflow_kind_raw is WorkflowKind.FLOW
 
     def test_none_converts_to_off(self):
@@ -343,7 +344,7 @@ class TestLegacyConversion:
         def noop(x):
             return x
 
-        wf = WorkflowFunction(func=noop, workflow_kind=None, vectorize="loop", seed=0)
+        wf = WorkflowFunction(func=noop, workflow_kind=None, dispatch="sequential", seed=0)
         assert wf._workflow_kind_raw is WorkflowKind.OFF
 
     def test_invalid_string_raises(self):
@@ -353,7 +354,7 @@ class TestLegacyConversion:
             return x
 
         with pytest.raises(ValueError):
-            WorkflowFunction(func=noop, workflow_kind="banana", vectorize="loop", seed=0)
+            WorkflowFunction(func=noop, workflow_kind="banana", dispatch="sequential", seed=0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_prefect_orchestration.py
+++ b/tests/core/test_prefect_orchestration.py
@@ -1,24 +1,26 @@
 """Tests for Prefect orchestration in WorkflowFunction.
 
 Exercises all Prefect dispatch paths:
-- workflow_kind="task" with loop and JAX vectorization
-- workflow_kind="flow" with loop and JAX vectorization
+- workflow_kind="task" with sequential and JAX dispatch
+- workflow_kind="flow" with sequential and JAX dispatch
 - Import guard when Prefect is unavailable
 - Provenance metadata includes orchestration info
 
 Requires ``prefect>=3`` (installed via ``pip install probpipe[prefect]``).
 Uses ``prefect_test_harness()`` for an in-process temporary server.
 """
-import jax
+
+from __future__ import annotations
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
-prefect = pytest.importorskip("prefect")
-from prefect.testing.utilities import prefect_test_harness
-
 from probpipe import Normal
 from probpipe.core.node import WorkflowFunction
+
+prefect_testing = pytest.importorskip("prefect.testing.utilities")
+prefect_test_harness = prefect_testing.prefect_test_harness
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -63,17 +65,17 @@ def sum_xy(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
 
 
 # ---------------------------------------------------------------------------
-# workflow_kind="task" with loop vectorization
+# workflow_kind="task" with sequential dispatch
 # ---------------------------------------------------------------------------
 
 class TestPrefectTaskLoop:
-    """Exercises _execute_many_prefect_task via loop vectorization."""
+    """Exercises _execute_many_prefect_task via sequential dispatch."""
 
     def test_returns_empirical_distribution(self, normal_dist):
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind="task",
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=30,
             seed=0,
         )
@@ -85,7 +87,7 @@ class TestPrefectTaskLoop:
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind="task",
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=200,
             seed=1,
         )
@@ -99,7 +101,7 @@ class TestPrefectTaskLoop:
         wf = WorkflowFunction(
             func=sum_xy,
             workflow_kind="task",
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=30,
             seed=2,
         )
@@ -110,17 +112,17 @@ class TestPrefectTaskLoop:
 
 
 # ---------------------------------------------------------------------------
-# workflow_kind="flow" with loop vectorization
+# workflow_kind="flow" with sequential dispatch
 # ---------------------------------------------------------------------------
 
 class TestPrefectFlowLoop:
-    """Exercises _execute_many_prefect_flow via loop vectorization."""
+    """Exercises _execute_many_prefect_flow via sequential dispatch."""
 
     def test_returns_empirical_distribution(self, normal_dist):
         wf = WorkflowFunction(
             func=double_it,
             workflow_kind="flow",
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=25,
             seed=10,
         )
@@ -132,7 +134,7 @@ class TestPrefectFlowLoop:
         wf = WorkflowFunction(
             func=double_it,
             workflow_kind="flow",
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=200,
             seed=11,
         )
@@ -144,7 +146,7 @@ class TestPrefectFlowLoop:
 
 
 # ---------------------------------------------------------------------------
-# workflow_kind="task" with JAX vectorization
+# workflow_kind="task" with JAX dispatch
 # ---------------------------------------------------------------------------
 
 class TestPrefectTaskJax:
@@ -154,7 +156,7 @@ class TestPrefectTaskJax:
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind="task",
-            vectorize="jax",
+            dispatch="jax",
             n_broadcast_samples=30,
             seed=20,
         )
@@ -166,7 +168,7 @@ class TestPrefectTaskJax:
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind="task",
-            vectorize="jax",
+            dispatch="jax",
             n_broadcast_samples=200,
             seed=21,
         )
@@ -177,7 +179,7 @@ class TestPrefectTaskJax:
 
 
 # ---------------------------------------------------------------------------
-# workflow_kind="flow" with JAX vectorization
+# workflow_kind="flow" with JAX dispatch
 # ---------------------------------------------------------------------------
 
 class TestPrefectFlowJax:
@@ -187,7 +189,7 @@ class TestPrefectFlowJax:
         wf = WorkflowFunction(
             func=double_it,
             workflow_kind="flow",
-            vectorize="jax",
+            dispatch="jax",
             n_broadcast_samples=25,
             seed=30,
         )
@@ -199,7 +201,7 @@ class TestPrefectFlowJax:
         wf = WorkflowFunction(
             func=double_it,
             workflow_kind="flow",
-            vectorize="jax",
+            dispatch="jax",
             n_broadcast_samples=200,
             seed=31,
         )
@@ -220,7 +222,7 @@ class TestPrefectProvenance:
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind="task",
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=20,
             seed=40,
         )
@@ -234,7 +236,7 @@ class TestPrefectProvenance:
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind="flow",
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=20,
             seed=41,
         )
@@ -246,7 +248,7 @@ class TestPrefectProvenance:
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind=None,
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=20,
             seed=42,
         )
@@ -266,7 +268,7 @@ class TestPrefectNonBroadcast:
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind="task",
-            vectorize="loop",
+            dispatch="sequential",
             seed=50,
         )
         # Pass concrete value, not a distribution — no broadcasting
@@ -277,7 +279,7 @@ class TestPrefectNonBroadcast:
         wf = WorkflowFunction(
             func=double_it,
             workflow_kind="flow",
-            vectorize="loop",
+            dispatch="sequential",
             seed=51,
         )
         result = wf(x=jnp.array(3.0))
@@ -299,7 +301,7 @@ class TestPrefectImportGuard:
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind="task",
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=10,
             seed=60,
         )
@@ -315,7 +317,7 @@ class TestPrefectImportGuard:
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind="flow",
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=10,
             seed=61,
         )
@@ -331,7 +333,7 @@ class TestPrefectImportGuard:
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind="task",
-            vectorize="jax",
+            dispatch="jax",
             n_broadcast_samples=10,
             seed=62,
         )

--- a/tests/core/test_provenance.py
+++ b/tests/core/test_provenance.py
@@ -1,28 +1,26 @@
 """Comprehensive tests for provenance tracking across all distribution operations."""
 
-import jax
+from __future__ import annotations
+
 import jax.numpy as jnp
-import numpy as np
 import pytest
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
 from probpipe import (
-    Normal,
     Beta,
-    MultivariateNormal,
-    RecordEmpiricalDistribution,
-    TransformedDistribution,
-    ProductDistribution,
-    SequentialJointDistribution,
     JointGaussian,
+    Normal,
+    ProductDistribution,
     Provenance,
-    provenance_ancestors,
-    provenance_dag,
+    RecordEmpiricalDistribution,
+    SequentialJointDistribution,
+    TransformedDistribution,
     condition_on,
     from_distribution,
+    provenance_ancestors,
+    provenance_dag,
 )
 from probpipe.core.node import WorkflowFunction
-
 
 # ===========================================================================
 # 1. Provenance basics (dataclass, with_source, write-once)
@@ -151,14 +149,14 @@ class TestBroadcastingProvenance:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, vectorize="loop",
+        wf = WorkflowFunction(func=identity, dispatch="sequential",
                       n_broadcast_samples=20, seed=42)
         result = wf(x=n)
         assert hasattr(result, "samples")
         assert result.source is not None
         assert result.source.operation == "broadcast"
         assert result.source.parents == (n,)
-        assert result.source.metadata["vectorize"] == "loop"
+        assert result.source.metadata["dispatch"] == "sequential"
         assert result.source.metadata["n_samples"] == 20
         assert result.source.metadata["func"] == "identity"
         assert result.source.metadata["broadcast_args"] == ["x"]
@@ -169,13 +167,13 @@ class TestBroadcastingProvenance:
         def double(x: float) -> float:
             return 2.0 * x
 
-        wf = WorkflowFunction(func=double, vectorize="jax",
+        wf = WorkflowFunction(func=double, dispatch="jax",
                       n_broadcast_samples=20, seed=42)
         result = wf(x=n)
         assert hasattr(result, "samples")
         assert result.source is not None
         assert result.source.operation == "broadcast"
-        assert result.source.metadata["vectorize"] == "jax"
+        assert result.source.metadata["dispatch"] == "jax"
 
     def test_broadcast_multiple_parents(self):
         a = Normal(loc=0.0, scale=1.0, name="a")
@@ -184,7 +182,7 @@ class TestBroadcastingProvenance:
         def add(x: float, y: float) -> float:
             return x + y
 
-        wf = WorkflowFunction(func=add, vectorize="loop",
+        wf = WorkflowFunction(func=add, dispatch="sequential",
                       n_broadcast_samples=20, seed=42)
         result = wf(x=a, y=b)
         assert result.source is not None
@@ -198,7 +196,7 @@ class TestBroadcastingProvenance:
         def add(a: float, b: float) -> float:
             return a + b
 
-        wf = WorkflowFunction(func=add, vectorize="loop",
+        wf = WorkflowFunction(func=add, dispatch="sequential",
                       n_broadcast_samples=20, seed=42)
         result = wf(a=ed, b=n)
         assert hasattr(result, "samples")
@@ -235,7 +233,7 @@ class TestProvenanceChains:
         def log_val(x: float) -> float:
             return jnp.log(x)
 
-        wf = WorkflowFunction(func=log_val, vectorize="loop",
+        wf = WorkflowFunction(func=log_val, dispatch="sequential",
                       n_broadcast_samples=20, seed=42)
         result = wf(x=td)
         # result → broadcast → td → transform → base
@@ -335,7 +333,7 @@ class TestProvenanceAncestors:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, vectorize="loop",
+        wf = WorkflowFunction(func=identity, dispatch="sequential",
                       n_broadcast_samples=10, seed=42)
         result = wf(x=td)
         ancestors = provenance_ancestors(result)
@@ -351,7 +349,7 @@ class TestProvenanceAncestors:
         def add(x: float, y: float) -> float:
             return x + y
 
-        wf = WorkflowFunction(func=add, vectorize="loop",
+        wf = WorkflowFunction(func=add, dispatch="sequential",
                       n_broadcast_samples=10, seed=42)
         result = wf(x=n, y=n)
         ancestors = provenance_ancestors(result)
@@ -401,7 +399,7 @@ class TestProvenanceDag:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, vectorize="loop",
+        wf = WorkflowFunction(func=identity, dispatch="sequential",
                       n_broadcast_samples=10, seed=42)
         result = wf(x=td)
         dag = provenance_dag(result)

--- a/tests/core/test_record_array_view.py
+++ b/tests/core/test_record_array_view.py
@@ -21,24 +21,24 @@ These tests cover:
   sweep grouping, independent axes.
 """
 
-import jax
+from __future__ import annotations
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from probpipe import (
+    DistributionArray,
     FullFactorialDesign,
     Normal,
     NumericRecord,
     NumericRecordArray,
     Record,
     RecordArray,
-    DistributionArray,
     workflow_function,
 )
 from probpipe.core._record_array import _RecordArrayView
 from probpipe.core.record import RecordTemplate
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -374,7 +374,6 @@ class TestMixedGroupingComposition:
         ``DistributionArray`` of shape (2,) products to batch (4, 2).
         Each cell sees scalar ``x`` and one component Distribution
         (``d``), so the inner body can call ``d.mean()``-style ops."""
-        from probpipe import mean
         da = DistributionArray(
             [Normal(loc=float(i), scale=1.0, name=f"n{i}") for i in range(2)],
         )
@@ -394,7 +393,7 @@ class TestMixedGroupingComposition:
         Output is a DistributionArray of (4,) per-row marginals."""
         noise = Normal(loc=0.0, scale=0.1, name="noise")
 
-        @workflow_function(n_broadcast_samples=20, vectorize="loop")
+        @workflow_function(n_broadcast_samples=20, dispatch="sequential")
         def f(x, noise: float):
             return x + noise
 

--- a/tests/core/test_recordarray_broadcasting.py
+++ b/tests/core/test_recordarray_broadcasting.py
@@ -2,14 +2,15 @@
 
 The four regimes (no broadcast, distribution-only, RecordArray-only,
 nested) cover the parity matrix in the issue: 4 inner-return types
-(scalar, ndarray, Record/NumericRecord, Distribution) × 2 broadcast
+(scalar, ndarray, Record/NumericRecord, Distribution) x 2 broadcast
 types (Distribution, RecordArray) = 8 core cases plus edge cases.
 
 Provenance tests confirm every broadcast output carries a source node
 pointing back to its input RecordArray / Distribution parents.
 """
 
-import jax
+from __future__ import annotations
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -19,13 +20,11 @@ from probpipe import (
     Normal,
     NumericRecord,
     NumericRecordArray,
-    ProductDistribution,
     Record,
     RecordArray,
     workflow_function,
 )
 from probpipe.core._distribution_base import Distribution
-
 
 # ---------------------------------------------------------------------------
 # Detection: _find_broadcast_args splits args into (dist, ra) groups
@@ -48,7 +47,7 @@ class TestRecordArrayDetection:
 
     def test_recordarray_hint_skips_broadcast(self):
         """When the hint is ``RecordArray``, the batched value flows
-        through as-is — the function expects the batch."""
+        through as-is - the function expects the batch."""
 
         @workflow_function
         def f(ra: NumericRecordArray):
@@ -58,7 +57,7 @@ class TestRecordArrayDetection:
             [NumericRecord(x=float(i)) for i in range(4)]
         )
         out = f(ra=ra)
-        # Single inner call — output is the unwrapped float result.
+        # Single inner call - output is the unwrapped float result.
         assert float(out) == 6.0
 
     def test_scalar_batch_shape_passes_through(self):
@@ -73,7 +72,7 @@ class TestRecordArrayDetection:
         tpl = RecordTemplate(x=())
         scalar_ra = NumericRecordArray({"x": jnp.asarray(7.0)},
                                        batch_shape=(), template=tpl)
-        # No broadcasting — one call with the batch_shape=() RecordArray
+        # No broadcasting - one call with the batch_shape=() RecordArray
         # passed through.
         out = f(p=scalar_ra)
         assert float(out) == 7.0
@@ -99,7 +98,7 @@ class TestRecordArrayDetection:
 
 
 # ---------------------------------------------------------------------------
-# Pure sweep (RecordArray-only) — stacked outputs, no marginalisation
+# Pure sweep (RecordArray-only) - stacked outputs, no marginalisation
 # ---------------------------------------------------------------------------
 
 
@@ -171,13 +170,13 @@ class TestPureSweepParityMatrix:
 
 
 # ---------------------------------------------------------------------------
-# Distribution-only (smoke check — refactor didn't break anything)
+# Distribution-only (smoke check - refactor didn't break anything)
 # ---------------------------------------------------------------------------
 
 
 class TestDistributionOnlyPath:
     def test_scalar_output_still_marginal(self):
-        @workflow_function(n_broadcast_samples=50, vectorize="loop")
+        @workflow_function(n_broadcast_samples=50, dispatch="sequential")
         def f(x: float) -> float:
             return x * 2
 
@@ -190,7 +189,7 @@ class TestDistributionOnlyPath:
 
 
 # ---------------------------------------------------------------------------
-# Nested (RecordArray + Distribution) — per-row marginal, stacked
+# Nested (RecordArray + Distribution) - per-row marginal, stacked
 # ---------------------------------------------------------------------------
 
 
@@ -207,7 +206,7 @@ class TestNestedSweepPlusDistribution:
         )
 
     def test_scalar_inner_gives_distribution_array(self, sweep):
-        @workflow_function(n_broadcast_samples=50, vectorize="loop")
+        @workflow_function(n_broadcast_samples=50, dispatch="sequential")
         def f(p: NumericRecord, noise: float) -> float:
             return p["bias"] + noise
 
@@ -220,7 +219,7 @@ class TestNestedSweepPlusDistribution:
         np.testing.assert_allclose(means, [0.0, 1.0, 2.0], atol=0.2)
 
     def test_record_inner_gives_distribution_array(self, sweep):
-        @workflow_function(n_broadcast_samples=30, vectorize="loop")
+        @workflow_function(n_broadcast_samples=30, dispatch="sequential")
         def f(p: NumericRecord, noise: float) -> NumericRecord:
             return NumericRecord(x=p["bias"] + noise, y=p["bias"] - noise)
 
@@ -229,7 +228,7 @@ class TestNestedSweepPlusDistribution:
         assert out.batch_shape == (3,)
 
     def test_distribution_inner_gives_distribution_array(self, sweep):
-        @workflow_function(n_broadcast_samples=20, vectorize="loop")
+        @workflow_function(n_broadcast_samples=20, dispatch="sequential")
         def f(p: NumericRecord, noise: float) -> Distribution:
             return Normal(loc=p["bias"] + noise, scale=1.0, name="out")
 
@@ -239,20 +238,20 @@ class TestNestedSweepPlusDistribution:
 
 
 # ---------------------------------------------------------------------------
-# Vectorisation — vmap path vs loop path agree on pure-sweep outputs
+# Dispatch - vmap path vs sequential path agree on pure-sweep outputs
 # ---------------------------------------------------------------------------
 
 
-class TestVectorization:
-    """The JAX-vmap and Python-loop execution paths should produce the
+class TestDispatch:
+    """The JAX-vmap and sequential execution paths should produce the
     same stacked output (modulo numerical noise) when both are feasible."""
 
-    def test_vmap_and_loop_agree_on_scalar_output(self):
-        @workflow_function(vectorize="loop")
+    def test_vmap_and_sequential_agree_on_scalar_output(self):
+        @workflow_function(dispatch="sequential")
         def f_loop(p: NumericRecord) -> float:
             return p["r"] * p["k"]
 
-        @workflow_function(vectorize="jax")
+        @workflow_function(dispatch="jax")
         def f_jax(p: NumericRecord) -> float:
             return p["r"] * p["k"]
 
@@ -263,9 +262,24 @@ class TestVectorization:
         out_jax = f_jax(p=sweep)
         np.testing.assert_allclose(out_loop["f_loop"], out_jax["f_jax"])
 
+    def test_explicit_jax_rejects_unsupported_sweep_shape(self):
+        @workflow_function(dispatch="jax")
+        def f(a: NumericRecord, b: NumericRecord) -> float:
+            return a["x"] + b["y"]
+
+        a = NumericRecordArray.stack(
+            [NumericRecord(x=float(i)) for i in range(3)]
+        )
+        b = NumericRecordArray.stack(
+            [NumericRecord(y=float(i)) for i in range(5)]
+        )
+
+        with pytest.raises(ValueError, match="single plain RecordArray sweep"):
+            f(a=a, b=b)
+
 
 # ---------------------------------------------------------------------------
-# Provenance — outputs carry a source pointing back to inputs
+# Provenance - outputs carry a source pointing back to inputs
 # ---------------------------------------------------------------------------
 
 
@@ -287,7 +301,7 @@ class TestProvenanceChain:
         assert out.source.metadata["func"] == "f"
 
     def test_nested_provenance_includes_both(self):
-        @workflow_function(n_broadcast_samples=10, vectorize="loop")
+        @workflow_function(n_broadcast_samples=10, dispatch="sequential")
         def f(p: NumericRecord, noise: float) -> float:
             return p["x"] + noise
 
@@ -386,7 +400,7 @@ class TestMultiDimensionalBatch:
         """Nested regime: each sweep cell marginalises over the MC
         draws; output is a DistributionArray matching the sweep's
         batch_shape."""
-        @workflow_function(n_broadcast_samples=10, vectorize="loop")
+        @workflow_function(n_broadcast_samples=10, dispatch="sequential")
         def f(p: NumericRecord, noise: float) -> float:
             return p["r"] * p["k"] + noise
 
@@ -395,7 +409,7 @@ class TestMultiDimensionalBatch:
         assert out.batch_shape == (3, 2)
 
     def test_3d_sweep(self):
-        """3-D sweep works too — the row-major flattening is general."""
+        """3-D sweep works too - the row-major flattening is general."""
         from probpipe.core.record import RecordTemplate
 
         shape = (2, 3, 4)
@@ -419,7 +433,7 @@ class TestMultiDimensionalBatch:
 class TestAutoWrapFieldName:
     def test_scalar_return_uses_function_name_as_field(self):
         """Scalar returns are auto-wrapped into a ``NumericRecordArray``
-        with a single field named after the ``@workflow_function`` — so
+        with a single field named after the ``@workflow_function`` - so
         the field name reflects which function produced the value rather
         than a fixed sentinel."""
 

--- a/tests/core/test_workflow_call_resolution.py
+++ b/tests/core/test_workflow_call_resolution.py
@@ -65,36 +65,36 @@ class CallResolutionModule(Module):
 
 class TestArgumentBinding:
     def test_positional_and_mixed_arguments_bind_like_python_calls(self, add_func):
-        wf = WorkflowFunction(func=add_func, vectorize="loop")
+        wf = WorkflowFunction(func=add_func, dispatch="sequential")
 
         assert float(wf(jnp.asarray(1.0), jnp.asarray(2.0))) == 3.0
         assert float(wf(jnp.asarray(1.0), y=jnp.asarray(2.0))) == 3.0
 
     def test_duplicate_positional_and_keyword_argument_raises(self, add_func):
-        wf = WorkflowFunction(func=add_func, vectorize="loop")
+        wf = WorkflowFunction(func=add_func, dispatch="sequential")
 
         with pytest.raises(TypeError, match="multiple values"):
             wf(jnp.asarray(1.0), x=jnp.asarray(2.0))
 
     def test_var_keyword_expands_extra_keywords(self, kwargs_recorder):
         identity, seen = kwargs_recorder
-        wf = WorkflowFunction(func=identity, vectorize="loop")
+        wf = WorkflowFunction(func=identity, dispatch="sequential")
 
         assert float(wf(x=1.0, scale=2.0)) == 1.0
         assert seen == [{"scale": 2.0}]
 
     def test_literal_kwargs_argument_is_not_unpacked(self, kwargs_recorder):
         identity, seen = kwargs_recorder
-        wf = WorkflowFunction(func=identity, vectorize="loop")
+        wf = WorkflowFunction(func=identity, dispatch="sequential")
 
         assert float(wf(x=1.0, kwargs={"scale": 2.0})) == 1.0
         assert seen == [{"kwargs": {"scale": 2.0}}]
 
     def test_bind_values_and_function_defaults_are_resolved_before_call(self, affine_func):
-        default_wf = WorkflowFunction(func=affine_func, vectorize="loop")
+        default_wf = WorkflowFunction(func=affine_func, dispatch="sequential")
         bound_wf = WorkflowFunction(
             func=affine_func,
-            vectorize="loop",
+            dispatch="sequential",
             bind={"offset": 3.0},
             scale=2.0,
         )
@@ -104,7 +104,7 @@ class TestArgumentBinding:
         assert float(bound_wf(x=1.0, offset=4.0)) == 10.0
 
     def test_missing_required_input_raises_after_all_resolution_sources_fail(self, add_func):
-        wf = WorkflowFunction(func=add_func, vectorize="loop")
+        wf = WorkflowFunction(func=add_func, dispatch="sequential")
 
         with pytest.raises(TypeError, match="Missing required input 'y'"):
             wf(x=1.0)
@@ -129,7 +129,7 @@ class TestModuleResolution:
         def use_dep(dep: DataNode):
             return 1.0
 
-        wf = WorkflowFunction(func=use_dep, vectorize="loop")
+        wf = WorkflowFunction(func=use_dep, dispatch="sequential")
 
         with pytest.raises(TypeError, match="expects dependency 'dep:"):
             wf(dep=object())
@@ -144,7 +144,7 @@ class TestReservedOverrides:
         wf = WorkflowFunction(
             func=identity_func,
             n_broadcast_samples=20,
-            vectorize="loop",
+            dispatch="sequential",
             seed=42,
         )
 
@@ -161,7 +161,7 @@ class TestReservedOverrides:
         wf = WorkflowFunction(
             func=identity_func,
             n_broadcast_samples=8,
-            vectorize="loop",
+            dispatch="sequential",
             seed=42,
         )
 

--- a/tests/core/test_workflow_distribution_normalization.py
+++ b/tests/core/test_workflow_distribution_normalization.py
@@ -51,7 +51,7 @@ class TestHintedDistributionConversion:
         normal_external,
     ):
         mean_of_normal, seen = mean_recorder
-        wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
+        wf = WorkflowFunction(func=mean_of_normal, dispatch="sequential")
 
         result = wf(dist=normal_external)
 
@@ -65,7 +65,7 @@ class TestHintedDistributionConversion:
             seen.append(dist)
             return log_prob(dist, jnp.asarray([0.0]))
 
-        wf = WorkflowFunction(func=log_prob_at_zero, vectorize="loop")
+        wf = WorkflowFunction(func=log_prob_at_zero, dispatch="sequential")
 
         result = wf(dist=empirical_dist)
 
@@ -88,7 +88,7 @@ class TestDistributionArrayHandling:
             scale=jnp.asarray(1.0),
             name="zero_d",
         )
-        wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
+        wf = WorkflowFunction(func=mean_of_normal, dispatch="sequential")
 
         result = wf(dist=da)
 
@@ -104,7 +104,7 @@ class TestDistributionArrayHandling:
             scale=jnp.asarray([1.0]),
             name="one_cell",
         )
-        wf = WorkflowFunction(func=mean_of_normal, vectorize="loop")
+        wf = WorkflowFunction(func=mean_of_normal, dispatch="sequential")
 
         result = wf(dist=da)
 
@@ -125,7 +125,7 @@ class TestUnhintedExternalDistribution:
         wf = WorkflowFunction(
             func=double,
             n_broadcast_samples=8,
-            vectorize="loop",
+            dispatch="sequential",
             seed=42,
         )
         external = tfd.Normal(loc=1.0, scale=0.1)

--- a/tests/core/test_workflow_parallel.py
+++ b/tests/core/test_workflow_parallel.py
@@ -126,6 +126,7 @@ class TestExecutionRequestShape:
     def test_execution_config_has_resolved_execution_fields_only(self):
         field_names = {field.name for field in fields(execution_mod.WorkflowExecutionConfig)}
 
+        assert "dispatch" not in field_names
         assert "parallel" not in field_names
         assert field_names == {
             "mode",
@@ -142,7 +143,7 @@ class TestExecutionRequestShape:
             return [request.func(**request.call_value_list[0])]
 
         monkeypatch.setattr(execution_mod, "execute_many", fake_execute_many)
-        wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=False)
+        wf = WorkflowFunction(func=add_one, dispatch="sequential")
 
         assert wf._execute_many([{"x": 1}]) == [2]
         assert seen["request"].func is add_one
@@ -260,114 +261,122 @@ class TestPrefectMapping:
 
 class TestWorkflowFunctionCompatibility:
     def test_execute_many_wrapper_preserves_private_call_behavior(self):
-        wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=False)
+        wf = WorkflowFunction(func=add_one, dispatch="sequential")
 
         assert wf._execute_many([{"x": 1}, {"x": 2}]) == [2, 3]
 
-    def test_make_execution_config_resolves_truthy_parallel_to_thread(self):
+    def test_make_execution_config_resolves_thread_dispatch_to_thread_mode(self):
         wf = WorkflowFunction(
             func=add_one,
-            vectorize="loop",
+            dispatch="thread",
             workflow_kind=WorkflowKind.OFF,
-            parallel=True,
         )
 
         assert wf._make_execution_config().mode == "thread"
 
-    def test_make_execution_config_rejects_max_workers_when_parallel_false(self):
-        wf = WorkflowFunction(
-            func=add_one,
-            vectorize="loop",
-            workflow_kind=WorkflowKind.OFF,
-            parallel=False,
-            max_workers=3,
-        )
+    def test_thread_dispatch_passes_max_workers_to_execution_config(self):
+        wf = WorkflowFunction(func=add_one, dispatch="thread", max_workers=3)
 
-        with pytest.raises(ValueError, match="requires parallel=True"):
-            wf._make_execution_config()
+        execution = wf._make_execution_config()
 
-    @pytest.mark.parametrize("parallel", [1, 0, None, "yes"])
-    def test_workflow_function_rejects_non_bool_parallel(self, parallel):
-        with pytest.raises(TypeError, match="parallel must be a bool"):
-            WorkflowFunction(func=add_one, vectorize="loop", parallel=parallel)
+        assert execution.mode == "thread"
+        assert execution.max_workers == 3
+
+    def test_auto_dispatch_does_not_use_max_workers_as_mode_switch(self):
+        with pytest.warns(UserWarning, match="max_workers configures only"):
+            wf = WorkflowFunction(func=add_one, dispatch="auto", max_workers=3)
+
+        execution = wf._make_execution_config()
+
+        assert execution.mode == "sequential"
+        assert execution.max_workers is None
+
+    @pytest.mark.parametrize("removed_keyword", ["parallel", "vectorize"])
+    def test_workflow_function_rejects_removed_keywords(self, removed_keyword):
+        with pytest.raises(TypeError, match="no longer accepts"):
+            WorkflowFunction(func=add_one, **{removed_keyword: True})
+
+    @pytest.mark.parametrize("dispatch", ["loop", "python", "map", None, 1])
+    def test_workflow_function_rejects_invalid_dispatch(self, dispatch):
+        with pytest.raises(ValueError, match="dispatch must be one of"):
+            WorkflowFunction(func=add_one, dispatch=dispatch)
 
     @pytest.mark.parametrize("max_workers", [0, -1])
     def test_workflow_function_rejects_non_positive_max_workers(self, max_workers):
         with pytest.raises(ValueError, match="max_workers"):
-            WorkflowFunction(func=add_one, vectorize="loop", max_workers=max_workers)
+            WorkflowFunction(func=add_one, dispatch="sequential", max_workers=max_workers)
 
     @pytest.mark.parametrize("max_workers", [True, False, "3"])
     def test_workflow_function_rejects_invalid_max_workers(self, max_workers):
         with pytest.raises(TypeError, match="max_workers"):
-            WorkflowFunction(func=add_one, vectorize="loop", max_workers=max_workers)
+            WorkflowFunction(func=add_one, dispatch="sequential", max_workers=max_workers)
+
+    def test_non_thread_dispatch_warns_and_ignores_max_workers(self):
+        with pytest.warns(UserWarning, match="max_workers configures only"):
+            wf = WorkflowFunction(func=add_one, dispatch="sequential", max_workers=3)
+
+        execution = wf._make_execution_config()
+
+        assert execution.mode == "sequential"
+        assert execution.max_workers is None
 
     def test_explicit_prefect_warns_and_ignores_local_thread_options(self, monkeypatch):
         monkeypatch.setattr(node_mod, "task", object())
         wf = WorkflowFunction(
             func=add_one,
             workflow_kind=WorkflowKind.TASK,
-            vectorize="loop",
-            parallel=True,
+            dispatch="thread",
             max_workers=3,
         )
 
-        with pytest.warns(UserWarning, match="do not control Prefect execution"):
+        with pytest.warns(UserWarning, match="do not control Prefect scheduling"):
             execution = wf._make_execution_config()
 
         assert execution.mode == "prefect_task"
         assert execution.max_workers is None
 
-    def test_global_prefect_warns_and_ignores_max_workers_with_parallel_false(
+    def test_global_prefect_warns_and_ignores_max_workers_with_sequential_dispatch(
         self,
         monkeypatch,
     ):
         monkeypatch.setattr(node_mod, "task", object())
         prefect_config.workflow_kind = WorkflowKind.FLOW
-        wf = WorkflowFunction(
-            func=add_one,
-            vectorize="loop",
-            parallel=False,
-            max_workers=3,
-        )
+        with pytest.warns(UserWarning, match="max_workers configures only"):
+            wf = WorkflowFunction(
+                func=add_one,
+                dispatch="sequential",
+                max_workers=3,
+            )
 
-        with pytest.warns(UserWarning, match="do not control Prefect execution"):
+        with pytest.warns(UserWarning, match="do not control Prefect scheduling"):
             execution = wf._make_execution_config()
 
         assert execution.mode == "prefect_flow"
         assert execution.max_workers is None
 
-    @pytest.mark.parametrize(
-        "kwargs",
-        [
-            {"parallel": True},
-            {"parallel": True, "max_workers": 2},
-        ],
-    )
-    def test_jax_vectorize_warns_for_local_thread_options(self, kwargs):
-        with pytest.warns(UserWarning, match="do not control JAX vmap"):
-            WorkflowFunction(func=add_one, vectorize="jax", **kwargs)
-
-    def test_jax_vectorize_max_workers_still_rejects_local_sequential_config(self):
-        with pytest.warns(UserWarning, match="do not control JAX vmap"):
+    def test_jax_dispatch_warns_and_ignores_max_workers(self):
+        with pytest.warns(UserWarning, match="max_workers configures only"):
             wf = WorkflowFunction(
                 func=add_one,
-                vectorize="jax",
+                dispatch="jax",
                 workflow_kind=WorkflowKind.OFF,
                 max_workers=3,
             )
 
-        with pytest.raises(ValueError, match="requires parallel=True"):
-            wf._make_execution_config()
+        execution = wf._make_execution_config()
+
+        assert execution.mode == "sequential"
+        assert execution.max_workers is None
 
     def test_jax_broadcast_ignores_max_workers_after_warning(self, monkeypatch):
         def fail_executor(*args, **kwargs):
             raise AssertionError("JAX broadcast should not use ThreadPoolExecutor")
 
         monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", fail_executor)
-        with pytest.warns(UserWarning, match="do not control JAX vmap"):
+        with pytest.warns(UserWarning, match="max_workers configures only"):
             wf = WorkflowFunction(
                 func=add_one,
-                vectorize="jax",
+                dispatch="jax",
                 workflow_kind=WorkflowKind.OFF,
                 max_workers=3,
                 n_broadcast_samples=8,
@@ -379,7 +388,7 @@ class TestWorkflowFunctionCompatibility:
         assert result.n == 8
 
     def test_private_wrappers_return_empty_before_building_request(self, monkeypatch):
-        wf = WorkflowFunction(func=add_one, workflow_kind=WorkflowKind.TASK, vectorize="loop")
+        wf = WorkflowFunction(func=add_one, workflow_kind=WorkflowKind.TASK, dispatch="sequential")
 
         def fail_request(*args, **kwargs):
             raise AssertionError("empty calls should not build an execution request")
@@ -404,12 +413,12 @@ class TestWorkflowFunctionCompatibility:
         task_wf = WorkflowFunction(
             func=add_one,
             workflow_kind=WorkflowKind.TASK,
-            vectorize="loop",
+            dispatch="sequential",
         )
         flow_wf = WorkflowFunction(
             func=add_one,
             workflow_kind=WorkflowKind.FLOW,
-            vectorize="loop",
+            dispatch="sequential",
         )
 
         calls = [{"x": 1}]
@@ -419,7 +428,7 @@ class TestWorkflowFunctionCompatibility:
 
     def test_threaded_wrapper_delegates_to_execution_module(self, monkeypatch):
         monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
-        wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=True, max_workers=2)
+        wf = WorkflowFunction(func=add_one, dispatch="thread", max_workers=2)
 
         assert wf._execute_many_threaded([{"x": 1}, {"x": 2}]) == [2, 3]
         assert RecordingExecutor.instances[0].max_workers == 2
@@ -427,7 +436,7 @@ class TestWorkflowFunctionCompatibility:
     def test_map_task_wrapper_delegates_to_execution_module(self, monkeypatch):
         monkeypatch.setattr(execution_mod, "task", fake_task)
         monkeypatch.setattr(execution_mod, "flow", None)
-        wf = WorkflowFunction(func=add_one, vectorize="loop")
+        wf = WorkflowFunction(func=add_one, dispatch="sequential")
 
         assert wf._map_task([{"x": 1}, {"x": 2}], task_name="add-one") == [2, 3]
         assert FakeMappedTask.created_names == ["add-one"]
@@ -440,6 +449,6 @@ class TestWorkflowFunctionCompatibility:
             raise AssertionError("direct _map_task should not resolve a task runner")
 
         monkeypatch.setattr(node_mod.prefect_config, "resolve_task_runner", fail_resolve_task_runner)
-        wf = WorkflowFunction(func=add_one, vectorize="loop")
+        wf = WorkflowFunction(func=add_one, dispatch="sequential")
 
         assert wf._map_task([{"x": 1}], task_name="add-one") == [2]

--- a/tests/core/test_workflow_parallel.py
+++ b/tests/core/test_workflow_parallel.py
@@ -183,14 +183,22 @@ class TestThreadExecution:
         assert len(RecordingExecutor.instances) == 1
         assert RecordingExecutor.instances[0].max_workers == 3
 
-    @pytest.mark.parametrize("max_workers", [0, -1])
+    def test_execute_many_accepts_true_max_workers_as_positive_int(self, monkeypatch):
+        monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
+        request = make_request(mode="thread", max_workers=True)
+
+        assert execution_mod.execute_many(request) == [2, 3]
+        assert len(RecordingExecutor.instances) == 1
+        assert RecordingExecutor.instances[0].max_workers is True
+
+    @pytest.mark.parametrize("max_workers", [0, -1, False])
     def test_execute_many_rejects_non_positive_max_workers(self, max_workers):
         request = make_request(mode="thread", max_workers=max_workers)
 
         with pytest.raises(ValueError, match="positive int"):
             execution_mod.execute_many(request)
 
-    @pytest.mark.parametrize("max_workers", [True, False, "3"])
+    @pytest.mark.parametrize("max_workers", ["3"])
     def test_execute_many_rejects_invalid_max_workers_value(self, max_workers):
         request = make_request(mode="thread", max_workers=max_workers)
 
@@ -282,6 +290,14 @@ class TestWorkflowFunctionCompatibility:
         assert execution.mode == "thread"
         assert execution.max_workers == 3
 
+    def test_thread_dispatch_accepts_true_max_workers_as_positive_int(self):
+        wf = WorkflowFunction(func=add_one, dispatch="thread", max_workers=True)
+
+        execution = wf._make_execution_config()
+
+        assert execution.mode == "thread"
+        assert execution.max_workers is True
+
     def test_auto_dispatch_does_not_use_max_workers_as_mode_switch(self):
         with pytest.warns(UserWarning, match="max_workers configures only"):
             wf = WorkflowFunction(func=add_one, dispatch="auto", max_workers=3)
@@ -301,12 +317,12 @@ class TestWorkflowFunctionCompatibility:
         with pytest.raises(ValueError, match="dispatch must be one of"):
             WorkflowFunction(func=add_one, dispatch=dispatch)
 
-    @pytest.mark.parametrize("max_workers", [0, -1])
+    @pytest.mark.parametrize("max_workers", [0, -1, False])
     def test_workflow_function_rejects_non_positive_max_workers(self, max_workers):
         with pytest.raises(ValueError, match="max_workers"):
             WorkflowFunction(func=add_one, dispatch="sequential", max_workers=max_workers)
 
-    @pytest.mark.parametrize("max_workers", [True, False, "3"])
+    @pytest.mark.parametrize("max_workers", ["3"])
     def test_workflow_function_rejects_invalid_max_workers(self, max_workers):
         with pytest.raises(TypeError, match="max_workers"):
             WorkflowFunction(func=add_one, dispatch="sequential", max_workers=max_workers)

--- a/tests/core/test_workflow_parallel.py
+++ b/tests/core/test_workflow_parallel.py
@@ -88,6 +88,7 @@ def make_request(
     *,
     mode="sequential",
     parallel=False,
+    max_workers=None,
     calls=None,
     func=add_one,
     name="add_one",
@@ -99,6 +100,7 @@ def make_request(
         execution=execution_mod.WorkflowExecutionConfig(
             mode=mode,
             parallel=parallel,
+            max_workers=max_workers,
             name=name,
             prefect_task_runner=prefect_task_runner,
         ),
@@ -157,25 +159,26 @@ class TestThreadExecution:
         assert len(RecordingExecutor.instances) == 1
         assert RecordingExecutor.instances[0].max_workers is None
 
-    def test_execute_many_parallel_int_uses_explicit_worker_count(self, monkeypatch):
+    def test_execute_many_max_workers_uses_explicit_worker_count(self, monkeypatch):
         monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
-        request = make_request(mode="thread", parallel=3)
+        request = make_request(mode="thread", parallel=True, max_workers=3)
 
         assert execution_mod.execute_many(request) == [2, 3]
         assert len(RecordingExecutor.instances) == 1
         assert RecordingExecutor.instances[0].max_workers == 3
 
-    @pytest.mark.parametrize("parallel", [0, -1])
-    def test_execute_many_rejects_non_positive_parallel_int(self, parallel):
-        request = make_request(mode="thread", parallel=parallel)
+    @pytest.mark.parametrize("max_workers", [0, -1])
+    def test_execute_many_rejects_non_positive_max_workers(self, max_workers):
+        request = make_request(mode="thread", parallel=True, max_workers=max_workers)
 
         with pytest.raises(ValueError, match="positive int"):
             execution_mod.execute_many(request)
 
-    def test_execute_many_rejects_invalid_parallel_value(self):
-        request = make_request(mode="thread", parallel=None)
+    @pytest.mark.parametrize("max_workers", [True, "3"])
+    def test_execute_many_rejects_invalid_max_workers_value(self, max_workers):
+        request = make_request(mode="thread", parallel=True, max_workers=max_workers)
 
-        with pytest.raises(TypeError, match="positive int"):
+        with pytest.raises(TypeError, match="max_workers"):
             execution_mod.execute_many(request)
 
 
@@ -256,6 +259,34 @@ class TestWorkflowFunctionCompatibility:
 
         assert wf._make_execution_config().mode == "thread"
 
+    def test_make_execution_config_ignores_max_workers_when_parallel_false(self):
+        wf = WorkflowFunction(
+            func=add_one,
+            vectorize="loop",
+            workflow_kind=WorkflowKind.OFF,
+            parallel=False,
+            max_workers=3,
+        )
+        execution = wf._make_execution_config()
+
+        assert execution.mode == "sequential"
+        assert execution.max_workers == 3
+
+    @pytest.mark.parametrize("parallel", [1, 0, None, "yes"])
+    def test_workflow_function_rejects_non_bool_parallel(self, parallel):
+        with pytest.raises(TypeError, match="parallel must be a bool"):
+            WorkflowFunction(func=add_one, vectorize="loop", parallel=parallel)
+
+    @pytest.mark.parametrize("max_workers", [0, -1])
+    def test_workflow_function_rejects_non_positive_max_workers(self, max_workers):
+        with pytest.raises(ValueError, match="max_workers"):
+            WorkflowFunction(func=add_one, vectorize="loop", max_workers=max_workers)
+
+    @pytest.mark.parametrize("max_workers", [True, "3"])
+    def test_workflow_function_rejects_invalid_max_workers(self, max_workers):
+        with pytest.raises(TypeError, match="max_workers"):
+            WorkflowFunction(func=add_one, vectorize="loop", max_workers=max_workers)
+
     def test_private_wrappers_return_empty_before_building_request(self, monkeypatch):
         wf = WorkflowFunction(func=add_one, workflow_kind=WorkflowKind.TASK, vectorize="loop")
 
@@ -297,7 +328,7 @@ class TestWorkflowFunctionCompatibility:
 
     def test_threaded_wrapper_delegates_to_execution_module(self, monkeypatch):
         monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
-        wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=2)
+        wf = WorkflowFunction(func=add_one, vectorize="loop", parallel=True, max_workers=2)
 
         assert wf._execute_many_threaded([{"x": 1}, {"x": 2}]) == [2, 3]
         assert RecordingExecutor.instances[0].max_workers == 2

--- a/tests/core/test_workflow_parallel.py
+++ b/tests/core/test_workflow_parallel.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import fields
 from typing import ClassVar
 
 import pytest
 
 import probpipe.core._workflow_execution as execution_mod
 import probpipe.core.node as node_mod
-from probpipe.core.config import WorkflowKind
+from probpipe import Normal
+from probpipe.core.config import WorkflowKind, prefect_config
 from probpipe.core.node import WorkflowFunction
 
 
@@ -87,7 +89,6 @@ def fake_flow(name=None, **flow_kwargs):
 def make_request(
     *,
     mode="sequential",
-    parallel=False,
     max_workers=None,
     calls=None,
     func=add_one,
@@ -99,7 +100,6 @@ def make_request(
         call_value_list=calls if calls is not None else [{"x": 1}, {"x": 2}],
         execution=execution_mod.WorkflowExecutionConfig(
             mode=mode,
-            parallel=parallel,
             max_workers=max_workers,
             name=name,
             prefect_task_runner=prefect_task_runner,
@@ -109,16 +109,31 @@ def make_request(
 
 @pytest.fixture(autouse=True)
 def _reset_fakes():
+    prefect_config.workflow_kind = WorkflowKind.OFF
+    prefect_config.task_runner = None
     RecordingExecutor.instances.clear()
     FakeMappedTask.created_names.clear()
     RecordingFlow.calls.clear()
     yield
+    prefect_config.workflow_kind = WorkflowKind.OFF
+    prefect_config.task_runner = None
     RecordingExecutor.instances.clear()
     FakeMappedTask.created_names.clear()
     RecordingFlow.calls.clear()
 
 
 class TestExecutionRequestShape:
+    def test_execution_config_has_resolved_execution_fields_only(self):
+        field_names = {field.name for field in fields(execution_mod.WorkflowExecutionConfig)}
+
+        assert "parallel" not in field_names
+        assert field_names == {
+            "mode",
+            "max_workers",
+            "name",
+            "prefect_task_runner",
+        }
+
     def test_workflow_function_request_contains_plain_function(self, monkeypatch):
         seen = {}
 
@@ -136,24 +151,24 @@ class TestExecutionRequestShape:
 
 
 class TestSequentialExecution:
-    def test_execute_many_parallel_false_runs_sequentially(self):
-        request = make_request(mode="sequential", parallel=False)
+    def test_execute_many_sequential_mode_preserves_order(self):
+        request = make_request(mode="sequential")
 
         assert execution_mod.execute_many(request) == [2, 3]
         assert RecordingExecutor.instances == []
 
     def test_execute_many_empty_input_returns_empty_without_executor(self, monkeypatch):
         monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
-        request = make_request(mode="thread", parallel=True, calls=[])
+        request = make_request(mode="thread", calls=[])
 
         assert execution_mod.execute_many(request) == []
         assert RecordingExecutor.instances == []
 
 
 class TestThreadExecution:
-    def test_execute_many_parallel_true_uses_executor_default_workers(self, monkeypatch):
+    def test_execute_many_thread_mode_uses_executor_default_workers(self, monkeypatch):
         monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
-        request = make_request(mode="thread", parallel=True)
+        request = make_request(mode="thread")
 
         assert execution_mod.execute_many(request) == [2, 3]
         assert len(RecordingExecutor.instances) == 1
@@ -161,7 +176,7 @@ class TestThreadExecution:
 
     def test_execute_many_max_workers_uses_explicit_worker_count(self, monkeypatch):
         monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
-        request = make_request(mode="thread", parallel=True, max_workers=3)
+        request = make_request(mode="thread", max_workers=3)
 
         assert execution_mod.execute_many(request) == [2, 3]
         assert len(RecordingExecutor.instances) == 1
@@ -169,14 +184,14 @@ class TestThreadExecution:
 
     @pytest.mark.parametrize("max_workers", [0, -1])
     def test_execute_many_rejects_non_positive_max_workers(self, max_workers):
-        request = make_request(mode="thread", parallel=True, max_workers=max_workers)
+        request = make_request(mode="thread", max_workers=max_workers)
 
         with pytest.raises(ValueError, match="positive int"):
             execution_mod.execute_many(request)
 
-    @pytest.mark.parametrize("max_workers", [True, "3"])
+    @pytest.mark.parametrize("max_workers", [True, False, "3"])
     def test_execute_many_rejects_invalid_max_workers_value(self, max_workers):
-        request = make_request(mode="thread", parallel=True, max_workers=max_workers)
+        request = make_request(mode="thread", max_workers=max_workers)
 
         with pytest.raises(TypeError, match="max_workers"):
             execution_mod.execute_many(request)
@@ -259,7 +274,7 @@ class TestWorkflowFunctionCompatibility:
 
         assert wf._make_execution_config().mode == "thread"
 
-    def test_make_execution_config_ignores_max_workers_when_parallel_false(self):
+    def test_make_execution_config_rejects_max_workers_when_parallel_false(self):
         wf = WorkflowFunction(
             func=add_one,
             vectorize="loop",
@@ -267,10 +282,9 @@ class TestWorkflowFunctionCompatibility:
             parallel=False,
             max_workers=3,
         )
-        execution = wf._make_execution_config()
 
-        assert execution.mode == "sequential"
-        assert execution.max_workers == 3
+        with pytest.raises(ValueError, match="requires parallel=True"):
+            wf._make_execution_config()
 
     @pytest.mark.parametrize("parallel", [1, 0, None, "yes"])
     def test_workflow_function_rejects_non_bool_parallel(self, parallel):
@@ -282,10 +296,87 @@ class TestWorkflowFunctionCompatibility:
         with pytest.raises(ValueError, match="max_workers"):
             WorkflowFunction(func=add_one, vectorize="loop", max_workers=max_workers)
 
-    @pytest.mark.parametrize("max_workers", [True, "3"])
+    @pytest.mark.parametrize("max_workers", [True, False, "3"])
     def test_workflow_function_rejects_invalid_max_workers(self, max_workers):
         with pytest.raises(TypeError, match="max_workers"):
             WorkflowFunction(func=add_one, vectorize="loop", max_workers=max_workers)
+
+    def test_explicit_prefect_warns_and_ignores_local_thread_options(self, monkeypatch):
+        monkeypatch.setattr(node_mod, "task", object())
+        wf = WorkflowFunction(
+            func=add_one,
+            workflow_kind=WorkflowKind.TASK,
+            vectorize="loop",
+            parallel=True,
+            max_workers=3,
+        )
+
+        with pytest.warns(UserWarning, match="do not control Prefect execution"):
+            execution = wf._make_execution_config()
+
+        assert execution.mode == "prefect_task"
+        assert execution.max_workers is None
+
+    def test_global_prefect_warns_and_ignores_max_workers_with_parallel_false(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(node_mod, "task", object())
+        prefect_config.workflow_kind = WorkflowKind.FLOW
+        wf = WorkflowFunction(
+            func=add_one,
+            vectorize="loop",
+            parallel=False,
+            max_workers=3,
+        )
+
+        with pytest.warns(UserWarning, match="do not control Prefect execution"):
+            execution = wf._make_execution_config()
+
+        assert execution.mode == "prefect_flow"
+        assert execution.max_workers is None
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"parallel": True},
+            {"parallel": True, "max_workers": 2},
+        ],
+    )
+    def test_jax_vectorize_warns_for_local_thread_options(self, kwargs):
+        with pytest.warns(UserWarning, match="do not control JAX vmap"):
+            WorkflowFunction(func=add_one, vectorize="jax", **kwargs)
+
+    def test_jax_vectorize_max_workers_still_rejects_local_sequential_config(self):
+        with pytest.warns(UserWarning, match="do not control JAX vmap"):
+            wf = WorkflowFunction(
+                func=add_one,
+                vectorize="jax",
+                workflow_kind=WorkflowKind.OFF,
+                max_workers=3,
+            )
+
+        with pytest.raises(ValueError, match="requires parallel=True"):
+            wf._make_execution_config()
+
+    def test_jax_broadcast_ignores_max_workers_after_warning(self, monkeypatch):
+        def fail_executor(*args, **kwargs):
+            raise AssertionError("JAX broadcast should not use ThreadPoolExecutor")
+
+        monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", fail_executor)
+        with pytest.warns(UserWarning, match="do not control JAX vmap"):
+            wf = WorkflowFunction(
+                func=add_one,
+                vectorize="jax",
+                workflow_kind=WorkflowKind.OFF,
+                max_workers=3,
+                n_broadcast_samples=8,
+                seed=0,
+            )
+
+        result = wf(x=Normal(loc=0.0, scale=1.0, name="x"))
+
+        assert result.n == 8
 
     def test_private_wrappers_return_empty_before_building_request(self, monkeypatch):
         wf = WorkflowFunction(func=add_one, workflow_kind=WorkflowKind.TASK, vectorize="loop")

--- a/tests/distributions/test_joint_empirical.py
+++ b/tests/distributions/test_joint_empirical.py
@@ -1,21 +1,26 @@
 """Tests for JointEmpirical."""
 
+from __future__ import annotations
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from probpipe import (
-    JointEmpirical,
     EmpiricalDistribution,
+    JointEmpirical,
     Record,
-    RecordDistribution,
     RecordArray,
+    RecordDistribution,
+    condition_on,
+    log_prob,
+    mean,
+    sample,
+    variance,
 )
 from probpipe.core._record_distribution import _RecordDistributionView
 from probpipe.core.node import WorkflowFunction
-from probpipe import condition_on, log_prob, mean, sample, variance
-
 
 # ---------------------------------------------------------------------------
 # Construction
@@ -390,7 +395,7 @@ class TestBroadcasting:
 
         wf = WorkflowFunction(
             func=add,
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=30,
             seed=42,
         )

--- a/tests/distributions/test_joint_gaussian.py
+++ b/tests/distributions/test_joint_gaussian.py
@@ -1,5 +1,7 @@
 """Tests for JointGaussian."""
 
+from __future__ import annotations
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -8,15 +10,16 @@ import pytest
 from probpipe import (
     JointGaussian,
     MultivariateNormal,
-    EmpiricalDistribution,
     Record,
-    RecordDistribution,
     RecordArray,
+    RecordDistribution,
+    condition_on,
+    log_prob,
+    mean,
+    sample,
+    variance,
 )
-from probpipe.core._record_distribution import _RecordDistributionView
 from probpipe.core.node import WorkflowFunction
-from probpipe import condition_on, log_prob, mean, sample, variance
-
 
 # ---------------------------------------------------------------------------
 # Construction
@@ -443,7 +446,7 @@ class TestBroadcasting:
 
         wf = WorkflowFunction(
             func=add,
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=50,
             seed=42,
         )

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -1,24 +1,31 @@
 """Comprehensive tests for joint distribution classes."""
 
+from __future__ import annotations
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from probpipe import (
-    Normal,
-    MultivariateNormal,
-    Gamma,
-    ProductDistribution,
-    EmpiricalDistribution,
-    NumericRecordDistribution,
-    RecordDistribution,
-)
-from probpipe.core._record_distribution import _RecordDistributionView
-from probpipe.core.record import Record
-from probpipe.core._record_array import RecordArray
-from probpipe.core.node import WorkflowFunction
-from probpipe import condition_on, from_distribution, log_prob, mean, sample, variance
 
+from probpipe import (
+    EmpiricalDistribution,
+    Gamma,
+    MultivariateNormal,
+    Normal,
+    NumericRecordDistribution,
+    ProductDistribution,
+    RecordDistribution,
+    condition_on,
+    from_distribution,
+    log_prob,
+    mean,
+    sample,
+    variance,
+)
+from probpipe.core._record_array import RecordArray
+from probpipe.core._record_distribution import _RecordDistributionView
+from probpipe.core.node import WorkflowFunction
+from probpipe.core.record import Record
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -338,14 +345,14 @@ class TestBroadcastingReconnection:
     """Test that _RecordDistributionViews from the same parent are sampled jointly."""
 
     @staticmethod
-    def _make_add_workflow(backend="loop"):
+    def _make_add_workflow(backend="sequential"):
         """Create a workflow that adds two arrays."""
         def add(a: float, b: float) -> float:
             return a + b
 
         return WorkflowFunction(
             func=add,
-            vectorize=backend,
+            dispatch=backend,
             n_broadcast_samples=50,
             seed=42,
         )
@@ -367,7 +374,7 @@ class TestBroadcastingReconnection:
             x=Normal(loc=0.0, scale=1.0, name="x"),
             y=Normal(loc=10.0, scale=1.0, name="y"),
         )
-        wf = self._make_add_workflow("loop")
+        wf = self._make_add_workflow("sequential")
         result = wf(a=joint["x"], b=joint["y"])
         assert hasattr(result, "samples")
         # x ~ N(0,1), y ~ N(10,1), independent => a+b ~ N(10, sqrt(2))
@@ -392,7 +399,7 @@ class TestBroadcastingReconnection:
 
         wf = WorkflowFunction(
             func=subtract,
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=20,
             seed=99,
         )
@@ -416,7 +423,7 @@ class TestBroadcastingReconnection:
 
         wf = WorkflowFunction(
             func=add3,
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=50,
             seed=77,
         )
@@ -438,7 +445,7 @@ class TestBroadcastingReconnection:
 
         wf = WorkflowFunction(
             func=add,
-            vectorize="jax",
+            dispatch="jax",
             n_broadcast_samples=50,
             seed=55,
         )
@@ -460,7 +467,7 @@ class TestBroadcastingReconnection:
 
         wf = WorkflowFunction(
             func=subtract,
-            vectorize="jax",
+            dispatch="jax",
             n_broadcast_samples=20,
             seed=88,
         )
@@ -532,7 +539,7 @@ class TestProductProtocolDuckTyping:
 
     def test_mixed_no_log_prob(self):
         """Component lacking SupportsLogProb → product lacks it too."""
-        from probpipe import SupportsLogProb, BootstrapDistribution
+        from probpipe import BootstrapDistribution, SupportsLogProb
         boot = BootstrapDistribution(jnp.array([1.0, 2.0, 3.0]), name="y")
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=boot)
         assert not isinstance(joint, SupportsLogProb)
@@ -639,7 +646,6 @@ class TestPositionalAndAutoRename:
 
     def test_auto_rename_preserves_provenance(self):
         """Auto-renamed component tracks provenance back to the original."""
-        from probpipe.core.provenance import Provenance
         n = Normal(loc=0.0, scale=1.0, name="x")
         joint = ProductDistribution(growth_rate=n)
         comp = joint.components["growth_rate"]
@@ -755,7 +761,7 @@ class TestEnumerateWithDistributionViews:
 
         wf = WorkflowFunction(
             func=compute,
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=50,
             seed=123,
         )
@@ -1100,7 +1106,7 @@ class TestNestedProductDistribution:
 
         wf = WorkflowFunction(
             func=add,
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=30,
             seed=42,
         )

--- a/tests/distributions/test_sequential_joint.py
+++ b/tests/distributions/test_sequential_joint.py
@@ -1,5 +1,7 @@
 """Tests for SequentialJointDistribution."""
 
+from __future__ import annotations
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -8,17 +10,17 @@ import scipy.stats
 
 from probpipe import (
     Normal,
-    MultivariateNormal,
-    SequentialJointDistribution,
-    EmpiricalDistribution,
     Record,
-    RecordDistribution,
     RecordArray,
+    RecordDistribution,
+    SequentialJointDistribution,
+    condition_on,
+    log_prob,
+    sample,
+    unnormalized_log_prob,
 )
 from probpipe.core._record_distribution import _RecordDistributionView
 from probpipe.core.node import WorkflowFunction
-from probpipe import condition_on, log_prob, sample, unnormalized_log_prob
-
 
 # ---------------------------------------------------------------------------
 # Construction
@@ -454,7 +456,7 @@ class TestBroadcastingReconnection:
 
         wf = WorkflowFunction(
             func=subtract,
-            vectorize="loop",
+            dispatch="sequential",
             n_broadcast_samples=30,
             seed=42,
         )
@@ -476,7 +478,7 @@ class TestBroadcastingReconnection:
 
         wf = WorkflowFunction(
             func=subtract,
-            vectorize="jax",
+            dispatch="jax",
             n_broadcast_samples=30,
             seed=55,
         )

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -7,6 +7,8 @@ Covers:
 - rwmh workflow function: basic sampling with SupportsLogProb
 """
 
+from __future__ import annotations
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -24,13 +26,10 @@ from probpipe import (
     sample,
     variance,
 )
-from unittest.mock import MagicMock
-
-from probpipe.inference import rwmh
 from probpipe.core.distribution import _RecordDistributionView
+from probpipe.inference import rwmh
 from probpipe.inference._approximate_distribution import make_posterior
 from probpipe.inference._tfp_mcmc import _build_mcmc_datatree
-
 
 # ---------------------------------------------------------------------------
 # ApproximateDistribution
@@ -277,7 +276,8 @@ class TestApproximateDistributionValuesTemplate:
         assert post.record_template["params"].fields == ("a", "b")
         # Moments key by the user's top-level fields, not by an
         # auto-wrap leaf.
-        from probpipe import mean as op_mean, variance as op_variance
+        from probpipe import mean as op_mean
+        from probpipe import variance as op_variance
         m = op_mean(post)
         assert m.fields == expected_fields
         assert m["params"].shape == (2,)  # flat per-component means
@@ -731,7 +731,7 @@ class TestViewProtocolDuckTyping:
 
     def test_view_always_isinstance_sampling(self):
         """Every view is SupportsSampling regardless of parent type."""
-        from probpipe import SupportsSampling, ProductDistribution
+        from probpipe import ProductDistribution, SupportsSampling
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(3, 2, name="y"))
         assert isinstance(joint["x"], SupportsSampling)
 
@@ -744,7 +744,7 @@ class TestViewProtocolDuckTyping:
 
     def test_view_always_isinstance_mean_variance(self):
         """Every view is SupportsMean and SupportsVariance."""
-        from probpipe import SupportsMean, SupportsVariance, ProductDistribution
+        from probpipe import ProductDistribution, SupportsMean, SupportsVariance
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(3, 2, name="y"))
         view = joint["x"]
         assert isinstance(view, SupportsMean)
@@ -752,8 +752,9 @@ class TestViewProtocolDuckTyping:
 
     def test_view_log_prob_delegates_to_component(self):
         """View _log_prob delegates to the underlying component distribution."""
-        from probpipe import ProductDistribution
         import scipy.stats
+
+        from probpipe import ProductDistribution
         joint = ProductDistribution(x=Normal(loc=2.0, scale=0.5, name="x"), y=Normal(0, 1, name="y"))
         view = joint["x"]
         lp = float(view._log_prob(jnp.array(2.0)))
@@ -762,14 +763,14 @@ class TestViewProtocolDuckTyping:
 
     def test_view_no_cov_when_parent_lacks_it(self):
         """View lacks SupportsCovariance when parent doesn't have it."""
-        from probpipe import SupportsCovariance, ProductDistribution
+        from probpipe import ProductDistribution, SupportsCovariance
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(3, 2, name="y"))
         view = joint["x"]
         assert not isinstance(view, SupportsCovariance)
 
     def test_dynamic_protocol_depends_on_parent(self):
         """Same _RecordDistributionView base, different isinstance results."""
-        from probpipe import SupportsLogProb, ProductDistribution
+        from probpipe import ProductDistribution, SupportsLogProb
         # ProductDistribution parent → isinstance True
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(3, 2, name="y"))
         view_with = joint["x"]
@@ -979,7 +980,7 @@ class TestEndToEndValuesPipeline:
         """Broadcast predict(params, x) computes correct function of posterior."""
         from probpipe.core.node import workflow_function
 
-        @workflow_function(n_broadcast_samples=100, vectorize="loop", seed=0)
+        @workflow_function(n_broadcast_samples=100, dispatch="sequential", seed=0)
         def predict(params, x):
             return params[0] + params[1] * x
 
@@ -998,7 +999,7 @@ class TestEndToEndValuesPipeline:
         """
         from probpipe.core.node import workflow_function
 
-        @workflow_function(n_broadcast_samples=50, vectorize="loop", seed=0)
+        @workflow_function(n_broadcast_samples=50, dispatch="sequential", seed=0)
         def identity_pair(a, b):
             return a - b
 
@@ -1026,7 +1027,6 @@ class TestEndToEndValuesPipeline:
 
         # Per-field views
         view_a = post["a"]
-        view_b = post["b"]
         assert isinstance(view_a, _RecordDistributionView)
         np.testing.assert_allclose(
             float(view_a._mean()), float(draws["a"].mean()), atol=1e-5
@@ -1040,7 +1040,7 @@ class TestEndToEndValuesPipeline:
         """Workflow with both posterior views and an independent distribution."""
         from probpipe.core.node import workflow_function
 
-        @workflow_function(n_broadcast_samples=50, vectorize="loop", seed=0)
+        @workflow_function(n_broadcast_samples=50, dispatch="sequential", seed=0)
         def noisy_predict(params, noise):
             return params[0] + params[1] * 0.5 + noise
 


### PR DESCRIPTION
## Summary

Refs #213.

This PR replaces the old `WorkflowFunction` `vectorize` / `parallel` controls with a single explicit dispatch API:

```python
WorkflowFunction(
    ...,
    dispatch="auto",  # "auto" | "jax" | "sequential" | "thread"
    max_workers=None,
)
```
Previously, the public API split behavior across `vectorize` and `parallel`, and `parallel` also overloaded two meanings: whether local threaded execution was enabled, and how many workers should be used. This was easy to misuse because bool is a subclass of int, and it also blurred the boundary between vectorization, local threaded execution, and orchestration.

This PR makes the public API explicit:

- `dispatch="auto"` probes JAX traceability and uses JAX when possible, otherwise falls back to local sequential dispatch.
- `dispatch="jax"` requires JAX dispatch and fails clearly if the function/path is not JAX-traceable.
- `dispatch="sequential"` uses local row-wise/function-call dispatch without threads.
- `dispatch="thread"` uses local row-wise/function-call dispatch through `ThreadPoolExecutor`. `max_workers` only configures dispatch="thread".

This is an intentional breaking API change. `vectorize=` and `parallel=` are no longer accepted.

## Behavior

Dispatch and orchestration are now treated as separate layers:

- `dispatch` controls how broadcast samples are dispatched: JAX vmap, local sequential calls, or local threaded calls.
- `workflow_kind` controls whether the dispatch is wrapped in Prefect task/flow orchestration.

The new behavior is:

- `dispatch="auto"`: use JAX if the wrapped function and broadcast path are JAX-traceable; otherwise use sequential dispatch.
- `dispatch="jax"`: use JAX vmap; raise a clear `ValueError` if tracing fails or the broadcast path is unsupported.
- `dispatch="sequential"`: use local row-wise dispatch.
- `dispatch="thread", max_workers=None`: use `ThreadPoolExecutor` with default worker selection.
- `dispatch="thread", max_workers=<positive int>`: use `ThreadPoolExecutor(max_workers=...)`.
- `max_workers` with any non-thread dispatch: warn and ignore it.
- `Prefect TASK / FLOW` orchestration remains separate; local thread settings do not control Prefect scheduling and warn when ignored.

## Implementation Notes

- Private `WorkflowExecutionConfig` remains a resolved execution contract. It carries execution facts such as `mode`, `max_workers`, `name`, and `prefect_task_runner`.
- `WorkflowExecutionConfig` does not carry public intent fields like `dispatch`, `vectorize`, or `parallel`.
- `_workflow_execution.execute_many(...)` dispatches directly on resolved `mode`.
- The explicit JAX path now reuses the same trace probe as auto-dispatch, but `dispatch="auto"` still probes only once.
- Docs and notebooks have been updated to use `dispatch=` terminology.

## Tests
```bash
ruff check --select I,F probpipe/core/node.py probpipe/core/_workflow_execution.py tests/core/test_workflow_parallel.py tests/core/test_broadcasting.py tests/core/test_prefect_config.py tests/core/test_prefect_orchestration.py tests/core/test_provenance.py tests/core/test_record_array_view.py tests/core/test_recordarray_broadcasting.py tests/core/test_workflow_call_resolution.py tests/core/test_workflow_distribution_normalization.py tests/distributions/test_joint_empirical.py tests/distributions/test_joint_gaussian.py tests/distributions/test_product.py tests/distributions/test_sequential_joint.py tests/inference/test_inference.py
ruff check probpipe/core/_workflow_execution.py tests/core/test_workflow_parallel.py tests/core/test_broadcasting.py tests/core/test_recordarray_broadcasting.py tests/core/test_prefect_orchestration.py
pytest -p no:xdist -o addopts= tests/core/test_workflow_parallel.py tests/core/test_broadcasting.py tests/core/test_prefect_config.py tests/core/test_prefect_orchestration.py tests/core/test_provenance.py tests/core/test_recordarray_broadcasting.py tests/core/test_workflow_call_resolution.py tests/core/test_workflow_distribution_normalization.py -q
pytest -p no:xdist -o addopts= tests/distributions/test_product.py tests/distributions/test_joint_empirical.py tests/distributions/test_joint_gaussian.py tests/distributions/test_sequential_joint.py tests/inference/test_inference.py -q
mkdocs build --strict
git diff --check
```