### PR TITLE
Name-keyed posterior assembly via field_order (mechanism)

### DIFF
--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -91,6 +91,20 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
         Optional per-sample importance weights (across all chains).
     name : str or None
         Distribution name for provenance.
+    record_template : RecordTemplate or None
+        If given, names the posterior's fields: the concatenated chain is
+        split into per-field arrays (multi-field) so :meth:`draws`,
+        :meth:`_mean` / :meth:`_variance`, etc. return Records keyed by
+        the template fields. ``None`` leaves the posterior a single
+        unnamed numeric block.
+    field_order : list of str or None
+        Names the field each contiguous column-block of *chains* belongs
+        to, in the order they appear. Default (``None``) assumes the
+        columns are already in ``record_template.fields`` order. Pass this
+        when the chain's column order may differ (e.g. a backend that
+        sorts variable names) so columns are aligned to fields by name
+        rather than position. Requires *record_template*, and must be a
+        permutation of its fields.
 
     Notes
     -----
@@ -138,17 +152,17 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
             # fields (raises otherwise) for any field count, so a
             # single-field typo or wrong name is also caught.
             perm = _column_permutation(record_template, field_order)
+            # Validate width for any field count, *before* the gather:
+            # ``c[..., perm]`` would otherwise silently drop extra columns
+            # (too-wide chain) or clamp out-of-bounds indices (too-narrow),
+            # then pass the post-gather total-size check.
+            for c in self._chains:
+                if c.shape[-1] != len(perm):
+                    raise ValueError(
+                        f"chain last dim ({c.shape[-1]}) doesn't match "
+                        f"the template total flat size ({len(perm)})."
+                    )
             if len(record_template.fields) > 1:
-                # Validate width *before* the gather: ``c[..., perm]``
-                # would otherwise silently drop extra columns (too-wide
-                # chain) or clamp out-of-bounds indices (too-narrow),
-                # then pass the post-gather total-size check.
-                for c in self._chains:
-                    if c.shape[-1] != len(perm):
-                        raise ValueError(
-                            f"chain last dim ({c.shape[-1]}) doesn't match "
-                            f"the template total flat size ({len(perm)})."
-                        )
                 self._chains = [c[..., perm] for c in self._chains]
                 self._concatenated = None
 

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -128,14 +128,29 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
         # order. The positional split below (and ``draws()`` unflatten)
         # then map each column to the right field by name rather than by
         # position, so callers don't have to pre-sort. See issue #233.
-        if (
-            field_order is not None
-            and record_template is not None
-            and len(record_template.fields) > 1
-        ):
+        if field_order is not None:
+            if record_template is None:
+                raise ValueError(
+                    "field_order requires a record_template; it names "
+                    "template fields and is meaningless without one."
+                )
+            # Validates field_order is a permutation of the template
+            # fields (raises otherwise) for any field count, so a
+            # single-field typo or wrong name is also caught.
             perm = _column_permutation(record_template, field_order)
-            self._chains = [c[..., perm] for c in self._chains]
-            self._concatenated = None
+            if len(record_template.fields) > 1:
+                # Validate width *before* the gather: ``c[..., perm]``
+                # would otherwise silently drop extra columns (too-wide
+                # chain) or clamp out-of-bounds indices (too-narrow),
+                # then pass the post-gather total-size check.
+                for c in self._chains:
+                    if c.shape[-1] != len(perm):
+                        raise ValueError(
+                            f"chain last dim ({c.shape[-1]}) doesn't match "
+                            f"the template total flat size ({len(perm)})."
+                        )
+                self._chains = [c[..., perm] for c in self._chains]
+                self._concatenated = None
 
         flat = self._concat_chains()
         # Track whether the user explicitly supplied a template; we use

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -20,6 +20,56 @@ __all__ = ["ApproximateDistribution", "make_posterior"]
 
 
 # ---------------------------------------------------------------------------
