### PR TITLE
refactor(core) [#196 PR-3]: Call resolution extraction

### DIFF
--- a/probpipe/core/_workflow_call.py
+++ b/probpipe/core/_workflow_call.py
@@ -1,0 +1,256 @@
+"""WorkflowFunction call-resolution helpers.
+
+This private module owns function signature metadata, call-time override
+extraction, argument binding, module/default resolution, and dependency
+validation. It deliberately knows nothing about distribution conversion,
+broadcast planning, execution, or result coercion.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, get_type_hints
+
+RESERVED_WORKFLOW_CALL_NAMES = frozenset(
+    {"n_broadcast_samples", "seed", "include_inputs"}
+)
+
+
+@dataclass(frozen=True)
+class WorkflowSignatureInfo:
+    """Cached signature metadata for one wrapped workflow function."""
+
+    signature: inspect.Signature
+    hints: Mapping[str, Any]
+    param_names: tuple[str, ...]
+    has_var_keyword: bool
+    reserved_names: frozenset[str]
+
+
+@dataclass(frozen=True)
+class WorkflowCallOverrides:
+    """Reserved call-time settings consumed by ``WorkflowFunction``."""
+
+    n_broadcast_samples: int
+    include_inputs: bool
+    seed: int | None
+
+
+@dataclass(frozen=True)
+class ResolvedWorkflowCall:
+    """Fully resolved call values plus call-time workflow overrides."""
+
+    values: dict[str, Any]
+    overrides: WorkflowCallOverrides
+
+
+def make_signature_info(
+    func: Callable[..., Any],
+    *,
+    reserved_names: frozenset[str] = RESERVED_WORKFLOW_CALL_NAMES,
+) -> WorkflowSignatureInfo:
+    """Build reusable signature metadata for a wrapped function."""
+    signature = inspect.signature(func)
+    hints = _get_type_hints(func)
+    param_names = tuple(p for p in signature.parameters if p != "self")
+    has_var_keyword = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD
+        for p in signature.parameters.values()
+    )
+    return WorkflowSignatureInfo(
+        signature=signature,
+        hints=hints,
+        param_names=param_names,
+        has_var_keyword=has_var_keyword,
+        reserved_names=reserved_names,
+    )
+
+
+def validate_reserved_parameter_names(
+    info: WorkflowSignatureInfo,
+    *,
+    workflow_name: str,
+) -> None:
+    """Raise if the wrapped function declares reserved workflow names."""
+    collision = info.reserved_names & set(info.param_names)
+    if collision:
+        raise ValueError(
+            f"Function '{workflow_name}' has parameter(s) {collision} which are "
+            f"reserved by WorkflowFunction for call-time overrides. Rename them in "
+            f"your function signature."
+        )
+
+
+def is_dependency_param(
+    info: WorkflowSignatureInfo,
+    name: str,
+    *,
+    dependency_type: type,
+) -> bool:
+    """Return whether a parameter annotation names a workflow dependency."""
+    ann = info.hints.get(name)
+    try:
+        return isinstance(ann, type) and issubclass(ann, dependency_type)
+    except TypeError:
+        return False
+
+
+def bind_call_inputs(
+    info: WorkflowSignatureInfo,
+    args: tuple[Any, ...],
+    call_inputs: dict[str, Any],
+    *,
+    default_n_broadcast_samples: int,
+    default_include_inputs: bool,
+) -> tuple[dict[str, Any], WorkflowCallOverrides]:
+    """Bind positional/keyword inputs and extract reserved overrides."""
+    raw_inputs = dict(call_inputs)
+    n_broadcast_samples = raw_inputs.pop(
+        "n_broadcast_samples", default_n_broadcast_samples
+    )
+    include_inputs = raw_inputs.pop("include_inputs", default_include_inputs)
+    seed = raw_inputs.pop("seed", None)
+
+    bound = info.signature.bind_partial(*args, **raw_inputs)
+    bound_inputs: dict[str, Any] = {}
+    for name, value in bound.arguments.items():
+        param = info.signature.parameters[name]
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            bound_inputs.update(value)
+        else:
+            bound_inputs[name] = value
+
+    return bound_inputs, WorkflowCallOverrides(
+        n_broadcast_samples=n_broadcast_samples,
+        include_inputs=include_inputs,
+        seed=seed,
+    )
+
+
+def resolve_workflow_values(
+    info: WorkflowSignatureInfo,
+    call_inputs: dict[str, Any],
+    *,
+    bind: Mapping[str, Any],
+    module: Any | None,
+    dependency_type: type,
+    workflow_name: str,
+) -> dict[str, Any]:
+    """Resolve final function kwargs from call, bind, module, and defaults."""
+    values: dict[str, Any] = {}
+    mod_child_nodes = getattr(module, "child_nodes", {}) if module is not None else {}
+    mod_inputs = getattr(module, "inputs", {}) if module is not None else {}
+
+    for name, param in info.signature.parameters.items():
+        if name == "self":
+            continue
+
+        is_dep = is_dependency_param(info, name, dependency_type=dependency_type)
+
+        if name in call_inputs:
+            if module is not None and is_dep and name in mod_child_nodes:
+                raise TypeError(
+                    f"Dependency '{name}' for workflow '{workflow_name}' is provided "
+                    f"by the module and cannot be overridden at call time."
+                )
+            values[name] = call_inputs[name]
+        elif name in bind:
+            values[name] = bind[name]
+        elif module is not None:
+            if is_dep and name in mod_child_nodes:
+                values[name] = mod_child_nodes[name]
+            elif not is_dep and name in mod_inputs:
+                values[name] = mod_inputs[name]
+
+        if name not in values and param.default is not param.empty:
+            values[name] = param.default
+
+    if info.has_var_keyword:
+        known_params = set(info.signature.parameters.keys())
+        for name, value in call_inputs.items():
+            if name not in known_params:
+                values[name] = value
+
+    _validate_required_values(info, values, workflow_name=workflow_name)
+    _validate_dependency_values(
+        info,
+        values,
+        dependency_type=dependency_type,
+        workflow_name=workflow_name,
+    )
+    return values
+
+
+def resolve_workflow_call(
+    info: WorkflowSignatureInfo,
+    args: tuple[Any, ...],
+    call_inputs: dict[str, Any],
+    *,
+    bind: Mapping[str, Any],
+    module: Any | None,
+    dependency_type: type,
+    workflow_name: str,
+    default_n_broadcast_samples: int,
+    default_include_inputs: bool,
+) -> ResolvedWorkflowCall:
+    """Resolve one ``WorkflowFunction`` call into values plus overrides."""
+    bound_inputs, overrides = bind_call_inputs(
+        info,
+        args,
+        call_inputs,
+        default_n_broadcast_samples=default_n_broadcast_samples,
+        default_include_inputs=default_include_inputs,
+    )
+    values = resolve_workflow_values(
+        info,
+        bound_inputs,
+        bind=bind,
+        module=module,
+        dependency_type=dependency_type,
+        workflow_name=workflow_name,
+    )
+    return ResolvedWorkflowCall(values=values, overrides=overrides)
+
+
+def _get_type_hints(func: Callable[..., Any]) -> dict[str, Any]:
+    type_params = getattr(func, "__type_params__", ())
+    if not type_params:
+        return get_type_hints(func)
+    localns = {param.__name__: param for param in type_params}
+    return get_type_hints(func, localns=localns)
+
+
+def _validate_required_values(
+    info: WorkflowSignatureInfo,
+    values: dict[str, Any],
+    *,
+    workflow_name: str,
+) -> None:
+    for name, param in info.signature.parameters.items():
+        if name == "self":
+            continue
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+            continue
+        if param.default is param.empty and name not in values:
+            raise TypeError(f"Missing required input '{name}' for workflow '{workflow_name}'")
+
+
+def _validate_dependency_values(
+    info: WorkflowSignatureInfo,
+    values: dict[str, Any],
+    *,
+    dependency_type: type,
+    workflow_name: str,
+) -> None:
+    for name in info.param_names:
+        if not is_dependency_param(info, name, dependency_type=dependency_type):
+            continue
+        value = values.get(name)
+        if not isinstance(value, dependency_type):
+            ann = info.hints.get(name)
+            raise TypeError(
+                f"WorkflowFunction '{workflow_name}' expects dependency "
+                f"'{name}: {ann}' to be a Node, but got {type(value)}."
+            )

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -457,38 +457,33 @@ class WorkflowFunction(Node):
     ) -> _workflow_execution.WorkflowExecutionConfig:
         """Build resolved execution metadata for sequential call dispatch."""
         if mode is None:
-            kind = self.effective_workflow_kind
-            if kind is WorkflowKind.TASK:
-                mode = "prefect_task"
-            elif kind is WorkflowKind.FLOW:
-                mode = "prefect_flow"
-            elif self._dispatch == "thread":
-                mode = "thread"
-            else:
-                mode = "sequential"
+            match self.effective_workflow_kind:
+                case WorkflowKind.TASK:
+                    mode = "prefect_task"
+                case WorkflowKind.FLOW:
+                    mode = "prefect_flow"
+                case _ if self._dispatch == "thread":
+                    mode = "thread"
+                case _:
+                    mode = "sequential"
 
-        max_workers = None
-        if mode == "thread":
-            max_workers = self._max_workers
-        elif mode in ("prefect_task", "prefect_flow"):
-            if self._dispatch == "thread" or self._max_workers is not None:
-                warnings.warn(
-                    "dispatch='thread' and max_workers configure only local "
-                    "ThreadPoolExecutor dispatch; they do not control Prefect "
-                    "scheduling.",
-                    stacklevel=2,
-                )
+        is_prefect = mode in ("prefect_task", "prefect_flow")
 
-        prefect_task_runner = (
-            prefect_config.resolve_task_runner()
-            if mode in ("prefect_task", "prefect_flow")
-            else None
-        )
+        if is_prefect and (self._dispatch == "thread" or self._max_workers is not None):
+            warnings.warn(
+                "dispatch='thread' and max_workers configure only local "
+                "ThreadPoolExecutor dispatch; they do not control Prefect "
+                "scheduling.",
+                stacklevel=2,
+            )
+
         return _workflow_execution.WorkflowExecutionConfig(
             mode=mode,
-            max_workers=max_workers,
+            max_workers=self._max_workers if mode == "thread" else None,
             name=self._name,
-            prefect_task_runner=prefect_task_runner,
+            prefect_task_runner=(
+                prefect_config.resolve_task_runner() if is_prefect else None
+            ),
         )
 
     def _make_execution_request(

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from itertools import product as cartesian_product
 from types import MappingProxyType
-from typing import Any, ClassVar, Literal, TypeAlias, get_args, get_type_hints
+from typing import Any, ClassVar, Literal, TypeAlias, get_args
 
 import jax
 import jax.numpy as jnp
@@ -27,7 +27,7 @@ except ImportError:
 from .._utils import prod
 from ..converters import converter_registry
 from ..custom_types import Array, PRNGKey
-from . import _workflow_execution, _workflow_result
+from . import _workflow_call, _workflow_execution, _workflow_result
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
 from ._record_array import RecordArray, _RecordArrayView
@@ -354,8 +354,9 @@ class WorkflowFunction(Node):
             )
 
         self._func = func
-        self._sig = inspect.signature(func)
-        self._hints = get_type_hints(func)
+        self._signature_info = _workflow_call.make_signature_info(func)
+        self._sig = self._signature_info.signature
+        self._hints = self._signature_info.hints
         # Convert legacy string / None values to WorkflowKind enum
         # TODO: remove this legacy conversion in follow-up issue
         if workflow_kind is None:
@@ -389,22 +390,13 @@ class WorkflowFunction(Node):
 
         super().__init__()
 
-        # Precompute parameter metadata once
-        self._param_names = [p for p in self._sig.parameters if p != "self"]
-        self._has_var_keyword = any(
-            p.kind == inspect.Parameter.VAR_KEYWORD
-            for p in self._sig.parameters.values()
-        )
+        # Compatibility attributes for callers/tests that inspect the facade.
+        self._param_names = list(self._signature_info.param_names)
+        self._has_var_keyword = self._signature_info.has_var_keyword
 
-        # Reserved names that would collide with WorkflowFunction call-time overrides
-        _RESERVED = {"n_broadcast_samples", "seed", "include_inputs"}
-        collision = _RESERVED & set(self._param_names)
-        if collision:
-            raise ValueError(
-                f"Function '{self._name}' has parameter(s) {collision} which are "
-                f"reserved by WorkflowFunction for call-time overrides. Rename them in "
-                f"your function signature."
-            )
+        _workflow_call.validate_reserved_parameter_names(
+            self._signature_info, workflow_name=self._name,
+        )
 
     @property
     def effective_workflow_kind(self) -> WorkflowKind:
@@ -509,42 +501,36 @@ class WorkflowFunction(Node):
 
         This matches your current architecture (deps are Nodes).
         """
-        ann = self._hints.get(name)
-        try:
-            return isinstance(ann, type) and issubclass(ann, Node)
-        except TypeError:
-            # Generic aliases (e.g. NDArray on Python 3.10) can pass
-            # isinstance(ann, type) but fail in issubclass().
-            return False
+        return _workflow_call.is_dependency_param(
+            self._signature_info, name, dependency_type=Node,
+        )
 
     def __call__(self, *args, **call_inputs):
-        # Extract reserved call-time overrides (collision already prevented in __init__)
-        n_broadcast_samples = call_inputs.pop("n_broadcast_samples", self._n_broadcast_samples)
-        do_include_inputs = call_inputs.pop("include_inputs", self._include_inputs)
+        call = _workflow_call.resolve_workflow_call(
+            self._signature_info,
+            args,
+            call_inputs,
+            bind=self._bind,
+            module=self._module,
+            dependency_type=Node,
+            workflow_name=self._name,
+            default_n_broadcast_samples=self._n_broadcast_samples,
+            default_include_inputs=self._include_inputs,
+        )
+        if call.overrides.seed is not None:
+            self._key = jax.random.PRNGKey(call.overrides.seed)
 
-        if "seed" in call_inputs:
-            self._key = jax.random.PRNGKey(call_inputs.pop("seed"))
-
-        # Bind user arguments through the wrapped function's real signature.
-        # ``bind_partial`` preserves module/default resolution below while
-        # still rejecting unexpected keywords and duplicate positional/keyword
-        # values with Python-call-compatible errors.
-        bound = self._sig.bind_partial(*args, **call_inputs)
-        call_inputs = {}
-        for name, value in bound.arguments.items():
-            param = self._sig.parameters[name]
-            if param.kind == inspect.Parameter.VAR_KEYWORD:
-                call_inputs.update(value)
-            else:
-                call_inputs[name] = value
-
-        values = self._resolve_inputs(call_inputs)
+        values = call.values
         values = self._convert_distributions(values)
 
         dist_args, ra_args = self._find_broadcast_args(values)
         if dist_args or ra_args:
             return self._broadcast(
-                values, dist_args, ra_args, n_broadcast_samples, do_include_inputs,
+                values,
+                dist_args,
+                ra_args,
+                call.overrides.n_broadcast_samples,
+                call.overrides.include_inputs,
             )
 
         # Non-broadcast call — one function invocation, then wrap.
@@ -576,76 +562,14 @@ class WorkflowFunction(Node):
           3) module.child_nodes/module.inputs (if module attached)
           4) function default values
         """
-        values: dict[str, Any] = {}
-
-        # convenience access
-        mod = self._module
-        mod_child_nodes = getattr(mod, "child_nodes", {}) if mod is not None else {}
-        mod_inputs = getattr(mod, "inputs", {}) if mod is not None else {}
-
-        for name, param in self._sig.parameters.items():
-            if name == "self":
-                continue
-
-            is_dep = self._is_dependency_param(name)
-
-            # 1) call-time inputs
-            if name in call_inputs:
-                if mod is not None and is_dep and name in mod_child_nodes:
-                    # Avoid accidental overriding of module-wired deps at call time
-                    raise TypeError(
-                        f"Dependency '{name}' for workflow '{self._name}' is provided by the module "
-                        f"and cannot be overridden at call time."
-                    )
-                values[name] = call_inputs[name]
-
-            # 2) construction-time bind
-            elif name in self._bind:
-                values[name] = self._bind[name]
-
-            # 3) resolve from module if available
-            elif mod is not None:
-                if is_dep and name in mod_child_nodes:
-                    values[name] = mod_child_nodes[name]
-                elif (not is_dep) and name in mod_inputs:
-                    values[name] = mod_inputs[name]
-                else:
-                    # fall through to default/missing
-                    pass
-
-            # 4) function defaults
-            if name not in values:
-                if param.default is not param.empty:
-                    values[name] = param.default
-
-        # Pass through extra kwargs when the function accepts **kwargs.
-        if self._has_var_keyword:
-            known_params = set(self._sig.parameters.keys())
-            for k, v in call_inputs.items():
-                if k not in known_params:
-                    values[k] = v
-
-        # validate required params exist (after resolution)
-        for name, param in self._sig.parameters.items():
-            if name == "self":
-                continue
-            if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
-                continue
-            if param.default is param.empty and name not in values:
-                raise TypeError(f"Missing required input '{name}' for workflow '{self._name}'")
-
-        # validate dependency types
-        for name in self._param_names:
-            if self._is_dependency_param(name):
-                v = values.get(name)
-                if not isinstance(v, Node):
-                    ann = self._hints.get(name)
-                    raise TypeError(
-                        f"WorkflowFunction '{self._name}' expects dependency '{name}: {ann}' to be a Node, "
-                        f"but got {type(v)}."
-                    )
-
-        return values
+        return _workflow_call.resolve_workflow_values(
+            self._signature_info,
+            call_inputs,
+            bind=self._bind,
+            module=self._module,
+            dependency_type=Node,
+            workflow_name=self._name,
+        )
 
     def _convert_distributions(self, values: dict[str, Any]) -> dict[str, Any]:
         """Convert distribution-valued args based on type hints.

