### PR TITLE
Reclaim pymc_nuts multi-core sampling via spawn (follow-up to #242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`pymc_nuts` reclaims multi-core sampling.** The method previously
+  forced `cores=1` to avoid an `os.fork()` deadlock against JAX's worker
+  threads. It now samples one worker per chain (capped at the CPU count,
+  overridable via a `cores=` kwarg) using the **`spawn`** multiprocessing
+  start method — clean worker processes with no inherited threads, so it
+  is deadlock-free on every platform (POSIX `fork`, the deadlock-prone
+  default on Linux, is never used). Empirically `cores=2` spawn is no
+  slower than the old single-core path; a new test exercises the
+  multi-core path after spinning up JAX's threads to reproduce the
+  hazard.
+
 - **Ecosystem cutover to arviz 1.x and pymc 6 (breaking).** The core
   `arviz` pin moves `>=0.13,<1.0` → `>=1.1,<2.0`, **dropping arviz 0.x
   entirely**, and the `[pymc]` extra moves `pymc>=5.28` → `pymc>=6`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `aux.children`). `[pymc]` additionally requires `matplotlib` (the
   pymc 6 sampler progress bar imports it). Internal pymc-6 fix:
   `pm.sample_prior_predictive(samples=)` → `draws=` (the `samples=`
-  kwarg was dropped in pymc 6); `pymc_nuts` keeps `cores=1` pending a
-  dedicated fork-safety review (the multicore reclaim is deferred). The
+  kwarg was dropped in pymc 6). The
   ArviZ 1.0 defaults — credible interval 0.94 → 0.89 and HDI → ETI —
   are adopted as-is: no affected statistic is called in ProbPipe
   source, so no `rcParams` pin is needed, and a frozen-fixture suite

--- a/probpipe/inference/_pymc_method.py
+++ b/probpipe/inference/_pymc_method.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from ..core._registry import MethodInfo
@@ -45,6 +46,10 @@ class PyMCNutsMethod(InferenceMethod):
         num_results = kwargs.get("num_results", 1000)
         num_warmup = kwargs.get("num_warmup", 500)
         num_chains = kwargs.get("num_chains", 4)
+        # Multi-core sampling forces the "spawn" start method: this process
+        # holds live JAX threads, and pymc's POSIX-"fork" default deadlocks
+        # when a forked worker inherits a held thread lock.
+        cores = kwargs.get("cores", min(num_chains, os.cpu_count() or 1))
         random_seed = kwargs.get("random_seed", 0)
 
         model = dist._pymc_model(data=observed)
@@ -57,7 +62,8 @@ class PyMCNutsMethod(InferenceMethod):
                 draws=num_results,
                 tune=num_warmup,
                 chains=num_chains,
-                cores=1,  # avoid os.fork() which deadlocks with JAX threads
+                cores=cores,
+                mp_ctx="spawn" if cores > 1 else None,
                 random_seed=random_seed,
                 return_inferencedata=True,
             )

--- a/probpipe/inference/_pymc_method.py
+++ b/probpipe/inference/_pymc_method.py
@@ -48,7 +48,10 @@ class PyMCNutsMethod(InferenceMethod):
         num_chains = kwargs.get("num_chains", 4)
         # Multi-core sampling forces the "spawn" start method: this process
         # holds live JAX threads, and pymc's POSIX-"fork" default deadlocks
-        # when a forked worker inherits a held thread lock.
+        # when a forked worker inherits a held thread lock. spawn pickles the
+        # model to each worker; if the model is not picklable, pymc logs a
+        # warning and falls back to single-process sampling — so multi-core
+        # is the default without making serializability a hard requirement.
         cores = kwargs.get("cores", min(num_chains, os.cpu_count() or 1))
         random_seed = kwargs.get("random_seed", 0)
 

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -142,6 +142,31 @@ class TestPyMCModel:
         assert result.source is not None
         assert result.source.operation == "pymc_nuts"
 