+# Column ordering
+# ---------------------------------------------------------------------------
+
+
+def _column_permutation(
+    record_template: RecordTemplate, field_order: list[str],
+) -> list[int]:
+    """Column-index permutation mapping a *field_order*-laid-out flat chain
+    into ``record_template.fields`` order.
+
+    *field_order* names the field each contiguous column-block of the flat
+    chain occupies. The returned ``perm`` satisfies: ``flat[..., perm]``
+    lays the columns out in template-field order, so the positional split
+    in :class:`ApproximateDistribution` maps each column to the right
+    field by name. See issue #233.
+
+    Raises
+    ------
+    ValueError
+        If *field_order* is not a permutation of the template's fields, or
+        a field has an opaque (``spec=None``) leaf with no flat size.
+    """
+    if sorted(field_order) != sorted(record_template.fields):
+        raise ValueError(
+            f"field_order {list(field_order)} is not a permutation of "
+            f"template fields {list(record_template.fields)}."
+        )
+    sizes: dict[str, int] = {}
+    for field_name in record_template.fields:
+        spec = record_template[field_name]
+        if spec is None:
+            raise ValueError(
+                f"ApproximateDistribution requires a numeric template; "
+                f"field {field_name!r} has spec=None (opaque). Opaque "
+                f"leaves don't have a flat size."
+            )
+        sizes[field_name] = _spec_size(spec)
+    bounds: dict[str, tuple[int, int]] = {}
+    offset = 0
+    for field_name in field_order:
+        bounds[field_name] = (offset, offset + sizes[field_name])
+        offset += sizes[field_name]
+    perm: list[int] = []
+    for field_name in record_template.fields:
+        lo, hi = bounds[field_name]
+        perm.extend(range(lo, hi))
+    return perm
+
+
+# ---------------------------------------------------------------------------
 # ApproximateDistribution
 # ---------------------------------------------------------------------------
 
@@ -64,12 +114,28 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
         weights: ArrayLike | Weights | None = None,
         name: str | None = None,
         record_template: RecordTemplate | None = None,
+        field_order: list[str] | None = None,
     ):
         if not chains:
             raise ValueError("Must provide at least one chain")
 
         self._chains = [jnp.asarray(c) for c in chains]
         self._concatenated: Array | None = None
+
+        # When the caller's chain columns are laid out in a different
+        # field order than the template — e.g. a backend whose trace
+        # sorts variable names — permute them into ``record_template``
+        # order. The positional split below (and ``draws()`` unflatten)
+        # then map each column to the right field by name rather than by
+        # position, so callers don't have to pre-sort. See issue #233.
+        if (
+            field_order is not None
+            and record_template is not None
+            and len(record_template.fields) > 1
+        ):
+            perm = _column_permutation(record_template, field_order)
+            self._chains = [c[..., perm] for c in self._chains]
+            self._concatenated = None
 
         flat = self._concat_chains()
         # Track whether the user explicitly supplied a template; we use
@@ -273,6 +339,7 @@ def make_posterior(
     *,
     auxiliary: DataTree | None = None,
     record_template: RecordTemplate | None = None,
+    field_order: list[str] | None = None,
     **meta: Any,
 ) -> ApproximateDistribution:
     """Build an ApproximateDistribution with provenance.
@@ -290,6 +357,13 @@ def make_posterior(
         Inference methods are responsible for building this.
     record_template : RecordTemplate or None
         If provided, ``draws()`` returns named ``Record``.
+    field_order : list of str or None
+        Names the field each contiguous column-block of ``chains`` belongs
+        to. Default (``None``) assumes the columns are laid out in
+        ``record_template.fields`` order. Pass this when the chain's column
+        order may differ from the template's (e.g. a backend that sorts
+        variable names) so columns are aligned to fields by name rather
+        than position (see issue #233).
     **meta
         Additional metadata stored in provenance.
 
@@ -300,6 +374,7 @@ def make_posterior(
     """
     result = ApproximateDistribution(
         chains, name="posterior", record_template=record_template,
+        field_order=field_order,
     )
 
     if auxiliary is not None:

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -231,6 +231,55 @@ class TestApproximateDistributionValuesTemplate:
                 record_template=template, field_order=["a", "c"],
             )
 