--- a/tests/core/test_workflow_call_resolution.py
+++ b/tests/core/test_workflow_call_resolution.py
@@ -6,10 +6,13 @@ internals are split into smaller private modules.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import jax.numpy as jnp
 import pytest
 
 from probpipe import BroadcastDistribution, Normal
+from probpipe.core import _workflow_call
 from probpipe.core.node import Module, Node, WorkflowFunction, workflow_method
 
 
@@ -61,6 +64,96 @@ class CallResolutionModule(Module):
     @workflow_method
     def step(self, dep: DataNode, x, y=7.0):
         return x + y
+
+
+def _resolve_call(
+    func,
+    *args,
+    bind=None,
+    module=None,
+    default_n_broadcast_samples=20,
+    default_include_inputs=False,
+    **call_inputs,
+):
+    info = _workflow_call.make_signature_info(func)
+    return _workflow_call.resolve_workflow_call(
+        info,
+        args,
+        call_inputs,
+        bind=bind or {},
+        module=module,
+        dependency_type=Node,
+        workflow_name=getattr(func, "__name__", "workflow"),
+        default_n_broadcast_samples=default_n_broadcast_samples,
+        default_include_inputs=default_include_inputs,
+    )
+
+
+class TestWorkflowCallHelpers:
+    def test_positional_and_mixed_arguments_bind_like_python_calls(self, add_func):
+        assert _resolve_call(add_func, 1.0, 2.0).values == {"x": 1.0, "y": 2.0}
+        assert _resolve_call(add_func, 1.0, y=2.0).values == {"x": 1.0, "y": 2.0}
+
+    def test_duplicate_positional_and_keyword_argument_raises(self, add_func):
+        with pytest.raises(TypeError, match="multiple values"):
+            _resolve_call(add_func, 1.0, x=2.0)
+
+    def test_var_keyword_expands_extra_keywords(self, kwargs_recorder):
+        identity, _ = kwargs_recorder
+
+        call = _resolve_call(identity, x=1.0, scale=2.0)
+
+        assert call.values == {"x": 1.0, "scale": 2.0}
+
+    def test_literal_kwargs_argument_is_not_unpacked(self, kwargs_recorder):
+        identity, _ = kwargs_recorder
+
+        call = _resolve_call(identity, x=1.0, kwargs={"scale": 2.0})
+
+        assert call.values == {"x": 1.0, "kwargs": {"scale": 2.0}}
+
+    def test_reserved_overrides_are_not_function_inputs(self, identity_func):
+        call = _resolve_call(
+            identity_func,
+            "value",
+            n_broadcast_samples=6,
+            include_inputs=True,
+            seed=123,
+        )
+
+        assert call.values == {"x": "value"}
+        assert call.overrides.n_broadcast_samples == 6
+        assert call.overrides.include_inputs is True
+        assert call.overrides.seed == 123
+
+    def test_bind_module_and_function_defaults_resolve_in_precedence_order(self):
+        dep = DataNode()
+        module = SimpleNamespace(child_nodes={"dep": dep}, inputs={"x": 5.0})
+
+        def step(dep: DataNode, x, y=7.0, scale=1.0):
+            return (x + y) * scale
+
+        call = _resolve_call(step, module=module, bind={"scale": 2.0})
+        override = _resolve_call(step, module=module, bind={"scale": 2.0}, y=3.0)
+
+        assert call.values == {"dep": dep, "x": 5.0, "y": 7.0, "scale": 2.0}
+        assert override.values == {"dep": dep, "x": 5.0, "y": 3.0, "scale": 2.0}
+
+    def test_module_wired_dependency_cannot_be_overridden_at_call_time(self):
+        def step(dep: DataNode):
+            return dep
+
+        module = SimpleNamespace(child_nodes={"dep": DataNode()}, inputs={})
+
+        with pytest.raises(TypeError, match="cannot be overridden"):
+            _resolve_call(step, module=module, dep=DataNode())
+
+    def test_dependency_typed_parameter_requires_node_instance(self):
+        def use_dep(dep: DataNode):
+            return dep
+
+        with pytest.raises(TypeError, match="expects dependency 'dep:"):
+            _resolve_call(use_dep, dep=object())
 
 
 class TestArgumentBinding:


### PR DESCRIPTION
This is the third stage of #196.

## Changes
1. Added `probpipe/core/_workflow_call.py` with the planned dataclasses and helpers for signature metadata, reserved override extraction, argument binding, module/default resolution, and dependency validation.
2. Updated `probpipe/core/node.py` so `WorkflowFunction` delegates call resolution to the new module while preserving `_sig`, `_hints`, `_param_names`, `_has_var_keyword`, `_is_dependency_param()`, and `_resolve_inputs()` compatibility.
3. Added helper-level tests in `test_workflow_call_resolution.py`.