### PR TITLE
Accept scalar int for sample_shape in sample op

### DIFF
--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -86,9 +86,6 @@ def sample(
             f"{type(dist).__name__} does not support sampling "
             f"(does not implement SupportsSampling)"
         )
-    # Scalar-int sugar: ``sample_shape=100`` -> ``(100,)``. The coercion
-    # lives at the public-op boundary so internal ``_sample``
-    # implementations can continue to assume ``sample_shape: tuple``.
     if isinstance(sample_shape, int):
         sample_shape = (sample_shape,)
     if key is None:

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -66,7 +66,7 @@ def sample(
     dist: SupportsSampling,
     *,
     key: PRNGKey | None = None,
-    sample_shape: tuple[int, ...] = (),
+    sample_shape: int | tuple[int, ...] = (),
 ) -> Any:
     """Draw samples from a distribution.
 
@@ -76,14 +76,21 @@ def sample(
         Distribution to sample from.
     key : PRNGKey, optional
         JAX PRNG key.  Auto-generated if ``None``.
-    sample_shape : tuple of int
-        Shape prefix for independent draws.
+    sample_shape : int or tuple of int
+        Shape prefix for independent draws.  A scalar ``N`` is treated
+        as sugar for ``(N,)``, matching the convention used by numpy,
+        JAX, scipy, and TFP.
     """
     if not isinstance(dist, SupportsSampling):
         raise TypeError(
             f"{type(dist).__name__} does not support sampling "
             f"(does not implement SupportsSampling)"
         )
+    # Scalar-int sugar: ``sample_shape=100`` -> ``(100,)``. The coercion
+    # lives at the public-op boundary so internal ``_sample``
+    # implementations can continue to assume ``sample_shape: tuple``.
+    if isinstance(sample_shape, int):
+        sample_shape = (sample_shape,)
     if key is None:
         key = _auto_key()
     return dist._sample(key, sample_shape)

--- a/tests/core/test_ops.py
+++ b/tests/core/test_ops.py
@@ -65,7 +65,7 @@ class TestSample:
         assert s.shape == (5, 2)
 
     def test_sample_shape_scalar_int_matches_1tuple(self, normal, mvn, empirical):
-        """Scalar ``sample_shape=N`` is sugar for ``(N,)`` (issue #226).
+        """Scalar ``sample_shape=N`` is sugar for ``(N,)``.
 
         Asserts numpy / JAX / scipy / TFP-style convenience: passing an
         int where a sample-shape tuple is expected produces output of

--- a/tests/core/test_ops.py
+++ b/tests/core/test_ops.py
@@ -64,6 +64,21 @@ class TestSample:
         s = ops.sample(empirical, key=jax.random.PRNGKey(0), sample_shape=(5,))
         assert s.shape == (5, 2)
 
+    def test_sample_shape_scalar_int_matches_1tuple(self, normal, mvn, empirical):
+        """Scalar ``sample_shape=N`` is sugar for ``(N,)`` (issue #226).
+
+        Asserts numpy / JAX / scipy / TFP-style convenience: passing an
+        int where a sample-shape tuple is expected produces output of
+        the same shape and the same values (under the same key) as the
+        tuple form.
+        """
+        key = jax.random.PRNGKey(0)
+        for dist, event_shape in [(normal, ()), (mvn, (3,)), (empirical, (2,))]:
+            s_int = ops.sample(dist, key=key, sample_shape=10)
+            s_tup = ops.sample(dist, key=key, sample_shape=(10,))
+            assert s_int.shape == (10, *event_shape) == s_tup.shape
+            np.testing.assert_array_equal(np.asarray(s_int), np.asarray(s_tup))
+
     def test_sample_type_error(self):
         with pytest.raises(TypeError, match="does not support sampling"):
             ops.sample("not a distribution")


### PR DESCRIPTION
Closes #226.

## Summary

- `probpipe/core/ops.py`: `sample` now accepts `sample_shape: int | tuple[int, ...]`. A scalar `N` is coerced to `(N,)` at the public-op boundary, so internal `_sample` implementations continue to receive a tuple.
- Updated docstring to call out the scalar form and the numpy / JAX / scipy / TFP convention it matches.
- `tests/core/test_ops.py`: regression test asserting `sample(d, sample_shape=10)` produces the same shape and the same values (under a fixed key) as `sample(d, sample_shape=(10,))` across `Normal`, `MultivariateNormal`, and `RecordEmpiricalDistribution`.

## Audit notes

`grep -rn 'sample_shape' probpipe/` surfaced these other hits; none warranted a mirrored coercion:

- `probpipe/core/protocols.py` — `SupportsSampling._sample`: internal contract, intentionally tuple-only per the issue.
- `probpipe/core/_numeric_record_distribution.py::_vmap_sample`, `probpipe/core/_empirical.py::_wrap_numeric_array_as_record`: underscore-prefixed internals, only reached through the public op (which now coerces).
- `probpipe/core/_empirical.py::RecordEmpiricalDistribution.__init__`: public but its `sample_shape` is a shape-validation parameter for pre-computed sample arrays, not a "draw N samples" knob. The trailing-comma friction the issue describes doesn't really land here, so I left it as a tuple-only parameter — happy to add the sugar in a follow-up if you'd prefer the consistency.

## Test plan

- [x] `pytest tests/core/test_ops.py` — 38 passed locally
- [x] CI green