+    def test_field_order_chain_too_wide_raises(self):
+        """With field_order, a chain wider than the template's total flat
+        size raises rather than silently dropping the extra columns in the
+        permutation gather."""
+        template = RecordTemplate(a=(), b=())          # total flat size 2
+        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 3))   # 3 columns
+        prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
+        with pytest.raises(ValueError, match="doesn't match"):
+            make_posterior(
+                [chain], parents=(prior,), algorithm="test",
+                record_template=template, field_order=["a", "b"],
+            )
+
+    def test_field_order_chain_too_narrow_raises(self):
+        """With field_order, a chain narrower than the template's total
+        flat size raises clearly rather than clamping the out-of-bounds
+        gather indices."""
+        template = RecordTemplate(a=(), b=(), c=())    # total flat size 3
+        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 2))   # 2 columns
+        prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="z")
+        with pytest.raises(ValueError, match="doesn't match"):
+            make_posterior(
+                [chain], parents=(prior,), algorithm="test",
+                record_template=template, field_order=["a", "b", "c"],
+            )
+
+    def test_field_order_without_template_raises(self):
+        """field_order without a record_template is a caller error, not a
+        silent no-op."""
+        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 2))
+        prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="z")
+        with pytest.raises(ValueError, match="requires a record_template"):
+            make_posterior(
+                [chain], parents=(prior,), algorithm="test",
+                field_order=["a", "b"],
+            )
+
+    def test_field_order_single_field_invalid_permutation_raises(self):
+        """field_order is validated even for a single-field template, so a
+        wrong name is caught rather than silently ignored."""
+        template = RecordTemplate(a=())
+        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 1))
+        prior = MultivariateNormal(loc=jnp.zeros(1), cov=jnp.eye(1), name="z")
+        with pytest.raises(ValueError, match="not a permutation"):
+            make_posterior(
+                [chain], parents=(prior,), algorithm="test",
+                record_template=template, field_order=["b"],
+            )
+
     def test_array_shaped_fields(self):
         """Template with non-scalar fields unflattens correctly."""
         template = RecordTemplate(

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -182,6 +182,55 @@ class TestApproximateDistributionValuesTemplate:
     def test_record_template_property(self, posterior_with_template, template):
         assert posterior_with_template.record_template is template
 
+    def test_field_order_reassembles_by_name(self):
+        """field_order maps chain column-blocks to template fields by name.
+
+        The chain's columns are laid out in a different order than the
+        template (``b`` block, then scalar ``a``). Passing ``field_order``
+        must reassemble each field from its own columns — not split the
+        flat chain positionally in template order (which would scramble
+        the draws).
+        """
+        template = RecordTemplate(a=(), b=(2,))  # sizes: a=1, b=2
+        # Columns laid out in field_order = (b, a): [b0, b1, a0].
+        b_block = jnp.array([[10.0, 11.0], [12.0, 13.0]])      # (2, 2)
+        a_block = jnp.array([[1.0], [2.0]])                    # (2, 1)
+        chain = jnp.concatenate([b_block, a_block], axis=-1)   # (2, 3)
+        prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
+        post = make_posterior(
+            [chain], parents=(prior,), algorithm="test",
+            record_template=template, field_order=["b", "a"],
+        )
+        draws = post.draws()
+        # a is the trailing column; b is the leading 2-column block.
+        np.testing.assert_allclose(np.asarray(draws["a"]), [1.0, 2.0])
+        np.testing.assert_allclose(np.asarray(draws["b"]), b_block)
+
+    def test_field_order_none_is_positional(self):
+        """field_order=None keeps the historical positional layout."""
+        template = RecordTemplate(a=(), b=(2,))
+        chain = jnp.array([[1.0, 10.0, 11.0], [2.0, 12.0, 13.0]])  # a, then b
+        prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
+        post = make_posterior(
+            [chain], parents=(prior,), algorithm="test", record_template=template,
+        )
+        draws = post.draws()
+        np.testing.assert_allclose(np.asarray(draws["a"]), [1.0, 2.0])
+        np.testing.assert_allclose(
+            np.asarray(draws["b"]), [[10.0, 11.0], [12.0, 13.0]]
+        )
+
+    def test_field_order_must_be_permutation(self):
+        """A field_order that isn't a permutation of template fields raises."""
+        template = RecordTemplate(a=(), b=())
+        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 2))
+        prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="z")
+        with pytest.raises(ValueError, match="not a permutation"):
+            make_posterior(
+                [chain], parents=(prior,), algorithm="test",
+                record_template=template, field_order=["a", "c"],
+            )
+
     def test_array_shaped_fields(self):
         """Template with non-scalar fields unflattens correctly."""
         template = RecordTemplate(

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -280,6 +280,18 @@ class TestApproximateDistributionValuesTemplate:
                 record_template=template, field_order=["b"],
             )
 