+    def test_condition_on_multicore_spawn(self, model):
+        """Multi-core sampling (``cores=2``) runs under the spawn start method
+        -- not the POSIX fork default -- so it does not deadlock against this
+        process's live JAX worker threads, and all chains are returned.
+
+        This exercises the reclaimed multi-core path: ``cores`` defaults to one
+        worker per chain (capped at the CPU count) and ``mp_ctx="spawn"`` is
+        forced whenever ``cores > 1``.
+        """
+        from probpipe import condition_on
+
+        # Spin up JAX's worker threads first, so the POSIX fork start method
+        # would be exposed to the deadlock this path avoids.
+        _ = jnp.ones(1000).sum().block_until_ready()
+
+        data = np.random.randn(50)
+        result = condition_on(
+            model, {"y": data}, method="pymc_nuts",
+            num_results=50, num_warmup=50, num_chains=2, cores=2, random_seed=0,
+        )
+        assert isinstance(result, ApproximateDistribution)
+        assert result.num_chains == 2
+        assert result.num_draws == 50
+        assert result.algorithm == "pymc_nuts"
+
 
 class TestRecordTemplate:
     """``PyMCModel.record_template`` exposes the free-RV layout that

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -10,10 +10,30 @@ pm = pytest.importorskip("pymc")
 import jax
 import jax.numpy as jnp
 import numpy as np
-from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+from unittest.mock import patch
 
 from probpipe import ApproximateDistribution
 from probpipe.modeling import PyMCModel
+
+
+@contextmanager
+def _captured_pm_sample_kwargs():
+    """Patch ``pm.sample`` to record its kwargs, then delegate to the real
+    sampler forced to ``cores=1, mp_ctx=None`` -- so the downstream
+    chain-extraction / posterior-assembly pipeline runs against a genuine
+    ``InferenceData`` without spawn overhead or a fork-deadlock hazard.
+    Yields the dict that receives the recorded kwargs.
+    """
+    real_sample = pm.sample  # capture before patching to avoid recursion
+    captured = {}
+
+    def record_then_sample(*args, **kw):
+        captured.update(kw)
+        return real_sample(*args, **{**kw, "cores": 1, "mp_ctx": None})
+
+    with patch("pymc.sample", side_effect=record_then_sample):
+        yield captured
 
 
 def simple_model_fn(y=None):
@@ -166,6 +186,77 @@ class TestPyMCModel:
         assert result.num_chains == 2
         assert result.num_draws == 50
         assert result.algorithm == "pymc_nuts"
+
+    def test_multicore_passes_spawn_to_pm_sample(self, model):
+        """Deterministically prove production calls ``pm.sample`` with
+        ``mp_ctx="spawn"`` and ``cores >= 2`` on the multi-core path.
+
+        Reverting to the POSIX ``fork`` default (dropping ``mp_ctx="spawn"``)
+        must fail this test regardless of whether a real fork run happens to
+        deadlock -- fork deadlocks are intermittent and cannot be relied on
+        to catch the regression.
+        """
+        from probpipe import condition_on
+
+        data = np.random.randn(50)
+        with _captured_pm_sample_kwargs() as captured:
+            result = condition_on(
+                model, {"y": data}, method="pymc_nuts",
+                num_results=20, num_warmup=10, num_chains=2, cores=2,
+                random_seed=0,
+            )
+
+        assert captured["mp_ctx"] == "spawn"
+        assert captured["cores"] >= 2
+        assert captured["chains"] == 2
+        assert isinstance(result, ApproximateDistribution)
+        assert result.algorithm == "pymc_nuts"
+
+    def test_default_chains_pass_spawn_to_pm_sample(self, model):
+        """The default path (no ``cores`` kwarg, ``num_chains`` defaults to 4)
+        also forces ``mp_ctx="spawn"``: ``cores`` defaults to
+        ``min(num_chains, os.cpu_count())``, so spawn is selected without the
+        caller asking for it. ``os.cpu_count`` is pinned to 4 so the assertion
+        is deterministic -- on a genuinely single-core runner the live default
+        is ``cores=1`` / ``mp_ctx=None`` (correct, not a regression; see
+        ``test_single_core_default_skips_spawn``).
+        """
+        from probpipe import condition_on
+
+        data = np.random.randn(50)
+        with (
+            patch("probpipe.inference._pymc_method.os.cpu_count", return_value=4),
+            _captured_pm_sample_kwargs() as captured,
+        ):
+            _ = condition_on(
+                model, {"y": data}, method="pymc_nuts",
+                num_results=20, num_warmup=10, random_seed=0,
+            )
+
+        assert captured["chains"] == 4               # the documented default
+        assert captured["cores"] == 4                # min(num_chains=4, cpu_count=4)
+        assert captured["mp_ctx"] == "spawn"
+
+    def test_single_core_default_skips_spawn(self, model):
+        """On a single-core host the default ``cores = min(num_chains,
+        os.cpu_count())`` collapses to 1, so ``mp_ctx`` stays ``None`` -- spawn
+        is forced only when it buys parallelism. Pinning ``os.cpu_count`` to 1
+        exercises the ``cores == 1`` branch deterministically.
+        """
+        from probpipe import condition_on
+
+        data = np.random.randn(50)
+        with (
+            patch("probpipe.inference._pymc_method.os.cpu_count", return_value=1),
+            _captured_pm_sample_kwargs() as captured,
+        ):
+            _ = condition_on(
+                model, {"y": data}, method="pymc_nuts",
+                num_results=20, num_warmup=10, random_seed=0,
+            )
+
+        assert captured["cores"] == 1
+        assert captured["mp_ctx"] is None
 
 
 class TestRecordTemplate:


### PR DESCRIPTION
## Summary

Follow-up to #242 (split out per request): **`pymc_nuts` reclaims multi-core sampling**, which #242 deliberately deferred pending a fork-safety investigation.

> ⚠️ **Stacked on #242 → #241 → #240.** Base is `dev/lift-arviz`. **Merge after #242.** CI (`ci.yml`) only triggers on PRs targeting `main`, so no checks run while the base is a `dev/*` branch; the local verification below stands in until this is retargeted to `main`.

## Background

`pymc_nuts` pinned `cores=1` with the comment *"avoid os.fork() which deadlocks with JAX threads."* The hazard is real: ProbPipe's process holds live JAX worker threads, and pymc's default multiprocessing start method on Linux is **`fork`** — forking with a thread lock held hangs the worker. The deadlock is **intermittent** (a lock-held-at-fork race), which is exactly why leaving it to chance is unsafe.

## Fix (`probpipe/inference/_pymc_method.py`)

- `cores` defaults to one worker per chain, capped at `os.cpu_count()`, overridable via a `cores=` kwarg.
- **`mp_ctx="spawn"` is forced whenever `cores>1`.** Spawned workers start clean (no inherited threads), so the fork/threads deadlock cannot arise on any platform. Spawn requires the model to pickle — which PyMC models do, verified against ProbPipe's `PyMCModel`s (all 29 existing pymc tests pass, plus the new one).

## Investigation (pymc 6.0.1 / jax 0.10.1 env)

| config | result |
|---|---|
| `cores=1` (old) | PASS — 5.6 s (2 chains, 500 draws) |
| `cores=2`, `mp_ctx="spawn"` | PASS — **3.8 s** |
| `cores=2`, `mp_ctx="fork"` | passed *this run* (3.4 s) — but the deadlock is intermittent, so fork is not relied upon |

spawn is **not slower** than the old single-core path (faster here) and is deterministically safe, so multi-core is reclaimed as the default via spawn. macOS already defaults to spawn; the explicit `mp_ctx="spawn"` is what protects the Linux/CI `fork` default.

## Test

`tests/modeling/test_pymc_model.py::test_condition_on_multicore_spawn` spins up JAX's worker threads, then runs `condition_on(model, data, method="pymc_nuts", num_chains=2, cores=2)` and asserts both chains are returned — exercising the spawn path against the deadlock condition.

## Verification

Full suite **`2853 passed, 8 skipped, 0 failed`** under arviz 1.1.0 / pymc 6.0.1 / jax 0.10.1 (Python 3.12) — the existing 29 pymc tests plus the new multi-core test pass.
