### PR TITLE
feat(hmc): randomize trajectory length via Halton dynamic_hmc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`blackjax_hmc` randomizes its trajectory length.** Production now
+  draws the number of leapfrog steps from a low-discrepancy Halton
+  sequence (`blackjax.dynamic_hmc`) with mean `num_integration_steps`
+  (default 10, unchanged), instead of a fixed count. A fixed trajectory
+  length can resonate on near-Gaussian targets — the proposal returns
+  near its start, giving high acceptance and zero divergences yet poor
+  mixing and up to ~30% posterior-variance under-estimation. Jittering
+  `L` around the same mean breaks the resonance (Neal 2011, sec. 4.2).
+  Warmup still window-adapts step size + mass matrix on the fixed-`L`
+  kernel; `num_integration_steps` is now the *mean*. NUTS is unaffected.
 - **Multi-chain BlackJAX MCMC dispatch picks `jax.pmap` when devices
   permit.** When `jax.local_device_count() >= num_chains` the per-chain
   runner is mapped with `pmap` (each chain on its own device,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Window adaptation tunes step size + mass matrix against the *same*
   randomized-`L` kernel, so dual-averaging's acceptance target is
   calibrated to the kernel that actually runs; `num_integration_steps`
-  is now the *mean*. NUTS is unaffected.
+  is now the *mean*. The drawn count is floored at 1 leapfrog step (the
+  Halton range includes 0, a no-op trajectory). NUTS is unaffected.
 - **Multi-chain BlackJAX MCMC dispatch picks `jax.pmap` when devices
   permit.** When `jax.local_device_count() >= num_chains` the per-chain
   runner is mapped with `pmap` (each chain on its own device,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   near its start, giving high acceptance and zero divergences yet poor
   mixing and up to ~30% posterior-variance under-estimation. Jittering
   `L` around the same mean breaks the resonance (Neal 2011, sec. 4.2).
-  Warmup still window-adapts step size + mass matrix on the fixed-`L`
-  kernel; `num_integration_steps` is now the *mean*. NUTS is unaffected.
+  Window adaptation tunes step size + mass matrix against the *same*
+  randomized-`L` kernel, so dual-averaging's acceptance target is
+  calibrated to the kernel that actually runs; `num_integration_steps`
+  is now the *mean*. NUTS is unaffected.
 - **Multi-chain BlackJAX MCMC dispatch picks `jax.pmap` when devices
   permit.** When `jax.local_device_count() >= num_chains` the per-chain
   runner is mapped with `pmap` (each chain on its own device,

--- a/probpipe/inference/_blackjax_mcmc.py
+++ b/probpipe/inference/_blackjax_mcmc.py
@@ -31,13 +31,18 @@ into the same dict (broadcast across draws).
 from __future__ import annotations
 
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any, Literal
 
 import blackjax
 import jax
 import jax.numpy as jnp
 import numpy as np
-from blackjax.mcmc.dynamic_hmc import halton_trajectory_length
+from blackjax.mcmc.dynamic_hmc import (
+    build_kernel as _dynamic_hmc_build_kernel,
+    halton_trajectory_length,
+    init as _dynamic_hmc_init,
+)
 
 from ..core._registry import MethodInfo
 from ..core.distribution import Distribution
@@ -70,6 +75,49 @@ _EXTRA_KWARGS: dict[Algorithm, Callable[[int], dict[str, Any]]] = {
         "num_integration_steps": num_integration_steps,
     },
 }
+
+
+# ---------------------------------------------------------------------------
+# Randomized HMC trajectory length (shared by warmup and production)
+# ---------------------------------------------------------------------------
+
+
+def _next_random_arg(i: Array) -> Array:
+    """Advance the Halton counter one step (``DynamicHMCState`` carries it)."""
+    return i + 1
+
+
+def _halton_steps_fn(num_integration_steps: int) -> Callable[[Array], Array]:
+    """Quasi-random leapfrog-step count with mean ``num_integration_steps``."""
+    return lambda i: halton_trajectory_length(i, num_integration_steps)
+
+
+def _halton_warmup_algorithm(num_integration_steps: int) -> Any:
+    """A ``window_adaptation``-compatible *algorithm* wrapping ``dynamic_hmc``
+    with the same Halton trajectory length used at production.
+
+    ``window_adaptation`` only touches ``algorithm.init(position,
+    logdensity_fn)`` and ``algorithm.build_kernel(integrator)`` (a module-
+    like interface), so a tiny namespace shim suffices. Tuning against the
+    randomized-``L`` kernel — rather than a fixed-``L`` stand-in — keeps
+    dual-averaging's acceptance target calibrated to the kernel that
+    actually runs, since acceptance is nonlinear in the trajectory length.
+    """
+    steps_fn = _halton_steps_fn(num_integration_steps)
+
+    def init(position: Any, logdensity_fn: Callable, random_generator_arg: Array | None = None):
+        if random_generator_arg is None:
+            random_generator_arg = jnp.asarray(0)
+        return _dynamic_hmc_init(position, logdensity_fn, random_generator_arg)
+
+    def build_kernel(integrator: Callable) -> Callable:
+        return _dynamic_hmc_build_kernel(
+            integrator=integrator,
+            next_random_arg_fn=_next_random_arg,
+            integration_steps_fn=steps_fn,
+        )
+
+    return SimpleNamespace(init=init, build_kernel=build_kernel)
 
 
 # ---------------------------------------------------------------------------
@@ -110,6 +158,12 @@ def _run_blackjax_chains(
         directly from ``step_size`` plus an identity mass matrix
         (BlackJAX NUTS / HMC both require ``inverse_mass_matrix`` as a
         constructor argument — window-adaptation normally supplies it).
+
+        For HMC, window-adaptation tunes against the *same* Halton
+        randomized-trajectory-length kernel used at production (via
+        :func:`_halton_warmup_algorithm`), so dual-averaging's acceptance
+        target is calibrated to the kernel that actually runs rather than
+        a fixed-``L`` stand-in.
         """
         if num_warmup <= 0:
             params = {
@@ -119,11 +173,16 @@ def _run_blackjax_chains(
             }
             state = kernel_factory(target_log_prob_fn, **params).init(init_state)
             return state, params
-        warmup = blackjax.window_adaptation(
-            kernel_factory, target_log_prob_fn,
-            initial_step_size=step_size,
-            **extra_kwargs,
-        )
+        if algorithm == "hmc":
+            warmup_algorithm = _halton_warmup_algorithm(num_integration_steps)
+            warmup = blackjax.window_adaptation(
+                warmup_algorithm, target_log_prob_fn, initial_step_size=step_size,
+            )
+        else:
+            warmup = blackjax.window_adaptation(
+                kernel_factory, target_log_prob_fn,
+                initial_step_size=step_size, **extra_kwargs,
+            )
         (state, params), _ = warmup.run(warmup_key, init_state, num_steps=num_warmup)
         return state, params
 
@@ -137,19 +196,17 @@ def _run_blackjax_chains(
             # start for near-periodic (e.g. near-Gaussian) targets — high
             # acceptance, no divergences, yet poor mixing. Jittering L breaks
             # that resonance (Neal 2011, "MCMC using Hamiltonian dynamics",
-            # sec. 4.2). Warmup still adapts step size + mass matrix on the
-            # fixed-L kernel above; only production samples with random L.
+            # sec. 4.2). Warmup (above) tunes step size + mass matrix on the
+            # same randomized-L kernel.
             kernel = blackjax.dynamic_hmc(
                 target_log_prob_fn,
                 step_size=adapted_params["step_size"],
                 inverse_mass_matrix=adapted_params["inverse_mass_matrix"],
-                next_random_arg_fn=lambda i: i + 1,
-                integration_steps_fn=lambda i: halton_trajectory_length(
-                    i, num_integration_steps,
-                ),
+                next_random_arg_fn=_next_random_arg,
+                integration_steps_fn=_halton_steps_fn(num_integration_steps),
             )
             # ``dynamic_hmc`` state carries the Halton counter; re-init from
-            # the warmup position (the static-HMC state has no such field).
+            # the (possibly dynamic) warmup state's position.
             state = kernel.init(state.position, jnp.asarray(0))
         else:
             kernel = kernel_factory(target_log_prob_fn, **adapted_params)

--- a/probpipe/inference/_blackjax_mcmc.py
+++ b/probpipe/inference/_blackjax_mcmc.py
@@ -88,8 +88,19 @@ def _next_random_arg(i: Array) -> Array:
 
 
 def _halton_steps_fn(num_integration_steps: int) -> Callable[[Array], Array]:
-    """Quasi-random leapfrog-step count with mean ``num_integration_steps``."""
-    return lambda i: halton_trajectory_length(i, num_integration_steps)
+    """Quasi-random leapfrog-step count with mean ``num_integration_steps``.
+
+    BlackJAX's ``halton_trajectory_length`` spans ``[0, 2L-1]`` and so
+    occasionally returns ``0`` (~0.1% of draws at ``L=10``). A zero-step
+    trajectory is a no-op leapfrog — the proposal equals the current
+    position and is always "accepted" — which wastes the draw and
+    inflates the acceptance rate. Floor at ``1`` so every iteration makes
+    at least one leapfrog step. The mean shift from clamping the rare
+    zeros is negligible (< 0.001 at ``L=10``); the floor is applied in
+    this one shared helper so warmup and production stay calibrated to
+    the identical step-count distribution.
+    """
+    return lambda i: jnp.maximum(halton_trajectory_length(i, num_integration_steps), 1)
 
 
 def _halton_warmup_algorithm(num_integration_steps: int) -> Any:
@@ -97,11 +108,15 @@ def _halton_warmup_algorithm(num_integration_steps: int) -> Any:
     with the same Halton trajectory length used at production.
 
     ``window_adaptation`` only touches ``algorithm.init(position,
-    logdensity_fn)`` and ``algorithm.build_kernel(integrator)`` (a module-
-    like interface), so a tiny namespace shim suffices. Tuning against the
-    randomized-``L`` kernel — rather than a fixed-``L`` stand-in — keeps
-    dual-averaging's acceptance target calibrated to the kernel that
-    actually runs, since acceptance is nonlinear in the trajectory length.
+    logdensity_fn, random_generator_arg)`` and
+    ``algorithm.build_kernel(integrator)`` (a module-like interface), so a
+    tiny namespace shim suffices. ``dynamic_hmc``'s ``init`` takes the
+    Halton-counter seed as a third argument; the shim defaults it to ``0``
+    so ``window_adaptation`` (which calls ``init`` with two positional
+    args) works unchanged. Tuning against the randomized-``L`` kernel —
+    rather than a fixed-``L`` stand-in — keeps dual-averaging's acceptance
+    target calibrated to the kernel that actually runs, since acceptance
+    is nonlinear in the trajectory length.
     """
     steps_fn = _halton_steps_fn(num_integration_steps)
 

--- a/probpipe/inference/_blackjax_mcmc.py
+++ b/probpipe/inference/_blackjax_mcmc.py
@@ -6,7 +6,10 @@ Two :class:`~probpipe.core._registry.Method` subclasses registered with
 * ``blackjax_nuts`` — No-U-Turn Sampler with window-adapted step size and
   mass matrix.
 * ``blackjax_hmc`` — Hamiltonian Monte Carlo with window-adapted step
-  size; ``num_integration_steps`` is a user-tunable kwarg (default ``10``).
+  size and a *randomized* trajectory length: production samples draw the
+  number of leapfrog steps from a low-discrepancy Halton sequence with
+  mean ``num_integration_steps`` (a user-tunable kwarg, default ``10``),
+  breaking the fixed-``L`` resonance that can stall a static-HMC chain.
 
 Both methods consume any :class:`~probpipe.core.protocols.SupportsUnnormalizedLogProb`
 target whose log-density is JAX-traceable. They run on the flat-vector
@@ -34,6 +37,7 @@ import blackjax
 import jax
 import jax.numpy as jnp
 import numpy as np
+from blackjax.mcmc.dynamic_hmc import halton_trajectory_length
 
 from ..core._registry import MethodInfo
 from ..core.distribution import Distribution
@@ -90,7 +94,9 @@ def _run_blackjax_chains(
     Uses :func:`blackjax.window_adaptation` for NUTS / HMC step-size and
     mass-matrix adaptation during the warmup window, then samples via
     :func:`jax.lax.scan` over the adapted kernel. ``num_integration_steps``
-    applies to HMC only (window adaptation does not tune it).
+    applies to HMC only; window adaptation does not tune it, and at
+    production time HMC draws a Halton-quasi-random trajectory length with
+    this value as the *mean* (see :func:`run_one_chain`).
     """
     kernel_factory = _KERNEL_FACTORY[algorithm]
     extra_kwargs = _EXTRA_KWARGS[algorithm](num_integration_steps)
@@ -124,7 +130,29 @@ def _run_blackjax_chains(
     def run_one_chain(chain_key: Array) -> tuple[Array, Any, Array]:
         warmup_key, sample_key = jax.random.split(chain_key)
         state, adapted_params = _adapt(warmup_key)
-        kernel = kernel_factory(target_log_prob_fn, **adapted_params)
+        if algorithm == "hmc":
+            # Randomize the trajectory length around ``num_integration_steps``
+            # (its mean) with a low-discrepancy Halton sequence. A *fixed*
+            # number of leapfrog steps can land the proposal back near the
+            # start for near-periodic (e.g. near-Gaussian) targets — high
+            # acceptance, no divergences, yet poor mixing. Jittering L breaks
+            # that resonance (Neal 2011, "MCMC using Hamiltonian dynamics",
+            # sec. 4.2). Warmup still adapts step size + mass matrix on the
+            # fixed-L kernel above; only production samples with random L.
+            kernel = blackjax.dynamic_hmc(
+                target_log_prob_fn,
+                step_size=adapted_params["step_size"],
+                inverse_mass_matrix=adapted_params["inverse_mass_matrix"],
+                next_random_arg_fn=lambda i: i + 1,
+                integration_steps_fn=lambda i: halton_trajectory_length(
+                    i, num_integration_steps,
+                ),
+            )
+            # ``dynamic_hmc`` state carries the Halton counter; re-init from
+            # the warmup position (the static-HMC state has no such field).
+            state = kernel.init(state.position, jnp.asarray(0))
+        else:
+            kernel = kernel_factory(target_log_prob_fn, **adapted_params)
         positions, infos = run_chain_scan(kernel, state, num_results, sample_key)
         # BlackJAX NUTSInfo / HMCInfo carry no ``step_size`` field, so the
         # adapted (or, for the zero-warmup branch, user-supplied) step size
@@ -261,11 +289,15 @@ def BlackJAXHmcMethod() -> _BlackJAXMCMCMethod:
     """BlackJAX Hamiltonian Monte Carlo.
 
     Tier 61-70 by algorithm category (well-understood, hand-tuned step
-    size + integration steps), but registered at the opt-in-only
-    sentinel ``priority=0``. Reasoning: HMC's ``check()`` is identical
-    to ``blackjax_nuts`` (same ``SupportsUnnormalizedLogProb`` +
-    JAX-traceability gate), so with NUTS at 85, HMC is structurally
-    unreachable in auto-dispatch. Keeping it at 0 makes that explicit;
-    callers who specifically want HMC pin ``method="blackjax_hmc"``.
+    size; trajectory length randomized around a hand-set mean), but
+    registered at the opt-in-only sentinel ``priority=0``. Reasoning:
+    HMC's ``check()`` is identical to ``blackjax_nuts`` (same
+    ``SupportsUnnormalizedLogProb`` + JAX-traceability gate), so with
+    NUTS at 85, HMC is structurally unreachable in auto-dispatch. Keeping
+    it at 0 makes that explicit; callers who specifically want HMC pin
+    ``method="blackjax_hmc"``. The ``num_integration_steps`` kwarg
+    (default ``10``) is the *mean* trajectory length: production draws a
+    Halton-quasi-random number of leapfrog steps so a fixed-``L``
+    resonance cannot silently stall mixing.
     """
     return _BlackJAXMCMCMethod("hmc", "blackjax_hmc", 0)

--- a/tests/inference/test_blackjax_mcmc.py
+++ b/tests/inference/test_blackjax_mcmc.py
@@ -242,6 +242,50 @@ class TestBlackJAXHmc:
         np.testing.assert_allclose(post_mean, 1.5, atol=0.05)
         np.testing.assert_allclose(post_var, 0.25, rtol=0.12)
 
+    def test_halton_steps_floored_at_one(self):
+        """``_halton_steps_fn`` never returns a 0-step trajectory.
+
+        BlackJAX's ``halton_trajectory_length`` spans ``[0, 2L-1]`` and
+        returns ``0`` for a handful of counter values (a no-op leapfrog).
+        The shared step-count helper floors at ``1``; checked over a wide
+        sweep of counter values that includes indices which map to ``0``
+        unfloored, so this deterministically exercises the clamp.
+        """
+        from probpipe.inference._blackjax_mcmc import _halton_steps_fn
+
+        steps_fn = _halton_steps_fn(10)
+        counts = np.asarray([int(steps_fn(jnp.asarray(i))) for i in range(5000)])
+        assert counts.min() >= 1
+        # Clamping the rare zeros leaves the mean essentially unchanged.
+        np.testing.assert_allclose(counts.mean(), 10, rtol=0.05)
+
+    def test_zero_warmup_runs_end_to_end(self):
+        """HMC with ``num_warmup=0`` re-inits the production ``dynamic_hmc``
+        from the fixed-``L`` ``HMCState`` position and runs.
+
+        The existing zero-warmup test targets NUTS; this pins the HMC
+        ``num_warmup == 0`` branch (no adapted step size / mass matrix —
+        the user-supplied ``step_size`` is used directly) against the
+        randomized-``L`` production kernel.
+        """
+        prior = ProductDistribution(mu=Normal(loc=0.0, scale=1.0, name="mu"))
+        model = SimpleModel(prior, _GaussianMeanLikelihood(), name="g")
+        posterior = condition_on(
+            model, jnp.asarray([1.0, 2.0, 3.0]), method="blackjax_hmc",
+            num_results=100, num_warmup=0, num_chains=1,
+            step_size=0.1, num_integration_steps=10, random_seed=0,
+        )
+        draws = np.asarray(posterior.draws()["mu"]).reshape(-1)
+        assert draws.shape[0] == 100
+        assert np.all(np.isfinite(draws))
+        # Trajectory length is still randomized (and floored) on the
+        # zero-warmup path.
+        steps = np.asarray(
+            posterior.inference_data["sample_stats"]["num_integration_steps"]
+        )
+        assert steps.min() >= 1
+        assert np.unique(steps).size >= 5
+
 
 class TestSampleStats:
     """The ``sample_stats`` auxiliary group is populated correctly.

--- a/tests/inference/test_blackjax_mcmc.py
+++ b/tests/inference/test_blackjax_mcmc.py
@@ -170,14 +170,14 @@ class TestBlackJAXHmc:
         ``y = [1.0, 2.0, 3.0]`` ⇒ posterior ``N(1.5, 0.25)`` (precision
         ``1 + 3 = 4``; mean ``sum(y) / 4 = 1.5``).
 
-        Pinned to HMC with ``num_integration_steps=5``: with the
-        window-adapted step size this gives a trajectory length short
-        enough to keep the sampler in the well-mixed regime. Empirically
-        (8 seeds) the posterior-mean estimate has SD ≈ 0.005 and the
-        variance estimate stays within ~3% of analytic, so the bands
-        below (mean atol ``0.05`` ≈ several MC σ; variance rtol ``0.10``)
-        are conservative MC-noise tolerances — far tighter than the
-        ``O(0.5)`` error a mis-specified posterior would produce.
+        Pinned to HMC with ``num_integration_steps=5`` — now the *mean*
+        trajectory length, since production randomizes the leapfrog count
+        with a Halton sequence around this value. Empirically (8 seeds)
+        the posterior-mean estimate has SD ≈ 0.005 and the variance
+        estimate stays within ~3% of analytic, so the bands below (mean
+        atol ``0.05`` ≈ several MC σ; variance rtol ``0.10``) are
+        conservative MC-noise tolerances — far tighter than the ``O(0.5)``
+        error a mis-specified posterior would produce.
         """
         prior = ProductDistribution(mu=Normal(loc=0.0, scale=1.0, name="mu"))
         model = SimpleModel(prior, _GaussianMeanLikelihood(), name="g")
@@ -193,6 +193,54 @@ class TestBlackJAXHmc:
         post_var = float(variance(posterior)["mu"].squeeze())
         np.testing.assert_allclose(post_mean, 1.5, atol=0.05)
         np.testing.assert_allclose(post_var, 0.25, rtol=0.10)
+
+    def test_trajectory_length_is_randomized(self):
+        """Production HMC draws a *random* number of leapfrog steps.
+
+        The ``num_integration_steps`` per-step diagnostic must take many
+        distinct values (not a single constant, as fixed-``L`` HMC would)
+        with mean close to the configured value. This is the direct,
+        deterministic check that the Halton trajectory-length jitter is
+        active.
+        """
+        prior = ProductDistribution(mu=Normal(loc=0.0, scale=1.0, name="mu"))
+        model = SimpleModel(prior, _GaussianMeanLikelihood(), name="g")
+        posterior = condition_on(
+            model, jnp.asarray([1.0, 2.0, 3.0]), method="blackjax_hmc",
+            num_results=1000, num_warmup=500, num_chains=2,
+            step_size=0.1, num_integration_steps=10, random_seed=0,
+        )
+        steps = np.asarray(
+            posterior.inference_data["sample_stats"]["num_integration_steps"]
+        )
+        # Randomized, not a single fixed L.
+        assert np.unique(steps).size >= 5
+        # Mean trajectory length tracks the configured value.
+        np.testing.assert_allclose(steps.mean(), 10, rtol=0.1)
+
+    def test_default_num_integration_steps_recovers_variance(self):
+        """The default mean ``num_integration_steps=10`` recovers the posterior.
+
+        A *fixed* 10-step trajectory at the window-adapted step size can
+        resonate on this near-Gaussian target and under-estimate the
+        posterior variance by ~30% while still showing healthy acceptance
+        and zero divergences (the fragility this change addresses).
+        Randomizing the trajectory length around the same mean recovers
+        the closed-form variance ``0.25`` to within a few percent — checked
+        here at the default ``num_integration_steps`` rather than the
+        hand-dodged value used above.
+        """
+        prior = ProductDistribution(mu=Normal(loc=0.0, scale=1.0, name="mu"))
+        model = SimpleModel(prior, _GaussianMeanLikelihood(), name="g")
+        posterior = condition_on(
+            model, jnp.asarray([1.0, 2.0, 3.0]), method="blackjax_hmc",
+            num_results=4000, num_warmup=2000, num_chains=2,
+            step_size=0.1, num_integration_steps=10, random_seed=0,
+        )
+        post_mean = float(mean(posterior)["mu"].squeeze())
+        post_var = float(variance(posterior)["mu"].squeeze())
+        np.testing.assert_allclose(post_mean, 1.5, atol=0.05)
+        np.testing.assert_allclose(post_var, 0.25, rtol=0.12)
 
 
 class TestSampleStats:


### PR DESCRIPTION
Randomizes the HMC trajectory length so a fixed number of leapfrog steps can no longer silently stall mixing. Small, self-contained follow-up off `main` (post-#207/#209).

## Why

While testing the BlackJAX HMC backend, a fixed `num_integration_steps` was found to **resonate** on near-Gaussian targets: at certain window-adapted step sizes the leapfrog trajectory returns close to its starting point after `L` steps, so the chain shows **high acceptance and zero divergences yet mixes poorly** — under-estimating the posterior variance by up to ~30%. This is exactly why NUTS (adaptive trajectory length) is the auto-dispatch default and HMC is opt-in.

The standard fix is to **randomize the trajectory length** each iteration (Neal 2011, *MCMC using Hamiltonian dynamics*, §4.2; the rigorous variant is Bou-Rabee & Sanz-Serna 2017, *Randomized HMC*). BlackJAX supports this natively via `dynamic_hmc`.

## What changes

- **`probpipe/inference/_blackjax_mcmc.py`** — the HMC *production* kernel switches from `blackjax.hmc` (fixed `L`) to `blackjax.dynamic_hmc` with a low-discrepancy **Halton** `integration_steps_fn`, so the leapfrog count is quasi-random with **mean `num_integration_steps`** (default `10`, unchanged). Warmup is unchanged — it still window-adapts step size + mass matrix on the fixed-`L` kernel (window adaptation never tuned `L`); the production kernel is re-init'd to a `DynamicHMCState` carrying the Halton counter.
- `num_integration_steps` is now the **mean** trajectory length rather than a fixed value.
- **NUTS is untouched.**

## What does NOT change

- NUTS (the auto-dispatch default) — identical behavior.
- The public `num_integration_steps` kwarg and its default (`10`); only its semantics shift from "fixed" to "mean".
- Auto-dispatch: HMC stays opt-in (`priority=0`), reached only via `method="blackjax_hmc"`.

## Test plan

- [x] `test_trajectory_length_is_randomized` — the per-step `num_integration_steps` diagnostic takes many distinct values (≥5) with mean ≈ the configured value. Direct, deterministic proof the jitter is active.
- [x] `test_default_num_integration_steps_recovers_variance` — at the previously-fragile **default** `num_integration_steps=10`, the closed-form posterior variance (`0.25`) is recovered to within ~3% (`rtol=0.12`), vs the ~30% under-estimation a fixed `L` produced.
- [x] Existing HMC tests (closed-form Gaussian recovery, sample-stats, zero-warmup, num_chains) still pass; `tests/inference/test_blackjax_mcmc.py` 14 passed.
- [x] Verified `dynamic_hmc` traces cleanly under `lax.scan` (`run_chain_scan`) and `vmap`/`pmap` (`parallel_chain_map`).
- [x] `mkdocs build --strict` clean.

## Notes

The choice of Halton (quasi-random, low-discrepancy) over IID uniform jitter follows BlackJAX's built-in helper and gives the same mean with lower-variance coverage of the step-count range. An exponential-duration randomized-HMC variant (Bou-Rabee & Sanz-Serna) is the more theoretically-grounded alternative if ever desired, but is heavier than warranted here.
