### PR TITLE
PyMCModel: data-dependent template shapes via stateless _record_template_for

### DIFF
--- a/probpipe/inference/_inference_utils.py
+++ b/probpipe/inference/_inference_utils.py
@@ -49,6 +49,7 @@ __all__ = [
     "build_mcmc_datatree",
     "build_target_log_prob",
     "build_target_log_prob_flat",
+    "extract_chain_columns",
     "get_init_state",
     "get_prior",
     "extract_record_template",
@@ -57,6 +58,50 @@ __all__ = [
     "parallel_chain_map",
     "run_chain_scan",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Chain extraction
+# ---------------------------------------------------------------------------
+
+def extract_chain_columns(
+    trace: Any, names: list[str], num_chains: int,
+) -> list[Array]:
+    """Per-chain flat sample matrices from an ArviZ-like trace.
+
+    For each chain ``c`` and each variable in *names* (in that order),
+    pulls ``trace.posterior[name].values[c]``, flattens trailing axes to
+    2-D ``(draws, -1)``, and concatenates across variables. Columns are
+    laid out in *names* order, so callers pass the order that matches the
+    ``record_template`` they build (the flat chain is split positionally
+    downstream).
+
+    Parameters
+    ----------
+    trace : ArviZ-like trace
+        Object exposing a ``posterior`` group indexable by variable name.
+    names : list of str
+        Variables to extract, in the desired column order.
+    num_chains : int
+        Number of chains (leading axis of each ``values`` array).
+
+    Returns
+    -------
+    list of Array
+        One ``(draws, total_flat_dim)`` array per chain.
+    """
+    chains = []
+    for c in range(num_chains):
+        chain_arrays = []
+        for name in names:
+            vals = trace.posterior[name].values[c]
+            if vals.ndim == 1:
+                vals = vals[:, None]
+            else:
+                vals = vals.reshape(vals.shape[0], -1)
+            chain_arrays.append(jnp.asarray(vals))
+        chains.append(jnp.concatenate(chain_arrays, axis=-1))
+    return chains
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/inference/_inference_utils.py
+++ b/probpipe/inference/_inference_utils.py
@@ -72,9 +72,8 @@ def extract_chain_columns(
     For each chain ``c`` and each variable in *names* (in that order),
     pulls ``trace.posterior[name].values[c]``, flattens trailing axes to
     2-D ``(draws, -1)``, and concatenates across variables. Columns are
-    laid out in *names* order, so callers pass the order that matches the
-    ``record_template`` they build (the flat chain is split positionally
-    downstream).
+    laid out in *names* order, to match the ``record_template`` field
+    order.
 
     Parameters
     ----------

--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -47,7 +47,7 @@ def condition_on_nutpie(
             "Install it with: pip install nutpie"
         ) from e
 
-    compiled = _compile_for_nutpie(model, data)
+    compiled, pymc_build = _compile_for_nutpie(model, data)
     trace = nutpie.sample(
         compiled, draws=num_results, tune=num_warmup,
         chains=num_chains, seed=random_seed, **kwargs,
@@ -55,9 +55,16 @@ def condition_on_nutpie(
 
     chains, param_names = _extract_chains(trace, num_chains)
 
+    # Build the template from the same conditioned model nutpie sampled
+    # (PyMC only); Stan models carry their own record_template, if any.
+    if pymc_build is not None:
+        record_template = model.record_template_for(pymc_build)
+    else:
+        record_template = getattr(model, "record_template", None)
+
     return make_posterior(
         chains, parents=(model,), algorithm="nutpie_nuts",
-        auxiliary=trace, record_template=getattr(model, "record_template", None),
+        auxiliary=trace, record_template=record_template,
         num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
     )
 
@@ -67,15 +74,22 @@ def condition_on_nutpie(
 # ---------------------------------------------------------------------------
 
 
-def _compile_for_nutpie(model: Any, data: Any) -> Any:
-    """Compile a model for nutpie sampling."""
+def _compile_for_nutpie(model: Any, data: Any) -> tuple[Any, Any]:
+    """Compile a model for nutpie sampling.
+
+    Returns ``(compiled, pymc_build)``. ``pymc_build`` is the
+    data-conditioned ``pm.Model`` for PyMCModel targets (so the caller
+    can derive a matching ``record_template``), and ``None`` for Stan
+    targets.
+    """
     if hasattr(model, "_bridgestan_model"):
         import nutpie
-        return nutpie.compile_stan_model(model._bridgestan_model(data=data))
+        return nutpie.compile_stan_model(model._bridgestan_model(data=data)), None
 
     if hasattr(model, "_pymc_model"):
         import nutpie
-        return nutpie.compile_pymc_model(model._pymc_model(data=data))
+        pymc_build = model._pymc_model(data=data)
+        return nutpie.compile_pymc_model(pymc_build), pymc_build
 
     raise TypeError(
         f"condition_on_nutpie does not support {type(model).__name__}. "

--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -48,14 +48,17 @@ def condition_on_nutpie(
 
     compiled, pymc_build = _compile_for_nutpie(model, data)
 
-    # Build the template from the same conditioned model before sampling,
-    # so a non-concrete or dynamic-RV model fails fast with a clear error
-    # rather than an opaque KeyError during chain extraction. PyMC derives
-    # it from the conditioned build; Stan models carry their own
+    # Resolve the PyMC param names + template from the same conditioned
+    # build before sampling, so a dynamic-RV or non-concrete model fails
+    # fast with a clear error rather than an opaque KeyError during chain
+    # extraction. The names cover canonical params plus any observed left
+    # free under partial conditioning. Stan models carry their own
     # record_template, if any.
     if pymc_build is not None:
-        record_template = model._record_template_for(pymc_build)
+        keep_names = list(model._conditioned_param_names(pymc_build))
+        record_template = model._record_template_for(pymc_build, keep_names)
     else:
+        keep_names = None
         record_template = getattr(model, "record_template", None)
 
     trace = nutpie.sample(
@@ -63,11 +66,10 @@ def condition_on_nutpie(
         chains=num_chains, seed=random_seed, **kwargs,
     )
 
-    # PyMC: extract chain columns in ``_param_names`` order so they line
-    # up with the template (nutpie sorts ``posterior.data_vars``
+    # PyMC: extract chain columns in `keep_names` order so they line up
+    # with the template (nutpie sorts ``posterior.data_vars``
     # alphabetically, which would otherwise mislabel draws). Stan: take
     # trace order.
-    keep_names = list(model._param_names) if pymc_build is not None else None
     chains, param_names = _extract_chains(trace, num_chains, keep_names=keep_names)
 
     return make_posterior(

--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -48,11 +48,9 @@ def condition_on_nutpie(
 
     compiled, pymc_build = _compile_for_nutpie(model, data)
 
-    # Resolve the PyMC param names + template from the same conditioned
-    # build before sampling, so a dynamic-RV or non-concrete model fails
-    # fast with a clear error rather than an opaque KeyError during chain
-    # extraction. The names cover canonical params plus any observed left
-    # free under partial conditioning. Stan models carry their own
+    # Resolve the PyMC inferred names + template from the conditioned
+    # build before sampling (fail fast on a dynamic-RV / non-concrete
+    # model); extraction shares the names. Stan models carry their own
     # record_template, if any.
     if pymc_build is not None:
         keep_names = list(model._conditioned_param_names(pymc_build))
@@ -120,12 +118,9 @@ def _extract_chains(
         Number of chains to extract.
     keep_names : list of str or None
         If given, extract exactly these variables, in this order, instead
-        of ``posterior.data_vars`` order. nutpie orders ``data_vars``
-        alphabetically, so PyMC callers pass the model's ``_param_names``
-        to keep chain-column order aligned with the ``record_template``
-        field order (otherwise the flat chain is split positionally and
-        draws are silently mislabeled). Stan callers pass ``None`` and
-        take trace order.
+        of ``posterior.data_vars`` order (which nutpie sorts
+        alphabetically). PyMC callers pass the param names so chain
+        columns align with the template; Stan callers pass ``None``.
 
     Returns
     -------

--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import jax.numpy as jnp
-
 from ..core._registry import MethodInfo
 from ..core.node import workflow_function
 from ..custom_types import ArrayLike
 from ._approximate_distribution import ApproximateDistribution, make_posterior
+from ._inference_utils import extract_chain_columns
 from ._registry import InferenceMethod
 
 logger = logging.getLogger(__name__)
@@ -48,24 +47,28 @@ def condition_on_nutpie(
         ) from e
 
     compiled, pymc_build = _compile_for_nutpie(model, data)
+
+    # Build the template from the same conditioned model before sampling,
+    # so a non-concrete or dynamic-RV model fails fast with a clear error
+    # rather than an opaque KeyError during chain extraction. PyMC derives
+    # it from the conditioned build; Stan models carry their own
+    # record_template, if any.
+    if pymc_build is not None:
+        record_template = model.record_template_for(pymc_build)
+    else:
+        record_template = getattr(model, "record_template", None)
+
     trace = nutpie.sample(
         compiled, draws=num_results, tune=num_warmup,
         chains=num_chains, seed=random_seed, **kwargs,
     )
 
     # PyMC: extract chain columns in ``_param_names`` order so they line
-    # up with ``record_template_for`` (nutpie sorts ``posterior.data_vars``
+    # up with the template (nutpie sorts ``posterior.data_vars``
     # alphabetically, which would otherwise mislabel draws). Stan: take
     # trace order.
     keep_names = list(model._param_names) if pymc_build is not None else None
     chains, param_names = _extract_chains(trace, num_chains, keep_names=keep_names)
-
-    # Build the template from the same conditioned model nutpie sampled
-    # (PyMC only); Stan models carry their own record_template, if any.
-    if pymc_build is not None:
-        record_template = model.record_template_for(pymc_build)
-    else:
-        record_template = getattr(model, "record_template", None)
 
     return make_posterior(
         chains, parents=(model,), algorithm="nutpie_nuts",
@@ -128,27 +131,15 @@ def _extract_chains(
         Per-chain concatenated arrays, and the resolved variable-name
         order.
     """
-    if hasattr(trace, "posterior"):
-        posterior = trace.posterior
-        if keep_names is not None:
-            param_names = list(keep_names)
-        else:
-            param_names = list(posterior.data_vars)
-        chains = []
-        for c in range(num_chains):
-            chain_arrays = []
-            for name in param_names:
-                vals = posterior[name].values[c]
-                if vals.ndim == 1:
-                    vals = vals[:, None]
-                else:
-                    vals = vals.reshape(vals.shape[0], -1)
-                chain_arrays.append(vals)
-            chains.append(jnp.concatenate(chain_arrays, axis=-1))
-        return chains, param_names
-    raise TypeError(
-        f"Cannot extract chains from nutpie trace of type {type(trace).__name__}"
-    )
+    if not hasattr(trace, "posterior"):
+        raise TypeError(
+            f"Cannot extract chains from nutpie trace of type {type(trace).__name__}"
+        )
+    if keep_names is not None:
+        param_names = list(keep_names)
+    else:
+        param_names = list(trace.posterior.data_vars)
+    return extract_chain_columns(trace, param_names, num_chains), param_names
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -74,7 +74,7 @@ def condition_on_nutpie(
 # ---------------------------------------------------------------------------
 
 
-def _compile_for_nutpie(model: Any, data: Any) -> tuple[Any, Any]:
+def _compile_for_nutpie(model: Any, data: Any) -> tuple[Any, Any | None]:
     """Compile a model for nutpie sampling.
 
     Returns ``(compiled, pymc_build)``. ``pymc_build`` is the

--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -54,7 +54,7 @@ def condition_on_nutpie(
     # it from the conditioned build; Stan models carry their own
     # record_template, if any.
     if pymc_build is not None:
-        record_template = model.record_template_for(pymc_build)
+        record_template = model._record_template_for(pymc_build)
     else:
         record_template = getattr(model, "record_template", None)
 

--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -53,7 +53,12 @@ def condition_on_nutpie(
         chains=num_chains, seed=random_seed, **kwargs,
     )
 
-    chains, param_names = _extract_chains(trace, num_chains)
+    # PyMC: extract chain columns in ``_param_names`` order so they line
+    # up with ``record_template_for`` (nutpie sorts ``posterior.data_vars``
+    # alphabetically, which would otherwise mislabel draws). Stan: take
+    # trace order.
+    keep_names = list(model._param_names) if pymc_build is not None else None
+    chains, param_names = _extract_chains(trace, num_chains, keep_names=keep_names)
 
     # Build the template from the same conditioned model nutpie sampled
     # (PyMC only); Stan models carry their own record_template, if any.
@@ -97,11 +102,38 @@ def _compile_for_nutpie(model: Any, data: Any) -> tuple[Any, Any | None]:
     )
 
 
-def _extract_chains(trace: Any, num_chains: int) -> tuple[list, list]:
-    """Extract per-chain sample arrays from a nutpie ArviZ trace."""
+def _extract_chains(
+    trace: Any, num_chains: int, *, keep_names: list[str] | None = None,
+) -> tuple[list, list]:
+    """Extract per-chain sample arrays from a nutpie ArviZ trace.
+
+    Parameters
+    ----------
+    trace : nutpie ArviZ trace
+        Trace exposing a ``posterior`` group.
+    num_chains : int
+        Number of chains to extract.
+    keep_names : list of str or None
+        If given, extract exactly these variables, in this order, instead
+        of ``posterior.data_vars`` order. nutpie orders ``data_vars``
+        alphabetically, so PyMC callers pass the model's ``_param_names``
+        to keep chain-column order aligned with the ``record_template``
+        field order (otherwise the flat chain is split positionally and
+        draws are silently mislabeled). Stan callers pass ``None`` and
+        take trace order.
+
+    Returns
+    -------
+    tuple[list, list]
+        Per-chain concatenated arrays, and the resolved variable-name
+        order.
+    """
     if hasattr(trace, "posterior"):
         posterior = trace.posterior
-        param_names = list(posterior.data_vars)
+        if keep_names is not None:
+            param_names = list(keep_names)
+        else:
+            param_names = list(posterior.data_vars)
         chains = []
         for c in range(num_chains):
             chain_arrays = []

--- a/probpipe/inference/_pymc_method.py
+++ b/probpipe/inference/_pymc_method.py
@@ -48,11 +48,8 @@ class PyMCNutsMethod(InferenceMethod):
         random_seed = kwargs.get("random_seed", 0)
 
         model = dist._pymc_model(data=observed)
-        # Resolve the names to infer (canonical params plus any observed
-        # left free under partial conditioning) and the template, before
-        # sampling — so a dynamic-RV or non-concrete model fails fast with
-        # a clear error rather than an opaque KeyError during extraction.
-        # Extraction and template share `param_names`, so columns line up.
+        # Resolve the inferred names + template before sampling (fail fast
+        # on a dynamic-RV / non-concrete model); extraction shares them.
         param_names = dist._conditioned_param_names(model)
         record_template = dist._record_template_for(model, param_names)
         with model:
@@ -114,8 +111,8 @@ class PyMCADVIMethod(InferenceMethod):
         vi_method = kwargs.get("vi_method", "advi")
 
         model = dist._pymc_model(data=observed)
-        # Resolve names + template before fitting (fail fast on dynamic-RV
-        # or non-concrete models); extraction shares `param_names`.
+        # Resolve the inferred names + template before fitting; extraction
+        # shares them.
         param_names = dist._conditioned_param_names(model)
         record_template = dist._record_template_for(model, param_names)
         with model:

--- a/probpipe/inference/_pymc_method.py
+++ b/probpipe/inference/_pymc_method.py
@@ -51,7 +51,7 @@ class PyMCNutsMethod(InferenceMethod):
         # Build the template before sampling so a non-concrete or
         # dynamic-RV model fails fast with a clear error rather than an
         # opaque KeyError during chain extraction.
-        record_template = dist.record_template_for(model)
+        record_template = dist._record_template_for(model)
         with model:
             trace = pm.sample(
                 draws=num_results,
@@ -113,7 +113,7 @@ class PyMCADVIMethod(InferenceMethod):
         model = dist._pymc_model(data=observed)
         # Build the template before fitting so a non-concrete or
         # dynamic-RV model fails fast with a clear error.
-        record_template = dist.record_template_for(model)
+        record_template = dist._record_template_for(model)
         with model:
             approx = pm.fit(n=num_iterations, method=vi_method, random_seed=random_seed)
             trace = approx.sample(num_results)

--- a/probpipe/inference/_pymc_method.py
+++ b/probpipe/inference/_pymc_method.py
@@ -48,10 +48,13 @@ class PyMCNutsMethod(InferenceMethod):
         random_seed = kwargs.get("random_seed", 0)
 
         model = dist._pymc_model(data=observed)
-        # Build the template before sampling so a non-concrete or
-        # dynamic-RV model fails fast with a clear error rather than an
-        # opaque KeyError during chain extraction.
-        record_template = dist._record_template_for(model)
+        # Resolve the names to infer (canonical params plus any observed
+        # left free under partial conditioning) and the template, before
+        # sampling — so a dynamic-RV or non-concrete model fails fast with
+        # a clear error rather than an opaque KeyError during extraction.
+        # Extraction and template share `param_names`, so columns line up.
+        param_names = dist._conditioned_param_names(model)
+        record_template = dist._record_template_for(model, param_names)
         with model:
             trace = pm.sample(
                 draws=num_results,
@@ -62,7 +65,7 @@ class PyMCNutsMethod(InferenceMethod):
                 return_inferencedata=True,
             )
 
-        chains = extract_chain_columns(trace, dist._param_names, num_chains)
+        chains = extract_chain_columns(trace, param_names, num_chains)
 
         return make_posterior(
             chains, parents=(dist,), algorithm="pymc_nuts",
@@ -111,15 +114,16 @@ class PyMCADVIMethod(InferenceMethod):
         vi_method = kwargs.get("vi_method", "advi")
 
         model = dist._pymc_model(data=observed)
-        # Build the template before fitting so a non-concrete or
-        # dynamic-RV model fails fast with a clear error.
-        record_template = dist._record_template_for(model)
+        # Resolve names + template before fitting (fail fast on dynamic-RV
+        # or non-concrete models); extraction shares `param_names`.
+        param_names = dist._conditioned_param_names(model)
+        record_template = dist._record_template_for(model, param_names)
         with model:
             approx = pm.fit(n=num_iterations, method=vi_method, random_seed=random_seed)
             trace = approx.sample(num_results)
 
         # ADVI's approx.sample yields a single chain of `num_results` draws.
-        chains = extract_chain_columns(trace, dist._param_names, num_chains=1)
+        chains = extract_chain_columns(trace, param_names, num_chains=1)
         algorithm = f"pymc_{vi_method}"
 
         return make_posterior(

--- a/probpipe/inference/_pymc_method.py
+++ b/probpipe/inference/_pymc_method.py
@@ -4,27 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-import jax.numpy as jnp
-
 from ..core._registry import MethodInfo
 from ._approximate_distribution import ApproximateDistribution, make_posterior
+from ._inference_utils import extract_chain_columns
 from ._registry import InferenceMethod
-
-
-def _extract_pymc_chains(trace: Any, param_names: list[str], num_chains: int) -> list:
-    """Extract per-chain sample arrays from a PyMC ArviZ trace."""
-    chains = []
-    for c in range(num_chains):
-        chain_arrays = []
-        for name in param_names:
-            vals = trace.posterior[name].values[c]
-            if vals.ndim == 1:
-                vals = vals[:, None]
-            else:
-                vals = vals.reshape(vals.shape[0], -1)
-            chain_arrays.append(jnp.asarray(vals))
-        chains.append(jnp.concatenate(chain_arrays, axis=-1))
-    return chains
 
 
 class PyMCNutsMethod(InferenceMethod):
@@ -65,6 +48,10 @@ class PyMCNutsMethod(InferenceMethod):
         random_seed = kwargs.get("random_seed", 0)
 
         model = dist._pymc_model(data=observed)
+        # Build the template before sampling so a non-concrete or
+        # dynamic-RV model fails fast with a clear error rather than an
+        # opaque KeyError during chain extraction.
+        record_template = dist.record_template_for(model)
         with model:
             trace = pm.sample(
                 draws=num_results,
@@ -75,11 +62,11 @@ class PyMCNutsMethod(InferenceMethod):
                 return_inferencedata=True,
             )
 
-        chains = _extract_pymc_chains(trace, dist._param_names, num_chains)
+        chains = extract_chain_columns(trace, dist._param_names, num_chains)
 
         return make_posterior(
             chains, parents=(dist,), algorithm="pymc_nuts",
-            auxiliary=trace, record_template=dist.record_template_for(model),
+            auxiliary=trace, record_template=record_template,
             num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
         )
 
@@ -117,7 +104,6 @@ class PyMCADVIMethod(InferenceMethod):
 
     def execute(self, dist: Any, observed: Any, **kwargs: Any) -> ApproximateDistribution:
         import pymc as pm
-        import numpy as np
 
         num_iterations = kwargs.get("num_iterations", 30000)
         num_results = kwargs.get("num_results", 1000)
@@ -125,20 +111,19 @@ class PyMCADVIMethod(InferenceMethod):
         vi_method = kwargs.get("vi_method", "advi")
 
         model = dist._pymc_model(data=observed)
+        # Build the template before fitting so a non-concrete or
+        # dynamic-RV model fails fast with a clear error.
+        record_template = dist.record_template_for(model)
         with model:
             approx = pm.fit(n=num_iterations, method=vi_method, random_seed=random_seed)
             trace = approx.sample(num_results)
 
-        chain_draws = [trace.posterior[n].values[0] for n in dist._param_names]
-        samples = np.concatenate(
-            [np.atleast_2d(d).reshape(num_results, -1) for d in chain_draws],
-            axis=1,
-        )
-        chains = [jnp.asarray(samples)]
+        # ADVI's approx.sample yields a single chain of `num_results` draws.
+        chains = extract_chain_columns(trace, dist._param_names, num_chains=1)
         algorithm = f"pymc_{vi_method}"
 
         return make_posterior(
             chains, parents=(dist,), algorithm=algorithm,
-            auxiliary=trace, record_template=dist.record_template_for(model),
+            auxiliary=trace, record_template=record_template,
             num_iterations=num_iterations,
         )

--- a/probpipe/inference/_pymc_method.py
+++ b/probpipe/inference/_pymc_method.py
@@ -79,7 +79,7 @@ class PyMCNutsMethod(InferenceMethod):
 
         return make_posterior(
             chains, parents=(dist,), algorithm="pymc_nuts",
-            auxiliary=trace, record_template=getattr(dist, "record_template", None),
+            auxiliary=trace, record_template=dist.record_template_for(model),
             num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
         )
 
@@ -139,6 +139,6 @@ class PyMCADVIMethod(InferenceMethod):
 
         return make_posterior(
             chains, parents=(dist,), algorithm=algorithm,
-            auxiliary=trace, record_template=getattr(dist, "record_template", None),
+            auxiliary=trace, record_template=dist.record_template_for(model),
             num_iterations=num_iterations,
         )

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -6,6 +6,7 @@ Inference is handled by registered methods in ``probpipe.inference``.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from typing import Any, Callable
 
 import jax.numpy as jnp
@@ -115,16 +116,21 @@ class PyMCModel(ProbabilisticModel):
         """
         return self._last_conditioned_model or self._unconditioned_model
 
+    def _param_rvs(self) -> Iterator[tuple[str, Any]]:
+        """Yield ``(name, rv)`` for each free parameter, in
+        ``_param_names`` order, looked up in the introspected model.
+        """
+        free_rvs = {rv.name: rv for rv in self._introspect_model().free_RVs}
+        for name in self._param_names:
+            rv = free_rvs.get(name)
+            if rv is not None:
+                yield name, rv
+
     @property
     def event_shape(self) -> tuple[int, ...]:
         # Total number of scalar parameters (excluding observed)
-        model = self._introspect_model()
-        free_rvs = {rv.name: rv for rv in model.free_RVs}
         total = 0
-        for name in self._param_names:
-            rv = free_rvs.get(name)
-            if rv is None:
-                continue
+        for _name, rv in self._param_rvs():
             size = 1
             for s in rv.type.shape:
                 if s is not None:
@@ -159,13 +165,8 @@ class PyMCModel(ProbabilisticModel):
             produce an under-shaped template and confusing downstream
             errors.
         """
-        model = self._introspect_model()
-        free_rvs = {rv.name: rv for rv in model.free_RVs}
         fields: dict[str, tuple[int, ...]] = {}
-        for name in self._param_names:
-            rv = free_rvs.get(name)
-            if rv is None:
-                continue
+        for name, rv in self._param_rvs():
             raw_shape = tuple(rv.type.shape)
             if any(s is None for s in raw_shape):
                 raise ValueError(

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -132,11 +132,13 @@ class PyMCModel(ProbabilisticModel):
         """Parameter template built from a specific PyMC model build.
 
         Inference paths call this with the data-conditioned model they
-        construct, so the template matches the chain even for RVs whose
-        shape depends on data size (e.g. per-observation random effects,
-        ``pm.Normal('alpha', 0, 1, shape=X.shape[0])``). The public
-        :attr:`record_template` property uses the declared (no-data)
-        build instead.
+        construct and pass the result through to :func:`make_posterior`,
+        so the posterior carries Record structure (``mean(post)`` returns
+        a ``NumericRecord`` keyed by the PyMC RV names) and the template
+        matches the chain even for RVs whose shape depends on data size
+        (e.g. per-observation random effects, ``pm.Normal('alpha', 0, 1,
+        shape=X.shape[0])``). The public :attr:`record_template` property
+        uses the declared (no-data) build instead.
 
         Scalar PyMC RVs (e.g. ``pm.Normal('intercept', 0, 1)``) become
         fields with event shape ``()``; shape-:math:`k` RVs (e.g.
@@ -169,19 +171,12 @@ class PyMCModel(ProbabilisticModel):
 
     @property
     def record_template(self) -> NumericRecordTemplate:
-        """Template that pairs each free PyMC parameter with its shape.
+        """Declared parameter template from the no-data build done at
+        construction (see :meth:`record_template_for`).
 
-        Inference methods pass this through to :func:`make_posterior` so
-        the resulting :class:`ApproximateDistribution` carries Record
-        structure: ``mean(post)`` returns a ``NumericRecord`` keyed by
-        the PyMC RV names, matching the field layout of any other
-        ProbPipe posterior.
-
-        Reports the declared shapes from the no-data build done at
-        construction. For RVs whose shape depends on data size, the
-        conditioned shapes are resolved at inference time via
-        :meth:`record_template_for`; this property cannot know them
-        without data.
+        For RVs whose shape depends on data size, the conditioned shapes
+        are resolved at inference time via :meth:`record_template_for`;
+        this property cannot know them without data.
         """
         return self.record_template_for(self._unconditioned_model)
 

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -103,24 +103,14 @@ class PyMCModel(ProbabilisticModel):
             for rv in self._unconditioned_model.free_RVs
             if rv.name not in observed_set
         )
-        # Cached by ``_pymc_model`` when given data, so shape queries can
-        # see data-dependent RV shapes rather than the no-data build's.
-        self._last_conditioned_model: Any | None = None
 
     # -- Distribution interface ---------------------------------------------
 
-    def _introspect_model(self) -> Any:
-        """Model whose RV shapes drive ``event_shape`` /
-        ``record_template``: the data-conditioned build when available,
-        else the unconditioned one from construction.
-        """
-        return self._last_conditioned_model or self._unconditioned_model
-
-    def _param_rvs(self) -> Iterator[tuple[str, Any]]:
+    def _param_rvs(self, model: Any) -> Iterator[tuple[str, Any]]:
         """Yield ``(name, rv)`` for each free parameter, in
-        ``_param_names`` order, looked up in the introspected model.
+        ``_param_names`` order, looked up in *model*.
         """
-        free_rvs = {rv.name: rv for rv in self._introspect_model().free_RVs}
+        free_rvs = {rv.name: rv for rv in model.free_RVs}
         for name in self._param_names:
             rv = free_rvs.get(name)
             if rv is not None:
@@ -130,7 +120,7 @@ class PyMCModel(ProbabilisticModel):
     def event_shape(self) -> tuple[int, ...]:
         # Total number of scalar parameters (excluding observed)
         total = 0
-        for _name, rv in self._param_rvs():
+        for _name, rv in self._param_rvs(self._unconditioned_model):
             size = 1
             for s in rv.type.shape:
                 if s is not None:
@@ -138,23 +128,20 @@ class PyMCModel(ProbabilisticModel):
             total += size
         return (total,)
 
-    @property
-    def record_template(self) -> NumericRecordTemplate:
-        """Template that pairs each free PyMC parameter with its shape.
+    def record_template_for(self, model: Any) -> NumericRecordTemplate:
+        """Parameter template built from a specific PyMC model build.
 
-        Inference methods pass this through to :func:`make_posterior` so
-        the resulting :class:`ApproximateDistribution` carries Record
-        structure: ``mean(post)`` returns a ``NumericRecord`` keyed by
-        the PyMC RV names, matching the field layout of any other
-        ProbPipe posterior.
+        Inference paths call this with the data-conditioned model they
+        construct, so the template matches the chain even for RVs whose
+        shape depends on data size (e.g. per-observation random effects,
+        ``pm.Normal('alpha', 0, 1, shape=X.shape[0])``). The public
+        :attr:`record_template` property uses the declared (no-data)
+        build instead.
 
         Scalar PyMC RVs (e.g. ``pm.Normal('intercept', 0, 1)``) become
         fields with event shape ``()``; shape-:math:`k` RVs (e.g.
         ``pm.Normal('beta', 0, 1, shape=k)``) become fields with event
-        shape ``(k,)``. Shapes that depend on the conditioning data
-        (e.g. per-observation random effects, ``pm.Normal('alpha', 0,
-        1, shape=X.shape[0])``) are reported correctly once the model
-        has been conditioned on data.
+        shape ``(k,)``.
 
         Raises
         ------
@@ -166,7 +153,7 @@ class PyMCModel(ProbabilisticModel):
             errors.
         """
         fields: dict[str, tuple[int, ...]] = {}
-        for name, rv in self._param_rvs():
+        for name, rv in self._param_rvs(model):
             raw_shape = tuple(rv.type.shape)
             if any(s is None for s in raw_shape):
                 raise ValueError(
@@ -179,6 +166,24 @@ class PyMCModel(ProbabilisticModel):
                 )
             fields[name] = tuple(int(s) for s in raw_shape)
         return NumericRecordTemplate(**fields)
+
+    @property
+    def record_template(self) -> NumericRecordTemplate:
+        """Template that pairs each free PyMC parameter with its shape.
+
+        Inference methods pass this through to :func:`make_posterior` so
+        the resulting :class:`ApproximateDistribution` carries Record
+        structure: ``mean(post)`` returns a ``NumericRecord`` keyed by
+        the PyMC RV names, matching the field layout of any other
+        ProbPipe posterior.
+
+        Reports the declared shapes from the no-data build done at
+        construction. For RVs whose shape depends on data size, the
+        conditioned shapes are resolved at inference time via
+        :meth:`record_template_for`; this property cannot know them
+        without data.
+        """
+        return self.record_template_for(self._unconditioned_model)
 
     # -- Named components interface ------------------------------------------
 
@@ -243,29 +248,23 @@ class PyMCModel(ProbabilisticModel):
         the user's model function — PyMC's tensor backend doesn't
         multiply with raw JAX arrays.
 
-        When ``data`` is given, the built model is cached on
-        ``self._last_conditioned_model`` so later shape queries see the
-        data-conditioned RV shapes.
+        The returned model is stateless and not retained on ``self``;
+        callers that need the conditioned shapes (e.g. for
+        :meth:`record_template_for`) pass this build back explicitly.
         """
         if data is None:
             return self._model_fn()
         if isinstance(data, dict):
-            model = self._model_fn(**{k: _to_numpy(v) for k, v in data.items()})
-        else:
-            # Local import to avoid a modeling→core cycle at module load.
-            from ..core.record import Record
-            if isinstance(data, Record):
-                model = self._model_fn(**{
-                    name: _to_numpy(data[name])
-                    for name in self._observed_names
-                    if name in data.fields
-                })
-            else:
-                model = self._model_fn(
-                    **{self._observed_names[0]: _to_numpy(data)}
-                )
-        self._last_conditioned_model = model
-        return model
+            return self._model_fn(**{k: _to_numpy(v) for k, v in data.items()})
+        # Local import to avoid a modeling→core cycle at module load.
+        from ..core.record import Record
+        if isinstance(data, Record):
+            return self._model_fn(**{
+                name: _to_numpy(data[name])
+                for name in self._observed_names
+                if name in data.fields
+            })
+        return self._model_fn(**{self._observed_names[0]: _to_numpy(data)})
 
     def __repr__(self) -> str:
         params = ", ".join(self._param_names)

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -113,20 +113,42 @@ class PyMCModel(ProbabilisticModel):
         Parameters
         ----------
         model : pymc.Model
-            A build of this model (conditioned or not). Its free RVs
-            must include every name in ``_param_names``.
+            A build of this model (conditioned or not). Its free
+            (non-observed) random variables must be exactly the set
+            frozen as ``_param_names`` at construction.
 
         Raises
         ------
         ValueError
-            If a name in ``_param_names`` (frozen from the no-data build
-            at construction) is absent from *model*'s free RVs — i.e.
-            the random-variable set changed between builds. ProbPipe
-            does not support such dynamic random variables; see
+            If *model*'s set of free (non-observed) random variables
+            differs from ``_param_names`` (frozen from the no-data build
+            at construction) in either direction — a canonical parameter
+            missing from this build, or a new free RV introduced by it.
+            ProbPipe does not support models whose random-variable set
+            changes with the data (dynamic random variables); see
             https://github.com/TARPS-group/prob-pipe/issues/232.
         """
         free_rvs = {rv.name: rv for rv in model.free_RVs}
+        # Reject additive dynamic RVs: a free RV in this build that was
+        # not a free parameter at construction (and isn't an observed
+        # name). Without this it would be silently dropped from both the
+        # template and the chain (extraction filters to _param_names),
+        # so the user's parameter would vanish from the posterior.
+        extra = set(free_rvs) - set(self._param_names) - set(self._observed_names)
+        if extra:
+            raise ValueError(
+                f"PyMC build introduced free random variable(s) "
+                f"{sorted(extra)} not present in the model built at "
+                f"construction. ProbPipe does not support models whose "
+                f"set of free random variables changes with the data "
+                f"(dynamic random variables); the parameter set must be "
+                f"fixed across builds, with only per-variable shapes "
+                f"allowed to depend on data size. See "
+                f"https://github.com/TARPS-group/prob-pipe/issues/232."
+            )
         for name in self._param_names:
+            # Reject subtractive dynamic RVs: a canonical parameter that
+            # this build dropped.
             if name not in free_rvs:
                 raise ValueError(
                     f"PyMC random variable {name!r} is present in the "
@@ -150,7 +172,7 @@ class PyMCModel(ProbabilisticModel):
         """
         return (self.record_template.flat_size,)
 
-    def record_template_for(self, model: Any) -> NumericRecordTemplate:
+    def _record_template_for(self, model: Any) -> NumericRecordTemplate:
         """Parameter template built from a specific PyMC model build.
 
         Inference paths call this with the data-conditioned model they
@@ -187,9 +209,10 @@ class PyMCModel(ProbabilisticModel):
             its ``type.shape``. The record-template machinery requires
             concrete shapes — silently dropping a ``None`` dim would
             produce an under-shaped template and confusing downstream
-            errors. Also raised if *model* is missing a free RV present
-            at construction (dynamic random variables are unsupported;
-            see :meth:`_param_rvs`).
+            errors. Also raised if *model*'s free-RV set differs from the
+            construction-time parameter set in either direction — a
+            canonical parameter missing, or a new RV introduced (dynamic
+            random variables are unsupported; see :meth:`_param_rvs`).
         """
         fields: dict[str, tuple[int, ...]] = {}
         for name, rv in self._param_rvs(model):
@@ -208,13 +231,13 @@ class PyMCModel(ProbabilisticModel):
     @property
     def record_template(self) -> NumericRecordTemplate:
         """Declared parameter template from the no-data build done at
-        construction (see :meth:`record_template_for`).
+        construction (see :meth:`_record_template_for`).
 
         For RVs whose shape depends on data size, the conditioned shapes
-        are resolved at inference time via :meth:`record_template_for`;
+        are resolved at inference time via :meth:`_record_template_for`;
         this property cannot know them without data.
         """
-        return self.record_template_for(self._unconditioned_model)
+        return self._record_template_for(self._unconditioned_model)
 
     # -- Named components interface ------------------------------------------
 
@@ -281,7 +304,7 @@ class PyMCModel(ProbabilisticModel):
 
         The returned model is stateless and not retained on ``self``;
         callers that need the conditioned shapes (e.g. for
-        :meth:`record_template_for`) pass this build back explicitly.
+        :meth:`_record_template_for`) pass this build back explicitly.
         """
         if data is None:
             return self._model_fn()

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -142,15 +142,13 @@ class PyMCModel(ProbabilisticModel):
 
     @property
     def event_shape(self) -> tuple[int, ...]:
-        # Total number of scalar parameters (excluding observed)
-        total = 0
-        for _name, rv in self._param_rvs(self._unconditioned_model):
-            size = 1
-            for s in rv.type.shape:
-                if s is not None:
-                    size *= s
-            total += size
-        return (total,)
+        """Total number of scalar free parameters (observed excluded).
+
+        Derived from :attr:`record_template` so the flat size and the
+        per-field template can never disagree; consequently this raises
+        on a non-concrete free-RV shape, just as the template does.
+        """
+        return (self.record_template.flat_size,)
 
     def record_template_for(self, model: Any) -> NumericRecordTemplate:
         """Parameter template built from a specific PyMC model build.

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -117,9 +117,7 @@ class PyMCModel(ProbabilisticModel):
             A build of this model.
         names : sequence of str
             Free-RV names to yield, in order. Every name must be a free
-            RV of *model*; callers derive *names* from the build itself —
-            ``_param_names`` for the declared template, or
-            :meth:`_conditioned_param_names` for a conditioned build.
+            RV of *model*.
         """
         free_rvs = {rv.name: rv for rv in model.free_RVs}
         for name in names:
@@ -143,9 +141,7 @@ class PyMCModel(ProbabilisticModel):
             introduced. ProbPipe does not support models whose
             non-observed random-variable set changes with the data
             (dynamic random variables); see
-            https://github.com/TARPS-group/prob-pipe/issues/232. Observed
-            names left free are allowed — that is partial conditioning,
-            not a dynamic RV.
+            https://github.com/TARPS-group/prob-pipe/issues/232.
         """
         free = {rv.name for rv in model.free_RVs}
         missing = [n for n in self._param_names if n not in free]
@@ -172,8 +168,7 @@ class PyMCModel(ProbabilisticModel):
                 f"on data size. See "
                 f"https://github.com/TARPS-group/prob-pipe/issues/232."
             )
-        # Partial conditioning: observed names the caller left unsupplied
-        # are free in this build and are inferred, so include them.
+        # Partial conditioning: include observed names left free.
         omitted_observed = tuple(n for n in self._observed_names if n in free)
         return tuple(self._param_names) + omitted_observed
 
@@ -181,9 +176,8 @@ class PyMCModel(ProbabilisticModel):
     def event_shape(self) -> tuple[int, ...]:
         """Total number of scalar free parameters (observed excluded).
 
-        Derived from :attr:`record_template` so the flat size and the
-        per-field template can never disagree; consequently this raises
-        on a non-concrete free-RV shape, just as the template does.
+        Derived from :attr:`record_template`; raises on a non-concrete
+        free-RV shape, as the template does.
         """
         return (self.record_template.flat_size,)
 
@@ -192,20 +186,11 @@ class PyMCModel(ProbabilisticModel):
     ) -> NumericRecordTemplate:
         """Parameter template over *names*, read from a PyMC *model* build.
 
-        Inference paths call this with the data-conditioned build and the
-        names from :meth:`_conditioned_param_names`, then pass the result
-        to :func:`make_posterior`, so the posterior carries Record
-        structure (``mean(post)`` returns a ``NumericRecord`` keyed by the
-        PyMC RV names) and the template matches the chain even for RVs
-        whose shape depends on data size (e.g. per-observation random
-        effects, ``pm.Normal('alpha', 0, 1, shape=X.shape[0])``). The
-        public :attr:`record_template` property passes the declared
-        (no-data) build and ``_param_names`` instead.
-
-        Scalar PyMC RVs (e.g. ``pm.Normal('intercept', 0, 1)``) become
-        fields with event shape ``()``; shape-:math:`k` RVs (e.g.
-        ``pm.Normal('beta', 0, 1, shape=k)``) become fields with event
-        shape ``(k,)``.
+        Inference passes the data-conditioned build and the names from
+        :meth:`_conditioned_param_names`; the :attr:`record_template`
+        property passes the no-data build and ``_param_names``. Scalar
+        PyMC RVs become fields with event shape ``()``; shape-:math:`k`
+        RVs become fields with event shape ``(k,)``.
 
         Parameters
         ----------
@@ -223,10 +208,7 @@ class PyMCModel(ProbabilisticModel):
         ------
         ValueError
             If any named free RV has a non-concrete (``None``) dimension
-            in its ``type.shape``. The record-template machinery requires
-            concrete shapes — silently dropping a ``None`` dim would
-            produce an under-shaped template and confusing downstream
-            errors.
+            in its ``type.shape``.
         """
         fields: dict[str, tuple[int, ...]] = {}
         for name, rv in self._param_rvs(model, names):
@@ -244,16 +226,12 @@ class PyMCModel(ProbabilisticModel):
 
     @property
     def record_template(self) -> NumericRecordTemplate:
-        """Declared parameter template from the no-data build done at
-        construction — the canonical parameters, with observed variables
-        excluded.
+        """Declared parameter template from the no-data build (canonical
+        parameters, observed variables excluded).
 
-        For RVs whose shape depends on data size, the conditioned shapes
-        are resolved at inference time via :meth:`_record_template_for`;
-        this property cannot know them without data. The inferred set can
-        also differ under partial conditioning (an unsupplied observed
-        variable becomes a free parameter), which this property likewise
-        does not reflect.
+        Data-dependent shapes, and any observed variable left free under
+        partial conditioning, are resolved at inference time via
+        :meth:`_record_template_for`; this property reflects neither.
         """
         return self._record_template_for(
             self._unconditioned_model, self._param_names,
@@ -322,9 +300,8 @@ class PyMCModel(ProbabilisticModel):
         the user's model function — PyMC's tensor backend doesn't
         multiply with raw JAX arrays.
 
-        The returned model is stateless and not retained on ``self``;
-        callers that need the conditioned shapes (e.g. for
-        :meth:`_record_template_for`) pass this build back explicitly.
+        The returned model is not retained on ``self``; callers that need
+        the conditioned shapes pass it back explicitly.
         """
         if data is None:
             return self._model_fn()

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -169,6 +169,19 @@ class PyMCModel(ProbabilisticModel):
         ``pm.Normal('beta', 0, 1, shape=k)``) become fields with event
         shape ``(k,)``.
 
+        Parameters
+        ----------
+        model : pymc.Model
+            A build of this model (typically the data-conditioned build
+            returned by :meth:`_pymc_model`) to introspect for free-RV
+            shapes.
+
+        Returns
+        -------
+        NumericRecordTemplate
+            One field per free parameter (observed variables excluded),
+            keyed by RV name and carrying its event shape.
+
         Raises
         ------
         ValueError
@@ -176,7 +189,9 @@ class PyMCModel(ProbabilisticModel):
             its ``type.shape``. The record-template machinery requires
             concrete shapes — silently dropping a ``None`` dim would
             produce an under-shaped template and confusing downstream
-            errors.
+            errors. Also raised if *model* is missing a free RV present
+            at construction (dynamic random variables are unsupported;
+            see :meth:`_param_rvs`).
         """
         fields: dict[str, tuple[int, ...]] = {}
         for name, rv in self._param_rvs(model):
@@ -184,10 +199,9 @@ class PyMCModel(ProbabilisticModel):
             if any(s is None for s in raw_shape):
                 raise ValueError(
                     f"PyMC RV {name!r} has a non-concrete shape "
-                    f"{raw_shape}; PyMCModel.record_template requires "
-                    f"every free RV to have a fully concrete event "
-                    f"shape. Specify the shape explicitly when "
-                    f"declaring the RV (e.g. "
+                    f"{raw_shape}; PyMCModel templates require every free "
+                    f"RV to have a fully concrete event shape. Specify the "
+                    f"shape explicitly when declaring the RV (e.g. "
                     f"`pm.Normal({name!r}, 0, 1, shape=k)`)."
                 )
             fields[name] = tuple(int(s) for s in raw_shape)

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -96,7 +96,6 @@ class PyMCModel(ProbabilisticModel):
         # Build the model once without data to discover free parameters.
         # When called with no args, observed vars become free RVs.
         self._unconditioned_model = model_fn()
-        all_free = {rv.name for rv in self._unconditioned_model.free_RVs}
         observed_set = set(self._observed_names)
         self._param_names = tuple(
             rv.name
@@ -106,61 +105,77 @@ class PyMCModel(ProbabilisticModel):
 
     # -- Distribution interface ---------------------------------------------
 
-    def _param_rvs(self, model: Any) -> Iterator[tuple[str, Any]]:
-        """Yield ``(name, rv)`` for each free parameter, in
-        ``_param_names`` order, looked up in *model*.
+    def _param_rvs(
+        self, model: Any, names: tuple[str, ...] | list[str],
+    ) -> Iterator[tuple[str, Any]]:
+        """Yield ``(name, rv)`` for each name in *names*, looked up in
+        *model*'s free RVs, in the given order.
 
         Parameters
         ----------
         model : pymc.Model
-            A build of this model (conditioned or not). Its free
-            (non-observed) random variables must be exactly the set
-            frozen as ``_param_names`` at construction.
+            A build of this model.
+        names : sequence of str
+            Free-RV names to yield, in order. Every name must be a free
+            RV of *model*; callers derive *names* from the build itself —
+            ``_param_names`` for the declared template, or
+            :meth:`_conditioned_param_names` for a conditioned build.
+        """
+        free_rvs = {rv.name: rv for rv in model.free_RVs}
+        for name in names:
+            yield name, free_rvs[name]
+
+    def _conditioned_param_names(self, model: Any) -> tuple[str, ...]:
+        """Free-parameter names to infer for a data-conditioned *model*.
+
+        Returns the canonical parameters (``_param_names``, frozen at
+        construction) plus any observed names left free in this build —
+        observed variables the caller did not supply data for, which are
+        then inferred (**partial conditioning**). Supplied observed
+        variables are observed (not free) and excluded.
 
         Raises
         ------
         ValueError
-            If *model*'s set of free (non-observed) random variables
-            differs from ``_param_names`` (frozen from the no-data build
-            at construction) in either direction — a canonical parameter
-            missing from this build, or a new free RV introduced by it.
-            ProbPipe does not support models whose random-variable set
-            changes with the data (dynamic random variables); see
-            https://github.com/TARPS-group/prob-pipe/issues/232.
+            If *model*'s free-RV set differs from the construction-time
+            parameter set by a **non-observed** RV — a canonical parameter
+            the build dropped, or a new non-observed free RV it
+            introduced. ProbPipe does not support models whose
+            non-observed random-variable set changes with the data
+            (dynamic random variables); see
+            https://github.com/TARPS-group/prob-pipe/issues/232. Observed
+            names left free are allowed — that is partial conditioning,
+            not a dynamic RV.
         """
-        free_rvs = {rv.name: rv for rv in model.free_RVs}
-        # Reject additive dynamic RVs: a free RV in this build that was
-        # not a free parameter at construction (and isn't an observed
-        # name). Without this it would be silently dropped from both the
-        # template and the chain (extraction filters to _param_names),
-        # so the user's parameter would vanish from the posterior.
-        extra = set(free_rvs) - set(self._param_names) - set(self._observed_names)
+        free = {rv.name for rv in model.free_RVs}
+        missing = [n for n in self._param_names if n not in free]
+        if missing:
+            raise ValueError(
+                f"PyMC random variable(s) {sorted(missing)} present in the "
+                f"model built at construction (no data) but absent from "
+                f"this build. ProbPipe does not support models whose set "
+                f"of free random variables changes with the data (dynamic "
+                f"random variables); the parameter set must be fixed across "
+                f"builds, with only per-variable shapes allowed to depend "
+                f"on data size. See "
+                f"https://github.com/TARPS-group/prob-pipe/issues/232."
+            )
+        extra = free - set(self._param_names) - set(self._observed_names)
         if extra:
             raise ValueError(
                 f"PyMC build introduced free random variable(s) "
                 f"{sorted(extra)} not present in the model built at "
-                f"construction. ProbPipe does not support models whose "
-                f"set of free random variables changes with the data "
-                f"(dynamic random variables); the parameter set must be "
-                f"fixed across builds, with only per-variable shapes "
-                f"allowed to depend on data size. See "
+                f"construction. ProbPipe does not support models whose set "
+                f"of free random variables changes with the data (dynamic "
+                f"random variables); the parameter set must be fixed across "
+                f"builds, with only per-variable shapes allowed to depend "
+                f"on data size. See "
                 f"https://github.com/TARPS-group/prob-pipe/issues/232."
             )
-        for name in self._param_names:
-            # Reject subtractive dynamic RVs: a canonical parameter that
-            # this build dropped.
-            if name not in free_rvs:
-                raise ValueError(
-                    f"PyMC random variable {name!r} is present in the "
-                    f"model built at construction (no data) but absent "
-                    f"from this build. ProbPipe does not support models "
-                    f"whose set of free random variables changes with the "
-                    f"data (dynamic random variables); the parameter set "
-                    f"must be fixed across builds, with only per-variable "
-                    f"shapes allowed to depend on data size. See "
-                    f"https://github.com/TARPS-group/prob-pipe/issues/232."
-                )
-            yield name, free_rvs[name]
+        # Partial conditioning: observed names the caller left unsupplied
+        # are free in this build and are inferred, so include them.
+        omitted_observed = tuple(n for n in self._observed_names if n in free)
+        return tuple(self._param_names) + omitted_observed
 
     @property
     def event_shape(self) -> tuple[int, ...]:
@@ -172,17 +187,20 @@ class PyMCModel(ProbabilisticModel):
         """
         return (self.record_template.flat_size,)
 
-    def _record_template_for(self, model: Any) -> NumericRecordTemplate:
-        """Parameter template built from a specific PyMC model build.
+    def _record_template_for(
+        self, model: Any, names: tuple[str, ...] | list[str],
+    ) -> NumericRecordTemplate:
+        """Parameter template over *names*, read from a PyMC *model* build.
 
-        Inference paths call this with the data-conditioned model they
-        construct and pass the result through to :func:`make_posterior`,
-        so the posterior carries Record structure (``mean(post)`` returns
-        a ``NumericRecord`` keyed by the PyMC RV names) and the template
-        matches the chain even for RVs whose shape depends on data size
-        (e.g. per-observation random effects, ``pm.Normal('alpha', 0, 1,
-        shape=X.shape[0])``). The public :attr:`record_template` property
-        uses the declared (no-data) build instead.
+        Inference paths call this with the data-conditioned build and the
+        names from :meth:`_conditioned_param_names`, then pass the result
+        to :func:`make_posterior`, so the posterior carries Record
+        structure (``mean(post)`` returns a ``NumericRecord`` keyed by the
+        PyMC RV names) and the template matches the chain even for RVs
+        whose shape depends on data size (e.g. per-observation random
+        effects, ``pm.Normal('alpha', 0, 1, shape=X.shape[0])``). The
+        public :attr:`record_template` property passes the declared
+        (no-data) build and ``_param_names`` instead.
 
         Scalar PyMC RVs (e.g. ``pm.Normal('intercept', 0, 1)``) become
         fields with event shape ``()``; shape-:math:`k` RVs (e.g.
@@ -192,30 +210,26 @@ class PyMCModel(ProbabilisticModel):
         Parameters
         ----------
         model : pymc.Model
-            A build of this model (typically the data-conditioned build
-            returned by :meth:`_pymc_model`) to introspect for free-RV
-            shapes.
+            A build of this model to introspect for free-RV shapes.
+        names : sequence of str
+            Free-RV names to include, in field order.
 
         Returns
         -------
         NumericRecordTemplate
-            One field per free parameter (observed variables excluded),
-            keyed by RV name and carrying its event shape.
+            One field per name, carrying its event shape.
 
         Raises
         ------
         ValueError
-            If any free RV has a non-concrete (``None``) dimension in
-            its ``type.shape``. The record-template machinery requires
+            If any named free RV has a non-concrete (``None``) dimension
+            in its ``type.shape``. The record-template machinery requires
             concrete shapes — silently dropping a ``None`` dim would
             produce an under-shaped template and confusing downstream
-            errors. Also raised if *model*'s free-RV set differs from the
-            construction-time parameter set in either direction — a
-            canonical parameter missing, or a new RV introduced (dynamic
-            random variables are unsupported; see :meth:`_param_rvs`).
+            errors.
         """
         fields: dict[str, tuple[int, ...]] = {}
-        for name, rv in self._param_rvs(model):
+        for name, rv in self._param_rvs(model, names):
             raw_shape = tuple(rv.type.shape)
             if any(s is None for s in raw_shape):
                 raise ValueError(
@@ -231,13 +245,19 @@ class PyMCModel(ProbabilisticModel):
     @property
     def record_template(self) -> NumericRecordTemplate:
         """Declared parameter template from the no-data build done at
-        construction (see :meth:`_record_template_for`).
+        construction — the canonical parameters, with observed variables
+        excluded.
 
         For RVs whose shape depends on data size, the conditioned shapes
         are resolved at inference time via :meth:`_record_template_for`;
-        this property cannot know them without data.
+        this property cannot know them without data. The inferred set can
+        also differ under partial conditioning (an unsupplied observed
+        variable becomes a free parameter), which this property likewise
+        does not reflect.
         """
-        return self._record_template_for(self._unconditioned_model)
+        return self._record_template_for(
+            self._unconditioned_model, self._param_names,
+        )
 
     # -- Named components interface ------------------------------------------
 

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -102,20 +102,40 @@ class PyMCModel(ProbabilisticModel):
             for rv in self._unconditioned_model.free_RVs
             if rv.name not in observed_set
         )
+        # Populated by ``_pymc_model(data)`` whenever data is supplied.
+        # ``event_shape`` / ``record_template`` prefer this cached build
+        # so RVs whose shape depends on data size (per-observation random
+        # effects, varying group counts, ...) report the conditioned
+        # shape rather than the sentinel-shape captured here.
+        self._last_conditioned_model: Any | None = None
 
     # -- Distribution interface ---------------------------------------------
+
+    def _introspect_model(self) -> Any:
+        """Return the model whose RV shapes drive ``event_shape`` /
+        ``record_template``.
+
+        Prefers ``_last_conditioned_model`` (populated by
+        ``_pymc_model(data)``) so RVs whose shape depends on data size
+        report the conditioned shape. Falls back to
+        ``_unconditioned_model`` only when conditioning hasn't happened
+        yet — pre-conditioning there is no data to derive a better
+        answer from.
+        """
+        return self._last_conditioned_model or self._unconditioned_model
 
     @property
     def event_shape(self) -> tuple[int, ...]:
         # Total number of scalar parameters (excluding observed)
-        observed_set = set(self._observed_names)
+        model = self._introspect_model()
+        free_rvs = {rv.name: rv for rv in model.free_RVs}
         total = 0
-        for rv in self._unconditioned_model.free_RVs:
-            if rv.name in observed_set:
+        for name in self._param_names:
+            rv = free_rvs.get(name)
+            if rv is None:
                 continue
-            shape = rv.type.shape
             size = 1
-            for s in shape:
+            for s in rv.type.shape:
                 if s is not None:
                     size *= s
             total += size
@@ -134,7 +154,12 @@ class PyMCModel(ProbabilisticModel):
         Scalar PyMC RVs (e.g. ``pm.Normal('intercept', 0, 1)``) become
         fields with event shape ``()``; shape-:math:`k` RVs (e.g.
         ``pm.Normal('beta', 0, 1, shape=k)``) become fields with event
-        shape ``(k,)``.
+        shape ``(k,)``. RVs whose shape depends on data size (e.g.
+        per-observation random effects ``pm.Normal('alpha', 0, 1,
+        shape=X.shape[0])``) report the conditioned shape once
+        ``_pymc_model(data)`` has been called — inference paths do this
+        before extracting the chain, so the template matches the
+        sampler's output.
 
         Raises
         ------
@@ -145,22 +170,24 @@ class PyMCModel(ProbabilisticModel):
             produce an under-shaped template and confusing downstream
             errors.
         """
-        observed_set = set(self._observed_names)
+        model = self._introspect_model()
+        free_rvs = {rv.name: rv for rv in model.free_RVs}
         fields: dict[str, tuple[int, ...]] = {}
-        for rv in self._unconditioned_model.free_RVs:
-            if rv.name in observed_set:
+        for name in self._param_names:
+            rv = free_rvs.get(name)
+            if rv is None:
                 continue
             raw_shape = tuple(rv.type.shape)
             if any(s is None for s in raw_shape):
                 raise ValueError(
-                    f"PyMC RV {rv.name!r} has a non-concrete shape "
+                    f"PyMC RV {name!r} has a non-concrete shape "
                     f"{raw_shape}; PyMCModel.record_template requires "
                     f"every free RV to have a fully concrete event "
                     f"shape. Specify the shape explicitly when "
                     f"declaring the RV (e.g. "
-                    f"`pm.Normal({rv.name!r}, 0, 1, shape=k)`)."
+                    f"`pm.Normal({name!r}, 0, 1, shape=k)`)."
                 )
-            fields[rv.name] = tuple(int(s) for s in raw_shape)
+            fields[name] = tuple(int(s) for s in raw_shape)
         return NumericRecordTemplate(**fields)
 
     # -- Named components interface ------------------------------------------
@@ -225,21 +252,31 @@ class PyMCModel(ProbabilisticModel):
         Array-typed values are coerced to numpy before being passed to
         the user's model function — PyMC's tensor backend doesn't
         multiply with raw JAX arrays.
+
+        Side effect: when ``data is not None``, the built model is also
+        cached on ``self._last_conditioned_model`` so
+        ``record_template`` / ``event_shape`` can introspect the
+        data-conditioned RV shapes (see ``_introspect_model``).
         """
-        import numpy as _np
         if data is None:
             return self._model_fn()
         if isinstance(data, dict):
-            return self._model_fn(**{k: _to_numpy(v) for k, v in data.items()})
-        # Local import to avoid a modeling→core cycle at module load.
-        from ..core.record import Record
-        if isinstance(data, Record):
-            return self._model_fn(**{
-                name: _to_numpy(data[name])
-                for name in self._observed_names
-                if name in data.fields
-            })
-        return self._model_fn(**{self._observed_names[0]: _to_numpy(data)})
+            model = self._model_fn(**{k: _to_numpy(v) for k, v in data.items()})
+        else:
+            # Local import to avoid a modeling→core cycle at module load.
+            from ..core.record import Record
+            if isinstance(data, Record):
+                model = self._model_fn(**{
+                    name: _to_numpy(data[name])
+                    for name in self._observed_names
+                    if name in data.fields
+                })
+            else:
+                model = self._model_fn(
+                    **{self._observed_names[0]: _to_numpy(data)}
+                )
+        self._last_conditioned_model = model
+        return model
 
     def __repr__(self) -> str:
         params = ", ".join(self._param_names)

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -6,8 +6,8 @@ Inference is handled by registered methods in ``probpipe.inference``.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
-from typing import Any, Callable
+from collections.abc import Callable, Iterator
+from typing import Any
 
 import jax.numpy as jnp
 

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -102,25 +102,16 @@ class PyMCModel(ProbabilisticModel):
             for rv in self._unconditioned_model.free_RVs
             if rv.name not in observed_set
         )
-        # Populated by ``_pymc_model(data)`` whenever data is supplied.
-        # ``event_shape`` / ``record_template`` prefer this cached build
-        # so RVs whose shape depends on data size (per-observation random
-        # effects, varying group counts, ...) report the conditioned
-        # shape rather than the sentinel-shape captured here.
+        # Cached by ``_pymc_model`` when given data, so shape queries can
+        # see data-dependent RV shapes rather than the no-data build's.
         self._last_conditioned_model: Any | None = None
 
     # -- Distribution interface ---------------------------------------------
 
     def _introspect_model(self) -> Any:
-        """Return the model whose RV shapes drive ``event_shape`` /
-        ``record_template``.
-
-        Prefers ``_last_conditioned_model`` (populated by
-        ``_pymc_model(data)``) so RVs whose shape depends on data size
-        report the conditioned shape. Falls back to
-        ``_unconditioned_model`` only when conditioning hasn't happened
-        yet — pre-conditioning there is no data to derive a better
-        answer from.
+        """Model whose RV shapes drive ``event_shape`` /
+        ``record_template``: the data-conditioned build when available,
+        else the unconditioned one from construction.
         """
         return self._last_conditioned_model or self._unconditioned_model
 
@@ -154,12 +145,10 @@ class PyMCModel(ProbabilisticModel):
         Scalar PyMC RVs (e.g. ``pm.Normal('intercept', 0, 1)``) become
         fields with event shape ``()``; shape-:math:`k` RVs (e.g.
         ``pm.Normal('beta', 0, 1, shape=k)``) become fields with event
-        shape ``(k,)``. RVs whose shape depends on data size (e.g.
-        per-observation random effects ``pm.Normal('alpha', 0, 1,
-        shape=X.shape[0])``) report the conditioned shape once
-        ``_pymc_model(data)`` has been called — inference paths do this
-        before extracting the chain, so the template matches the
-        sampler's output.
+        shape ``(k,)``. Shapes that depend on the conditioning data
+        (e.g. per-observation random effects, ``pm.Normal('alpha', 0,
+        1, shape=X.shape[0])``) are reported correctly once the model
+        has been conditioned on data.
 
         Raises
         ------
@@ -253,10 +242,9 @@ class PyMCModel(ProbabilisticModel):
         the user's model function — PyMC's tensor backend doesn't
         multiply with raw JAX arrays.
 
-        Side effect: when ``data is not None``, the built model is also
-        cached on ``self._last_conditioned_model`` so
-        ``record_template`` / ``event_shape`` can introspect the
-        data-conditioned RV shapes (see ``_introspect_model``).
+        When ``data`` is given, the built model is cached on
+        ``self._last_conditioned_model`` so later shape queries see the
+        data-conditioned RV shapes.
         """
         if data is None:
             return self._model_fn()

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -109,12 +109,36 @@ class PyMCModel(ProbabilisticModel):
     def _param_rvs(self, model: Any) -> Iterator[tuple[str, Any]]:
         """Yield ``(name, rv)`` for each free parameter, in
         ``_param_names`` order, looked up in *model*.
+
+        Parameters
+        ----------
+        model : pymc.Model
+            A build of this model (conditioned or not). Its free RVs
+            must include every name in ``_param_names``.
+
+        Raises
+        ------
+        ValueError
+            If a name in ``_param_names`` (frozen from the no-data build
+            at construction) is absent from *model*'s free RVs — i.e.
+            the random-variable set changed between builds. ProbPipe
+            does not support such dynamic random variables; see
+            https://github.com/TARPS-group/prob-pipe/issues/232.
         """
         free_rvs = {rv.name: rv for rv in model.free_RVs}
         for name in self._param_names:
-            rv = free_rvs.get(name)
-            if rv is not None:
-                yield name, rv
+            if name not in free_rvs:
+                raise ValueError(
+                    f"PyMC random variable {name!r} is present in the "
+                    f"model built at construction (no data) but absent "
+                    f"from this build. ProbPipe does not support models "
+                    f"whose set of free random variables changes with the "
+                    f"data (dynamic random variables); the parameter set "
+                    f"must be fixed across builds, with only per-variable "
+                    f"shapes allowed to depend on data size. See "
+                    f"https://github.com/TARPS-group/prob-pipe/issues/232."
+                )
+            yield name, free_rvs[name]
 
     @property
     def event_shape(self) -> tuple[int, ...]:

--- a/tests/inference/test_nutpie.py
+++ b/tests/inference/test_nutpie.py
@@ -36,21 +36,24 @@ class TestCompileForNutpie:
         model._bridgestan_model.return_value = "bs_model"
         with patch.object(nutpie, "compile_stan_model",
                           return_value="compiled") as compile_stan:
-            result = _compile_for_nutpie(model, data={"N": 10})
+            compiled, pymc_build = _compile_for_nutpie(model, data={"N": 10})
         compile_stan.assert_called_once_with("bs_model")
         model._bridgestan_model.assert_called_once_with(data={"N": 10})
-        assert result == "compiled"
+        assert compiled == "compiled"
+        assert pymc_build is None  # Stan target — no PyMC build to thread
 
     def test_pymc_path(self):
-        """Models with _pymc_model use nutpie.compile_pymc_model."""
+        """Models with _pymc_model use nutpie.compile_pymc_model and
+        return the conditioned build for record_template derivation."""
         model = MagicMock(spec=[])
         model._pymc_model = MagicMock(return_value="pm_model")
         with patch.object(nutpie, "compile_pymc_model",
                           return_value="compiled") as compile_pymc:
-            result = _compile_for_nutpie(model, data={"y": [1, 2]})
+            compiled, pymc_build = _compile_for_nutpie(model, data={"y": [1, 2]})
         compile_pymc.assert_called_once_with("pm_model")
         model._pymc_model.assert_called_once_with(data={"y": [1, 2]})
-        assert result == "compiled"
+        assert compiled == "compiled"
+        assert pymc_build == "pm_model"
 
     def test_unsupported_model_raises(self):
         model = MagicMock(spec=[])

--- a/tests/inference/test_nutpie.py
+++ b/tests/inference/test_nutpie.py
@@ -120,6 +120,33 @@ class TestExtractChains:
         with pytest.raises(TypeError, match="Cannot extract chains"):
             _extract_chains(mock_trace, num_chains=1)
 
+    def test_keep_names_overrides_data_vars_order(self):
+        """keep_names selects and orders columns explicitly, overriding
+        the alphabetical posterior.data_vars order.
+
+        nutpie sorts data_vars alphabetically; without an explicit order
+        the concatenated columns would not line up with the PyMC template
+        field order (declaration order), silently mislabeling draws.
+        """
+        mock_trace = MagicMock()
+        a = np.full((1, 4), 1.0); m = np.full((1, 4), 2.0); z = np.full((1, 4), 3.0)
+        va = MagicMock(); va.values = a
+        vm = MagicMock(); vm.values = m
+        vz = MagicMock(); vz.values = z
+        mock_posterior = MagicMock()
+        mock_posterior.data_vars = ["alpha", "mu", "zeta"]  # nutpie's sorted order
+        mock_posterior.__getitem__ = (
+            lambda self, k: {"alpha": va, "mu": vm, "zeta": vz}[k]
+        )
+        mock_trace.posterior = mock_posterior
+
+        chains, names = _extract_chains(
+            mock_trace, num_chains=1, keep_names=["zeta", "alpha", "mu"],
+        )
+        assert names == ["zeta", "alpha", "mu"]
+        # Columns concatenated in keep_names order: zeta=3, alpha=1, mu=2.
+        np.testing.assert_array_equal(chains[0][0], [3.0, 1.0, 2.0])
+
 
 # ---------------------------------------------------------------------------
 # Real integration: nutpie + PyMCModel
@@ -185,3 +212,32 @@ class TestNutpieIntegration:
         assert result.inference_data is not None
         # arviz-like trace exposes posterior as an xarray Dataset/DataTree
         assert hasattr(result.inference_data, "posterior")
+
+    def test_multiparam_draws_not_mislabeled(self):
+        """Draws are labeled by the model's parameter order, not nutpie's
+        alphabetical ``posterior.data_vars`` order.
+
+        Declares ``zeta``, ``alpha``, ``mu`` (non-alphabetical) with
+        distinct tight priors and a near-flat likelihood, so each
+        posterior stays near its prior. If chain columns were taken in
+        alphabetical order while the template uses declaration order,
+        the means would be assigned to the wrong fields.
+        """
+        def model_fn(y=None):
+            with pm.Model() as m:
+                zeta = pm.Normal("zeta", 100.0, 1.0)
+                alpha = pm.Normal("alpha", 0.0, 1.0)
+                mu = pm.Normal("mu", -100.0, 1.0)
+                pm.Normal("y", mu=zeta + alpha + mu, sigma=1000.0, observed=y)
+            return m
+
+        model = PyMCModel(model_fn, name="ordering")
+        result = condition_on_nutpie._func(
+            model, data={"y": np.zeros(4, dtype=float)},
+            num_results=300, num_warmup=300, num_chains=1, random_seed=0,
+        )
+        draws = result.draws()
+        assert draws.fields == ("zeta", "alpha", "mu")
+        for field, prior_mean in [("zeta", 100.0), ("alpha", 0.0), ("mu", -100.0)]:
+            got = float(jnp.mean(jnp.asarray(draws[field])))
+            np.testing.assert_allclose(got, prior_mean, atol=10.0)

--- a/tests/inference/test_nutpie.py
+++ b/tests/inference/test_nutpie.py
@@ -241,3 +241,34 @@ class TestNutpieIntegration:
         for field, prior_mean in [("zeta", 100.0), ("alpha", 0.0), ("mu", -100.0)]:
             got = float(jnp.mean(jnp.asarray(draws[field])))
             np.testing.assert_allclose(got, prior_mean, atol=10.0)
+
+    def test_partial_conditioning_draws_not_mislabeled(self):
+        """Partial conditioning via nutpie: an unsupplied observed variable
+        is inferred and its draws are labeled correctly.
+
+        ``X`` is declared ``observed=X``; conditioning on ``y`` alone
+        leaves it free, so the posterior covers ``mu`` and ``X``. ``X``
+        sorts before ``mu`` in nutpie's alphabetical ``data_vars`` while
+        the param order is ``(mu, X)``, so distinct priors catch any
+        column mislabeling.
+        """
+        def model_fn(X=None, y=None):
+            with pm.Model() as m:
+                mu = pm.Normal("mu", 100.0, 0.5)
+                X_rv = pm.Normal("X", -100.0, 0.5, observed=X)
+                pm.Normal("y", mu=mu + X_rv, sigma=1000.0, observed=y)
+            return m
+
+        model = PyMCModel(model_fn, name="partial")
+        result = condition_on_nutpie._func(
+            model, data={"y": np.zeros(5, dtype=float)},
+            num_results=200, num_warmup=200, num_chains=1, random_seed=0,
+        )
+        draws = result.draws()
+        assert set(draws.fields) == {"mu", "X"}
+        np.testing.assert_allclose(
+            float(jnp.mean(jnp.asarray(draws["mu"]))), 100.0, atol=10.0
+        )
+        np.testing.assert_allclose(
+            float(jnp.mean(jnp.asarray(draws["X"]))), -100.0, atol=10.0
+        )

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -255,6 +255,31 @@ class TestRecordTemplate:
         with pytest.raises(ValueError, match="dynamic random variables"):
             model.record_template_for(conditioned)
 
+    def test_dynamic_rv_set_rejected_via_inference(self):
+        """The clean dynamic-RV error fires on the inference path too.
+
+        Inference builds the template before sampling, so a dynamic-RV
+        model raises the clear ValueError up front rather than an opaque
+        KeyError during chain extraction (and before any sampling runs).
+        """
+        from probpipe import condition_on
+
+        def model_fn(y=None):
+            with pm.Model() as m:
+                if y is None:
+                    pm.Normal("ghost", 0, 1)
+                mu = pm.Normal("mu", 0, 1)
+                pm.Normal("y", mu=mu, sigma=1.0, observed=y)
+            return m
+
+        model = PyMCModel(model_fn)
+        with pytest.raises(ValueError, match="dynamic random variables"):
+            condition_on(
+                model, {"y": np.zeros(5, dtype=np.float32)},
+                method="pymc_nuts",
+                num_results=5, num_warmup=5, num_chains=1, random_seed=0,
+            )
+
     def test_non_concrete_shape_rejected(self):
         """A free RV with a ``None`` dimension raises ``ValueError``.
 

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -160,14 +160,17 @@ class TestRecordTemplate:
         assert "y" not in tpl.fields
 
     def test_data_dependent_shape_reflects_conditioned_build(self):
-        """RVs whose shape depends on data size report the conditioned
-        shape after ``_pymc_model(data)`` is called (issue #224).
+        """``record_template_for(model)`` reports the data-conditioned
+        shape for an RV whose shape depends on data size, while the bare
+        ``record_template`` property reports the declared (no-data)
+        shape (issue #224).
 
-        Pre-conditioning, the template reports the sentinel shape from
-        the unconditioned build at ``__init__`` time. Post-conditioning
-        (which the inference paths always do before reading the
-        template), the per-observation effect's shape matches the data.
-        Both ``record_template`` and ``event_shape`` follow this rule.
+        The inference paths call ``record_template_for`` with the model
+        they build from data, so the template matches the chain. The
+        property cannot know the conditioned shape without data, so it
+        stays at the declared sentinel — and, crucially, holds no
+        per-call mutable state, so concurrent inference on one instance
+        can't race.
         """
         def model_fn(X=None, y=None):
             if X is None:
@@ -179,22 +182,26 @@ class TestRecordTemplate:
             return m
 
         model = PyMCModel(model_fn)
-        # Pre-conditioning: sentinel (1,) for alpha.
-        tpl_pre = model.record_template
-        assert tpl_pre.fields == ("intercept", "alpha")
-        assert tpl_pre["intercept"] == ()
-        assert tpl_pre["alpha"] == (1,)
+        # Declared (no-data) property: sentinel (1,) for alpha.
+        tpl = model.record_template
+        assert tpl.fields == ("intercept", "alpha")
+        assert tpl["intercept"] == ()
+        assert tpl["alpha"] == (1,)
         assert model.event_shape == (1 + 1,)
 
-        # After conditioning on N=50 data, alpha picks up the real shape.
+        # Template built from a data-conditioned build picks up the real
+        # shape — and the instance carries no cached state afterward.
         N = 50
-        X = np.zeros(N, dtype=np.float32)
-        y = np.zeros(N, dtype=np.float32)
-        _ = model._pymc_model(data={"X": X, "y": y})
-        tpl_post = model.record_template
-        assert tpl_post.fields == ("intercept", "alpha")
-        assert tpl_post["alpha"] == (N,)
-        assert model.event_shape == (1 + N,)
+        conditioned = model._pymc_model(data={
+            "X": np.zeros(N, dtype=np.float32),
+            "y": np.zeros(N, dtype=np.float32),
+        })
+        tpl_c = model.record_template_for(conditioned)
+        assert tpl_c.fields == ("intercept", "alpha")
+        assert tpl_c["alpha"] == (N,)
+        assert not hasattr(model, "_last_conditioned_model")
+        # Property still reports the declared shape (no hidden mutation).
+        assert model.record_template["alpha"] == (1,)
 
     def test_data_dependent_shape_inference_recovers_correct_layout(self):
         """End-to-end: NUTS with a per-observation effect produces a

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -202,7 +202,8 @@ class TestRecordTemplate:
             "X": np.zeros(N, dtype=np.float32),
             "y": np.zeros(N, dtype=np.float32),
         })
-        tpl_c = model._record_template_for(conditioned)
+        names = model._conditioned_param_names(conditioned)
+        tpl_c = model._record_template_for(conditioned, names)
         assert tpl_c.fields == ("intercept", "alpha")
         assert tpl_c["alpha"] == (N,)
         assert not hasattr(model, "_last_conditioned_model")
@@ -253,7 +254,7 @@ class TestRecordTemplate:
         assert "ghost" in model.parameter_names
         conditioned = model._pymc_model(data={"y": np.zeros(5, dtype=np.float32)})
         with pytest.raises(ValueError, match="dynamic random variables"):
-            model._record_template_for(conditioned)
+            model._conditioned_param_names(conditioned)
 
     def test_additive_dynamic_rv_set_rejected(self):
         """An RV that exists *only* in the conditioned build is rejected
@@ -276,7 +277,54 @@ class TestRecordTemplate:
         assert model.parameter_names == ("mu",)     # extra absent at construction
         conditioned = model._pymc_model(data={"y": np.zeros(5, dtype=np.float32)})
         with pytest.raises(ValueError, match="dynamic random variables"):
-            model._record_template_for(conditioned)
+            model._conditioned_param_names(conditioned)
+
+    def test_partial_conditioning_includes_unsupplied_observed(self):
+        """An observed variable left unsupplied becomes a free parameter
+        and is inferred (partial conditioning) rather than rejected or
+        silently dropped.
+
+        ``X`` is declared ``observed=X``: supplied as data it is observed,
+        omitted it is a free RV. Conditioning on ``y`` alone must yield a
+        posterior over both ``mu`` and ``X``.
+        """
+        def model_fn(X=None, y=None):
+            with pm.Model() as m:
+                mu = pm.Normal("mu", 0, 1)
+                X_rv = pm.Normal("X", 0, 1, observed=X)
+                pm.Normal("y", mu=mu + X_rv, sigma=1.0, observed=y)
+            return m
+
+        model = PyMCModel(model_fn)
+        # Declared template excludes observed names entirely.
+        assert model.record_template.fields == ("mu",)
+
+        # Condition on y only — X is left free and should be inferred.
+        conditioned = model._pymc_model(data={"y": np.zeros(5, dtype=np.float32)})
+        names = model._conditioned_param_names(conditioned)
+        assert set(names) == {"mu", "X"}
+        tpl = model._record_template_for(conditioned, names)
+        assert set(tpl.fields) == {"mu", "X"}
+
+    def test_partial_conditioning_via_inference(self):
+        """End-to-end: conditioning on a subset of observed variables
+        produces a posterior that includes the unsupplied one."""
+        from probpipe import condition_on
+
+        def model_fn(X=None, y=None):
+            with pm.Model() as m:
+                mu = pm.Normal("mu", 0, 1)
+                X_rv = pm.Normal("X", 0, 1, observed=X)
+                pm.Normal("y", mu=mu + X_rv, sigma=1.0, observed=y)
+            return m
+
+        model = PyMCModel(model_fn)
+        result = condition_on(
+            model, {"y": np.zeros(5, dtype=np.float32)},
+            method="pymc_nuts",
+            num_results=20, num_warmup=10, num_chains=1, random_seed=0,
+        )
+        assert set(result.draws().fields) == {"mu", "X"}
 
     def test_dynamic_rv_set_rejected_via_inference(self):
         """The clean dynamic-RV error fires on the inference path too.

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -159,6 +159,75 @@ class TestRecordTemplate:
         assert tpl.fields == ("mu",)
         assert "y" not in tpl.fields
 
+    def test_data_dependent_shape_reflects_conditioned_build(self):
+        """RVs whose shape depends on data size report the conditioned
+        shape after ``_pymc_model(data)`` is called (issue #224).
+
+        Pre-conditioning, the template reports the sentinel shape from
+        the unconditioned build at ``__init__`` time. Post-conditioning
+        (which the inference paths always do before reading the
+        template), the per-observation effect's shape matches the data.
+        Both ``record_template`` and ``event_shape`` follow this rule.
+        """
+        def model_fn(X=None, y=None):
+            if X is None:
+                X = np.ones(1, dtype=np.float32)  # sentinel
+            with pm.Model() as m:
+                intercept = pm.Normal("intercept", 0, 1)
+                alpha = pm.Normal("alpha", 0, 1, shape=X.shape[0])
+                pm.Normal("y", mu=intercept + alpha, sigma=1.0, observed=y)
+            return m
+
+        model = PyMCModel(model_fn)
+        # Pre-conditioning: sentinel (1,) for alpha.
+        tpl_pre = model.record_template
+        assert tpl_pre.fields == ("intercept", "alpha")
+        assert tpl_pre["intercept"] == ()
+        assert tpl_pre["alpha"] == (1,)
+        assert model.event_shape == (1 + 1,)
+
+        # After conditioning on N=50 data, alpha picks up the real shape.
+        N = 50
+        X = np.zeros(N, dtype=np.float32)
+        y = np.zeros(N, dtype=np.float32)
+        _ = model._pymc_model(data={"X": X, "y": y})
+        tpl_post = model.record_template
+        assert tpl_post.fields == ("intercept", "alpha")
+        assert tpl_post["alpha"] == (N,)
+        assert model.event_shape == (1 + N,)
+
+    def test_data_dependent_shape_inference_recovers_correct_layout(self):
+        """End-to-end: NUTS with a per-observation effect produces a
+        posterior whose ``draws()`` records match the conditioned
+        template (issue #224 — would previously shape-mismatch at
+        posterior assembly).
+        """
+        from probpipe import condition_on
+
+        def model_fn(X=None, y=None):
+            if X is None:
+                X = np.ones(1, dtype=np.float32)
+            with pm.Model() as m:
+                intercept = pm.Normal("intercept", 0, 1)
+                alpha = pm.Normal("alpha", 0, 1, shape=X.shape[0])
+                pm.Normal("y", mu=intercept + alpha, sigma=1.0, observed=y)
+            return m
+
+        N = 12
+        rng = np.random.default_rng(0)
+        X = np.arange(N, dtype=np.float32)
+        y = rng.normal(size=N).astype(np.float32)
+        model = PyMCModel(model_fn)
+        result = condition_on(
+            model, {"X": X, "y": y},
+            method="pymc_nuts",
+            num_results=20, num_warmup=10, num_chains=1, random_seed=0,
+        )
+        draws = result.draws()
+        assert draws.fields == ("intercept", "alpha")
+        assert jnp.asarray(draws["intercept"]).shape == (20,)
+        assert jnp.asarray(draws["alpha"]).shape == (20, N)
+
     def test_non_concrete_shape_rejected(self):
         """A free RV with a ``None`` dimension raises ``ValueError``.
 

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -175,12 +175,12 @@ class TestRecordTemplate:
         assert "y" not in tpl.fields
 
     def test_data_dependent_shape_reflects_conditioned_build(self):
-        """``record_template_for(model)`` reports the data-conditioned
+        """``_record_template_for(model)`` reports the data-conditioned
         shape for an RV whose shape depends on data size, while the bare
         ``record_template`` property reports the declared (no-data)
         shape (issue #224).
 
-        The inference paths call ``record_template_for`` with the model
+        The inference paths call ``_record_template_for`` with the model
         they build from data, so the template matches the chain. The
         property cannot know the conditioned shape without data, so it
         stays at the declared sentinel — and, crucially, holds no
@@ -202,7 +202,7 @@ class TestRecordTemplate:
             "X": np.zeros(N, dtype=np.float32),
             "y": np.zeros(N, dtype=np.float32),
         })
-        tpl_c = model.record_template_for(conditioned)
+        tpl_c = model._record_template_for(conditioned)
         assert tpl_c.fields == ("intercept", "alpha")
         assert tpl_c["alpha"] == (N,)
         assert not hasattr(model, "_last_conditioned_model")
@@ -253,7 +253,30 @@ class TestRecordTemplate:
         assert "ghost" in model.parameter_names
         conditioned = model._pymc_model(data={"y": np.zeros(5, dtype=np.float32)})
         with pytest.raises(ValueError, match="dynamic random variables"):
-            model.record_template_for(conditioned)
+            model._record_template_for(conditioned)
+
+    def test_additive_dynamic_rv_set_rejected(self):
+        """An RV that exists *only* in the conditioned build is rejected
+        rather than silently dropped (issue #232, additive direction).
+
+        ``extra`` is created only when data is present, so it is absent
+        from ``_param_names`` (frozen from the no-data build). Without an
+        explicit check it would be omitted from the template and filtered
+        out of the chain, silently vanishing from the posterior.
+        """
+        def model_fn(y=None):
+            with pm.Model() as m:
+                mu = pm.Normal("mu", 0, 1)
+                if y is not None:                   # conditioned build only
+                    pm.Normal("extra", 0, 1)
+                pm.Normal("y", mu=mu, sigma=1.0, observed=y)
+            return m
+
+        model = PyMCModel(model_fn)
+        assert model.parameter_names == ("mu",)     # extra absent at construction
+        conditioned = model._pymc_model(data={"y": np.zeros(5, dtype=np.float32)})
+        with pytest.raises(ValueError, match="dynamic random variables"):
+            model._record_template_for(conditioned)
 
     def test_dynamic_rv_set_rejected_via_inference(self):
         """The clean dynamic-RV error fires on the inference path too.

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -25,6 +25,21 @@ def simple_model_fn(y=None):
     return m
 
 
+def per_observation_effect_model_fn(X=None, y=None):
+    """Model with a per-observation random effect (data-dependent shape).
+
+    ``alpha`` has shape ``X.shape[0]``, so its event shape is the sentinel
+    ``(1,)`` in the no-data build and ``(N,)`` once conditioned on data.
+    """
+    if X is None:
+        X = np.ones(1, dtype=np.float32)  # sentinel for the no-data build
+    with pm.Model() as m:
+        intercept = pm.Normal("intercept", 0, 1)
+        alpha = pm.Normal("alpha", 0, 1, shape=X.shape[0])
+        pm.Normal("y", mu=intercept + alpha, sigma=1.0, observed=y)
+    return m
+
+
 class TestPyMCModel:
     """Test PyMCModel construction and protocol compliance."""
 
@@ -172,16 +187,7 @@ class TestRecordTemplate:
         per-call mutable state, so concurrent inference on one instance
         can't race.
         """
-        def model_fn(X=None, y=None):
-            if X is None:
-                X = np.ones(1, dtype=np.float32)  # sentinel
-            with pm.Model() as m:
-                intercept = pm.Normal("intercept", 0, 1)
-                alpha = pm.Normal("alpha", 0, 1, shape=X.shape[0])
-                pm.Normal("y", mu=intercept + alpha, sigma=1.0, observed=y)
-            return m
-
-        model = PyMCModel(model_fn)
+        model = PyMCModel(per_observation_effect_model_fn)
         # Declared (no-data) property: sentinel (1,) for alpha.
         tpl = model.record_template
         assert tpl.fields == ("intercept", "alpha")
@@ -211,20 +217,11 @@ class TestRecordTemplate:
         """
         from probpipe import condition_on
 
-        def model_fn(X=None, y=None):
-            if X is None:
-                X = np.ones(1, dtype=np.float32)
-            with pm.Model() as m:
-                intercept = pm.Normal("intercept", 0, 1)
-                alpha = pm.Normal("alpha", 0, 1, shape=X.shape[0])
-                pm.Normal("y", mu=intercept + alpha, sigma=1.0, observed=y)
-            return m
-
         N = 12
         rng = np.random.default_rng(0)
         X = np.arange(N, dtype=np.float32)
         y = rng.normal(size=N).astype(np.float32)
-        model = PyMCModel(model_fn)
+        model = PyMCModel(per_observation_effect_model_fn)
         result = condition_on(
             model, {"X": X, "y": y},
             method="pymc_nuts",

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -235,6 +235,29 @@ class TestRecordTemplate:
         assert jnp.asarray(draws["intercept"]).shape == (20,)
         assert jnp.asarray(draws["alpha"]).shape == (20, N)
 
+    def test_dynamic_rv_set_rejected(self):
+        """A model whose free-RV *set* changes with data raises a clear
+        ``ValueError`` rather than silently dropping a field (issue #232).
+
+        Here ``ghost`` exists only in the no-data build, so it lands in
+        ``_param_names`` (frozen at construction) but is absent from the
+        data-conditioned build. ProbPipe does not support such dynamic
+        random variables; the template builder must refuse cleanly.
+        """
+        def model_fn(y=None):
+            with pm.Model() as m:
+                if y is None:                       # no-data build only
+                    pm.Normal("ghost", 0, 1)
+                mu = pm.Normal("mu", 0, 1)
+                pm.Normal("y", mu=mu, sigma=1.0, observed=y)
+            return m
+
+        model = PyMCModel(model_fn)
+        assert "ghost" in model.parameter_names
+        conditioned = model._pymc_model(data={"y": np.zeros(5, dtype=np.float32)})
+        with pytest.raises(ValueError, match="dynamic random variables"):
+            model.record_template_for(conditioned)
+
     def test_non_concrete_shape_rejected(self):
         """A free RV with a ``None`` dimension raises ``ValueError``.
 

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -326,6 +326,36 @@ class TestRecordTemplate:
         )
         assert set(result.draws().fields) == {"mu", "X"}
 
+    def test_partial_conditioning_draws_not_mislabeled(self):
+        """The inferred observed variable's draws are labeled correctly —
+        not swapped with a canonical parameter.
+
+        ``mu`` and the unsupplied ``X`` get distinct, identifiable priors
+        and a near-flat likelihood, so each marginal posterior stays near
+        its own prior. A mislabeling (X's draws under field ``mu``, or
+        vice versa) would flip the recovered means. ``X`` also sorts
+        before ``mu`` alphabetically, exercising column-order alignment.
+        """
+        from probpipe import condition_on
+
+        def model_fn(X=None, y=None):
+            with pm.Model() as m:
+                mu = pm.Normal("mu", 100.0, 0.5)
+                X_rv = pm.Normal("X", -100.0, 0.5, observed=X)
+                pm.Normal("y", mu=mu + X_rv, sigma=1000.0, observed=y)
+            return m
+
+        model = PyMCModel(model_fn)
+        result = condition_on(
+            model, {"y": np.zeros(5, dtype=np.float32)},
+            method="pymc_nuts",
+            num_results=200, num_warmup=200, num_chains=1, random_seed=0,
+        )
+        draws = result.draws()
+        assert set(draws.fields) == {"mu", "X"}
+        assert float(jnp.mean(jnp.asarray(draws["mu"]))) > 50.0    # ~ +100
+        assert float(jnp.mean(jnp.asarray(draws["X"]))) < -50.0    # ~ -100
+
     def test_dynamic_rv_set_rejected_via_inference(self):
         """The clean dynamic-RV error fires on the inference path too.
 
@@ -372,6 +402,22 @@ class TestRecordTemplate:
 
         with pytest.raises(ValueError, match="non-concrete shape"):
             _ = PyMCModel(model_fn).record_template
+
+    def test_event_shape_rejects_non_concrete_shape(self):
+        """``event_shape`` derives from ``record_template``, so it rejects
+        a non-concrete free-RV shape rather than silently under-counting.
+        """
+        import pytensor.tensor as pt
+
+        def model_fn(y=None):
+            with pm.Model() as m:
+                mu = pt.vector("mu_data")
+                pm.Normal("z", mu=mu, sigma=1.0)
+                pm.Normal("y", 0, 1, observed=y)
+            return m
+
+        with pytest.raises(ValueError, match="non-concrete shape"):
+            _ = PyMCModel(model_fn).event_shape
 
 
 class TestRecordDataUnpacking:


### PR DESCRIPTION
Closes #224.

## Diagnosis

`PyMCModel.record_template` / `event_shape` read RV shapes from `_unconditioned_model` (the no-data build done at `__init__`), but inference samples from the data-conditioned rebuild in `_pymc_model(data)`. For any RV whose shape depends on data size (per-observation random effects, hierarchical group-level effects with varying group counts), the two builds disagreed and posterior assembly failed with the issue's exact error:

```
ValueError: chain last dim (13) doesn't match template total flat size (2);
template fields=('intercept', 'alpha'), sizes=[1, 1].
```

(Verified end-to-end: the integration regression test below reproduces it on `main`.)

## Change — stateless `_record_template_for(model, names)`

The template is now a **pure function of a model build**, not of cached instance state:

- `PyMCModel._record_template_for(model, names)` builds the template from a passed PyMC build over an explicit name list. A shared `_param_rvs(model, names)` iterator backs it.
- The inference paths already hold the conditioned `pm.Model` locally, so they build the template from that exact build — template and chain provably come from the same model. `_compile_for_nutpie` now returns `(compiled, pymc_build)` so `condition_on_nutpie` can do the same (Stan targets return `None` and keep the old `getattr` path).
- The public `record_template` property reports the **declared** (no-data) shapes — unchanged from `main` — and documents that data-dependent shapes resolve at inference.

**No instance cache.** An earlier revision cached the conditioned model on `self._last_conditioned_model` and had the property read it. That introduced a concurrency race: under threaded broadcast (`ThreadPoolTaskRunner` / `dispatch="thread"`), two inference calls sharing one `PyMCModel` could interleave their cache writes, so one call's template would be built from another's data. The stateless design removes that shared mutable state entirely.

## Per-build parameter set: dynamic RVs and partial conditioning

The set of parameters to infer is resolved per build by `_conditioned_param_names(model)`:

- **Dynamic RVs are rejected** with a clear `ValueError` (tracked in #232): a canonical parameter the build dropped (subtractive), or a new **non-observed** free RV the build introduced (additive). Per-variable data-dependent *shapes* remain supported (the point of this PR).
- **Partial conditioning is supported**: an observed variable the caller leaves unsupplied becomes a free RV in the conditioned build and is *inferred* — it is included in the template and the chain rather than silently dropped. Supplied observed variables are observed (not free) and excluded.

Chain extraction and the template share this one ordered name set, so columns align by construction (PR #234 generalizes that into name-keyed assembly).

## Tests (`tests/modeling/test_pymc_model.py`)

- `test_data_dependent_shape_reflects_conditioned_build` — the bare property reports the declared `(1,)`; the conditioned build reports `(N,)`; no cached state.
- `test_data_dependent_shape_inference_recovers_correct_layout` — end-to-end `condition_on(method="pymc_nuts")`; asserts `draws["alpha"].shape == (num_results, N)`. Fails on `main`.
- `test_dynamic_rv_set_rejected` / `test_additive_dynamic_rv_set_rejected` — both directions of a changed RV *set* raise the clear `ValueError`.
- `test_partial_conditioning_includes_unsupplied_observed` / `test_partial_conditioning_via_inference` — an unsupplied observed variable is inferred and present in the posterior.
- nutpie helper tests updated for the `(compiled, pymc_build)` return.

## Test plan

- [x] `pytest tests/modeling/test_pymc_model.py tests/inference/test_nutpie.py` — 38 passed
- [x] `pytest tests/inference/ tests/modeling/` — 395 passed, 4 skipped
- [ ] CI green