+    def test_field_order_single_field_width_mismatch_raises(self):
+        """With field_order, the chain width is validated for a
+        single-field template too — not only for multi-field ones."""
+        template = RecordTemplate(a=(2,))              # flat size 2
+        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 3))   # 3 columns
+        prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
+        with pytest.raises(ValueError, match="doesn't match"):
+            make_posterior(
+                [chain], parents=(prior,), algorithm="test",
+                record_template=template, field_order=["a"],
+            )
+
     def test_array_shaped_fields(self):
         """Template with non-scalar fields unflattens correctly."""
         template = RecordTemplate(


### PR DESCRIPTION
Refs #233.

## Problem

`ApproximateDistribution` splits the concatenated flat chain into template fields **positionally** — by `record_template.fields` order and per-field flat sizes, with only a total-flat-size sanity check. Correctness has rested on an unwritten contract: *every caller must concatenate chain columns in `record_template.fields` order.* A backend whose trace orders variables differently (nutpie sorts `posterior.data_vars` alphabetically) silently mislabels draws unless the caller pre-sorts — exactly the bug fixed per-caller in #231.

## Change (mechanism only)

Adds an optional `field_order: list[str] | None` to `ApproximateDistribution.__init__` and `make_posterior`. It names the field each contiguous column-block of the chain occupies. When provided, the flat chain's columns are permuted into `record_template` order (new `_column_permutation` helper) **before** the existing positional split, so columns are aligned to fields by name instead of by position.

- **Default `field_order=None` is unchanged** — every current backend keeps the positional contract byte-for-byte (the reorder is a no-op preprocessing step that only runs when `field_order` is passed).
- Reordering the flat columns up front (rather than building a per-field Record) means all downstream consumers — `draws()`'s `unflatten`, `mean`, the `chains` property — see template-ordered columns and stay correct.

## Validation (when `field_order` is given)

Hardened so misuse fails loudly rather than silently corrupting draws:

- **Requires a template** — `field_order` without `record_template` raises (it names template fields).
- **Permutation-checked for any field count** — a wrong/typo'd name raises, including for single-field templates.
- **Chain width validated before the gather, for any field count** — `c[..., perm]` would otherwise silently drop extra columns (too-wide chain) or clamp out-of-bounds gather indices (too-narrow), then pass the post-gather size check.
- `ApproximateDistribution`'s `Parameters` docstring now documents `record_template` and `field_order` (it's public via mkdocstrings).

## Scope / follow-up

This PR lands the **assembly mechanism + validation** only. Wiring the PyMC inference paths to pass `field_order` (retiring the #231 `keep_names` pre-sort) is **#236**, stacked on this. Branched off `main`.

## Tests (`tests/inference/test_inference.py`)

- `test_field_order_reassembles_by_name` — non-template column order is reassembled by name.
- `test_field_order_none_is_positional` — default path matches the historical layout.
- `test_field_order_must_be_permutation` / `test_field_order_single_field_invalid_permutation_raises` — non-permutation raises (multi- and single-field).
- `test_field_order_chain_too_wide_raises` / `test_field_order_chain_too_narrow_raises` / `test_field_order_single_field_width_mismatch_raises` — width mismatches raise.
- `test_field_order_without_template_raises` — `field_order` without a template raises.

## Test plan

- [x] `pytest tests/inference/test_inference.py` — 95 passed (incl. positional backward-compat)
- [x] `pytest tests/inference/ tests/modeling/` — green
- [ ] CI green
