### PR TITLE
Cut over to arviz 1.x + pymc 6; drop arviz 0.x straddle (upgrade plan step 2+3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,8 @@ jobs:
           # tracks jax's internal API, and a fresh nightly can lag the current
           # jax release (DeprecationWarnings, occasionally hard errors) under
           # jax 0.10+. Refresh this pair when the nightly is purged from PyPI.
-          pip install -e ".[dev,nutpie]" \
+          # [pymc] is installed so pymc 6 is exercised on both matrix legs.
+          pip install -e ".[dev,nutpie,pymc]" \
             "jax==0.10.1" "jaxlib==0.10.1" "tfp-nightly==0.26.0.dev20260608"
 
       - name: Run tests (changed files only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Ecosystem cutover to arviz 1.x and pymc 6 (breaking).** The core
+  `arviz` pin moves `>=0.13,<1.0` → `>=1.1,<2.0`, **dropping arviz 0.x
+  entirely**, and the `[pymc]` extra moves `pymc>=5.28` → `pymc>=6`
+  (pymc 5.x hard-caps `arviz<1.0`; pymc 6.0 is the first
+  arviz-1.x-compatible release). ProbPipe now binds the arviz 1.x split
+  packages **by name** — `arviz_base.from_dict` (`build_mcmc_datatree`),
+  `arviz_base.from_cmdstanpy` (the CmdStan method), and `arviz_stats.*`
+  — never bare `import arviz`; the runtime 0.x/1.x version probes are
+  removed and the auxiliary is an arviz 1.x `xarray.DataTree`
+  throughout (`ApproximateDistribution.warmup_samples` reads
+  `aux.children`). `[pymc]` additionally requires `matplotlib` (the
+  pymc 6 sampler progress bar imports it). Internal pymc-6 fix:
+  `pm.sample_prior_predictive(samples=)` → `draws=` (the `samples=`
+  kwarg was dropped in pymc 6); `pymc_nuts` keeps `cores=1` pending a
+  dedicated fork-safety review (the multicore reclaim is deferred). The
+  ArviZ 1.0 defaults — credible interval 0.94 → 0.89 and HDI → ETI —
+  are adopted as-is: no affected statistic is called in ProbPipe
+  source, so no `rcParams` pin is needed, and a frozen-fixture suite
+  (`tests/inference/test_arviz_regression.py`) locks the 0.89/ETI
+  defaults plus golden `arviz_stats` values as a tripwire against
+  future silent default drift.
+
 - **Core jax / jaxlib floor raised to `>=0.9`; blackjax to `>=1.4`.**
   With sbijax gone (see *Removed*), the `<0.9` jax / jaxlib cap that
   existed solely to keep sbijax's hard `jax==0.8.1` pin satisfiable is

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -79,9 +79,8 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
 
     Stores per-chain sample arrays for chain-structured access via
     :meth:`draws`.  Algorithm metadata, sample statistics, warmup
-    samples, and the ArviZ ``InferenceData`` object live in
-    ``dist.auxiliary`` (a DataTree on the Distribution base class),
-    not as attributes of this class.
+    samples, and the ArviZ ``DataTree`` live in ``dist.auxiliary``
+    (on the Distribution base class), not as attributes of this class.
 
     Parameters
     ----------
@@ -271,8 +270,8 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
 
         Alias for ``self.auxiliary``.  Use ArviZ functions for diagnostics::
 
-            import arviz as az
-            az.summary(posterior.inference_data)
+            import arviz_stats
+            arviz_stats.summary(posterior.inference_data)
         """
         return self.auxiliary
 
@@ -282,12 +281,8 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
         aux = self.auxiliary
         if aux is None:
             return None
-        # arviz 1.x DataTree uses .children; arviz 0.x InferenceData uses .groups()
-        has_warmup = (
-            ("warmup" in aux.children) if hasattr(aux, "children")
-            else hasattr(aux, "warmup")
-        )
-        if not has_warmup:
+        # auxiliary is an arviz 1.x ``xarray.DataTree``; groups are children
+        if "warmup" not in aux.children:
             return None
         warmup = aux["warmup"]["params"]
         n_chains = warmup.sizes.get("chain", 1)

--- a/probpipe/inference/_cmdstan_method.py
+++ b/probpipe/inference/_cmdstan_method.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import arviz as az
+import arviz_base as azb
 import jax.numpy as jnp
 
 from ..core._registry import MethodInfo
@@ -79,7 +79,7 @@ class CmdStanNutsMethod(InferenceMethod):
             chain_draws = jnp.asarray(fit.draws(concat_chains=False)[c])
             chains.append(chain_draws)
 
-        inference_data = az.from_cmdstanpy(fit)
+        inference_data = azb.from_cmdstanpy(fit)
 
         return make_posterior(
             chains, parents=(dist,), algorithm="cmdstan_nuts",

--- a/probpipe/inference/_inference_utils.py
+++ b/probpipe/inference/_inference_utils.py
@@ -429,28 +429,17 @@ def build_mcmc_datatree(
     (if provided). Backend-agnostic — consumed by both the TFP and
     BlackJAX MCMC paths.
     """
-    import arviz as az
+    import arviz_base as azb
     import xarray as xr
 
     def _stack(chain_list):
         return np.stack([np.asarray(c) for c in chain_list], axis=0)
 
-    posterior_dict = {"params": _stack(chains)}
-    # arviz 1.x ``from_dict`` takes a positional groups dict; arviz 0.x
-    # takes keyword arguments (``posterior=``, ``sample_stats=``, ...).
-    import inspect
-    sig = inspect.signature(az.from_dict)
-    first_param = next(iter(sig.parameters))
-    if first_param == "posterior":
-        kw: dict = {"posterior": posterior_dict}
-        if sample_stats:
-            kw["sample_stats"] = sample_stats
-        dt = az.from_dict(**kw)
-    else:
-        groups: dict = {"posterior": posterior_dict}
-        if sample_stats:
-            groups["sample_stats"] = sample_stats
-        dt = az.from_dict(groups)
+    # arviz 1.x: positional ``{group: {var: array}}`` -> ``xarray.DataTree``.
+    groups: dict = {"posterior": {"params": _stack(chains)}}
+    if sample_stats:
+        groups["sample_stats"] = sample_stats
+    dt = azb.from_dict(groups)
 
     if warmup_chains is not None and all(w is not None for w in warmup_chains):
         warmup_array = _stack(warmup_chains)

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -266,7 +266,7 @@ class PyMCModel(ProbabilisticModel):
 
         model = self._model_fn()
         with model:
-            prior = pm.sample_prior_predictive(samples=max(n, 1))
+            prior = pm.sample_prior_predictive(draws=max(n, 1))
 
         # Concatenate parameter values into a single array
         arrays = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,13 @@ authors = [
   { name = "Jiaqiang Zhu",      email = "julian25@bu.edu" },
 ]  # See AUTHORS file for full list
 dependencies = [
-  # jax/jaxlib floor raised to >=0.9 now that sbijax (which hard-pinned
-  # jax 0.8.1) is gone; the verified stack resolves to 0.10.1. blackjax
-  # was held at >=1.3 only to spare sbijax's jax 0.8.1. The arviz <1.0
-  # ceiling is retained here and lifted in its own isolated PR (the
-  # arviz-1.x ceiling lift).
+  # arviz 0.x was only reachable while [pymc] allowed pymc 5.x (which caps
+  # arviz<1.0); [pymc] now needs pymc>=6, so the floor moves to arviz>=1.1.
   "jax>=0.9",
   "jaxlib>=0.9",
   "tfp-nightly>=0.26.0.dev20260318",
   "blackjax>=1.4",
-  "arviz>=0.13,<1.0",
+  "arviz>=1.1,<2.0",
 ]
 
 [project.optional-dependencies]
@@ -38,7 +35,9 @@ docs = [
   "mkdocs-jupyter<0.26",
 ]
 stan = ["bridgestan>=2.0", "cmdstanpy>=1.2"]
-pymc = ["pymc>=5.28"]
+# pymc 6 is the first release compatible with arviz 1.x (pymc 5.x caps
+# arviz<1.0); matplotlib is required by the pymc 6 sampler progress bar.
+pymc = ["pymc>=6", "matplotlib"]
 nutpie = ["nutpie>=0.12"]
 dev = [
   "probpipe[prefect,viz,docs]",

--- a/tests/inference/test_arviz_regression.py
+++ b/tests/inference/test_arviz_regression.py
@@ -1,0 +1,84 @@
+"""Frozen-fixture regression tests locking ArviZ 1.x diagnostic defaults.
+
+ArviZ 1.0 changed reporting defaults that silently alter published numbers:
+the default credible interval moved ``0.94 -> 0.89`` and the default kind
+from HDI to ETI, resolved from ``arviz_base.rcParams`` when ``ci_prob`` /
+``ci_kind`` is ``None``.  ProbPipe does not call these statistics in source
+today (the diagnostics ops land in a later step), but the upgrade pins the
+arviz 1.x line, so these tests freeze a fixed-seed posterior plus
+log-likelihood against golden ``arviz_stats`` values.  A future default flip
+-- or an algorithm change in arviz -- trips a test here rather than surfacing
+unannounced in a downstream analysis.
+
+``numpy.random.default_rng`` (PCG64) guarantees a stable stream across numpy
+versions, so the golden values below depend only on ``arviz_stats``.
+"""
+
+from __future__ import annotations
+
+import arviz_base as azb
+import arviz_stats as azs
+import numpy as np
+import pytest
+
+
+@pytest.fixture(scope="module")
+def frozen_idata():
+    """Deterministic posterior + log-likelihood ``DataTree`` (PCG64 seed 0)."""
+    rng = np.random.default_rng(0)
+    nchain, ndraw, nobs = 4, 600, 12
+    mu = rng.normal(0.0, 1.0, (nchain, ndraw)) + 0.05 * np.arange(nchain)[:, None]
+    sigma = np.abs(rng.normal(1.0, 0.2, (nchain, ndraw)))
+    loglik = {"y": rng.normal(-2.0, 0.5, (nchain, ndraw, nobs))}
+    return azb.from_dict({
+        "posterior": {"mu": mu, "sigma": sigma},
+        "log_likelihood": loglik,
+    })
+
+
+# -- The load-bearing default-drift tripwire ----------------------------------
+
+
+class TestArviZDefaultDrift:
+    def test_summary_default_interval_is_eti_089(self, frozen_idata):
+        """The default summary interval is the 0.89 ETI, not the 0.94 HDI.
+
+        The column names encode both the kind (``eti``) and the probability
+        (``89``); a flip back to HDI or to 0.94 renames them and fails here.
+        """
+        cols = list(azs.summary(frozen_idata).columns)
+        assert "eti89_lb" in cols and "eti89_ub" in cols
+        assert not any(c.startswith("hdi") for c in cols)
+
+    def test_summary_golden_values(self, frozen_idata):
+        """ESS counts (``Int64``) and ETI bounds (string-formatted under
+        ``round_to="auto"``) match golden values for the frozen fixture."""
+        s = azs.summary(frozen_idata)
+        assert int(s.loc["mu", "ess_bulk"]) == pytest.approx(2383, rel=0.02)
+        assert int(s.loc["mu", "ess_tail"]) == pytest.approx(2312, rel=0.02)
+        assert int(s.loc["sigma", "ess_bulk"]) == pytest.approx(2390, rel=0.02)
+        assert float(s.loc["mu", "eti89_lb"]) == pytest.approx(-1.5, abs=0.05)
+        assert float(s.loc["mu", "eti89_ub"]) == pytest.approx(1.7, abs=0.05)
+
+    def test_rhat_rank_default(self, frozen_idata):
+        """R-hat uses the rank-normalized method by default (~1.0 here)."""
+        r = azs.rhat(frozen_idata)
+        assert float(r["mu"]) == pytest.approx(1.001, abs=5e-3)
+        assert float(r["sigma"]) == pytest.approx(1.0, abs=5e-3)
+
+
+# -- LOO / PSIS golden values -------------------------------------------------
+
+
+class TestLOOFrozen:
+    def test_loo_golden(self, frozen_idata):
+        loo = azs.loo(frozen_idata)
+        assert loo.scale == "log"
+        assert float(loo.elpd) == pytest.approx(-25.469, rel=1e-3)
+        assert float(loo.p) == pytest.approx(2.999, rel=1e-2)
+
+    def test_pareto_k_good_threshold(self, frozen_idata):
+        """The good-k threshold is the sample-size-derived ``min(1-1/log10(S), 0.7)``
+        -- 0.7 for this fixture -- and every observation is below it."""
+        loo = azs.loo(frozen_idata)
+        assert loo.good_k == pytest.approx(0.7)

--- a/tests/inference/test_cmdstan_method.py
+++ b/tests/inference/test_cmdstan_method.py
@@ -1,0 +1,68 @@
+"""CmdStan NUTS method: arviz 1.x integration.
+
+The cmdstan path builds its auxiliary ``DataTree`` via
+``arviz_base.from_cmdstanpy`` -- rebound from the arviz-0.x ``arviz.from_cmdstanpy``
+during the arviz 1.x cutover. The ecosystem readiness probe never exercised
+this path, so a smoke test guards it. The static binding test runs everywhere
+(arviz is core); the end-to-end fit requires the ``[stan]`` extra plus a CmdStan
+toolchain and is skipped otherwise.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def test_cmdstan_method_binds_arviz_base():
+    """The CmdStan method binds arviz 1.x by name (``arviz_base``), never bare
+    ``arviz`` -- it builds its auxiliary via ``arviz_base.from_cmdstanpy``."""
+    import arviz_base
+
+    from probpipe.inference import _cmdstan_method
+
+    assert _cmdstan_method.azb is arviz_base
+    assert callable(arviz_base.from_cmdstanpy)
+
+
+def _cmdstan_available() -> bool:
+    try:
+        import cmdstanpy
+
+        cmdstanpy.cmdstan_path()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _cmdstan_available(),
+    reason="requires the [stan] extra plus an installed CmdStan toolchain",
+)
+def test_from_cmdstanpy_produces_arviz1x_datatree(tmp_path):
+    """End-to-end: a cmdstanpy fit round-trips through ``arviz_base.from_cmdstanpy``
+    into an arviz 1.x ``DataTree`` with a populated ``posterior`` group."""
+    import arviz_base as azb
+    import cmdstanpy
+    from xarray import DataTree
+
+    stan_src = (
+        "data { int<lower=0> N; vector[N] y; }\n"
+        "parameters { real mu; real<lower=0> sigma; }\n"
+        "model { mu ~ normal(0, 5); sigma ~ normal(0, 5); y ~ normal(mu, sigma); }\n"
+    )
+    stan_file = tmp_path / "gauss.stan"
+    stan_file.write_text(stan_src)
+    model = cmdstanpy.CmdStanModel(stan_file=str(stan_file))
+
+    rng = np.random.default_rng(0)
+    y = rng.normal(1.0, 2.0, size=30)
+    fit = model.sample(
+        data={"N": int(y.size), "y": y.tolist()},
+        chains=2, iter_sampling=200, iter_warmup=200, seed=0, show_console=False,
+    )
+
+    idata = azb.from_cmdstanpy(fit)
+    assert isinstance(idata, DataTree)
+    assert "posterior" in idata.children
+    assert {"mu", "sigma"} <= set(idata["posterior"].data_vars)


### PR DESCRIPTION
## Summary

Combined **Step 2 (arviz `<1.0`→`<2.0` ceiling lift)** and **Step 3 (pymc-6 bump)** of the integrated upgrade into a single ecosystem cutover. Per the decision to **floor arviz at the 1.x line** rather than carry the 0.x/1.x straddle: pymc 5.x hard-caps `arviz<1.0`, so flooring `arviz>=1.1` *requires* `pymc>=6` (the first arviz-1.x-compatible pymc). The result is the §2 readiness-probe-verified stack — **pymc 6.0.1 + arviz 1.1.0 + jax 0.10.1** — and the 0.x straddle code is deleted.

> ⚠️ **Stacked on #241 (`dev/bump-jax`), which is stacked on #240.** Base is `dev/bump-jax`, so the diff is only the Step-2/3 delta. **Merge after #241.** CI (`ci.yml`) only triggers on PRs targeting `main`, so no checks run while the base is a `dev/*` branch; the local verification below stands in until this is retargeted to `main`.

## Changes

**`pyproject.toml`:**
- `arviz>=0.13,<1.0` → `arviz>=1.1,<2.0` — **drops arviz 0.x entirely**. The 1.x metapackage pulls `arviz-base` / `arviz-stats` / `arviz-plots`, so a separate `[diagnostics]` extra would be redundant and is omitted.
- `[pymc]`: `pymc>=5.28` → `pymc>=6`, plus `matplotlib` (the pymc 6 sampler progress bar imports it).

**Source — arviz bound by name, 0.x straddle removed:**
- `build_mcmc_datatree`: `arviz_base.from_dict` (positional groups dict); the `from_dict` signature probe is gone.
- `_cmdstan_method`: `arviz_base.from_cmdstanpy` (was bare `import arviz`).
- `ApproximateDistribution.warmup_samples` reads `aux.children` directly — every auxiliary is an arviz 1.x `xarray.DataTree` now (verified: the JAX-backend datatree *and* pymc 6's `return_inferencedata=True` trace are both `DataTree`s). Docstrings rebind `arviz_stats` by name.
- `_pymc.py`: `pm.sample_prior_predictive(samples=)` → `draws=` (the `samples=` kwarg was dropped in pymc 6).

**Deferred:** `pymc_nuts` keeps `cores=1` — the `os.fork()`/JAX-threads deadlock guard. The plan's multicore reclaim is gated on a fork-safety check it wasn't sure about; reclaiming it risks intermittent CI deadlocks for a perf-only gain, so it's deferred to its own review rather than bundled here.

**Tests:**
- `tests/inference/test_arviz_regression.py` — a frozen-fixture (fixed PCG64 seed) tripwire that locks the ArviZ 1.0 reporting defaults (credible interval `0.94→0.89`, HDI→ETI, confirmed via the `eti89_lb`/`eti89_ub` summary columns) plus golden `arviz_stats` rhat / ESS / LOO values, so a future silent default flip fails a test rather than surfacing in an analysis.
- `tests/inference/test_cmdstan_method.py` — a static check that the CmdStan method binds `arviz_base.from_cmdstanpy` (runs everywhere), plus a guarded end-to-end `cmdstanpy fit → from_cmdstanpy → DataTree` smoke test (skips without the `[stan]` extra and a CmdStan toolchain).

**`.github/workflows/ci.yml`:** `[pymc]` added to the test-job install so pymc 6 is exercised on both the 3.12 and 3.13 matrix legs (cp313 wheels confirmed for pymc / pytensor / numba / llvmlite). The arviz 1.x line is enforced by the core floor; the notebook job stays lean.

## Verification

Built a fresh isolated venv (Python 3.12) from the updated pyproject; it resolved exactly the readiness-probe stack: **arviz 1.1.0 / arviz-base / arviz-stats / arviz-plots 1.1.0, pymc 6.0.1, pytensor 3.0.4, numba 0.65.1, jax 0.10.1, numpy 2.4.6**, plus cmdstanpy/bridgestan.

- **Full suite: `2852 passed, 8 skipped, 0 failed`** under this stack — including all pymc-6 tests (with the `draws=` fix) and the JAX backends; the new frozen-fixture tests pass and the cmdstan fit smoke skips cleanly (no CmdStan toolchain in this env — its download is SSL-blocked here). `mkdocs build --strict` is also clean (exit 0).
- The arviz 1.x APIs were exercised directly: `build_mcmc_datatree` and pymc 6's trace both yield `xarray.DataTree`s; `warmup_samples` extraction works end-to-end.
- cp313 manylinux wheels confirmed for the full pymc stack, so the 3.13 CI leg installs cleanly.
