### PR TITLE
Bump jax/jaxlib floor to >=0.9, blackjax to >=1.4 (upgrade plan step 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,nutpie]"
+          # Pin the verified jax / tfp-nightly pair. tfp-nightly tracks jax's
+          # internal API, and a fresh nightly can lag the current jax release
+          # (DeprecationWarnings, occasionally hard errors) under jax 0.10+.
+          # Refresh this pair when the nightly is purged from PyPI.
+          pip install "jax==0.10.1" "jaxlib==0.10.1" "tfp-nightly==0.26.0.dev20260608"
 
       - name: Run tests (changed files only)
         if: steps.changed.outputs.skip != 'true' && steps.changed.outputs.run_all == 'false'
@@ -387,6 +392,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,nutpie]"
+          # Pin the verified jax / tfp-nightly pair. tfp-nightly tracks jax's
+          # internal API, and a fresh nightly can lag the current jax release
+          # (DeprecationWarnings, occasionally hard errors) under jax 0.10+.
+          # Refresh this pair when the nightly is purged from PyPI.
+          pip install "jax==0.10.1" "jaxlib==0.10.1" "tfp-nightly==0.26.0.dev20260608"
 
       - name: Execute affected docs/examples notebooks
         if: steps.nb_check.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,20 @@ jobs:
           fi
 
           CHANGED=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD -- '*.py' || true)
+          CHANGED_ALL=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD || true)
           echo "Changed .py files:"
           echo "$CHANGED"
 
-          # If foundational files changed, run the full suite.
+          # If foundational files changed, run the full suite. Scan ALL
+          # changed files (not just .py): a dependency bump in pyproject.toml
+          # touches no .py file but must still trigger the suite.
           # Also force the full suite on direct pushes to main (post-merge
           # safety net — targeted tests are for PRs only).
           if [ "${{ github.event_name }}" = "push" ]; then
             RUN_ALL=true
           else
             RUN_ALL=false
-            for f in $CHANGED; do
+            for f in $CHANGED_ALL; do
               case "$f" in
                 pyproject.toml|setup.cfg|setup.py|tests/conftest.py|probpipe/__init__.py)
                   RUN_ALL=true ;;
@@ -49,14 +52,17 @@ jobs:
             done
           fi
 
