### PR TITLE
nutpie+PyMC: drop auto-transformed value vars at chain extraction

### DIFF
--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -53,7 +53,15 @@ def condition_on_nutpie(
         chains=num_chains, seed=random_seed, **kwargs,
     )
 
-    chains, param_names = _extract_chains(trace, num_chains)
+    # For PyMC models, restrict extraction to the user-named (constrained)
+    # free RVs. Nutpie's posterior also exposes auto-introduced
+    # unconstrained value vars (e.g. ``sigma_log__`` for a
+    # ``HalfNormal('sigma', ...)``); pulling them in would double-count
+    # those RVs and shape-mismatch against ``record_template``.
+    keep_names = getattr(model, "_param_names", None)
+    chains, param_names = _extract_chains(
+        trace, num_chains, keep_names=keep_names,
+    )
 
     return make_posterior(
         chains, parents=(model,), algorithm="nutpie_nuts",
@@ -83,11 +91,33 @@ def _compile_for_nutpie(model: Any, data: Any) -> Any:
     )
 
 
-def _extract_chains(trace: Any, num_chains: int) -> tuple[list, list]:
-    """Extract per-chain sample arrays from a nutpie ArviZ trace."""
+def _extract_chains(
+    trace: Any,
+    num_chains: int,
+    *,
+    keep_names: list[str] | tuple[str, ...] | None = None,
+) -> tuple[list, list]:
+    """Extract per-chain sample arrays from a nutpie ArviZ trace.
+
+    Parameters
+    ----------
+    trace
+        Nutpie trace exposing ``posterior`` as an ArviZ-like
+        ``Dataset`` / ``DataTree``.
+    num_chains
+        Number of chains in the trace.
+    keep_names
+        Restrict extraction to these data-var names, in this order. When
+        ``None`` (default), every ``posterior.data_vars`` entry is
+        extracted. Used by the PyMC path to drop nutpie's
+        auto-introduced unconstrained value vars (e.g. ``sigma_log__``).
+    """
     if hasattr(trace, "posterior"):
         posterior = trace.posterior
-        param_names = list(posterior.data_vars)
+        if keep_names is None:
+            param_names = list(posterior.data_vars)
+        else:
+            param_names = list(keep_names)
         chains = []
         for c in range(num_chains):
             chain_arrays = []

--- a/tests/inference/test_nutpie.py
+++ b/tests/inference/test_nutpie.py
@@ -117,6 +117,40 @@ class TestExtractChains:
         with pytest.raises(TypeError, match="Cannot extract chains"):
             _extract_chains(mock_trace, num_chains=1)
 
+    def test_keep_names_filters_out_transformed_value_vars(self):
+        """``keep_names`` restricts extraction to the named RVs and
+        preserves their order.
+
+        Mirrors the nutpie + PyMC shape: ``posterior.data_vars`` carries
+        both the constrained ``sigma`` and the auto-introduced
+        unconstrained ``sigma_log__``; with ``keep_names=['mu', 'sigma']``
+        only the constrained columns make it into the chain.
+        """
+        mock_trace = MagicMock()
+        mu_vals = np.random.randn(1, 8)
+        sigma_vals = np.random.randn(1, 8)
+        sigma_log_vals = np.random.randn(1, 8)
+        mu_var = MagicMock(); mu_var.values = mu_vals
+        sigma_var = MagicMock(); sigma_var.values = sigma_vals
+        sigma_log_var = MagicMock(); sigma_log_var.values = sigma_log_vals
+
+        mock_posterior = MagicMock()
+        mock_posterior.data_vars = ["mu", "sigma", "sigma_log__"]
+        mock_posterior.__getitem__ = (
+            lambda self, k: {
+                "mu": mu_var, "sigma": sigma_var, "sigma_log__": sigma_log_var,
+            }[k]
+        )
+        mock_trace.posterior = mock_posterior
+
+        chains, param_names = _extract_chains(
+            mock_trace, num_chains=1, keep_names=["mu", "sigma"],
+        )
+        assert param_names == ["mu", "sigma"]
+        assert chains[0].shape == (8, 2)
+        np.testing.assert_allclose(chains[0][:, 0], mu_vals[0])
+        np.testing.assert_allclose(chains[0][:, 1], sigma_vals[0])
+
 
 # ---------------------------------------------------------------------------
 # Real integration: nutpie + PyMCModel
