### PR TITLE
Wire PyMC paths through name-keyed field_order (closes #233)

### DIFF
--- a/probpipe/inference/_inference_utils.py
+++ b/probpipe/inference/_inference_utils.py
@@ -114,9 +114,26 @@ def posterior_var_order(trace: Any, keep: Iterable[str]) -> list[str]:
     (:func:`make_posterior`), so name-keyed assembly realigns columns to
     the template regardless of the backend's variable order — nutpie, for
     instance, sorts ``data_vars`` alphabetically.
+
+    Raises
+    ------
+    ValueError
+        If any name in *keep* is absent from ``trace.posterior``. Failing
+        here names the missing variables, rather than letting them surface
+        later as a cryptic "not a permutation" error in
+        :func:`make_posterior`'s column realignment.
     """
-    keep = set(keep)
-    return [name for name in trace.posterior.data_vars if name in keep]
+    keep = list(keep)
+    available = list(trace.posterior.data_vars)
+    missing = [name for name in keep if name not in available]
+    if missing:
+        raise ValueError(
+            f"trace posterior is missing expected variable name(s) "
+            f"{missing}; available posterior variables are {available}. "
+            f"Every parameter being assembled must be present in the trace."
+        )
+    keep_set = set(keep)
+    return [name for name in available if name in keep_set]
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/inference/_inference_utils.py
+++ b/probpipe/inference/_inference_utils.py
@@ -23,7 +23,7 @@ utilities shared across the backend modules; not re-exported through
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -50,6 +50,7 @@ __all__ = [
     "build_target_log_prob",
     "build_target_log_prob_flat",
     "extract_chain_columns",
+    "posterior_var_order",
     "get_init_state",
     "get_prior",
     "extract_record_template",
@@ -72,8 +73,9 @@ def extract_chain_columns(
     For each chain ``c`` and each variable in *names* (in that order),
     pulls ``trace.posterior[name].values[c]``, flattens trailing axes to
     2-D ``(draws, -1)``, and concatenates across variables. Columns are
-    laid out in *names* order, to match the ``record_template`` field
-    order.
+    laid out in *names* order; pass the same order as ``field_order`` to
+    :func:`make_posterior` so assembly aligns them to the template fields
+    by name.
 
     Parameters
     ----------
@@ -101,6 +103,20 @@ def extract_chain_columns(
             chain_arrays.append(jnp.asarray(vals))
         chains.append(jnp.concatenate(chain_arrays, axis=-1))
     return chains
+
+
+def posterior_var_order(trace: Any, keep: Iterable[str]) -> list[str]:
+    """Variable names in *trace*'s ``posterior`` natural order, filtered
+    to *keep*.
+
+    Pass the result as both the extraction order
+    (:func:`extract_chain_columns`) and ``field_order``
+    (:func:`make_posterior`), so name-keyed assembly realigns columns to
+    the template regardless of the backend's variable order — nutpie, for
+    instance, sorts ``data_vars`` alphabetically.
+    """
+    keep = set(keep)
+    return [name for name in trace.posterior.data_vars if name in keep]
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -9,7 +9,7 @@ from ..core._registry import MethodInfo
 from ..core.node import workflow_function
 from ..custom_types import ArrayLike
 from ._approximate_distribution import ApproximateDistribution, make_posterior
-from ._inference_utils import extract_chain_columns
+from ._inference_utils import extract_chain_columns, posterior_var_order
 from ._registry import InferenceMethod
 
 logger = logging.getLogger(__name__)
@@ -48,15 +48,14 @@ def condition_on_nutpie(
 
     compiled, pymc_build = _compile_for_nutpie(model, data)
 
-    # Resolve the PyMC inferred names + template from the conditioned
+    # Build the template in canonical field order from the conditioned
     # build before sampling (fail fast on a dynamic-RV / non-concrete
-    # model); extraction shares the names. Stan models carry their own
-    # record_template, if any.
+    # model). Stan models carry their own record_template, if any.
     if pymc_build is not None:
-        keep_names = list(model._conditioned_param_names(pymc_build))
-        record_template = model._record_template_for(pymc_build, keep_names)
+        param_names = list(model._conditioned_param_names(pymc_build))
+        record_template = model._record_template_for(pymc_build, param_names)
     else:
-        keep_names = None
+        param_names = None
         record_template = getattr(model, "record_template", None)
 
     trace = nutpie.sample(
@@ -64,15 +63,19 @@ def condition_on_nutpie(
         chains=num_chains, seed=random_seed, **kwargs,
     )
 
-    # PyMC: extract chain columns in `keep_names` order so they line up
-    # with the template (nutpie sorts ``posterior.data_vars``
-    # alphabetically, which would otherwise mislabel draws). Stan: take
-    # trace order.
-    chains, param_names = _extract_chains(trace, num_chains, keep_names=keep_names)
+    # Extract in nutpie's natural ``data_vars`` order (it sorts
+    # alphabetically); ``field_order`` lets make_posterior realign columns
+    # to the template by name, so we don't depend on the orders matching.
+    if param_names is not None:
+        field_order = posterior_var_order(trace, param_names)
+        chains, _ = _extract_chains(trace, num_chains, keep_names=field_order)
+    else:
+        field_order = None
+        chains, _ = _extract_chains(trace, num_chains)
 
     return make_posterior(
         chains, parents=(model,), algorithm="nutpie_nuts",
-        auxiliary=trace, record_template=record_template,
+        auxiliary=trace, record_template=record_template, field_order=field_order,
         num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
     )
 

--- a/probpipe/inference/_pymc_method.py
+++ b/probpipe/inference/_pymc_method.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from ..core._registry import MethodInfo
 from ._approximate_distribution import ApproximateDistribution, make_posterior
-from ._inference_utils import extract_chain_columns
+from ._inference_utils import extract_chain_columns, posterior_var_order
 from ._registry import InferenceMethod
 
 
@@ -48,8 +48,8 @@ class PyMCNutsMethod(InferenceMethod):
         random_seed = kwargs.get("random_seed", 0)
 
         model = dist._pymc_model(data=observed)
-        # Resolve the inferred names + template before sampling (fail fast
-        # on a dynamic-RV / non-concrete model); extraction shares them.
+        # Build the template in canonical field order before sampling
+        # (fail fast on a dynamic-RV / non-concrete model).
         param_names = dist._conditioned_param_names(model)
         record_template = dist._record_template_for(model, param_names)
         with model:
@@ -62,11 +62,14 @@ class PyMCNutsMethod(InferenceMethod):
                 return_inferencedata=True,
             )
 
-        chains = extract_chain_columns(trace, param_names, num_chains)
+        # Extract in the trace's natural order; field_order lets
+        # make_posterior realign columns to the template by name.
+        order = posterior_var_order(trace, param_names)
+        chains = extract_chain_columns(trace, order, num_chains)
 
         return make_posterior(
             chains, parents=(dist,), algorithm="pymc_nuts",
-            auxiliary=trace, record_template=record_template,
+            auxiliary=trace, record_template=record_template, field_order=order,
             num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
         )
 
@@ -111,20 +114,22 @@ class PyMCADVIMethod(InferenceMethod):
         vi_method = kwargs.get("vi_method", "advi")
 
         model = dist._pymc_model(data=observed)
-        # Resolve the inferred names + template before fitting; extraction
-        # shares them.
+        # Build the template in canonical field order before fitting (fail
+        # fast on a dynamic-RV / non-concrete model).
         param_names = dist._conditioned_param_names(model)
         record_template = dist._record_template_for(model, param_names)
         with model:
             approx = pm.fit(n=num_iterations, method=vi_method, random_seed=random_seed)
             trace = approx.sample(num_results)
 
-        # ADVI's approx.sample yields a single chain of `num_results` draws.
-        chains = extract_chain_columns(trace, param_names, num_chains=1)
+        # ADVI's approx.sample yields a single chain of `num_results`
+        # draws; extract in natural order and realign by name.
+        order = posterior_var_order(trace, param_names)
+        chains = extract_chain_columns(trace, order, num_chains=1)
         algorithm = f"pymc_{vi_method}"
 
         return make_posterior(
             chains, parents=(dist,), algorithm=algorithm,
-            auxiliary=trace, record_template=record_template,
+            auxiliary=trace, record_template=record_template, field_order=order,
             num_iterations=num_iterations,
         )

--- a/tests/inference/test_inference_utils.py
+++ b/tests/inference/test_inference_utils.py
@@ -26,6 +26,7 @@ from probpipe.inference._inference_utils import (
     get_init_state,
     get_prior,
     is_jax_traceable,
+    posterior_var_order,
     run_chain_scan,
 )
 from probpipe.modeling._likelihood import Likelihood
@@ -449,3 +450,50 @@ class TestParallelChainMap:
             f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
         )
         assert "OK" in result.stdout
+
+
+class _StubPosterior:
+    def __init__(self, var_names):
+        # dict preserves insertion order, mimicking a trace's data_vars.
+        self.data_vars = dict.fromkeys(var_names)
+
+
+class _StubTrace:
+    """Minimal stand-in: ``posterior_var_order`` reads only
+    ``trace.posterior.data_vars`` (ordered)."""
+
+    def __init__(self, var_names):
+        self.posterior = _StubPosterior(var_names)
+
+
+class TestPosteriorVarOrder:
+    """``posterior_var_order`` returns a trace's posterior variables in the
+    backend's natural order filtered to *keep*, and fails loudly when a
+    kept name is missing (PR #236 / #233)."""
+
+    def test_preserves_trace_order_not_keep_order(self):
+        trace = _StubTrace(["slope", "intercept", "lp__"])
+        # The trace's data_vars order wins; the keep argument's order does not.
+        assert posterior_var_order(trace, ["intercept", "slope"]) == ["slope", "intercept"]
+
+    def test_alphabetical_backend_order_returned_for_realignment(self):
+        # nutpie, e.g., sorts data_vars alphabetically; the helper returns
+        # that order so field_order can realign columns by name.
+        trace = _StubTrace(["a", "b", "c"])
+        assert posterior_var_order(trace, ["c", "a", "b"]) == ["a", "b", "c"]
+
+    def test_ignores_unkept_trace_vars(self):
+        trace = _StubTrace(["mu", "sigma", "lp__", "diverging"])
+        assert posterior_var_order(trace, ["mu", "sigma"]) == ["mu", "sigma"]
+
+    def test_missing_expected_var_raises_valueerror(self):
+        """A kept name absent from the trace raises a clear ValueError here,
+        not a cryptic 'not a permutation' error later in make_posterior."""
+        trace = _StubTrace(["mu"])
+        with pytest.raises(ValueError, match="missing expected variable"):
+            posterior_var_order(trace, ["mu", "sigma"])
+
+    def test_error_message_names_the_missing_vars(self):
+        trace = _StubTrace(["mu"])
+        with pytest.raises(ValueError, match="sigma"):
+            posterior_var_order(trace, ["mu", "sigma"])

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -233,6 +233,39 @@ class TestRecordTemplate:
         assert jnp.asarray(draws["intercept"]).shape == (20,)
         assert jnp.asarray(draws["alpha"]).shape == (20, N)
 
+    def test_advi_field_order_realignment(self):
+        """End-to-end: ``pymc_advi`` realigns posterior columns to the
+        template by name, like the NUTS/nutpie paths (PR #236).
+
+        ADVI's trace comes from ``approx.sample`` rather than a NUTS run,
+        so it exercises ``posterior_var_order`` on a distinct trace source.
+        The names are chosen so the backend's alphabetical column order
+        (``alpha`` before ``intercept``) differs from the template order
+        (``intercept`` defined first), and the shapes differ (scalar vs.
+        ``(3,)``) — a positional split would shape-scramble instead of
+        realigning by name.
+        """
+        from probpipe import condition_on
+
+        def model_fn(y=None):
+            with pm.Model() as m:
+                intercept = pm.Normal("intercept", 0, 1)      # scalar, defined first
+                pm.Normal("alpha", 0, 1, shape=3)             # shape (3,), sorts first
+                pm.Normal("y", mu=intercept, sigma=1.0, observed=y)
+            return m
+
+        y = np.zeros(8, dtype=np.float32)
+        result = condition_on(
+            PyMCModel(model_fn), {"y": y},
+            method="pymc_advi",
+            num_iterations=200, num_results=25, random_seed=0,
+        )
+        assert result.algorithm == "pymc_advi"
+        draws = result.draws()
+        assert draws.fields == ("intercept", "alpha")
+        assert jnp.asarray(draws["intercept"]).shape == (25,)
+        assert jnp.asarray(draws["alpha"]).shape == (25, 3)
+
     def test_dynamic_rv_set_rejected(self):
         """A model whose free-RV *set* changes with data raises a clear
         ``ValueError`` rather than silently dropping a field (issue #232).

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -356,6 +356,41 @@ class TestRecordTemplate:
         assert float(jnp.mean(jnp.asarray(draws["mu"]))) > 50.0    # ~ +100
         assert float(jnp.mean(jnp.asarray(draws["X"]))) < -50.0    # ~ -100
 
+    def test_pymc_nuts_multiparam_field_order_realigned(self):
+        """End-to-end check of the name-keyed wiring (issue #233): the
+        pymc_nuts path extracts in the trace's alphabetical ``data_vars``
+        order, and ``field_order`` realigns columns to the declared
+        (template) order by name.
+
+        ``zeta``, ``alpha``, ``mu`` are declared non-alphabetically with
+        distinct tight priors and a near-flat likelihood. The posterior
+        fields must come back in declaration order (not alphabetical), and
+        each must recover its own prior mean — a mislabeling would reorder
+        the fields and flip the means.
+        """
+        from probpipe import condition_on
+
+        def model_fn(y=None):
+            with pm.Model() as m:
+                zeta = pm.Normal("zeta", 100.0, 0.5)
+                alpha = pm.Normal("alpha", 0.0, 0.5)
+                mu = pm.Normal("mu", -100.0, 0.5)
+                pm.Normal("y", mu=zeta + alpha + mu, sigma=1000.0, observed=y)
+            return m
+
+        model = PyMCModel(model_fn)
+        result = condition_on(
+            model, {"y": np.zeros(5, dtype=np.float32)},
+            method="pymc_nuts",
+            num_results=200, num_warmup=200, num_chains=1, random_seed=0,
+        )
+        draws = result.draws()
+        # Declared order, not nutpie/pymc's alphabetical data_vars order.
+        assert draws.fields == ("zeta", "alpha", "mu")
+        for field, prior_mean in [("zeta", 100.0), ("alpha", 0.0), ("mu", -100.0)]:
+            got = float(jnp.mean(jnp.asarray(draws[field])))
+            np.testing.assert_allclose(got, prior_mean, atol=10.0)
+
     def test_dynamic_rv_set_rejected_via_inference(self):
         """The clean dynamic-RV error fires on the inference path too.
 


### PR DESCRIPTION
Closes #233. **Stacked on #234** — until that merges, the diff below includes #234's `field_order` mechanism commits; review the wiring commit (`69545af`) or merge #234 first.

## What

#234 added the name-keyed assembly *mechanism* (`field_order` on `ApproximateDistribution` / `make_posterior`). This routes the three PyMC inference paths (`nutpie_nuts`, `pymc_nuts`, `pymc_advi`) through it, completing the #233 goal: **column order from any backend is now structurally safe**, retiring the per-caller `keep_names` pre-sort introduced in #231.

Each PyMC path now:
- builds the `record_template` in canonical field order (`_conditioned_param_names`);
- extracts chain columns in the trace's **natural** variable order (new `posterior_var_order` helper — nutpie sorts `data_vars` alphabetically);
- passes that order as `make_posterior(field_order=...)`, so `ApproximateDistribution` realigns columns to the template fields **by name**.

Previously (#231) the extraction was force-sorted into template order via `keep_names`; correctness relied on that per-caller discipline. Now the positional split only ever sees columns already realigned by name, so a backend whose trace orders variables differently can't silently mislabel draws. `posterior_var_order` still filters to the param set, preserving the drop of any transformed/observed vars.

## Why this is the structural fix

The nutpie alphabetical-`data_vars` bug (#231) showed the fragility of "every caller must pre-sort columns into template order." This makes the alignment a property of the assembly layer (by name) rather than caller discipline.

## Tests

No new tests required — the existing value tests already exercise this and are now genuine `field_order` regression guards (extraction is now natural-order, so they fail without the wiring). Verified: removing `field_order` from the nutpie path makes `test_multiparam_draws_not_mislabeled` fail (alphabetical extraction vs canonical template), and restoring it passes. The mechanism itself is unit-tested in #234 (`test_field_order_*`).

## Test plan

- [x] `pytest tests/inference/ tests/modeling/` — 405 passed, 4 skipped
- [x] Confirmed `field_order` wiring is load-bearing (revert → mislabel test fails)
- [ ] CI green (after #234 merges / base settles)