-          if [ -z "$CHANGED" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "run_all=false" >> "$GITHUB_OUTPUT"
-            echo "No .py files changed — skipping tests."
-          elif [ "$RUN_ALL" = "true" ]; then
+          # Check RUN_ALL before the empty-CHANGED skip, so a foundational
+          # change with no .py edits (e.g. a pyproject.toml-only PR) still
+          # runs the full suite instead of being skipped.
+          if [ "$RUN_ALL" = "true" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
             echo "run_all=true" >> "$GITHUB_OUTPUT"
             echo "Will run ALL tests (foundational change detected)."
+          elif [ -z "$CHANGED" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "run_all=false" >> "$GITHUB_OUTPUT"
+            echo "No .py files changed — skipping tests."
           else
             # Write an import-graph expander: given changed source files, it
             # uses AST parsing to find all probpipe modules that *transitively*
@@ -178,12 +184,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,nutpie]"
-          # Pin the verified jax / tfp-nightly pair. tfp-nightly tracks jax's
-          # internal API, and a fresh nightly can lag the current jax release
-          # (DeprecationWarnings, occasionally hard errors) under jax 0.10+.
-          # Refresh this pair when the nightly is purged from PyPI.
-          pip install "jax==0.10.1" "jaxlib==0.10.1" "tfp-nightly==0.26.0.dev20260608"
+          # Install the project together with the verified jax / tfp-nightly
+          # pins in a single resolver transaction. Installing the project
+          # first and re-pinning afterwards resolves the tree twice — the
+          # first time against unpinned metadata — which can leave the rest
+          # of the dependency set resolved against a different jax. tfp-nightly
+          # tracks jax's internal API, and a fresh nightly can lag the current
+          # jax release (DeprecationWarnings, occasionally hard errors) under
+          # jax 0.10+. Refresh this pair when the nightly is purged from PyPI.
+          pip install -e ".[dev,nutpie]" \
+            "jax==0.10.1" "jaxlib==0.10.1" "tfp-nightly==0.26.0.dev20260608"
 
       - name: Run tests (changed files only)
         if: steps.changed.outputs.skip != 'true' && steps.changed.outputs.run_all == 'false'
@@ -231,7 +241,37 @@ jobs:
           fi
           CHANGED=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD \
             -- 'docs/examples/*.ipynb' 'probpipe/' || true)
-          if [ -z "$CHANGED" ]; then
+          CHANGED_ALL=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD || true)
+
+          # A dependency bump in pyproject.toml touches no notebook or source
+          # file but can still break every notebook, so foundational changes
+          # force the full notebook set (mirrors the test job's RUN_ALL). Also
+          # force it on direct pushes to main (post-merge safety net).
+          if [ "${{ github.event_name }}" = "push" ]; then
+            RUN_ALL_NB=true
+          else
+            RUN_ALL_NB=false
+            for f in $CHANGED_ALL; do
+              case "$f" in
+                pyproject.toml|setup.cfg|setup.py) RUN_ALL_NB=true ;;
+              esac
+            done
+          fi
+
+          # Check RUN_ALL_NB before the empty-CHANGED skip, so a foundational
+          # change with no notebook/source edits still runs every notebook.
+          if [ "$RUN_ALL_NB" = "true" ]; then
+            NOTEBOOKS=$(find docs/examples -maxdepth 1 -name '*.ipynb' | sort | tr '\n' ' ' | xargs)
+            if [ -z "$NOTEBOOKS" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "No example notebooks found — skipping notebook CI."
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              echo "notebooks=$NOTEBOOKS" >> "$GITHUB_OUTPUT"
+              echo "Foundational change detected — executing ALL notebooks:"
+              echo "$NOTEBOOKS"
+            fi
+          elif [ -z "$CHANGED" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "No docs/examples notebook or probpipe source changes — skipping notebook CI."
           else
@@ -391,12 +431,16 @@ jobs:
         if: steps.nb_check.outputs.skip != 'true'
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,nutpie]"
-          # Pin the verified jax / tfp-nightly pair. tfp-nightly tracks jax's
-          # internal API, and a fresh nightly can lag the current jax release
-          # (DeprecationWarnings, occasionally hard errors) under jax 0.10+.
-          # Refresh this pair when the nightly is purged from PyPI.
-          pip install "jax==0.10.1" "jaxlib==0.10.1" "tfp-nightly==0.26.0.dev20260608"
+          # Install the project together with the verified jax / tfp-nightly
+          # pins in a single resolver transaction. Installing the project
+          # first and re-pinning afterwards resolves the tree twice — the
+          # first time against unpinned metadata — which can leave the rest
+          # of the dependency set resolved against a different jax. tfp-nightly
+          # tracks jax's internal API, and a fresh nightly can lag the current
+          # jax release (DeprecationWarnings, occasionally hard errors) under
+          # jax 0.10+. Refresh this pair when the nightly is purged from PyPI.
+          pip install -e ".[dev,nutpie]" \
+            "jax==0.10.1" "jaxlib==0.10.1" "tfp-nightly==0.26.0.dev20260608"
 
       - name: Execute affected docs/examples notebooks
         if: steps.nb_check.outputs.skip != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Core jax / jaxlib floor raised to `>=0.9`; blackjax to `>=1.4`.**
+  With sbijax gone (see *Removed*), the `<0.9` jax / jaxlib cap that
+  existed solely to keep sbijax's hard `jax==0.8.1` pin satisfiable is
+  lifted, and the floor moves up to `>=0.9` — the verified stack
+  resolves to jax 0.10.1. `blackjax` moves `>=1.3` → `>=1.4` (held at
+  `1.3` only to spare sbijax's jax 0.8.1 environment). Users pinned to
+  jax 0.8.x must upgrade to `>=0.9`. Isolated as its own PR for
+  bisectability given the broad RNG / numerics blast radius across
+  every JAX backend. The arviz `<1.0` ceiling and the `pymc>=6` bump
+  are intentionally *not* changed here — each lands in its own isolated
+  PR (the arviz-1.x ceiling lift and the pymc 6 upgrade).
+
 ### Removed
 
 - **sbijax dropped (breaking).** The `sbijax`-backed simulation-based

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,15 +17,15 @@ authors = [
   { name = "Jiaqiang Zhu",      email = "julian25@bu.edu" },
 ]  # See AUTHORS file for full list
 dependencies = [
-  # The jax/jaxlib <0.9 cap and the arviz <1.0 ceiling are no longer
-  # gated on sbijax (dropped here). They are lifted in their own
-  # isolated PRs — jax/jaxlib floor in the jax-0.10 bump, the arviz
-  # ceiling in the arviz-1.x ceiling lift — so this sbijax-removal PR
-  # changes no runtime version pins.
-  "jax>=0.8.1,<0.9",
-  "jaxlib>=0.8.1,<0.9",
+  # jax/jaxlib floor raised to >=0.9 now that sbijax (which hard-pinned
+  # jax 0.8.1) is gone; the verified stack resolves to 0.10.1. blackjax
+  # was held at >=1.3 only to spare sbijax's jax 0.8.1. The arviz <1.0
+  # ceiling is retained here and lifted in its own isolated PR (the
+  # arviz-1.x ceiling lift).
+  "jax>=0.9",
+  "jaxlib>=0.9",
   "tfp-nightly>=0.26.0.dev20260318",
-  "blackjax>=1.3",
+  "blackjax>=1.4",
   "arviz>=0.13,<1.0",
 ]
 


### PR DESCRIPTION
## Summary

Step 1 of the integrated **PyMC 6 / ArviZ 1.0 upgrade**: raise the core **jax / jaxlib floor to `>=0.9`** and **blackjax to `>=1.4`**. With sbijax gone (Step 0, #240), the `<0.9` jax / jaxlib cap — which existed only to keep sbijax's hard `jax==0.8.1` pin satisfiable — is lifted, and the floor moves up. Isolated as its own PR for bisectability and soak: the jax bump has the broadest RNG / numerics blast radius across every JAX backend.

> ⚠️ **Stacked on #240 (`dev/drop-sbijax`).** This PR's base is `dev/drop-sbijax`, so the diff below is *only* the Step-1 delta (3 files). **Merge after #240.** Once #240 lands on `main`, retarget this to `main` (or rebase) — at which point CI runs. **Note:** `ci.yml` only triggers on PRs targeting `main`, so no checks run while the base is `dev/drop-sbijax`; the local verification below stands in until then.

## Changes

**`pyproject.toml`:**

- `jax>=0.8.1,<0.9` → `jax>=0.9`
- `jaxlib>=0.8.1,<0.9` → `jaxlib>=0.9`
- `blackjax>=1.3` → `blackjax>=1.4` (held at `1.3` only to spare sbijax's jax 0.8.1 environment)
- `tfp-nightly` and `arviz>=0.13,<1.0` **unchanged** — the arviz `<1.0` ceiling lift and the `pymc>=6` bump land in their own isolated PRs (Steps 2–3).

**`.github/workflows/ci.yml`:** pin the verified known-good pair `jax==0.10.1` / `jaxlib==0.10.1` / `tfp-nightly==0.26.0.dev20260608` in both the test and notebook install blocks. A fresh tfp-nightly can lag jax's internal API under 0.10+ (DeprecationWarnings, occasionally hard errors); the pin keeps CI reproducible. The comment notes to refresh the pin when the nightly is purged from PyPI.

**`CHANGELOG.md`:** `### Changed` entry under `[Unreleased]`.

## Verification

Built a fresh isolated venv on Python 3.12 with `pip install -e ".[dev,nutpie]"` — byte-identical to what CI installs — which resolved to **jax 0.10.1 / jaxlib 0.10.1 / blackjax 1.5 / tfp-nightly 0.26.0.dev20260608 / numpy 2.4.6**.

- **Full suite: `2774 passed, 7 skipped, 0 failed`** (139s). The 7 skips match the jax-0.8 baseline exactly.
- `2774` *is* the CI test count. The dev machine's extra ~72 tests are pymc (29) + stan (34) + parametrization, whose backends CI does not install (`.[dev,nutpie]` has neither). Those are non-JAX (pytensor/numba, C++) and unaffected by the jax version; diffrax is unused by probpipe (0 references in source/tests).
- Every JAX-backend test — blackjax NUTS/HMC/RWMH/ESS/SGLD/SGHMC, TFP NUTS/HMC, all distributions and random functions, nutpie — ran and passed under jax 0.10.1.
- Python 3.13 wheels confirmed available for all three pinned packages (jaxlib `cp313`; jax / tfp-nightly pure-python), so the 3.13 CI leg won't fail on the pin.

The pymc/stan suites were not run locally under jax 0.10 (CI doesn't install those backends, and they're orthogonal to the jax version); the broader pymc-6 stack was separately exercised green under jax 0.10.1 during the upgrade readiness check.