@@ -182,3 +216,37 @@ class TestNutpieIntegration:
         assert result.inference_data is not None
         # arviz-like trace exposes posterior as an xarray Dataset/DataTree
         assert hasattr(result.inference_data, "posterior")
+
+    def test_auto_transformed_rv_not_double_counted(self):
+        """A ``HalfNormal`` (auto-log-transformed) must not contribute a
+        second column to the chain (issue #225).
+
+        Nutpie's posterior carries both the constrained ``sigma`` and
+        the unconstrained ``sigma_log__`` as data_vars; extracting both
+        would shape-mismatch against ``record_template`` (template has
+        one field for ``sigma``, chain would have two columns for it).
+        We assert (i) extraction succeeds, (ii) draws expose exactly
+        the user-named RVs, and (iii) the recovered ``sigma`` samples
+        are all positive (i.e., constrained values, not log-transformed).
+        """
+        def model_fn(y=None):
+            with pm.Model() as m:
+                mu = pm.Normal("mu", 0, 1)
+                sigma = pm.HalfNormal("sigma", 1)
+                pm.Normal("obs", mu, sigma, observed=y)
+            return m
+
+        np.random.seed(0)
+        y_obs = np.random.randn(50).astype(float)
+        model = PyMCModel(model_fn, name="half_normal")
+        result = condition_on_nutpie._func(
+            model, data={"obs": y_obs},
+            num_results=200, num_warmup=200, num_chains=2, random_seed=7,
+        )
+
+        draws = result.draws()
+        assert draws.fields == ("mu", "sigma")
+        sigma_draws = jnp.asarray(draws["sigma"])
+        assert sigma_draws.shape == (400,)
+        # Constrained-positive values, not log-transformed.
+        assert float(jnp.min(sigma_draws)) > 0.0


### PR DESCRIPTION
Closes #225.

## Diagnosis

`PyMCNutsMethod.execute` already filtered correctly via `dist._param_names` (in `_pymc_method.py`), so the bug only fired on the nutpie path. `_nutpie.py::_extract_chains` iterated every `posterior.data_vars`, which for a PyMC model includes both the user-named constrained RV (`sigma`) and its auto-introduced unconstrained value var (`sigma_log__`). That doubled the column count for any RV with an automatic transform — `HalfNormal`, `Exponential`, `Gamma`, `LogNormal`, `HalfCauchy`, ... — and shape-mismatched against `record_template`.

## Change

- `_extract_chains` gains an optional `keep_names: list[str] | tuple[str, ...] | None` argument. When supplied, only those data-vars are extracted, in the given order. Default `None` preserves the existing "extract everything" behaviour for the Stan path.
- `condition_on_nutpie` passes `getattr(model, "_param_names", None)`. PyMCModel exposes that attribute (constrained free RV names, in template order); StanModel does not, so the fallback path is unchanged.

This mirrors how `_pymc_method.py::_extract_pymc_chains` has always worked — the nutpie path was just inconsistent.

## Tests

- **Unit test** (`TestExtractChains.test_keep_names_filters_out_transformed_value_vars`): mock posterior with `mu`, `sigma`, `sigma_log__`; asserts that `keep_names=["mu", "sigma"]` drops the transformed column and preserves order.
- **Integration test** (`TestNutpieIntegration.test_auto_transformed_rv_not_double_counted`): the canonical reproducer from the issue — `pm.HalfNormal('sigma', 1)` with 50 observations. Asserts `draws.fields == ("mu", "sigma")` (no `sigma_log__`) and `min(sigma_draws) > 0` (constrained values, not log-transformed).

## Test plan

- [ ] CI: `pytest tests/inference/test_nutpie.py` (nutpie + pymc installed)
- [x] AST-validates locally; logic mirrors the already-working `_pymc_method.py` path.
