### PR TITLE
refactor(core) [#196 PR-5]: Sweep execution extraction & clean-up

### DIFF
--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -1,0 +1,274 @@
+"""WorkflowFunction sweep execution helpers.
+
+This private module owns array-valued workflow sweeps after call
+resolution, distribution normalization, and broadcast planning have
+already classified the call. It executes pure parameter sweeps and the
+outer sweep layer of nested array + distribution broadcasts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import jax
+
+from . import _workflow_execution, _workflow_plan, _workflow_result
+from ._broadcast_distributions import _make_stack
+from ._distribution_array import DistributionArray, _make_distribution_array
+from ._record_array import _RecordArrayView
+from .distribution import BroadcastDistribution, Distribution
+from .provenance import Provenance
+
+
+def execute_sweep(
+    *,
+    func: Callable[..., Any],
+    values: dict[str, Any],
+    plan: _workflow_plan.BroadcastPlan,
+    make_execution_config: Callable[
+        [],
+        _workflow_execution.WorkflowExecutionConfig,
+    ],
+    requested_dispatch: str,
+    resolve_dispatch: Callable[..., str],
+    require_jax_traceable: Callable[[dict[str, Any], list[str]], None],
+    distribution_broadcast: Callable[
+        [dict[str, Any], list[str], int, bool],
+        BroadcastDistribution | Distribution,
+    ],
+    workflow_name: str,
+    n_broadcast_samples: int,
+    include_inputs: bool = False,
+) -> Any:
+    """Execute pure or nested sweep regimes for one workflow call."""
+    if plan.regime not in ("sweep", "nested"):
+        raise ValueError(f"execute_sweep requires a sweep plan; got {plan.regime!r}")
+
+    array_args = list(plan.array_args)
+    dist_args = list(plan.dist_args)
+
+    if include_inputs:
+        raise NotImplementedError(
+            "include_inputs=True is not supported with RecordArray "
+            "broadcasting. The inputs are already available via "
+            "provenance on the stacked output."
+        )
+
+    if not dist_args:
+        per_row = execute_sweep_rows(
+            func=func,
+            values=values,
+            array_args=array_args,
+            plan=plan,
+            make_execution_config=make_execution_config,
+            requested_dispatch=requested_dispatch,
+            resolve_dispatch=resolve_dispatch,
+            require_jax_traceable=require_jax_traceable,
+        )
+        aggregate = _make_stack(
+            per_row,
+            batch_shape=plan.sweep_batch_shape,
+            name=workflow_name,
+            field_name=workflow_name,
+        )
+        provenance = make_sweep_provenance(
+            values=values,
+            array_args=array_args,
+            dist_args=dist_args,
+            workflow_name=workflow_name,
+            batch_shape=plan.sweep_batch_shape,
+            k=0,
+        )
+        return _workflow_result._coerce_output(
+            aggregate,
+            broadcast_mode=_workflow_result.BROADCAST_STACK,
+            provenance=provenance,
+            field_name=workflow_name,
+        )
+
+    per_row_marginals: list[Distribution] = []
+    for i in range(plan.n_sweep):
+        row_values = slice_sweep_values(
+            values=values,
+            index=i,
+            array_groups=plan.array_groups,
+        )
+        inner = distribution_broadcast(
+            row_values,
+            dist_args,
+            n_broadcast_samples,
+            True,
+        )
+        if isinstance(inner, BroadcastDistribution):
+            marginal = inner.marginalize()
+        else:
+            marginal = inner
+        per_row_marginals.append(marginal)
+
+    stacked = _make_distribution_array(
+        per_row_marginals,
+        batch_shape=plan.sweep_batch_shape,
+        name=workflow_name or "sweep",
+    )
+    provenance = make_sweep_provenance(
+        values=values,
+        array_args=array_args,
+        dist_args=dist_args,
+        workflow_name=workflow_name,
+        batch_shape=plan.sweep_batch_shape,
+        k=n_broadcast_samples,
+    )
+    return _workflow_result._coerce_output(
+        stacked,
+        broadcast_mode=_workflow_result.BROADCAST_NESTED,
+        provenance=provenance,
+        field_name=workflow_name,
+    )
+
+
+def slice_sweep_values(
+    *,
+    values: Mapping[str, Any],
+    index: int,
+    array_groups: tuple[_workflow_plan.ArrayBroadcastGroup, ...],
+) -> dict[str, Any]:
+    """Materialize one row-major sweep cell under parent-grouped arrays."""
+    out = dict(values)
+    rem = index
+    # Highest-index group varies fastest under row-major flattening of
+    # the concatenated sweep shape.
+    for group in reversed(array_groups):
+        idx = rem % group.size
+        rem = rem // group.size
+        for name in group.arg_names:
+            source = values[name]
+            if isinstance(source, DistributionArray):
+                out[name] = source._flat_component(idx)
+            else:
+                out[name] = source[idx]
+    return out
+
+
+def execute_sweep_rows(
+    *,
+    func: Callable[..., Any],
+    values: dict[str, Any],
+    array_args: list[str],
+    plan: _workflow_plan.BroadcastPlan,
+    make_execution_config: Callable[
+        [],
+        _workflow_execution.WorkflowExecutionConfig,
+    ],
+    requested_dispatch: str,
+    resolve_dispatch: Callable[..., str],
+    require_jax_traceable: Callable[[dict[str, Any], list[str]], None],
+) -> Any:
+    """Execute pure sweep rows through JAX vmap or row-wise execution."""
+    has_dist_array = any(
+        isinstance(values[name], DistributionArray) for name in array_args
+    )
+    has_view = any(
+        isinstance(values[name], _RecordArrayView) for name in array_args
+    )
+    jax_supported = not (
+        has_dist_array
+        or has_view
+        or len(plan.array_groups) > 1
+        or len(array_args) > 1
+    )
+    if requested_dispatch == "jax" and not jax_supported:
+        raise ValueError(
+            "dispatch='jax' supports only a single plain RecordArray sweep; "
+            "use dispatch='auto', 'sequential', or 'thread' for this path."
+        )
+
+    dispatch = resolve_dispatch(
+        values,
+        array_args,
+        jax_supported=jax_supported,
+    )
+
+    if dispatch == "jax":
+        if requested_dispatch == "jax":
+            require_jax_traceable(values, array_args)
+        return execute_sweep_rows_jax(
+            func=func,
+            values=values,
+            array_args=array_args,
+            n_total=plan.n_sweep,
+        )
+
+    per_row_values = [
+        slice_sweep_values(
+            values=values,
+            index=i,
+            array_groups=plan.array_groups,
+        )
+        for i in range(plan.n_sweep)
+    ]
+    request = _workflow_execution.WorkflowExecutionRequest(
+        func=func,
+        call_value_list=per_row_values,
+        execution=make_execution_config(),
+    )
+    return _workflow_execution.execute_many(request)
+
+
+def execute_sweep_rows_jax(
+    *,
+    func: Callable[..., Any],
+    values: dict[str, Any],
+    array_args: list[str],
+    n_total: int,
+) -> Any:
+    """Execute the limited single-RecordArray sweep through ``jax.vmap``."""
+    static = {name: value for name, value in values.items() if name not in array_args}
+
+    def single_call(array_slice_leaves):
+        kwargs = dict(static)
+        for name in array_args:
+            array_value = values[name]
+            kwargs[name] = array_value._record_cls(array_slice_leaves[name])
+        return func(**kwargs)
+
+    vmap_input = {}
+    for name in array_args:
+        array_value = values[name]
+        n_batch = len(array_value.batch_shape)
+        vmap_input[name] = {
+            field: array_value[field].reshape(
+                (n_total, *array_value[field].shape[n_batch:])
+            )
+            for field in array_value.fields
+        }
+    return jax.vmap(single_call)(vmap_input)
+
+
+def make_sweep_provenance(
+    *,
+    values: Mapping[str, Any],
+    array_args: list[str],
+    dist_args: list[str],
+    workflow_name: str,
+    batch_shape: tuple[int, ...],
+    k: int,
+) -> Provenance:
+    """Build provenance metadata for pure and nested sweep outputs."""
+    regime = "nested" if dist_args else "stack"
+    parents = tuple(values[name] for name in array_args) + tuple(
+        values[name]
+        for name in dist_args
+        if isinstance(values[name], Distribution)
+    )
+    return Provenance(
+        operation=f"workflow.{regime}",
+        parents=parents,
+        metadata={
+            "func": workflow_name,
+            "batch_shape": tuple(batch_shape),
+            "k": k,
+            "ra_args": list(array_args),
+            "dist_args": list(dist_args),
+        },
+    )

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from itertools import product as cartesian_product
 from types import MappingProxyType
-from typing import Any, ClassVar, Literal, TypeAlias, get_args
+from typing import Any, ClassVar, Literal
 
 import jax
 import jax.numpy as jnp
@@ -31,10 +31,9 @@ from . import (
     _workflow_execution,
     _workflow_plan,
     _workflow_result,
+    _workflow_sweep,
 )
-from ._broadcast_distributions import _make_stack
-from ._distribution_array import DistributionArray, _make_distribution_array
-from ._record_array import RecordArray, _RecordArrayView
+from ._record_array import RecordArray
 from ._record_distribution import _RecordDistributionView
 from .distribution import (
     BroadcastDistribution,
@@ -61,17 +60,17 @@ _wrap_as_record = _workflow_result._wrap_as_record
 _coerce_output = _workflow_result._coerce_output
 
 __all__ = [
+    "AbstractModule",
     "InputFrozenError",
-    "workflow_method",
-    "abstract_workflow_method",
-    "workflow_function",
+    "Module",
     "Node",
     "WorkflowFunction",
-    "Module",
-    "AbstractModule",
+    "abstract_workflow_method",
+    "workflow_function",
+    "workflow_method",
 ]
 
-_WorkflowFunctionDispatch: TypeAlias = Literal[
+type _WorkflowFunctionDispatch = Literal[
     "auto", "jax", "sequential", "thread"
 ]
 
@@ -124,9 +123,9 @@ def workflow_function(_func=None, /, **kwargs):
     return decorator
 
 
-class Node(ABC):
+class Node(ABC):  # noqa: B024
     """
-    Base unit of the ProbPipe computational dependency graph. 
+    Base unit of the ProbPipe computational dependency graph.
 
     Keyword arguments are automatically split by type: values that are
     ``Node`` instances become *child nodes* (dependencies on other DAG
@@ -273,8 +272,11 @@ class WorkflowFunction(Node):
     """
 
     DEFAULT_N_BROADCAST_SAMPLES: int = 128
-    _VALID_DISPATCH_STRATEGIES: ClassVar[tuple[str, ...]] = get_args(
-        _WorkflowFunctionDispatch
+    _VALID_DISPATCH_STRATEGIES: ClassVar[tuple[str, ...]] = (
+        "auto",
+        "jax",
+        "sequential",
+        "thread",
     )
 
     def __init__(
@@ -405,7 +407,7 @@ class WorkflowFunction(Node):
         *,
         mode: _workflow_execution.WorkflowExecutionMode | None = None,
     ) -> _workflow_execution.WorkflowExecutionConfig:
-        """Build resolved execution metadata for sequential call dispatch."""
+        """Build resolved execution metadata for row-wise call dispatch."""
         if mode is None:
             match self.effective_workflow_kind:
                 case WorkflowKind.TASK:
@@ -646,239 +648,27 @@ class WorkflowFunction(Node):
         n_broadcast_samples: int,
         do_include_inputs: bool = False,
     ) -> Any:
-        """Dispatcher: route to the right broadcast regime (issue #130).
-
-        Three regimes:
-
-        - ``dist_args`` only — existing Monte Carlo marginalisation via
-          ``_broadcast_distributions_only``. Output: marginal
-          distribution (``_MixtureMarginal`` / ``_RecordMarginal`` / ...).
-        - ``ra_args`` only — pure parameter sweep. One inner call per
-          RecordArray row; no marginalisation. Output: stacked
-          aggregate (``NumericRecordArray`` / ``RecordArray`` /
-          ``DistributionArray``) via ``_make_stack``.
-        - **Both** — nested regime. Outer loop over ``ra_args[0]`` rows,
-          each iteration running an inner distribution-only broadcast
-          for ``dist_args``. Output always a ``DistributionArray`` of
-          per-row marginals (satisfies the
-          Record | RecordArray | Distribution output contract).
-
-        The ``include_inputs=True`` override still produces the
-        inner-path ``BroadcastDistribution`` when ``dist_args`` fire,
-        but it is **not** supported on the pure-sweep or nested paths
-        (the stack has no single joint distribution to return; the
-        inputs are known via provenance). Calling with
-        ``include_inputs=True`` and any ``ra_args`` raises.
-        """
+        """Dispatcher: route to distribution broadcast or sweep execution."""
         dist_args = list(broadcast_plan.dist_args)
         ra_args = list(broadcast_plan.array_args)
 
-        # ---- No RecordArray: delegate to the existing path -------------
         if not ra_args:
             return self._broadcast_distributions_only(
                 values, dist_args, n_broadcast_samples, do_include_inputs,
             )
 
-        if do_include_inputs:
-            raise NotImplementedError(
-                "include_inputs=True is not supported with RecordArray "
-                "broadcasting. The inputs are already available via "
-                "provenance on the stacked output."
-            )
-
-        ra_groups = broadcast_plan.array_groups
-        sweep_batch_shape = broadcast_plan.sweep_batch_shape
-        n_total = broadcast_plan.n_sweep
-
-        # ---- Pure sweep (no Distribution args) -------------------------
-        if not dist_args:
-            per_row = self._execute_sweep_rows(
-                values, ra_args, n_total, sweep_batch_shape, ra_groups,
-            )
-            aggregate = _make_stack(
-                per_row,
-                batch_shape=sweep_batch_shape,
-                name=self._name,
-                field_name=self._name,
-            )
-            provenance = self._make_sweep_provenance(
-                values, ra_args, dist_args, batch_shape=sweep_batch_shape, k=0,
-            )
-            return _coerce_output(
-                aggregate,
-                broadcast_mode=BROADCAST_STACK,
-                provenance=provenance,
-                field_name=self._name,
-            )
-
-        # ---- Nested (array + Distribution) -----------------------------
-        # Per sweep cell (in flat row-major order over the multi-d batch):
-        # run an inner distribution-only broadcast, marginalise over the
-        # k MC draws, collect the n_total per-cell marginals and stack
-        # them into a DistributionArray that presents the sweep's
-        # multi-d batch_shape.
-        per_row_marginals: list[Distribution] = []
-        for i in range(n_total):
-            row_values = self._slice_ra_args(values, i, ra_groups)
-            inner = self._broadcast_distributions_only(
-                row_values, dist_args, n_broadcast_samples,
-                do_include_inputs=True,
-            )
-            if isinstance(inner, BroadcastDistribution):
-                marginal = inner.marginalize()
-            else:
-                marginal = inner
-            per_row_marginals.append(marginal)
-
-        stacked = _make_distribution_array(
-            per_row_marginals,
-            batch_shape=sweep_batch_shape,
-            name=self._name or "sweep",
-        )
-        provenance = self._make_sweep_provenance(
-            values, ra_args, dist_args,
-            batch_shape=sweep_batch_shape, k=n_broadcast_samples,
-        )
-        return _coerce_output(
-            stacked,
-            broadcast_mode=BROADCAST_NESTED,
-            provenance=provenance,
-            field_name=self._name,
-        )
-
-    # ----- Helpers for the array-broadcast path ---------------------------
-
-    def _slice_ra_args(
-        self,
-        values: dict[str, Any],
-        i: int,
-        ra_groups: tuple[_workflow_plan.ArrayBroadcastGroup, ...],
-    ) -> dict[str, Any]:
-        """Materialise the ``i``-th sweep cell under parent-grouped sweep.
-
-        Each group's args share a flat in-group index (zip); groups
-        compose by row-major unravel of the outer flat index ``i`` over
-        the concatenated batch shapes.
-        """
-        out = dict(values)
-        rem = i
-        # Highest-index group varies fastest (row-major over the
-        # concatenated sweep shape).
-        for group in reversed(ra_groups):
-            idx = rem % group.size
-            rem = rem // group.size
-            for name in group.arg_names:
-                source = values[name]
-                if isinstance(source, DistributionArray):
-                    out[name] = source._flat_component(idx)
-                else:
-                    out[name] = source[idx]
-        return out
-
-    def _execute_sweep_rows(
-        self,
-        values: dict[str, Any],
-        ra_args: list[str],
-        n_total: int,
-        sweep_batch_shape: tuple[int, ...],
-        ra_groups: tuple[_workflow_plan.ArrayBroadcastGroup, ...],
-    ) -> Any:
-        """Execute ``n_total`` inner calls, one per sweep cell in flat
-        row-major order over the concatenated ``sweep_batch_shape``.
-
-        Returns a Python list of outputs (sequential path) or a stacked
-        pytree with leading axis ``n_total`` (vmap path). Either form
-        is a valid input for ``_make_stack``.
-        """
-        # The vmap path only handles the simple single-RecordArray
-        # case: one group, one RA arg, no DistributionArray, no views
-        # (views carry parent references that would confuse vmap's
-        # leading-axis flattening).
-        has_dist_array = any(
-            isinstance(values[name], DistributionArray) for name in ra_args
-        )
-        has_view = any(
-            isinstance(values[name], _RecordArrayView) for name in ra_args
-        )
-        jax_supported = not (
-            has_dist_array or has_view or len(ra_groups) > 1 or len(ra_args) > 1
-        )
-        if self._dispatch == "jax" and not jax_supported:
-            raise ValueError(
-                "dispatch='jax' supports only a single plain RecordArray sweep; "
-                "use dispatch='auto', 'sequential', or 'thread' for this path."
-            )
-
-        dispatch = self._resolve_dispatch(
-            values,
-            ra_args,
-            jax_supported=jax_supported,
-        )
-
-        if dispatch == "jax":
-            if self._dispatch == "jax":
-                self._require_jax_traceable(values, ra_args)
-            # Flatten the single RecordArray's batch axes to one leading
-            # dim so vmap maps over axis 0 uniformly regardless of the
-            # sweep's original batch_shape.
-            static = {k: v for k, v in values.items() if k not in ra_args}
-
-            def single_call(ra_slice_leaves):
-                kw = dict(static)
-                for name in ra_args:
-                    ra = values[name]
-                    kw[name] = ra._record_cls(ra_slice_leaves[name])
-                return self._func(**kw)
-
-            vmap_input = {}
-            for name in ra_args:
-                ra = values[name]
-                n_batch = len(ra.batch_shape)
-                vmap_input[name] = {
-                    f: ra[f].reshape((n_total,) + ra[f].shape[n_batch:])
-                    for f in ra.fields
-                }
-            return jax.vmap(single_call)(vmap_input)
-
-        # Sequential path.
-        per_row_values = [
-            self._slice_ra_args(values, i, ra_groups)
-            for i in range(n_total)
-        ]
-        return self._execute_many(per_row_values)
-
-    def _make_sweep_provenance(
-        self,
-        values: dict[str, Any],
-        ra_args: list[str],
-        dist_args: list[str],
-        *,
-        batch_shape: tuple[int, ...],
-        k: int,
-    ) -> Provenance:
-        """Build the Provenance node for a sweep output.
-
-        Parents are the RecordArray / Distribution inputs that drove
-        the broadcast. Metadata records the regime, the full sweep
-        ``batch_shape`` (for multi-d), and the MC count so downstream
-        tooling can report whether uncertainty was marginalised or
-        stacked.
-        """
-        regime = "nested" if dist_args else "stack"
-        parents = tuple(values[name] for name in ra_args) + tuple(
-            values[name] for name in dist_args
-            if isinstance(values[name], Distribution)
-        )
-        return Provenance(
-            operation=f"workflow.{regime}",
-            parents=parents,
-            metadata={
-                "func": self._name or self._func.__name__,
-                "batch_shape": tuple(batch_shape),
-                "k": k,
-                "ra_args": list(ra_args),
-                "dist_args": list(dist_args),
-            },
+        return _workflow_sweep.execute_sweep(
+            func=self._func,
+            values=values,
+            plan=broadcast_plan,
+            make_execution_config=self._make_execution_config,
+            requested_dispatch=self._dispatch,
+            resolve_dispatch=self._resolve_dispatch,
+            require_jax_traceable=self._require_jax_traceable,
+            distribution_broadcast=self._broadcast_distributions_only,
+            workflow_name=self._name,
+            n_broadcast_samples=n_broadcast_samples,
+            include_inputs=do_include_inputs,
         )
 
     def _broadcast_distributions_only(
@@ -1130,7 +920,7 @@ class WorkflowFunction(Node):
         for combo in cartesian_product(*(range(d.num_atoms) for d in emp_dists)):
             # Compute empirical product weight
             emp_weight = 1.0
-            for name, dist, i in zip(emp_names, emp_dists, combo):
+            for _name, dist, i in zip(emp_names, emp_dists, combo):
                 emp_weight *= float(dist.weights[i])
 
             for _ in range(reps_per_combo):
@@ -1371,7 +1161,7 @@ class Module(Node):
                     dot.edge(param_name, wf_name)
 
         return dot
-    
+
     def _validate_abstract_workflow_implementations(self) -> None:
         """
         Ensure that any abstract workflow interfaces in the MRO are implemented
@@ -1460,7 +1250,7 @@ class Module(Node):
                     f"Expected (abstract): {abs_sig}\n"
                     f"Got (impl):          {impl_sig}"
                 )
-            
+
 class AbstractModule(Module, ABC):
     """
     Base class for modules that declare workflow interfaces via @abstract_workflow_method.

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -640,9 +640,15 @@ class WorkflowFunction(Node):
           tracing.
         """
         MIN_BROADCAST_SAMPLES = 5  # Recommended minimum samples
+        
+        if not isinstance(n_broadcast_samples, int):
+            raise TypeError(f"n_broadcast_samples must be an integer; got {n_broadcast_samples!r}")
+        
+        if n_broadcast_samples <= 0:
+            raise ValueError(f"n_broadcast_samples must be a positive integer; got {n_broadcast_samples!r}")
 
         # Validate n_broadcast_samples value and warn if too small
-        if not isinstance(n_broadcast_samples, int) or n_broadcast_samples < MIN_BROADCAST_SAMPLES:
+        if n_broadcast_samples < MIN_BROADCAST_SAMPLES:
             warnings.warn(
                 f"n_broadcast_samples={n_broadcast_samples} is too low; "
                 f"results may be unreliable. "

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -563,9 +563,9 @@ class WorkflowFunction(Node):
                         # those distributions don't have a single
                         # array-shaped placeholder, so the probe can't
                         # produce a dummy. Falling out to the outer
-                        # ``except Exception`` triggers loop
-                        # vectorization, which is the right default for
-                        # multi-field record-valued inputs.
+                        # ``except Exception`` triggers row-wise dispatch,
+                        # which is the right default for multi-field
+                        # record-valued inputs.
                         try:
                             es = dist.event_shape
                         except (TypeError, NotImplementedError) as exc:
@@ -574,7 +574,7 @@ class WorkflowFunction(Node):
                                 f"{type(dist).__name__} broadcast arg "
                                 f"{name!r}: no single ``event_shape`` "
                                 f"(multi-field or abstract). "
-                                f"Falling back to loop vectorization."
+                                f"Falling back to row-wise dispatch."
                             ) from exc
                         # Match the distribution's own dtype so the probe
                         # mirrors what the inner function actually sees.
@@ -994,43 +994,6 @@ class WorkflowFunction(Node):
             return []
         request = self._make_execution_request(call_value_list)
         return _workflow_execution.execute_many(request)
-
-    # Cleanup note (#196): these mode-specific wrappers are retained for
-    # private-call compatibility during the staged execution extraction.
-    # Future cleanup can move tests/callers to ``_workflow_execution`` and
-    # remove the wrappers below.
-    def _execute_many_threaded(self, call_value_list: list[dict[str, Any]]) -> list:
-        """Compatibility wrapper around threaded workflow execution."""
-        if not call_value_list:
-            return []
-        request = self._make_execution_request(call_value_list, mode="thread")
-        return _workflow_execution.execute_many_threaded(request)
-
-    def _map_task(self, call_value_list: list[dict[str, Any]], task_name: str | None = None) -> list:
-        """Compatibility wrapper around Prefect task mapping."""
-        request = _workflow_execution.WorkflowExecutionRequest(
-            func=self._func,
-            call_value_list=call_value_list,
-            execution=_workflow_execution.WorkflowExecutionConfig(
-                mode="prefect_task",
-                name=self._name,
-            ),
-        )
-        return _workflow_execution.map_task(request, task_name=task_name)
-
-    def _execute_many_prefect_task(self, call_value_list: list[dict[str, Any]]) -> list:
-        """Compatibility wrapper around Prefect task execution."""
-        if not call_value_list:
-            return []
-        request = self._make_execution_request(call_value_list, mode="prefect_task")
-        return _workflow_execution.execute_many_prefect_task(request)
-
-    def _execute_many_prefect_flow(self, call_value_list: list[dict[str, Any]]) -> list:
-        """Compatibility wrapper around Prefect flow execution."""
-        if not call_value_list:
-            return []
-        request = self._make_execution_request(call_value_list, mode="prefect_flow")
-        return _workflow_execution.execute_many_prefect_flow(request)
 
 
 class Module(Node):

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -450,6 +450,9 @@ class WorkflowFunction(Node):
         # Non-broadcast call — one function invocation, then wrap.
         # Provenance parents are the inputs that carry their own
         # ``.source`` slot (Distribution / Record / RecordArray).
+        # Known harmless duplication: distribution-broadcast paths below build
+        # the same request shape. A future Distribution broadcast extraction
+        # should centralize this without reintroducing private facade wrappers.
         request = _workflow_execution.WorkflowExecutionRequest(
             func=self._func,
             call_value_list=[values],
@@ -883,6 +886,9 @@ class WorkflowFunction(Node):
                 call_value_list.append(call_values)
                 sample_idx += 1
 
+        # Known harmless duplication: this request construction also appears in
+        # the non-broadcast and ordinary sampling paths. Distribution broadcast
+        # extraction should centralize it in the module that owns these paths.
         request = _workflow_execution.WorkflowExecutionRequest(
             func=self._func,
             call_value_list=call_value_list,
@@ -923,6 +929,9 @@ class WorkflowFunction(Node):
                 call_values[name] = _index_sample(samples_per_arg[name], i)
             call_value_list.append(call_values)
 
+        # Known harmless duplication: this request construction also appears in
+        # the non-broadcast and empirical-enumeration paths. Distribution
+        # broadcast extraction should centralize it with the rest of this logic.
         request = _workflow_execution.WorkflowExecutionRequest(
             func=self._func,
             call_value_list=call_value_list,

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from itertools import product as cartesian_product
 from types import MappingProxyType
-from typing import Any, ClassVar, Literal
+from typing import Any, Literal, get_args
 
 import jax
 import jax.numpy as jnp
@@ -56,9 +56,10 @@ __all__ = [
     "workflow_method",
 ]
 
-type _WorkflowFunctionDispatch = Literal[
+_WorkflowFunctionDispatch = Literal[
     "auto", "jax", "sequential", "thread"
 ]
+_VALID_DISPATCH_STRATEGIES: tuple[str, ...] = get_args(_WorkflowFunctionDispatch)
 
 
 class InputFrozenError(Exception):
@@ -258,13 +259,6 @@ class WorkflowFunction(Node):
     """
 
     DEFAULT_N_BROADCAST_SAMPLES: int = 128
-    _VALID_DISPATCH_STRATEGIES: ClassVar[tuple[str, ...]] = (
-        "auto",
-        "jax",
-        "sequential",
-        "thread",
-    )
-
     def __init__(
         self,
         *,
@@ -287,9 +281,9 @@ class WorkflowFunction(Node):
                 f"WorkflowFunction no longer accepts {names}; use dispatch= instead."
             )
 
-        if dispatch not in self._VALID_DISPATCH_STRATEGIES:
+        if dispatch not in _VALID_DISPATCH_STRATEGIES:
             raise ValueError(
-                f"dispatch must be one of {self._VALID_DISPATCH_STRATEGIES}; got {dispatch!r}"
+                f"dispatch must be one of {_VALID_DISPATCH_STRATEGIES}; got {dispatch!r}"
             )
         _workflow_execution._validate_max_workers(max_workers)
         if dispatch != "thread" and max_workers is not None:
@@ -640,10 +634,10 @@ class WorkflowFunction(Node):
           tracing.
         """
         MIN_BROADCAST_SAMPLES = 5  # Recommended minimum samples
-        
+
         if not isinstance(n_broadcast_samples, int):
             raise TypeError(f"n_broadcast_samples must be an integer; got {n_broadcast_samples!r}")
-        
+
         if n_broadcast_samples <= 0:
             raise ValueError(f"n_broadcast_samples must be a positive integer; got {n_broadcast_samples!r}")
 

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -45,20 +45,6 @@ from .provenance import Provenance
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Output-type coercion for WorkflowFunction returns (issue #130)
-# ---------------------------------------------------------------------------
-
-# Compatibility aliases for tests or downstream code that imported these
-# private helpers from ``probpipe.core.node`` before the extraction.
-# Will be removed in a follow-up issue after downstream updates.
-BroadcastMode = _workflow_result.BroadcastMode
-BROADCAST_WRAP = _workflow_result.BROADCAST_WRAP
-BROADCAST_STACK = _workflow_result.BROADCAST_STACK
-BROADCAST_NESTED = _workflow_result.BROADCAST_NESTED
-_wrap_as_record = _workflow_result._wrap_as_record
-_coerce_output = _workflow_result._coerce_output
-
 __all__ = [
     "AbstractModule",
     "InputFrozenError",
@@ -162,8 +148,8 @@ def _index_sample(s: Any, i: int) -> Any:
     Parameters
     ----------
     s : Any
-        Either a bare array (single-field broadcast draws / legacy
-        callers), a :class:`Record` (multi-field auto-wrap or an
+        Either a bare array (single-field broadcast draws), a
+        :class:`Record` (multi-field auto-wrap or an
         explicit Record source), or a :class:`NumericRecord` (the
         unified ``EmpiricalDistribution`` — numeric arrays auto-wrap
         as a single-field Record — returns a ``NumericRecord`` with
@@ -315,8 +301,6 @@ class WorkflowFunction(Node):
 
         self._func = func
         self._signature_info = _workflow_call.make_signature_info(func)
-        self._sig = self._signature_info.signature
-        self._hints = self._signature_info.hints
         # Convert legacy string / None values to WorkflowKind enum
         # TODO: remove this legacy conversion in follow-up issue
         if workflow_kind is None:
@@ -333,7 +317,7 @@ class WorkflowFunction(Node):
         self.__doc__ = func.__doc__
         self.__name__ = self._name
         self.__qualname__ = getattr(func, "__qualname__", self._name)
-        self.__signature__ = self._sig
+        self.__signature__ = self._signature_info.signature
         self.__module__ = getattr(func, "__module__", None)
         self._module = module
         self._n_broadcast_samples = n_broadcast_samples if n_broadcast_samples is not None else self.DEFAULT_N_BROADCAST_SAMPLES
@@ -349,10 +333,6 @@ class WorkflowFunction(Node):
         self._bind = b
 
         super().__init__()
-
-        # Compatibility attributes for callers/tests that inspect the facade.
-        self._param_names = list(self._signature_info.param_names)
-        self._has_var_keyword = self._signature_info.has_var_keyword
 
         _workflow_call.validate_reserved_parameter_names(
             self._signature_info, workflow_name=self._name,
@@ -438,33 +418,6 @@ class WorkflowFunction(Node):
             ),
         )
 
-    def _make_execution_request(
-        self,
-        call_value_list: list[dict[str, Any]],
-        *,
-        mode: _workflow_execution.WorkflowExecutionMode | None = None,
-    ) -> _workflow_execution.WorkflowExecutionRequest:
-        """Build a backend-neutral execution request without capturing ``self``."""
-        return _workflow_execution.WorkflowExecutionRequest(
-            func=self._func,
-            call_value_list=call_value_list,
-            execution=self._make_execution_config(mode=mode),
-        )
-
-    def _is_dependency_param(self, name: str) -> bool:
-        """
-        Decide whether a parameter is a dependency (Node) vs normal input.
-
-        Rule:
-          - If annotation is a Node subclass => dependency
-          - Else => normal input
-
-        This matches your current architecture (deps are Nodes).
-        """
-        return _workflow_call.is_dependency_param(
-            self._signature_info, name, dependency_type=Node,
-        )
-
     def __call__(self, *args, **call_inputs):
         call = _workflow_call.resolve_workflow_call(
             self._signature_info,
@@ -481,10 +434,10 @@ class WorkflowFunction(Node):
             self._key = jax.random.PRNGKey(call.overrides.seed)
 
         values = _workflow_distribution_normalization.normalize_distribution_values(
-            values=call.values, hints=self._hints,
+            values=call.values, hints=self._signature_info.hints,
         )
         broadcast_plan = _workflow_plan.build_broadcast_plan(
-            values=values, hints=self._hints,
+            values=values, hints=self._signature_info.hints,
         )
         if broadcast_plan.regime != "none":
             return self._broadcast(
@@ -497,7 +450,12 @@ class WorkflowFunction(Node):
         # Non-broadcast call — one function invocation, then wrap.
         # Provenance parents are the inputs that carry their own
         # ``.source`` slot (Distribution / Record / RecordArray).
-        result = self._execute_many([values])[0]
+        request = _workflow_execution.WorkflowExecutionRequest(
+            func=self._func,
+            call_value_list=[values],
+            execution=self._make_execution_config(),
+        )
+        result = _workflow_execution.execute_many(request)[0]
         parents = tuple(
             v for v in values.values() if hasattr(v, "source")
         )
@@ -506,30 +464,11 @@ class WorkflowFunction(Node):
             parents=parents,
             metadata={"func": self._name or self._func.__name__},
         )
-        return _coerce_output(
+        return _workflow_result._coerce_output(
             result,
-            broadcast_mode=BROADCAST_WRAP,
+            broadcast_mode=_workflow_result.BROADCAST_WRAP,
             provenance=provenance,
             field_name=self._name,
-        )
-
-    def _resolve_inputs(self, call_inputs: dict[str, Any]) -> dict[str, Any]:
-        """
-        Build kwargs for calling the underlying function.
-
-        Precedence (highest -> lowest):
-          1) call_inputs
-          2) self._bind
-          3) module.child_nodes/module.inputs (if module attached)
-          4) function default values
-        """
-        return _workflow_call.resolve_workflow_values(
-            self._signature_info,
-            call_inputs,
-            bind=self._bind,
-            module=self._module,
-            dependency_type=Node,
-            workflow_name=self._name,
         )
 
     def _get_key(self):
@@ -545,7 +484,7 @@ class WorkflowFunction(Node):
         """Return the JAX trace-probe error for the current call, if any."""
         try:
             dummy_kw = {}
-            for name in self._sig.parameters:
+            for name in self._signature_info.signature.parameters:
                 if name == "self":
                     continue
                 if name in broadcast_args:
@@ -944,7 +883,12 @@ class WorkflowFunction(Node):
                 call_value_list.append(call_values)
                 sample_idx += 1
 
-        results = self._execute_many(call_value_list)
+        request = _workflow_execution.WorkflowExecutionRequest(
+            func=self._func,
+            call_value_list=call_value_list,
+            execution=self._make_execution_config(),
+        )
+        results = _workflow_execution.execute_many(request)
 
         # Assemble input samples aligned with results
         all_input_samples = {
@@ -979,7 +923,12 @@ class WorkflowFunction(Node):
                 call_values[name] = _index_sample(samples_per_arg[name], i)
             call_value_list.append(call_values)
 
-        results = self._execute_many(call_value_list)
+        request = _workflow_execution.WorkflowExecutionRequest(
+            func=self._func,
+            call_value_list=call_value_list,
+            execution=self._make_execution_config(),
+        )
+        results = _workflow_execution.execute_many(request)
 
         return BroadcastDistribution(
             input_samples=samples_per_arg,
@@ -987,13 +936,6 @@ class WorkflowFunction(Node):
             weights=None,
             broadcast_args=broadcast_args,
         )
-
-    def _execute_many(self, call_value_list: list[dict[str, Any]]) -> list:
-        """Compatibility wrapper around ``_workflow_execution.execute_many``."""
-        if not call_value_list:
-            return []
-        request = self._make_execution_request(call_value_list)
-        return _workflow_execution.execute_many(request)
 
 
 class Module(Node):
@@ -1119,8 +1061,13 @@ class Module(Node):
 
             # Infer dependencies from workflow signature
             # (WorkflowFunctions don't store child_nodes; they resolve dependencies at runtime)
-            for param_name in attr._param_names:
-                if attr._is_dependency_param(param_name) and param_name in self._child_nodes:
+            for param_name in attr._signature_info.param_names:
+                is_dependency = _workflow_call.is_dependency_param(
+                    attr._signature_info,
+                    param_name,
+                    dependency_type=Node,
+                )
+                if is_dependency and param_name in self._child_nodes:
                     dot.edge(param_name, wf_name)
 
         return dot

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -838,18 +838,17 @@ class TestCoerceOutput:
     unchanged (scalars / ndarrays / callables stay usable in idiomatic
     arithmetic / attribute access)."""
 
-    def test_none_mode_passes_through(self):
-        from probpipe.core._workflow_result import _coerce_output
-        # Non-Record/Dist values wouldn't normally have .with_source
-        # but the "none" mode short-circuits before the check anyway.
-        assert _coerce_output(
-            3.14, broadcast_mode="none", provenance=None, field_name="f",
-        ) == 3.14
-        # None provenance also short-circuits.
-        prov = Provenance("x", parents=())
-        assert _coerce_output(
-            3.14, broadcast_mode="none", provenance=prov, field_name="f",
-        ) == 3.14
+    def test_wrap_mode_with_no_provenance_wraps_scalar(self):
+        from probpipe.core import _workflow_result
+        out = _workflow_result._coerce_output(
+            3.14,
+            broadcast_mode=_workflow_result.BROADCAST_WRAP,
+            provenance=None,
+            field_name="f",
+        )
+
+        np.testing.assert_allclose(float(out), 3.14)
+        assert out.source is None
 
     def test_stack_mode_attaches_to_recordarray(self):
         from probpipe import NumericRecord, NumericRecordArray

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -1,4 +1,5 @@
 """Unit tests for BroadcastDistribution and MarginalizedBroadcastDistribution."""
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -8,19 +9,25 @@ from probpipe import (
     BroadcastDistribution,
     EmpiricalDistribution,
     Normal,
+    ProductDistribution,
     Provenance,
-    SupportsSampling,
-    SupportsMean,
-    SupportsVariance,
+    Record,
     SupportsCovariance,
     SupportsLogProb,
+    SupportsMean,
+    SupportsSampling,
+    SupportsVariance,
+    mean,
+    sample,
+    variance,
+    workflow_function,
 )
 from probpipe.core.distribution import (
-    _RecordMarginal,
     _ListMarginal,
-    _MixtureMarginal,
     _make_marginal,
     _make_mixture_marginal,
+    _MixtureMarginal,
+    _RecordMarginal,
 )
 
 
@@ -137,8 +144,7 @@ class TestBroadcastDistributionSampling:
         assert batch["_output"].shape == (5, 3)
 
     def test_joint_sample_preserves_pairing(self, key):
-        """Resampled pairs should match original input–output pairs."""
-        n = 3
+        """Resampled pairs should match original input-output pairs."""
         inputs = {"x": jnp.array([[1.0], [2.0], [3.0]])}
         outputs = jnp.array([[10.0], [20.0], [30.0]])
         bd = BroadcastDistribution(
@@ -455,7 +461,6 @@ class TestBroadcastDistributionListOutputSampling:
 
     def test_joint_sample_with_weights(self, key):
         """Weighted joint sampling selects pairs according to weights."""
-        n = 3
         inputs = {"x": jnp.array([[1.0], [2.0], [3.0]])}
         outputs = jnp.array([[10.0], [20.0], [30.0]])
         # Put all weight on the last sample
@@ -656,12 +661,6 @@ class TestMakeMarginalEdgeCases:
 # ---------------------------------------------------------------------------
 
 
-from probpipe import Record, RecordArray, ProductDistribution  # noqa: E402
-from probpipe.core._broadcast_distributions import _RecordMarginal  # noqa: E402
-from probpipe.core.node import workflow_function  # noqa: E402
-from probpipe import mean, variance, sample  # noqa: E402
-
-
 class TestRecordArrayMarginal:
     """Record-returning WorkflowFunction outputs should be RecordArrayMarginal,
     not _ListMarginal, and must support mean/variance/sample."""
@@ -760,7 +759,7 @@ class TestMakeStack:
         ``NumericRecordArray.stack``. The fallback path builds each
         field independently — numeric leaves via ``jnp.stack``,
         opaque leaves via ``np.asarray(dtype=object)``."""
-        from probpipe import Record, NumericRecordArray, RecordArray
+        from probpipe import NumericRecordArray, Record, RecordArray
         from probpipe.core._broadcast_distributions import _make_stack
         records = [Record(a=float(i), label=f"row{i}") for i in range(3)]
         out = _make_stack(records, n=3, field_name="demo")
@@ -840,7 +839,7 @@ class TestCoerceOutput:
     arithmetic / attribute access)."""
 
     def test_none_mode_passes_through(self):
-        from probpipe.core.node import _coerce_output
+        from probpipe.core._workflow_result import _coerce_output
         # Non-Record/Dist values wouldn't normally have .with_source
         # but the "none" mode short-circuits before the check anyway.
         assert _coerce_output(
@@ -854,7 +853,7 @@ class TestCoerceOutput:
 
     def test_stack_mode_attaches_to_recordarray(self):
         from probpipe import NumericRecord, NumericRecordArray
-        from probpipe.core.node import _coerce_output
+        from probpipe.core._workflow_result import _coerce_output
         ra = NumericRecordArray.stack(
             [NumericRecord(x=float(i)) for i in range(3)]
         )
@@ -867,7 +866,7 @@ class TestCoerceOutput:
     def test_attaches_to_distribution_array(self):
         from probpipe import DistributionArray, Normal
         from probpipe.core._broadcast_distributions import _make_stack
-        from probpipe.core.node import _coerce_output
+        from probpipe.core._workflow_result import _coerce_output
         da = _make_stack(
             [Normal(loc=0.0, scale=1.0, name=f"d{i}") for i in range(3)],
             n=3,
@@ -885,7 +884,7 @@ class TestCoerceOutput:
         its own provenance), ``_coerce_output`` must not crash and the
         existing source must remain."""
         from probpipe import NumericRecord
-        from probpipe.core.node import _coerce_output
+        from probpipe.core._workflow_result import _coerce_output
         nr = NumericRecord(x=1.0).with_source(Provenance("inner", parents=()))
         # Second set would normally raise RuntimeError; _coerce_output
         # swallows it.

--- a/tests/core/test_broadcasting.py
+++ b/tests/core/test_broadcasting.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -409,12 +411,12 @@ class TestAutoDispatch:
         with pytest.raises(ValueError, match="failed while tracing"):
             w(x=g)
 
-    def test_auto_falls_back_to_loop_for_multi_field_joint(self):
+    def test_auto_falls_back_to_row_wise_for_multi_field_joint(self):
         """A multi-field ``ProductDistribution`` broadcast argument
         can't be probed with a single ``event_shape`` (the property
         raises ``NotImplementedError`` / ``TypeError`` on multi-leaf
         instances). The auto-detect path should catch that and
-        fall back to loop vectorization rather than crash.
+        fall back to row-wise dispatch rather than crash.
         """
         from probpipe import ProductDistribution
 
@@ -434,10 +436,8 @@ class TestAutoDispatch:
         # inside the broad ``except Exception`` in ``_resolve_dispatch``);
         # we don't assert on the result type since the function works
         # on a Record, only that the resolution settles on ``"sequential"``.
-        try:
+        with suppress(Exception):
             w(joint=joint)
-        except Exception:
-            pass
         assert w._resolved_dispatch == "sequential"
 
 
@@ -651,7 +651,7 @@ class TestDispatchConsistency:
 
         for mode in self.ROWWISE_DISPATCH_MODES:
             r = self._run(mode, add_them, a=ed, b=g, n_broadcast_samples=30)
-            # 3 empirical combos × 10 reps each = 30 evaluations.
+            # 3 empirical combos x 10 reps each = 30 evaluations.
             assert r.num_atoms == 30, f"{mode}: expected n=30, got {r.num_atoms}"
             np.testing.assert_allclose(float(r.weights.sum()), 1.0, atol=1e-5)
 

--- a/tests/core/test_broadcasting.py
+++ b/tests/core/test_broadcasting.py
@@ -130,6 +130,27 @@ class TestBroadcastingNSamples:
         result = w(x=g, n_broadcast_samples=10)
         assert result.num_atoms == 10
 
+    def test_call_time_override_rejects_non_integer(self):
+        def identity(x: jnp.ndarray) -> jnp.ndarray:
+            return x
+
+        w = WorkflowFunction(func=identity, dispatch="sequential", seed=6)
+        g = Normal(loc=0.0, scale=1.0, name="x")
+
+        with pytest.raises(TypeError, match="n_broadcast_samples must be an integer"):
+            w(x=g, n_broadcast_samples=2.5)
+
+    @pytest.mark.parametrize("n_broadcast_samples", [0, -1])
+    def test_call_time_override_rejects_non_positive(self, n_broadcast_samples):
+        def identity(x: jnp.ndarray) -> jnp.ndarray:
+            return x
+
+        w = WorkflowFunction(func=identity, dispatch="sequential", seed=6)
+        g = Normal(loc=0.0, scale=1.0, name="x")
+
+        with pytest.raises(ValueError, match="n_broadcast_samples must be a positive integer"):
+            w(x=g, n_broadcast_samples=n_broadcast_samples)
+
 
 class TestReservedParameterNames:
     def test_n_broadcast_samples_forbidden(self):

--- a/tests/core/test_pep695_workflow.py
+++ b/tests/core/test_pep695_workflow.py
@@ -17,11 +17,10 @@ from typing import Generic, TypeVar
 
 from probpipe.core.node import WorkflowFunction, workflow_function
 
-
 _T = TypeVar("_T")
 
 
-class _Box(Generic[_T]):
+class _Box(Generic[_T]):  # noqa: UP046
     def __init__(self, value: _T):
         self.value = value
 
@@ -36,8 +35,8 @@ def test_pep695_generic_function_can_be_wrapped():
     assert isinstance(identity, WorkflowFunction)
     assert identity.__name__ == "identity"
     # The hint for ``x`` should resolve to a parameterized _Box, not raise.
-    assert "x" in identity._hints
-    assert "return" in identity._hints
+    assert "x" in identity._signature_info.hints
+    assert "return" in identity._signature_info.hints
 
 
 def test_pep695_multiple_type_params():
@@ -47,9 +46,9 @@ def test_pep695_multiple_type_params():
     def pair[T, S](a: _Box[T], b: _Box[S]) -> tuple[_Box[T], _Box[S]]:
         return (a, b)
 
-    assert "a" in pair._hints
-    assert "b" in pair._hints
-    assert "return" in pair._hints
+    assert "a" in pair._signature_info.hints
+    assert "b" in pair._signature_info.hints
+    assert "return" in pair._signature_info.hints
 
 
 def test_iterate_imports():

--- a/tests/core/test_prefect_orchestration.py
+++ b/tests/core/test_prefect_orchestration.py
@@ -68,8 +68,8 @@ def sum_xy(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
 # workflow_kind="task" with sequential dispatch
 # ---------------------------------------------------------------------------
 
-class TestPrefectTaskLoop:
-    """Exercises _execute_many_prefect_task via sequential dispatch."""
+class TestPrefectTaskRowWise:
+    """Exercises Prefect task execution via row-wise dispatch."""
 
     def test_returns_empirical_distribution(self, normal_dist):
         wf = WorkflowFunction(
@@ -115,8 +115,8 @@ class TestPrefectTaskLoop:
 # workflow_kind="flow" with sequential dispatch
 # ---------------------------------------------------------------------------
 
-class TestPrefectFlowLoop:
-    """Exercises _execute_many_prefect_flow via sequential dispatch."""
+class TestPrefectFlowRowWise:
+    """Exercises Prefect flow execution via row-wise dispatch."""
 
     def test_returns_empirical_distribution(self, normal_dist):
         wf = WorkflowFunction(

--- a/tests/core/test_workflow_parallel.py
+++ b/tests/core/test_workflow_parallel.py
@@ -145,7 +145,9 @@ class TestExecutionRequestShape:
         monkeypatch.setattr(execution_mod, "execute_many", fake_execute_many)
         wf = WorkflowFunction(func=add_one, dispatch="sequential")
 
-        assert wf._execute_many([{"x": 1}]) == [2]
+        result = wf(x=1)
+
+        assert float(result["add_one"]) == 2.0
         assert seen["request"].func is add_one
         assert not isinstance(seen["request"].func, WorkflowFunction)
         assert seen["request"].execution.mode == "sequential"
@@ -267,12 +269,7 @@ class TestPrefectMapping:
         assert FakeMappedTask.created_names == ["plus_one_run"]
 
 
-class TestWorkflowFunctionCompatibility:
-    def test_execute_many_wrapper_preserves_private_call_behavior(self):
-        wf = WorkflowFunction(func=add_one, dispatch="sequential")
-
-        assert wf._execute_many([{"x": 1}, {"x": 2}]) == [2, 3]
-
+class TestWorkflowFunctionExecutionConfig:
     def test_make_execution_config_resolves_thread_dispatch_to_thread_mode(self):
         wf = WorkflowFunction(
             func=add_one,
@@ -403,29 +400,12 @@ class TestWorkflowFunctionCompatibility:
 
         assert result.num_atoms == 8
 
-    def test_execute_many_wrapper_returns_empty_before_building_request(
-        self,
-        monkeypatch,
-    ):
-        wf = WorkflowFunction(
-            func=add_one,
-            workflow_kind=WorkflowKind.TASK,
-            dispatch="sequential",
-        )
-
-        def fail_request(*args, **kwargs):
-            raise AssertionError("empty calls should not build an execution request")
-
-        monkeypatch.setattr(wf, "_make_execution_request", fail_request)
-
-        assert wf._execute_many([]) == []
-
-    def test_execute_many_wrapper_resolves_task_and_flow_modes(self, monkeypatch):
+    def test_public_call_resolves_task_and_flow_modes(self, monkeypatch):
         seen_modes = []
 
         def fake_execute_many(request):
             seen_modes.append(request.execution.mode)
-            return ("ok", request.call_value_list)
+            return [request.func(**request.call_value_list[0])]
 
         monkeypatch.setattr(node_mod, "task", object())
         monkeypatch.setattr(execution_mod, "execute_many", fake_execute_many)
@@ -440,7 +420,6 @@ class TestWorkflowFunctionCompatibility:
             dispatch="sequential",
         )
 
-        calls = [{"x": 1}]
-        assert task_wf._execute_many(calls) == ("ok", calls)
-        assert flow_wf._execute_many(calls) == ("ok", calls)
+        assert float(task_wf(x=1)["add_one"]) == 2.0
+        assert float(flow_wf(x=1)["add_one"]) == 2.0
         assert seen_modes == ["prefect_task", "prefect_flow"]

--- a/tests/core/test_workflow_parallel.py
+++ b/tests/core/test_workflow_parallel.py
@@ -403,8 +403,15 @@ class TestWorkflowFunctionCompatibility:
 
         assert result.num_atoms == 8
 
-    def test_private_wrappers_return_empty_before_building_request(self, monkeypatch):
-        wf = WorkflowFunction(func=add_one, workflow_kind=WorkflowKind.TASK, dispatch="sequential")
+    def test_execute_many_wrapper_returns_empty_before_building_request(
+        self,
+        monkeypatch,
+    ):
+        wf = WorkflowFunction(
+            func=add_one,
+            workflow_kind=WorkflowKind.TASK,
+            dispatch="sequential",
+        )
 
         def fail_request(*args, **kwargs):
             raise AssertionError("empty calls should not build an execution request")
@@ -412,10 +419,6 @@ class TestWorkflowFunctionCompatibility:
         monkeypatch.setattr(wf, "_make_execution_request", fail_request)
 
         assert wf._execute_many([]) == []
-        assert wf._execute_many_threaded([]) == []
-        assert wf._map_task([]) == []
-        assert wf._execute_many_prefect_task([]) == []
-        assert wf._execute_many_prefect_flow([]) == []
 
     def test_execute_many_wrapper_resolves_task_and_flow_modes(self, monkeypatch):
         seen_modes = []
@@ -441,30 +444,3 @@ class TestWorkflowFunctionCompatibility:
         assert task_wf._execute_many(calls) == ("ok", calls)
         assert flow_wf._execute_many(calls) == ("ok", calls)
         assert seen_modes == ["prefect_task", "prefect_flow"]
-
-    def test_threaded_wrapper_delegates_to_execution_module(self, monkeypatch):
-        monkeypatch.setattr(execution_mod, "ThreadPoolExecutor", RecordingExecutor)
-        wf = WorkflowFunction(func=add_one, dispatch="thread", max_workers=2)
-
-        assert wf._execute_many_threaded([{"x": 1}, {"x": 2}]) == [2, 3]
-        assert RecordingExecutor.instances[0].max_workers == 2
-
-    def test_map_task_wrapper_delegates_to_execution_module(self, monkeypatch):
-        monkeypatch.setattr(execution_mod, "task", fake_task)
-        monkeypatch.setattr(execution_mod, "flow", None)
-        wf = WorkflowFunction(func=add_one, dispatch="sequential")
-
-        assert wf._map_task([{"x": 1}, {"x": 2}], task_name="add-one") == [2, 3]
-        assert FakeMappedTask.created_names == ["add-one"]
-
-    def test_map_task_wrapper_does_not_resolve_task_runner(self, monkeypatch):
-        monkeypatch.setattr(execution_mod, "task", fake_task)
-        monkeypatch.setattr(execution_mod, "flow", None)
-
-        def fail_resolve_task_runner():
-            raise AssertionError("direct _map_task should not resolve a task runner")
-
-        monkeypatch.setattr(node_mod.prefect_config, "resolve_task_runner", fail_resolve_task_runner)
-        wf = WorkflowFunction(func=add_one, dispatch="sequential")
-
-        assert wf._map_task([{"x": 1}], task_name="add-one") == [2]

--- a/tests/core/test_workflow_sweep.py
+++ b/tests/core/test_workflow_sweep.py
@@ -6,7 +6,14 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import DistributionArray, Normal, NumericRecord, NumericRecordArray
+from probpipe import (
+    BroadcastDistribution,
+    DistributionArray,
+    Normal,
+    NumericRecord,
+    NumericRecordArray,
+    mean,
+)
 from probpipe.core import _workflow_execution, _workflow_sweep
 from probpipe.core._workflow_plan import build_broadcast_plan
 
@@ -181,3 +188,75 @@ class TestExecuteSweep:
                 n_broadcast_samples=5,
                 include_inputs=True,
             )
+
+    def test_nested_sweep_calls_distribution_broadcast_and_marginalizes(self):
+        values = {
+            "p": _numeric_record_array("x", range(2)),
+            "noise": Normal(loc=0.0, scale=1.0, name="noise"),
+        }
+        plan = build_broadcast_plan(values=values, hints={})
+        execution = _workflow_execution.WorkflowExecutionConfig(
+            mode="sequential",
+            name="nested",
+        )
+        calls = []
+
+        def distribution_broadcast(
+            row_values,
+            dist_args,
+            n_broadcast_samples,
+            include_inputs,
+        ):
+            calls.append(
+                {
+                    "x": float(row_values["p"]["x"]),
+                    "dist_args": tuple(dist_args),
+                    "n": n_broadcast_samples,
+                    "include_inputs": include_inputs,
+                }
+            )
+            loc = float(row_values["p"]["x"])
+            return BroadcastDistribution(
+                input_samples={"noise": jnp.asarray([0.0])},
+                output_samples=jnp.asarray([loc]),
+                output_distributions=[
+                    Normal(loc=loc, scale=1.0, name=f"row_{int(loc)}")
+                ],
+                weights=None,
+                broadcast_args=["noise"],
+            )
+
+        result = _workflow_sweep.execute_sweep(
+            func=lambda p, noise: p["x"] + noise,
+            values=values,
+            plan=plan,
+            make_execution_config=lambda: execution,
+            requested_dispatch="sequential",
+            resolve_dispatch=lambda *args, **kwargs: "sequential",
+            require_jax_traceable=_require_not_called,
+            distribution_broadcast=distribution_broadcast,
+            workflow_name="nested",
+            n_broadcast_samples=7,
+        )
+
+        assert result.batch_shape == (2,)
+        assert [float(mean(component)) for component in result.components] == [
+            0.0,
+            1.0,
+        ]
+        assert calls == [
+            {
+                "x": 0.0,
+                "dist_args": ("noise",),
+                "n": 7,
+                "include_inputs": True,
+            },
+            {
+                "x": 1.0,
+                "dist_args": ("noise",),
+                "n": 7,
+                "include_inputs": True,
+            },
+        ]
+        assert result.source.operation == "workflow.nested"
+        assert result.source.metadata["k"] == 7

--- a/tests/core/test_workflow_sweep.py
+++ b/tests/core/test_workflow_sweep.py
@@ -1,0 +1,183 @@
+"""Tests for WorkflowFunction sweep execution helpers."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import DistributionArray, Normal, NumericRecord, NumericRecordArray
+from probpipe.core import _workflow_execution, _workflow_sweep
+from probpipe.core._workflow_plan import build_broadcast_plan
+
+
+def _numeric_record_array(field: str, values: range) -> NumericRecordArray:
+    return NumericRecordArray.stack(
+        [NumericRecord(**{field: float(value)}) for value in values]
+    )
+
+
+def _unexpected_distribution_broadcast(*args, **kwargs):
+    raise AssertionError("distribution broadcast should not run")
+
+
+def _require_not_called(*args, **kwargs):
+    raise AssertionError("JAX traceability should not be required")
+
+
+class TestSliceSweepValues:
+    def test_views_from_same_parent_zip(self):
+        parent = NumericRecordArray.stack(
+            [
+                NumericRecord(x=float(i), y=float(10 + i))
+                for i in range(3)
+            ]
+        )
+        values = {"x": parent.view("x"), "y": parent.view("y")}
+        plan = build_broadcast_plan(values=values, hints={})
+
+        observed = [
+            _workflow_sweep.slice_sweep_values(
+                values=values,
+                index=i,
+                array_groups=plan.array_groups,
+            )
+            for i in range(plan.n_sweep)
+        ]
+
+        assert [
+            (float(row["x"]), float(row["y"]))
+            for row in observed
+        ] == [(0.0, 10.0), (1.0, 11.0), (2.0, 12.0)]
+
+    def test_arrays_from_different_parents_use_row_major_product(self):
+        values = {
+            "a": _numeric_record_array("a", range(2)),
+            "b": _numeric_record_array("b", range(3)),
+        }
+        plan = build_broadcast_plan(values=values, hints={})
+
+        observed = [
+            _workflow_sweep.slice_sweep_values(
+                values=values,
+                index=i,
+                array_groups=plan.array_groups,
+            )
+            for i in range(plan.n_sweep)
+        ]
+
+        assert [
+            (float(row["a"]["a"]), float(row["b"]["b"]))
+            for row in observed
+        ] == [
+            (0.0, 0.0),
+            (0.0, 1.0),
+            (0.0, 2.0),
+            (1.0, 0.0),
+            (1.0, 1.0),
+            (1.0, 2.0),
+        ]
+
+    def test_distribution_array_cell_uses_flat_component(self):
+        da = DistributionArray.from_batched_params(
+            Normal,
+            batch_shape=(2,),
+            loc=jnp.asarray([3.0, 4.0]),
+            scale=jnp.asarray([1.0, 1.0]),
+            name="d",
+        )
+        values = {"d": da}
+        plan = build_broadcast_plan(values=values, hints={})
+
+        first = _workflow_sweep.slice_sweep_values(
+            values=values,
+            index=0,
+            array_groups=plan.array_groups,
+        )
+        second = _workflow_sweep.slice_sweep_values(
+            values=values,
+            index=1,
+            array_groups=plan.array_groups,
+        )
+
+        assert isinstance(first["d"], Normal)
+        assert isinstance(second["d"], Normal)
+        assert float(first["d"].loc) == 3.0
+        assert float(second["d"].loc) == 4.0
+
+
+class TestExecuteSweep:
+    def test_row_wise_sweep_uses_execution_request(self, monkeypatch):
+        values = {"p": _numeric_record_array("x", range(3))}
+        plan = build_broadcast_plan(values=values, hints={})
+        execution = _workflow_execution.WorkflowExecutionConfig(
+            mode="thread",
+            max_workers=2,
+            name="double",
+        )
+        seen = {}
+
+        def double(p):
+            return 2.0 * p["x"]
+
+        def resolve_dispatch(values, array_args, *, jax_supported):
+            return "thread"
+
+        def fake_execute_many(request):
+            seen["request"] = request
+            return [
+                request.func(**call_values)
+                for call_values in request.call_value_list
+            ]
+
+        monkeypatch.setattr(
+            _workflow_sweep._workflow_execution,
+            "execute_many",
+            fake_execute_many,
+        )
+
+        result = _workflow_sweep.execute_sweep(
+            func=double,
+            values=values,
+            plan=plan,
+            make_execution_config=lambda: execution,
+            requested_dispatch="thread",
+            resolve_dispatch=resolve_dispatch,
+            require_jax_traceable=_require_not_called,
+            distribution_broadcast=_unexpected_distribution_broadcast,
+            workflow_name="double",
+            n_broadcast_samples=5,
+        )
+
+        request = seen["request"]
+        assert request.execution is execution
+        assert request.func is double
+        assert [float(row["p"]["x"]) for row in request.call_value_list] == [
+            0.0,
+            1.0,
+            2.0,
+        ]
+        np.testing.assert_allclose(result["double"], jnp.asarray([0.0, 2.0, 4.0]))
+
+    def test_include_inputs_is_rejected_for_sweep(self):
+        values = {"p": _numeric_record_array("x", range(1))}
+        plan = build_broadcast_plan(values=values, hints={})
+        execution = _workflow_execution.WorkflowExecutionConfig(
+            mode="sequential",
+            name="identity",
+        )
+
+        with pytest.raises(NotImplementedError, match="include_inputs=True"):
+            _workflow_sweep.execute_sweep(
+                func=lambda p: p["x"],
+                values=values,
+                plan=plan,
+                make_execution_config=lambda: execution,
+                requested_dispatch="sequential",
+                resolve_dispatch=lambda *args, **kwargs: "sequential",
+                require_jax_traceable=_require_not_called,
+                distribution_broadcast=_unexpected_distribution_broadcast,
+                workflow_name="identity",
+                n_broadcast_samples=5,
+                include_inputs=True,
+            )


### PR DESCRIPTION
This is the stage 5 of #196, also the last stage. Distribution broadcast extraction is considered a legacy issue and will be addressed later.

## Changes
1. Added `probpipe/core/_workflow_sweep.py`.
2. None JAX-vmap row-wise sweep now explicitly handled by `_workflow_execution.execute_many(WorkflowExecutionRequest(...))`.
3. Change `execution config` to a lazy factory that passes to the `sweep` module, which only parses the row-wise path, avoiding warnings/side effects from changing JAX-vmap or early failure paths.
4. Deleted all wrappers and aliases left before. Now say goodbye to old names.
5. Fixed a small bug in `WorkflowFunction._broadcast_distributions_only`.  (Not directly related to the current topic, but there's no harm in making the change. I just happened to see it, or I might forget about it next time.)