### PR TITLE
refactor(core) [#196 PR-4]: Distribution normalization and BroadcastPlan introduction

### DIFF
--- a/probpipe/_utils.py
+++ b/probpipe/_utils.py
@@ -1,13 +1,12 @@
-"""Shared utility functions for probpipe."""
+"""Shared utility functions for ProbPipe."""
 
 from __future__ import annotations
 
 import math
-
-import numpy as np
+from collections.abc import Iterable
 
 import jax
-import jax.numpy as jnp
+import numpy as np
 
 from .custom_types import PRNGKey
 
@@ -43,11 +42,10 @@ def _is_numeric_array(x: object) -> bool:
     return False
 
 
-def prod(shape: tuple[int, ...]) -> int:
-    """Product of a shape tuple, returning 1 for an empty tuple.
+def prod(values: Iterable[int]) -> int:
+    """Return the product of integer values.
 
-    This is a thin wrapper around :func:`math.prod` that treats the empty
-    tuple as having product 1, which is the correct convention for scalar
-    (0-dimensional) shapes throughout probpipe.
+    This is a compatibility wrapper around :func:`math.prod`; empty
+    iterables naturally return 1.
     """
-    return math.prod(shape) if shape else 1
+    return math.prod(values)

--- a/probpipe/core/_workflow_distribution_normalization.py
+++ b/probpipe/core/_workflow_distribution_normalization.py
@@ -1,8 +1,19 @@
-"""WorkflowFunction distribution-normalization helpers.
+"""WorkflowFunction distribution-input normalization helpers.
 
-This private module owns distribution-valued input conversion before
-broadcast planning. It centralizes the existing converter-registry use
-so the planner can stay a pure classification step.
+This private module handles only distribution-valued workflow inputs.
+It is not a general normalization layer for all values entering a
+``WorkflowFunction`` call.
+
+The normalization step runs after call resolution and before broadcast
+planning. It performs value-changing work that the planner should not
+do: converting external distribution objects through the converter
+registry, converting ProbPipe distributions to satisfy concrete
+``Distribution`` hints or distribution capability protocols, and
+unwrapping scalar ``DistributionArray`` inputs when the function expects
+a scalar distribution value.
+
+Keeping those conversions here lets broadcast planning remain a pure
+classification step over already-normalized values.
 """
 
 from __future__ import annotations
@@ -56,12 +67,19 @@ def is_distribution_hint(expected: Any) -> bool:
     return expected in DISTRIBUTION_HINT_PROTOCOLS
 
 
-def normalize_workflow_values(
+def normalize_distribution_values(
     *,
     values: dict[str, Any],
     hints: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Normalize distribution-valued workflow inputs before planning."""
+    """Normalize distribution-valued inputs before broadcast planning.
+
+    Non-distribution values are copied through unchanged. Distribution
+    values may be converted according to the function's type hints, and
+    external distribution objects in non-distribution slots are converted
+    to ProbPipe ``NumericRecordDistribution`` so the distribution-broadcast
+    path can sample them uniformly.
+    """
     out = dict(values)
 
     for name, value in values.items():

--- a/probpipe/core/_workflow_normalize.py
+++ b/probpipe/core/_workflow_normalize.py
@@ -1,0 +1,128 @@
+"""WorkflowFunction distribution-normalization helpers.
+
+This private module owns distribution-valued input conversion before
+broadcast planning. It centralizes the existing converter-registry use
+so the planner can stay a pure classification step.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ..converters import converter_registry
+from ._distribution_array import DistributionArray
+from .distribution import Distribution, NumericRecordDistribution
+from .protocols import (
+    SupportsConditioning,
+    SupportsCovariance,
+    SupportsExpectation,
+    SupportsLogProb,
+    SupportsMean,
+    SupportsRandomLogProb,
+    SupportsRandomUnnormalizedLogProb,
+    SupportsSampling,
+    SupportsUnnormalizedLogProb,
+    SupportsVariance,
+)
+
+DISTRIBUTION_HINT_PROTOCOLS: tuple[type, ...] = (
+    SupportsExpectation,
+    SupportsSampling,
+    SupportsUnnormalizedLogProb,
+    SupportsLogProb,
+    SupportsMean,
+    SupportsVariance,
+    SupportsCovariance,
+    SupportsRandomLogProb,
+    SupportsRandomUnnormalizedLogProb,
+    SupportsConditioning,
+)
+
+
+def is_distribution_hint(expected: Any) -> bool:
+    """Return whether a type hint asks for a distribution object."""
+    origin = getattr(expected, "__origin__", None)
+    expected_type = origin if isinstance(origin, type) else expected
+    try:
+        if (
+            expected_type is not None
+            and isinstance(expected_type, type)
+            and issubclass(expected_type, Distribution)
+        ):
+            return True
+    except TypeError:
+        pass
+    return expected in DISTRIBUTION_HINT_PROTOCOLS
+
+
+def normalize_workflow_values(
+    *,
+    values: dict[str, Any],
+    hints: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Normalize distribution-valued workflow inputs before planning."""
+    out = dict(values)
+
+    for name, value in values.items():
+        expected = hints.get(name)
+
+        if isinstance(value, DistributionArray):
+            if (
+                value.batch_shape == ()
+                and not _is_distribution_array_hint(expected)
+                and expected is not Any
+            ):
+                out[name] = value._flat_component(0)
+            continue
+
+        if expected is not None:
+            out[name] = _convert_hinted_distribution(value, expected)
+            value = out[name]
+
+        if (
+            not is_distribution_hint(expected)
+            and converter_registry.is_distribution_type(value)
+            and not isinstance(value, Distribution)
+        ):
+            out[name] = converter_registry.convert(value, NumericRecordDistribution)
+
+    return out
+
+
+def _convert_hinted_distribution(value: Any, expected: Any) -> Any:
+    is_dist_subclass = _is_concrete_distribution_hint(expected)
+
+    if (
+        is_dist_subclass
+        and converter_registry.is_distribution_type(value)
+        and not isinstance(value, expected)
+    ):
+        return converter_registry.convert(value, expected)
+
+    if (
+        not is_dist_subclass
+        and expected in DISTRIBUTION_HINT_PROTOCOLS
+        and isinstance(value, Distribution)
+        and not isinstance(value, expected)
+    ):
+        try:
+            return converter_registry.convert(value, expected)
+        except (TypeError, AttributeError):
+            return value
+
+    return value
+
+
+def _is_concrete_distribution_hint(expected: Any) -> bool:
+    try:
+        return isinstance(expected, type) and issubclass(expected, Distribution)
+    except TypeError:
+        return False
+
+
+def _is_distribution_array_hint(expected: Any) -> bool:
+    try:
+        return isinstance(expected, type) and issubclass(expected, DistributionArray)
+    except TypeError:
+        return False

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from math import prod
 from typing import Any, Literal
 
-from . import _workflow_normalize
+from . import _workflow_distribution_normalization
 from ._distribution_array import DistributionArray
 from ._record_array import RecordArray
 from .distribution import Distribution
@@ -66,7 +66,7 @@ def build_broadcast_plan(
             continue
 
         if isinstance(value, Distribution):
-            if _workflow_normalize.is_distribution_hint(expected):
+            if _workflow_distribution_normalization.is_distribution_hint(expected):
                 continue
             dist_args.append(name)
 

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -1,0 +1,148 @@
+"""WorkflowFunction broadcast-planning helpers.
+
+This private module classifies already-normalized workflow inputs into
+the broadcast regime and sweep shape that ``WorkflowFunction`` should
+execute. Planning is intentionally side-effect-free.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import prod
+from typing import Any, Literal
+
+from . import _workflow_normalize
+from ._distribution_array import DistributionArray
+from ._record_array import RecordArray
+from .distribution import Distribution
+
+BroadcastRegime = Literal["none", "distribution", "sweep", "nested"]
+
+
+@dataclass(frozen=True)
+class ArrayBroadcastGroup:
+    """One parent-identity group of array-valued sweep arguments."""
+
+    arg_names: tuple[str, ...]
+    batch_shape: tuple[int, ...]
+    size: int
+
+
+@dataclass(frozen=True)
+class BroadcastPlan:
+    """Pure broadcast classification for one resolved workflow call."""
+
+    regime: BroadcastRegime
+    dist_args: tuple[str, ...]
+    array_args: tuple[str, ...]
+    array_groups: tuple[ArrayBroadcastGroup, ...]
+    sweep_batch_shape: tuple[int, ...]
+    n_sweep: int
+
+
+def build_broadcast_plan(
+    *,
+    values: Mapping[str, Any],
+    hints: Mapping[str, Any],
+) -> BroadcastPlan:
+    """Classify normalized values into a broadcast execution plan."""
+    dist_args: list[str] = []
+    array_args: list[str] = []
+
+    for name, value in values.items():
+        expected = hints.get(name)
+
+        is_record_array = isinstance(value, RecordArray)
+        is_dist_array = isinstance(value, DistributionArray)
+        if (is_record_array or is_dist_array) and len(value.batch_shape) > 0:
+            if _is_same_array_hint(
+                expected,
+                is_record_array=is_record_array,
+                is_dist_array=is_dist_array,
+            ) or expected is Any:
+                continue
+            array_args.append(name)
+            continue
+
+        if isinstance(value, Distribution):
+            if _workflow_normalize.is_distribution_hint(expected):
+                continue
+            dist_args.append(name)
+
+    array_groups = group_array_args_by_parent(values=values, names=array_args)
+    sweep_batch_shape = tuple(
+        axis for group in array_groups for axis in group.batch_shape
+    )
+    n_sweep = prod(sweep_batch_shape)
+
+    return BroadcastPlan(
+        regime=_broadcast_regime(dist_args=dist_args, array_args=array_args),
+        dist_args=tuple(dist_args),
+        array_args=tuple(array_args),
+        array_groups=tuple(array_groups),
+        sweep_batch_shape=sweep_batch_shape,
+        n_sweep=n_sweep,
+    )
+
+
+def group_by_parent(
+    *,
+    values: Mapping[str, Any],
+    names: Sequence[str],
+) -> dict[int, list[str]]:
+    """Group argument names by the identity of their source parent."""
+    groups: dict[int, list[str]] = {}
+    for name in names:
+        value = values[name]
+        parent = getattr(value, "parent", value)
+        groups.setdefault(id(parent), []).append(name)
+    return groups
+
+
+def group_array_args_by_parent(
+    *,
+    values: Mapping[str, Any],
+    names: Sequence[str],
+) -> tuple[ArrayBroadcastGroup, ...]:
+    """Build parent-identity groups for array-valued sweep arguments."""
+    groups: list[ArrayBroadcastGroup] = []
+    for arg_names in group_by_parent(values=values, names=names).values():
+        batch_shape = tuple(values[arg_names[0]].batch_shape)
+        groups.append(
+            ArrayBroadcastGroup(
+                arg_names=tuple(arg_names),
+                batch_shape=batch_shape,
+                size=prod(batch_shape),
+            )
+        )
+    return tuple(groups)
+
+
+def _broadcast_regime(
+    *,
+    dist_args: Sequence[str],
+    array_args: Sequence[str],
+) -> BroadcastRegime:
+    if dist_args and array_args:
+        return "nested"
+    if dist_args:
+        return "distribution"
+    if array_args:
+        return "sweep"
+    return "none"
+
+
+def _is_same_array_hint(
+    expected: Any,
+    *,
+    is_record_array: bool,
+    is_dist_array: bool,
+) -> bool:
+    try:
+        return isinstance(expected, type) and (
+            (is_record_array and issubclass(expected, RecordArray))
+            or (is_dist_array and issubclass(expected, DistributionArray))
+        )
+    except TypeError:
+        return False

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -24,10 +24,14 @@ try:
 except ImportError:
     Digraph = None
 
-from .._utils import prod
-from ..converters import converter_registry
 from ..custom_types import Array, PRNGKey
-from . import _workflow_call, _workflow_execution, _workflow_result
+from . import (
+    _workflow_call,
+    _workflow_execution,
+    _workflow_normalize,
+    _workflow_plan,
+    _workflow_result,
+)
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
 from ._record_array import RecordArray, _RecordArrayView
@@ -36,36 +40,8 @@ from .distribution import (
     BroadcastDistribution,
     Distribution,
     EmpiricalDistribution,
-    NumericRecordDistribution,
-)
-from .protocols import (
-    SupportsConditioning,
-    SupportsCovariance,
-    SupportsExpectation,
-    SupportsLogProb,
-    SupportsMean,
-    SupportsRandomLogProb,
-    SupportsRandomUnnormalizedLogProb,
-    SupportsSampling,
-    SupportsUnnormalizedLogProb,
-    SupportsVariance,
 )
 from .provenance import Provenance
-
-# Protocol types that indicate a parameter expects a distribution object.
-# Used by _find_broadcast_args to avoid broadcasting over such parameters.
-_DISTRIBUTION_PROTOCOLS: tuple[type, ...] = (
-    SupportsExpectation,
-    SupportsSampling,
-    SupportsUnnormalizedLogProb,
-    SupportsLogProb,
-    SupportsMean,
-    SupportsVariance,
-    SupportsCovariance,
-    SupportsRandomLogProb,
-    SupportsRandomUnnormalizedLogProb,
-    SupportsConditioning,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -102,24 +78,6 @@ _WorkflowFunctionDispatch: TypeAlias = Literal[
 
 class InputFrozenError(Exception):
     pass
-
-
-def _group_by_parent(
-    values: dict[str, Any],
-    names: list[str],
-) -> dict[int, list[str]]:
-    """Group arg names by the ``id()`` of their source parent.
-
-    Views (``_RecordArrayView`` / ``_RecordDistributionView``) expose
-    ``.parent`` and group with other views sharing it; plain container
-    args are each their own parent. First-occurrence order preserved.
-    """
-    groups: dict[int, list[str]] = {}
-    for name in names:
-        value = values[name]
-        parent = getattr(value, "parent", value)
-        groups.setdefault(id(parent), []).append(name)
-    return groups
 
 
 def workflow_method(func: Callable):
@@ -520,15 +478,14 @@ class WorkflowFunction(Node):
         if call.overrides.seed is not None:
             self._key = jax.random.PRNGKey(call.overrides.seed)
 
-        values = call.values
-        values = self._convert_distributions(values)
-
-        dist_args, ra_args = self._find_broadcast_args(values)
-        if dist_args or ra_args:
+        values = self._convert_distributions(call.values)
+        broadcast_plan = _workflow_plan.build_broadcast_plan(
+            values=values, hints=self._hints,
+        )
+        if broadcast_plan.regime != "none":
             return self._broadcast(
                 values,
-                dist_args,
-                ra_args,
+                broadcast_plan,
                 call.overrides.n_broadcast_samples,
                 call.overrides.include_inputs,
             )
@@ -572,169 +529,10 @@ class WorkflowFunction(Node):
         )
 
     def _convert_distributions(self, values: dict[str, Any]) -> dict[str, Any]:
-        """Convert distribution-valued args based on type hints.
-
-        Handles two conversion cases and one skip:
-
-        1. **Concrete type hints** – if the hint is a ``Distribution``
-           subclass and the value is a recognised distribution that is
-           not already an instance, convert via the registry.
-        2. **Protocol type hints** – if the hint is a
-           ``@runtime_checkable`` protocol (e.g., ``SupportsLogProb``)
-           and the value is a ``Distribution`` that does not satisfy the
-           protocol, convert via protocol-based resolution.
-        3. **``DistributionArray`` skip** – ``Array[Distribution]``
-           values are handled by the sweep path in
-           ``_find_broadcast_args`` (cell-by-cell); they never go
-           through the scalar-distribution conversion.
-        """
-        out = dict(values)
-
-        for name, value in values.items():
-            expected = self._hints.get(name)
-            # DistributionArray is ``Array[Distribution]`` — handled by
-            # the sweep path, not the scalar-distribution conversion.
-            # A 0-d DA (``batch_shape == ()``) has zero axes to sweep
-            # over, so the sweep path would skip it and the op would
-            # see a raw ``DistributionArray`` in a scalar-Distribution
-            # slot. Unwrap it here unless the hint explicitly asks for
-            # a DA (or ``Any``), so the cell flows through dispatch as
-            # any scalar Distribution would — the natural extension of
-            # the sweep convention "no batch cells to iterate → one
-            # call with the cell". Size-1 DAs (``batch_shape == (1,)``)
-            # are *not* collapsed here: their sweep is well-defined
-            # (one cell → ``batch_shape=(1,)`` output), and treating
-            # them as scalars would silently change the result shape
-            # of ``mean(da)`` / ``sample(da)`` for any deliberately
-            # one-element batch.
-            if isinstance(value, DistributionArray):
-                if value.batch_shape == ():
-                    try:
-                        wants_da = (
-                            isinstance(expected, type)
-                            and issubclass(expected, DistributionArray)
-                        )
-                    except TypeError:
-                        wants_da = False
-                    if not wants_da and expected is not Any:
-                        out[name] = value._flat_component(0)
-                continue
-            if expected is None:
-                continue
-
-            try:
-                is_dist_subclass = isinstance(expected, type) and issubclass(
-                    expected, Distribution
-                )
-            except TypeError:
-                is_dist_subclass = False
-
-            if (
-                is_dist_subclass
-                and converter_registry.is_distribution_type(value)
-                and not isinstance(value, expected)
-            ):
-                out[name] = converter_registry.convert(value, expected)
-            elif (
-                not is_dist_subclass
-                and expected in _DISTRIBUTION_PROTOCOLS
-                and isinstance(value, Distribution)
-                and not isinstance(value, expected)
-            ):
-                try:
-                    out[name] = converter_registry.convert(value, expected)
-                except (TypeError, AttributeError):
-                    pass  # Let the impl function's own check raise
-
-        return out
-
-    def _find_broadcast_args(
-        self, values: dict[str, Any]
-    ) -> tuple[list[str], list[str]]:
-        """Classify argument values into distribution-broadcast and
-        array-broadcast groups.
-
-        Returns
-        -------
-        (dist_args, ra_args) : tuple of list
-            - ``dist_args``: scalar Distribution args passed to a slot
-              whose type hint is *not* a Distribution; sampled from
-              and Monte-Carlo-marginalised.
-            - ``ra_args``: array-valued args (``RecordArray`` or
-              ``DistributionArray`` with nonempty ``batch_shape``)
-              passed to a slot whose type hint is *not* that same array
-              type. Multiple ``ra_args`` combine by the **product
-              rule**: one call per cell of the Cartesian product across
-              all array inputs' batch shapes.
-
-        A ``DistributionArray`` is treated as ``Array[Distribution]``:
-        always a sweep arg (not marginalised), even when the hint is a
-        distribution protocol like ``SupportsSampling``. Each cell's
-        component becomes the scalar Distribution seen by the inner
-        call.
-
-        The two groups are disjoint — a value is either an array or a
-        (scalar) Distribution or neither. Both groups firing on the
-        same call triggers the nested regime in ``_broadcast``: outer
-        stack over the array product, inner marginalise over the
-        Distribution MC draws.
-        """
-        dist_broadcast: list[str] = []
-        ra_broadcast: list[str] = []
-        for name, value in values.items():
-            expected = self._hints.get(name)
-
-            # --- Array-valued branch (RecordArray + DistributionArray) ---
-            is_record_array = isinstance(value, RecordArray)
-            is_dist_array = isinstance(value, DistributionArray)
-            if (is_record_array or is_dist_array) and len(value.batch_shape) > 0:
-                # Hint matches the batched type exactly → caller wants
-                # the batched object as-is.
-                # ``typing.Any`` → caller opted out of broadcasting.
-                # Anything else (scalar Record / Distribution / protocol
-                # / no hint) → per-cell sweep.
-                try:
-                    is_same_array_hint = (
-                        isinstance(expected, type) and (
-                            (is_record_array and issubclass(expected, RecordArray))
-                            or (is_dist_array and issubclass(expected, DistributionArray))
-                        )
-                    )
-                except TypeError:
-                    is_same_array_hint = False
-                is_any_hint = expected is Any
-                if is_same_array_hint or is_any_hint:
-                    continue
-                ra_broadcast.append(name)
-                continue
-
-            # --- Scalar-Distribution branch -------------------------------
-            if not converter_registry.is_distribution_type(value):
-                continue
-            # Unwrap parameterized generics (e.g. Distribution[T]).
-            origin = getattr(expected, "__origin__", None)
-            expected_type = origin if isinstance(origin, type) else expected
-            try:
-                is_dist_hint = (
-                    expected_type is not None
-                    and isinstance(expected_type, type)
-                    and issubclass(expected_type, Distribution)
-                )
-            except TypeError:
-                is_dist_hint = False
-            if not is_dist_hint and expected in _DISTRIBUTION_PROTOCOLS:
-                is_dist_hint = True
-            if is_dist_hint:
-                continue
-            # Auto-convert external distribution types to ProbPipe
-            if not isinstance(value, Distribution):
-                values[name] = converter_registry.convert(
-                    value, NumericRecordDistribution,
-                )
-                value = values[name]
-            dist_broadcast.append(name)
-
-        return dist_broadcast, ra_broadcast
+        """Normalize distribution-valued args based on type hints."""
+        return _workflow_normalize.normalize_workflow_values(
+            values=values, hints=self._hints,
+        )
 
     def _get_key(self):
         """Split and advance the internal PRNG key."""
@@ -848,8 +646,7 @@ class WorkflowFunction(Node):
     def _broadcast(
         self,
         values: dict[str, Any],
-        dist_args: list[str],
-        ra_args: list[str],
+        broadcast_plan: _workflow_plan.BroadcastPlan,
         n_broadcast_samples: int,
         do_include_inputs: bool = False,
     ) -> Any:
@@ -877,6 +674,9 @@ class WorkflowFunction(Node):
         inputs are known via provenance). Calling with
         ``include_inputs=True`` and any ``ra_args`` raises.
         """
+        dist_args = list(broadcast_plan.dist_args)
+        ra_args = list(broadcast_plan.array_args)
+
         # ---- No RecordArray: delegate to the existing path -------------
         if not ra_args:
             return self._broadcast_distributions_only(
@@ -890,18 +690,9 @@ class WorkflowFunction(Node):
                 "provenance on the stacked output."
             )
 
-        # Group ``ra_args`` by parent identity. Views from the same
-        # ``RecordArray`` (e.g. ``Design.select_all()`` outputs) zip —
-        # they contribute a single axis block to the sweep. Plain
-        # ``RecordArray`` / ``DistributionArray`` args and views from
-        # different parents each form their own group and product
-        # across the sweep. Insertion order of first occurrence
-        # preserves axis ordering in the output.
-        ra_groups = self._group_ra_args_by_parent(values, ra_args)
-        sweep_batch_shape = tuple(
-            ax for _, bshape, _ in ra_groups for ax in bshape
-        )
-        n_total = prod(sweep_batch_shape) if sweep_batch_shape else 1
+        ra_groups = broadcast_plan.array_groups
+        sweep_batch_shape = broadcast_plan.sweep_batch_shape
+        n_total = broadcast_plan.n_sweep
 
         # ---- Pure sweep (no Distribution args) -------------------------
         if not dist_args:
@@ -932,7 +723,7 @@ class WorkflowFunction(Node):
         # multi-d batch_shape.
         per_row_marginals: list[Distribution] = []
         for i in range(n_total):
-            row_values = self._slice_ra_args(values, ra_args, i, ra_groups)
+            row_values = self._slice_ra_args(values, i, ra_groups)
             inner = self._broadcast_distributions_only(
                 row_values, dist_args, n_broadcast_samples,
                 do_include_inputs=True,
@@ -961,55 +752,26 @@ class WorkflowFunction(Node):
 
     # ----- Helpers for the array-broadcast path ---------------------------
 
-    def _group_ra_args_by_parent(
-        self,
-        values: dict[str, Any],
-        ra_args: list[str],
-    ) -> list[tuple[list[str], tuple[int, ...], int]]:
-        """Group array-valued sweep args by parent identity.
-
-        Views (``_RecordArrayView``) from the same parent
-        ``RecordArray`` — e.g. the output dict of
-        ``Design.select_all()`` — belong to one group and iterate in
-        lockstep (zip). Plain ``RecordArray`` / ``DistributionArray``
-        args and views from distinct parents each form their own group
-        and product across the sweep.
-
-        Returns a list of tuples ``(arg_names, batch_shape, size)``
-        in first-occurrence order; each tuple is one axis block of the
-        sweep. ``size`` is ``prod(batch_shape)``.
-        """
-        groups: list[tuple[list[str], tuple[int, ...], int]] = []
-        for arg_names in _group_by_parent(values, ra_args).values():
-            # Sibling views share their parent's batch_shape by
-            # construction, so the first arg's batch_shape stands for
-            # the group.
-            bshape = tuple(values[arg_names[0]].batch_shape)
-            groups.append((arg_names, bshape, prod(bshape) if bshape else 1))
-        return groups
-
     def _slice_ra_args(
         self,
         values: dict[str, Any],
-        ra_args: list[str],
         i: int,
-        ra_groups: list[tuple[list[str], tuple[int, ...], int]],
+        ra_groups: tuple[_workflow_plan.ArrayBroadcastGroup, ...],
     ) -> dict[str, Any]:
         """Materialise the ``i``-th sweep cell under parent-grouped sweep.
 
-        ``ra_groups`` is the per-parent grouping from
-        :meth:`_group_ra_args_by_parent`. Each group's args share a flat
-        in-group index (zip); groups compose by row-major unravel of
-        the outer flat index ``i`` over the concatenated batch shapes.
+        Each group's args share a flat in-group index (zip); groups
+        compose by row-major unravel of the outer flat index ``i`` over
+        the concatenated batch shapes.
         """
         out = dict(values)
         rem = i
         # Highest-index group varies fastest (row-major over the
         # concatenated sweep shape).
-        for arg_names, _, size in reversed(ra_groups):
-            idx = rem % size
-            rem = rem // size
-            for name in arg_names:
+        for group in reversed(ra_groups):
+            idx = rem % group.size
+            rem = rem // group.size
+            for name in group.arg_names:
                 source = values[name]
                 if isinstance(source, DistributionArray):
                     out[name] = source._flat_component(idx)
@@ -1023,7 +785,7 @@ class WorkflowFunction(Node):
         ra_args: list[str],
         n_total: int,
         sweep_batch_shape: tuple[int, ...],
-        ra_groups: list[tuple[list[str], tuple[int, ...], int]],
+        ra_groups: tuple[_workflow_plan.ArrayBroadcastGroup, ...],
     ) -> Any:
         """Execute ``n_total`` inner calls, one per sweep cell in flat
         row-major order over the concatenated ``sweep_batch_shape``.
@@ -1084,7 +846,7 @@ class WorkflowFunction(Node):
 
         # Sequential path.
         per_row_values = [
-            self._slice_ra_args(values, ra_args, i, ra_groups)
+            self._slice_ra_args(values, i, ra_groups)
             for i in range(n_total)
         ]
         return self._execute_many(per_row_values)
@@ -1133,7 +895,7 @@ class WorkflowFunction(Node):
         """Distribution-only broadcast path (Monte Carlo marginalisation).
 
         Samples from each ``broadcast_args`` entry (all of which are
-        ``Distribution`` instances after ``_find_broadcast_args``),
+        ``Distribution`` instances after workflow normalization),
         calls the user's function once per sample, and wraps the n
         outputs as a single marginal distribution.
 
@@ -1257,7 +1019,9 @@ class WorkflowFunction(Node):
         even if the same object is passed under multiple names.
         """
         sampled: dict[str, Array] = {}
-        for arg_names in _group_by_parent(values, broadcast_args).values():
+        for arg_names in _workflow_plan.group_by_parent(
+            values=values, names=broadcast_args,
+        ).values():
             first = values[arg_names[0]]
             if not isinstance(first, _RecordDistributionView):
                 for arg_name in arg_names:

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -27,8 +27,8 @@ except ImportError:
 from ..custom_types import Array, PRNGKey
 from . import (
     _workflow_call,
+    _workflow_distribution_normalization,
     _workflow_execution,
-    _workflow_normalize,
     _workflow_plan,
     _workflow_result,
 )
@@ -478,7 +478,9 @@ class WorkflowFunction(Node):
         if call.overrides.seed is not None:
             self._key = jax.random.PRNGKey(call.overrides.seed)
 
-        values = self._convert_distributions(call.values)
+        values = _workflow_distribution_normalization.normalize_distribution_values(
+            values=call.values, hints=self._hints,
+        )
         broadcast_plan = _workflow_plan.build_broadcast_plan(
             values=values, hints=self._hints,
         )
@@ -526,12 +528,6 @@ class WorkflowFunction(Node):
             module=self._module,
             dependency_type=Node,
             workflow_name=self._name,
-        )
-
-    def _convert_distributions(self, values: dict[str, Any]) -> dict[str, Any]:
-        """Normalize distribution-valued args based on type hints."""
-        return _workflow_normalize.normalize_workflow_values(
-            values=values, hints=self._hints,
         )
 
     def _get_key(self):

--- a/tests/core/test_recordarray_broadcasting.py
+++ b/tests/core/test_recordarray_broadcasting.py
@@ -27,12 +27,12 @@ from probpipe import (
 from probpipe.core._distribution_base import Distribution
 
 # ---------------------------------------------------------------------------
-# Detection: _find_broadcast_args splits args into (dist, ra) groups
+# Detection: BroadcastPlan splits args into distribution and array groups
 # ---------------------------------------------------------------------------
 
 
 class TestRecordArrayDetection:
-    """``_find_broadcast_args`` classifies inputs and validates shapes."""
+    """Broadcast planning classifies inputs and validates shapes."""
 
     def test_recordarray_triggers_broadcast(self):
         @workflow_function

--- a/tests/core/test_workflow_distribution_normalization.py
+++ b/tests/core/test_workflow_distribution_normalization.py
@@ -8,6 +8,7 @@ import pytest
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from probpipe import (
+    Distribution,
     DistributionArray,
     EmpiricalDistribution,
     KDEDistribution,
@@ -49,6 +50,8 @@ def mean_recorder():
 
 
 class TestNormalizeDistributionValues:
+    """Direct helper coverage mirrors facade cases for clearer failure locality."""
+
     def test_concrete_distribution_hint_converts_external_distribution(
         self,
         normal_external,
@@ -60,6 +63,21 @@ class TestNormalizeDistributionValues:
 
         assert isinstance(normalized["dist"], Normal)
         assert normalized["dist"] is not normal_external
+
+    def test_concrete_distribution_hint_without_converter_raises(self):
+        class UnsupportedDistribution(Distribution):
+            pass
+
+        source = Normal(loc=0.0, scale=1.0, name="source")
+
+        with pytest.raises(
+            TypeError,
+            match=r"No converter registered for Normal -> UnsupportedDistribution",
+        ):
+            normalize_distribution_values(
+                values={"dist": source},
+                hints={"dist": UnsupportedDistribution},
+            )
 
     def test_protocol_hint_converts_distribution_that_lacks_protocol(
         self,
@@ -120,6 +138,7 @@ class TestNormalizeDistributionValues:
         assert normalized["x"] is not normal_external
 
 
+# Facade checks below are retained to verify WorkflowFunction wiring.
 class TestHintedDistributionConversion:
     def test_concrete_distribution_hint_converts_external_distribution(
         self,

--- a/tests/core/test_workflow_distribution_normalization.py
+++ b/tests/core/test_workflow_distribution_normalization.py
@@ -13,9 +13,11 @@ from probpipe import (
     KDEDistribution,
     Normal,
     NumericRecordArray,
+    NumericRecordDistribution,
     log_prob,
     mean,
 )
+from probpipe.core._workflow_normalize import normalize_workflow_values
 from probpipe.core.node import WorkflowFunction
 from probpipe.core.protocols import SupportsLogProb
 
@@ -42,6 +44,78 @@ def mean_recorder():
         return mean(dist)
 
     return mean_of_normal, seen
+
+
+class TestNormalizeWorkflowValues:
+    def test_concrete_distribution_hint_converts_external_distribution(
+        self,
+        normal_external,
+    ):
+        normalized = normalize_workflow_values(
+            values={"dist": normal_external},
+            hints={"dist": Normal},
+        )
+
+        assert isinstance(normalized["dist"], Normal)
+        assert normalized["dist"] is not normal_external
+
+    def test_protocol_hint_converts_distribution_that_lacks_protocol(
+        self,
+        empirical_dist,
+    ):
+        normalized = normalize_workflow_values(
+            values={"dist": empirical_dist},
+            hints={"dist": SupportsLogProb},
+        )
+
+        assert normalized["dist"] is not empirical_dist
+        assert isinstance(normalized["dist"], KDEDistribution)
+        assert isinstance(normalized["dist"], SupportsLogProb)
+
+    def test_zero_dimensional_distribution_array_unwraps_to_scalar_component(self):
+        da = DistributionArray.from_batched_params(
+            Normal,
+            batch_shape=(),
+            loc=jnp.asarray(3.0),
+            scale=jnp.asarray(1.0),
+            name="zero_d",
+        )
+
+        normalized = normalize_workflow_values(
+            values={"dist": da},
+            hints={"dist": Normal},
+        )
+
+        assert isinstance(normalized["dist"], Normal)
+        assert float(normalized["dist"].loc) == 3.0
+
+    def test_size_one_distribution_array_remains_a_sweep(self):
+        da = DistributionArray.from_batched_params(
+            Normal,
+            batch_shape=(1,),
+            loc=jnp.asarray([3.0]),
+            scale=jnp.asarray([1.0]),
+            name="one_cell",
+        )
+
+        normalized = normalize_workflow_values(
+            values={"dist": da},
+            hints={"dist": Normal},
+        )
+
+        assert normalized["dist"] is da
+
+    def test_unhinted_external_distribution_converts_for_broadcast(
+        self,
+        normal_external,
+    ):
+        normalized = normalize_workflow_values(
+            values={"x": normal_external},
+            hints={},
+        )
+
+        assert isinstance(normalized["x"], NumericRecordDistribution)
+        assert normalized["x"] is not normal_external
 
 
 class TestHintedDistributionConversion:

--- a/tests/core/test_workflow_distribution_normalization.py
+++ b/tests/core/test_workflow_distribution_normalization.py
@@ -17,7 +17,9 @@ from probpipe import (
     log_prob,
     mean,
 )
-from probpipe.core._workflow_normalize import normalize_workflow_values
+from probpipe.core._workflow_distribution_normalization import (
+    normalize_distribution_values,
+)
 from probpipe.core.node import WorkflowFunction
 from probpipe.core.protocols import SupportsLogProb
 
@@ -46,12 +48,12 @@ def mean_recorder():
     return mean_of_normal, seen
 
 
-class TestNormalizeWorkflowValues:
+class TestNormalizeDistributionValues:
     def test_concrete_distribution_hint_converts_external_distribution(
         self,
         normal_external,
     ):
-        normalized = normalize_workflow_values(
+        normalized = normalize_distribution_values(
             values={"dist": normal_external},
             hints={"dist": Normal},
         )
@@ -63,7 +65,7 @@ class TestNormalizeWorkflowValues:
         self,
         empirical_dist,
     ):
-        normalized = normalize_workflow_values(
+        normalized = normalize_distribution_values(
             values={"dist": empirical_dist},
             hints={"dist": SupportsLogProb},
         )
@@ -81,7 +83,7 @@ class TestNormalizeWorkflowValues:
             name="zero_d",
         )
 
-        normalized = normalize_workflow_values(
+        normalized = normalize_distribution_values(
             values={"dist": da},
             hints={"dist": Normal},
         )
@@ -98,7 +100,7 @@ class TestNormalizeWorkflowValues:
             name="one_cell",
         )
 
-        normalized = normalize_workflow_values(
+        normalized = normalize_distribution_values(
             values={"dist": da},
             hints={"dist": Normal},
         )
@@ -109,7 +111,7 @@ class TestNormalizeWorkflowValues:
         self,
         normal_external,
     ):
-        normalized = normalize_workflow_values(
+        normalized = normalize_distribution_values(
             values={"x": normal_external},
             hints={},
         )

--- a/tests/core/test_workflow_plan.py
+++ b/tests/core/test_workflow_plan.py
@@ -8,7 +8,9 @@ import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from probpipe import DistributionArray, Normal, NumericRecord, NumericRecordArray
-from probpipe.core._workflow_normalize import normalize_workflow_values
+from probpipe.core._workflow_distribution_normalization import (
+    normalize_distribution_values,
+)
 from probpipe.core._workflow_plan import ArrayBroadcastGroup, build_broadcast_plan
 from probpipe.core.distribution import Distribution
 from probpipe.core.protocols import SupportsSampling
@@ -176,7 +178,7 @@ class TestPlanPurity:
         values = {"x": external}
 
         raw_plan = build_broadcast_plan(values=values, hints={})
-        normalized = normalize_workflow_values(values=values, hints={})
+        normalized = normalize_distribution_values(values=values, hints={})
         normalized_plan = build_broadcast_plan(values=normalized, hints={})
 
         assert values["x"] is external

--- a/tests/core/test_workflow_plan.py
+++ b/tests/core/test_workflow_plan.py
@@ -1,0 +1,184 @@
+"""Tests for WorkflowFunction broadcast planning."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+import tensorflow_probability.substrates.jax.distributions as tfd
+
+from probpipe import DistributionArray, Normal, NumericRecord, NumericRecordArray
+from probpipe.core._workflow_normalize import normalize_workflow_values
+from probpipe.core._workflow_plan import ArrayBroadcastGroup, build_broadcast_plan
+from probpipe.core.distribution import Distribution
+from probpipe.core.protocols import SupportsSampling
+
+
+def _numeric_record_array(field: str, values: range) -> NumericRecordArray:
+    return NumericRecordArray.stack(
+        [NumericRecord(**{field: float(value)}) for value in values]
+    )
+
+
+class TestBroadcastRegime:
+    def test_plain_values_do_not_broadcast(self):
+        plan = build_broadcast_plan(values={"x": 1.0}, hints={})
+
+        assert plan.regime == "none"
+        assert plan.dist_args == ()
+        assert plan.array_args == ()
+        assert plan.array_groups == ()
+        assert plan.sweep_batch_shape == ()
+        assert plan.n_sweep == 1
+
+    def test_distribution_value_selects_distribution_regime(self):
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+
+        plan = build_broadcast_plan(values={"x": dist}, hints={})
+
+        assert plan.regime == "distribution"
+        assert plan.dist_args == ("x",)
+        assert plan.array_args == ()
+
+    def test_record_array_value_selects_sweep_regime(self):
+        values = {"p": _numeric_record_array("x", range(4))}
+
+        plan = build_broadcast_plan(values=values, hints={})
+
+        assert plan.regime == "sweep"
+        assert plan.dist_args == ()
+        assert plan.array_args == ("p",)
+        assert plan.array_groups == (
+            ArrayBroadcastGroup(arg_names=("p",), batch_shape=(4,), size=4),
+        )
+        assert plan.sweep_batch_shape == (4,)
+        assert plan.n_sweep == 4
+
+    def test_array_and_distribution_values_select_nested_regime(self):
+        values = {
+            "p": _numeric_record_array("x", range(4)),
+            "noise": Normal(loc=0.0, scale=1.0, name="noise"),
+        }
+
+        plan = build_broadcast_plan(values=values, hints={})
+
+        assert plan.regime == "nested"
+        assert plan.dist_args == ("noise",)
+        assert plan.array_args == ("p",)
+
+
+class TestHintClassification:
+    def test_distribution_hints_skip_scalar_distribution_broadcast(self):
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+
+        concrete = build_broadcast_plan(
+            values={"x": dist},
+            hints={"x": Distribution},
+        )
+        protocol = build_broadcast_plan(
+            values={"x": dist},
+            hints={"x": SupportsSampling},
+        )
+
+        assert concrete.regime == "none"
+        assert protocol.regime == "none"
+
+    def test_array_hints_skip_array_sweep(self):
+        ra = _numeric_record_array("x", range(4))
+        da = DistributionArray.from_batched_params(
+            Normal,
+            batch_shape=(2,),
+            loc=jnp.asarray([0.0, 1.0]),
+            scale=1.0,
+            name="d",
+        )
+
+        record_plan = build_broadcast_plan(
+            values={"p": ra},
+            hints={"p": NumericRecordArray},
+        )
+        dist_plan = build_broadcast_plan(
+            values={"d": da},
+            hints={"d": DistributionArray},
+        )
+        any_plan = build_broadcast_plan(
+            values={"p": ra},
+            hints={"p": Any},
+        )
+
+        assert record_plan.regime == "none"
+        assert dist_plan.regime == "none"
+        assert any_plan.regime == "none"
+
+
+class TestArrayGrouping:
+    def test_sibling_views_zip_into_one_group(self):
+        ra = NumericRecordArray.stack(
+            [
+                NumericRecord(x=float(i), y=float(2 * i))
+                for i in range(4)
+            ]
+        )
+
+        plan = build_broadcast_plan(
+            values={"x": ra.view("x"), "y": ra.view("y")},
+            hints={},
+        )
+
+        assert plan.regime == "sweep"
+        assert plan.array_args == ("x", "y")
+        assert plan.array_groups == (
+            ArrayBroadcastGroup(arg_names=("x", "y"), batch_shape=(4,), size=4),
+        )
+        assert plan.sweep_batch_shape == (4,)
+        assert plan.n_sweep == 4
+
+    def test_views_from_different_parents_use_product_shape(self):
+        ra_a = _numeric_record_array("a", range(3))
+        ra_b = _numeric_record_array("b", range(2))
+
+        plan = build_broadcast_plan(
+            values={"a": ra_a.view("a"), "b": ra_b.view("b")},
+            hints={},
+        )
+
+        assert plan.regime == "sweep"
+        assert plan.array_groups == (
+            ArrayBroadcastGroup(arg_names=("a",), batch_shape=(3,), size=3),
+            ArrayBroadcastGroup(arg_names=("b",), batch_shape=(2,), size=2),
+        )
+        assert plan.sweep_batch_shape == (3, 2)
+        assert plan.n_sweep == 6
+
+    def test_distribution_array_uses_sweep_group(self):
+        da = DistributionArray.from_batched_params(
+            Normal,
+            batch_shape=(2, 3),
+            loc=jnp.arange(6.0).reshape(2, 3),
+            scale=1.0,
+            name="d",
+        )
+
+        plan = build_broadcast_plan(values={"d": da}, hints={})
+
+        assert plan.regime == "sweep"
+        assert plan.array_args == ("d",)
+        assert plan.array_groups == (
+            ArrayBroadcastGroup(arg_names=("d",), batch_shape=(2, 3), size=6),
+        )
+        assert plan.sweep_batch_shape == (2, 3)
+        assert plan.n_sweep == 6
+
+
+class TestPlanPurity:
+    def test_planner_does_not_convert_or_mutate_external_distributions(self):
+        external = tfd.Normal(loc=0.0, scale=1.0)
+        values = {"x": external}
+
+        raw_plan = build_broadcast_plan(values=values, hints={})
+        normalized = normalize_workflow_values(values=values, hints={})
+        normalized_plan = build_broadcast_plan(values=normalized, hints={})
+
+        assert values["x"] is external
+        assert raw_plan.regime == "none"
+        assert normalized_plan.regime == "distribution"


### PR DESCRIPTION
This is the 4th stage of #196.

## Changes

1. `WorkflowFunction.__call__` now coordinates the process as resolve -> normalize -> build BroadcastPlan -> execute; the converter registry logic is centralized in normalization; broadcast planning becomes a pure classification step.
2. A new `test_workflow_plan.py` has been added, and normalization direct tests have been expanded.
3. The dependency on `_utils.py` has been removed. I believe `prod` was a redundant and unnecessary wrapper from before, and I plan to create a new PR to remove it completely.