### PR TITLE
Add BayesFlow amortized-SBI backend (NPE/FMPE/CMPE) (upgrade plan step 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,47 @@ jobs:
           name: coverage-html
           path: htmlcov/
 
+  bayesflow:
+    # Amortized SBI backend (keras-on-jax). BayesFlow 2.x caps Python <3.14, so
+    # this leg runs on 3.12 & 3.13 only — kept separate from the main matrix so
+    # a future 3.14 entry there is unaffected by the cap.
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    env:
+      KERAS_BACKEND: jax
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        # Versions (jax/jaxlib/tfp-nightly/keras/bayesflow) are pinned in uv.lock;
+        # --frozen fails if the lockfile drifts. --python pins the interpreter to
+        # the matrix leg. The bayesflow extra is locked behind a python_version
+        # < 3.14 marker (BayesFlow caps <3.14), so it resolves only on these legs.
+        run: uv sync --frozen --python ${{ matrix.python-version }} --extra dev --extra nutpie --extra bayesflow
+
+      - name: Run BayesFlow backend tests
+        run: uv run pytest tests/inference/test_bayesflow.py --cov-report=xml
+
+      - name: Upload coverage reports to Codecov
+        # The test job's upload measures the BayesFlow backend as uncovered: it
+        # does not install [bayesflow], so these tests importorskip out there.
+        # Upload this leg's report too — Codecov's per-commit union then counts
+        # _bayesflow.py toward patch coverage. 3.12 only, matching the test job.
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: TARPS-group/prob-pipe
+
   notebooks:
     # Execute every docs/examples notebook to keep the reference set
     # honest against the current codebase. Separate job so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `learn_amortized_posterior(prior, simulator, method="npe"|"fmpe"|"cmpe",
   ...)` trains a jax-native (keras-on-JAX) amortized neural posterior
   estimator — NPE (coupling flow), FMPE (flow matching), or CMPE
-  (consistency model) — and returns a `BayesFlowModel` of the joint
-  `p(theta, y)`: `sample(model)` draws `(params, data)` forward through the
-  prior and simulator, and `condition_on(model, observed)` draws from
-  `p(theta | observed)` in a single network forward pass (no MCMC). This
-  restores the amortized half of the SBI layer dropped with sbijax.
+  (consistency model) — and returns a `BayesFlowModel` bundling the joint
+  model (prior + simulator, exposed as properties) with the trained
+  estimator: `condition_on(model, observed)` draws from `p(theta | observed)`
+  in a single network forward pass (no MCMC). This restores the amortized
+  half of the SBI layer dropped with sbijax.
   - Training simulates `(theta, y)` offline (`prior` drawn via the `sample`
     op, `simulator.generate_data` for the data); the prior is used only to
     draw `theta` and needs no TFP translation. The trained estimator is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,14 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Training seeds keras for reproducibility but snapshots and restores the
     caller's global NumPy / Python RNG state, so a call does not perturb
     unrelated random streams.
-
-- **`ProductDistribution.supports`** — per-field support constraints (each
-  component's `support`), implementing the canonical `RecordDistribution`
-  accessor that previously raised `NotImplementedError`.
   - The `[bayesflow]` extra is **Python 3.12–3.13 only** (BayesFlow 2.x caps
     `<3.14`); keras runs on the JAX backend (`KERAS_BACKEND=jax`) — no
     TensorFlow or PyTorch. The backend is imported lazily, so `import
     probpipe` does not load keras.
+
+- **`ProductDistribution.supports`** — per-field support constraints (each
+  component's `support`), implementing the canonical `RecordDistribution`
+  accessor that previously raised `NotImplementedError`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **BayesFlow amortized-SBI backend (`[bayesflow]` extra).** New
+  `learn_amortized_posterior(prior, simulator, method="npe"|"fmpe"|"cmpe",
+  ...)` trains a jax-native (keras-on-JAX) amortized neural posterior
+  estimator — NPE (coupling flow), FMPE (flow matching), or CMPE
+  (consistency model) — and returns a `SupportsConditioning` distribution, so
+  `condition_on(model, observed)` draws from `p(theta | observed)` in a single
+  forward pass (no MCMC). This restores the amortized half of the SBI layer
+  dropped with sbijax.
+  - Training simulates `(theta, y)` offline (`prior` drawn via the `sample`
+    op, `simulator.generate_data` for the data); the prior is used only to
+    draw `theta` and needs no TFP translation. The trained estimator is
+    amortized — the same instance conditions on any observation with no
+    retraining — and its draws are named via the prior's `record_template`.
+  - The `[bayesflow]` extra is **Python 3.12–3.13 only** (BayesFlow 2.x caps
+    `<3.14`); keras runs on the JAX backend (`KERAS_BACKEND=jax`) — no
+    TensorFlow or PyTorch. The backend is imported lazily, so `import
+    probpipe` does not load keras.
+
 ### Changed
 
 - **Dev tooling: migrated to [uv](https://docs.astral.sh/uv/) for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     The simulator receives the prior's native structured per-draw sample (named
     fields), matching the `GenerativeLikelihood` contract, and keras training is
     seeded for reproducibility.
-  - Continuous priors with constrained supports (positive, an interval, …) are
-    handled by per-field `bijector_for` reparameterization: training runs in the
-    unconstrained space and draws are mapped back to the support (identity for
-    real-valued fields). Discrete priors have no smooth bijector and are rejected
-    with a clear error.
+  - Continuous priors with constrained supports — including matrix- and
+    simplex-valued ones (positive, an interval, Dirichlet's simplex, Wishart's
+    positive-definite matrices, …) — are handled by per-field `bijector_for`
+    reparameterization applied at each field's native event shape: training runs
+    in the unconstrained space and draws are mapped back to the support (identity
+    for real-valued fields). NPE's coupling-flow minimum is counted in
+    unconstrained dimensions. Discrete priors have no smooth bijector and are
+    rejected with a clear error.
+  - Training seeds keras for reproducibility but snapshots and restores the
+    caller's global NumPy / Python RNG state, so a call does not perturb
+    unrelated random streams.
+
+- **`ProductDistribution.supports`** — per-field support constraints (each
+  component's `support`), implementing the canonical `RecordDistribution`
+  accessor that previously raised `NotImplementedError`.
   - The `[bayesflow]` extra is **Python 3.12–3.13 only** (BayesFlow 2.x caps
     `<3.14`); keras runs on the JAX backend (`KERAS_BACKEND=jax`) — no
     TensorFlow or PyTorch. The backend is imported lazily, so `import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     draw `theta` and needs no TFP translation. The trained estimator is
     amortized — the same instance conditions on any observation with no
     retraining — and its draws are named via the prior's `record_template`.
+    The simulator receives the prior's native structured per-draw sample (named
+    fields), matching the `GenerativeLikelihood` contract, and keras training is
+    seeded for reproducibility.
+  - Continuous priors with constrained supports (positive, an interval, …) are
+    handled by per-field `bijector_for` reparameterization: training runs in the
+    unconstrained space and draws are mapped back to the support (identity for
+    real-valued fields). Discrete priors have no smooth bijector and are rejected
+    with a clear error.
   - The `[bayesflow]` extra is **Python 3.12–3.13 only** (BayesFlow 2.x caps
     `<3.14`); keras runs on the JAX backend (`KERAS_BACKEND=jax`) — no
     TensorFlow or PyTorch. The backend is imported lazily, so `import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `learn_amortized_posterior(prior, simulator, method="npe"|"fmpe"|"cmpe",
   ...)` trains a jax-native (keras-on-JAX) amortized neural posterior
   estimator — NPE (coupling flow), FMPE (flow matching), or CMPE
-  (consistency model) — and returns a `SupportsConditioning` distribution, so
-  `condition_on(model, observed)` draws from `p(theta | observed)` in a single
-  forward pass (no MCMC). This restores the amortized half of the SBI layer
-  dropped with sbijax.
+  (consistency model) — and returns a `BayesFlowModel` of the joint
+  `p(theta, y)`: `sample(model)` draws `(params, data)` forward through the
+  prior and simulator, and `condition_on(model, observed)` draws from
+  `p(theta | observed)` in a single network forward pass (no MCMC). This
+  restores the amortized half of the SBI layer dropped with sbijax.
   - Training simulates `(theta, y)` offline (`prior` drawn via the `sample`
     op, `simulator.generate_data` for the data); the prior is used only to
     draw `theta` and needs no TFP translation. The trained estimator is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,8 @@ uv sync --extra dev --extra nutpie --extra pymc   # + pymc backend
 
 The `pip install -e ".[dev]"` path still works for contributors with an
 existing pip-based setup, but uv is the recommended path. Optional backends
-not required for tests: `bridgestan`, `pymc`.
+not required for tests: `bridgestan`, `pymc`, `bayesflow` (amortized SBI;
+Python 3.12–3.13 only).
 
 ### Running Tests
 
@@ -221,6 +222,8 @@ GitHub Actions (`.github/workflows/ci.yml`):
   for pinned dependency versions, shared between local dev and CI)
 - Test job uses extras `dev,nutpie,pymc`; the notebooks job uses
   `dev,nutpie` only (`bridgestan` is not included anywhere by default)
+- A separate `bayesflow` leg (Python 3.12 and 3.13 only — BayesFlow caps
+  `<3.14`) syncs `dev,nutpie,bayesflow` and runs the amortized-SBI tests
 - Coverage uploaded to Codecov
 
 Docs build (`.github/workflows/docs.yml`) with `uv run mkdocs build --strict`.
@@ -414,6 +417,13 @@ Built-in methods:
 | 0 | `pymc_advi` | PyMC | `PyMCModel`; opt-in only via `method=` |
 | 0 | `tfp_nuts` | TFP | Any `SupportsLogProb` (JAX-traceable); opt-in only via `method=` |
 | 0 | `tfp_hmc` | TFP | Any `SupportsLogProb` (JAX-traceable); opt-in only via `method=` |
+
+**Amortized SBI bypasses the registry.** Trained amortized posterior estimators
+(`learn_amortized_posterior` → `BayesFlowPosterior`, the `[bayesflow]` extra)
+implement `SupportsConditioning` directly, so `condition_on(model, observed)` is
+a single forward pass through the trained network. Because `condition_on` checks
+`SupportsConditioning` *before* the inference-method registry, these estimators
+short-circuit it and register no method.
 
 ### Converter priority system
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -536,9 +536,16 @@ class SupportsFoo(Protocol):
 ### 7.2 Protocol hierarchy
 
 - `SupportsLogProb` extends `SupportsUnnormalizedLogProb`.
-- All other protocols (`SupportsSampling`, `SupportsMean`,
+- All other capability protocols (`SupportsSampling`, `SupportsMean`,
   `SupportsVariance`, `SupportsCovariance`, `SupportsExpectation`,
   `SupportsConditioning`) are standalone.
+- The likelihood / simulator protocols `Likelihood`,
+  `ConditionallyIndependentLikelihood` (extends `Likelihood`), and
+  `GenerativeLikelihood` also live in `core/protocols.py`. They type model
+  components — log-density, per-datum log-density, and data generation —
+  rather than distribution capabilities, so they are *not* named `Supports*`
+  (they describe what a likelihood/simulator *is*, not a capability a
+  distribution *supports*).
 
 ### 7.3 Implementing protocols
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -518,6 +518,9 @@ inference/    (imports core/, custom_types)
 >
 > - `inference/` → `modeling/` (lazy imports for model-type dispatch in
 >   `_tfp_mcmc`, `_nutpie`, `_cmdstan_method`, `_pymc_method`)
+> - `inference/` → `distributions/` (lazy imports: prior-type dispatch on
+>   distribution classes in `_blackjax_ess`, `bijector_for` constraint
+>   reparameterization in `_bayesflow`)
 >
 > These use lazy (in-function) imports to avoid circular imports at
 > module load time.  Do not add new reverse edges without discussion.

--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -76,11 +76,11 @@ when choosing a number for a new method are documented under
 Simulation-based inference with a trained amortized estimator (requires the
 `[bayesflow]` extra; Python 3.12–3.13 only). `learn_amortized_posterior`
 trains an NPE / FMPE / CMPE network from a prior and a `GenerativeLikelihood`
-simulator; the returned `BayesFlowModel` represents the joint model:
-`sample(model)` draws `(params, data)` forward through the prior and
-simulator, and `condition_on(model, observed)` draws from
-`p(theta | observed)` in a single network forward pass — the same trained
-instance conditions on any observation with no retraining.
+simulator; the returned `BayesFlowModel` bundles the joint model (the prior
+and simulator are exposed as properties) with the trained estimator, and
+`condition_on(model, observed)` draws from `p(theta | observed)` in a single
+network forward pass — the same trained instance conditions on any
+observation with no retraining.
 
 ::: probpipe.learn_amortized_posterior
 

--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -71,6 +71,20 @@ when choosing a number for a new method are documented under
     options:
       show_root_heading: true
 
+## Amortized SBI
+
+Simulation-based inference with a trained amortized estimator (requires the
+`[bayesflow]` extra; Python 3.12–3.13 only). `learn_amortized_posterior`
+trains an NPE / FMPE / CMPE network from a prior and a `GenerativeLikelihood`
+simulator; the returned `BayesFlowPosterior` implements `SupportsConditioning`,
+so `condition_on(model, observed)` draws from `p(theta | observed)` in a
+single forward pass — the same trained instance conditions on any observation
+with no retraining.
+
+::: probpipe.learn_amortized_posterior
+
+::: probpipe.BayesFlowPosterior
+
 ## Iterative transformations
 
 Step functions folded over inputs by `iterate`, with `with_conversion` and

--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -76,14 +76,15 @@ when choosing a number for a new method are documented under
 Simulation-based inference with a trained amortized estimator (requires the
 `[bayesflow]` extra; Python 3.12–3.13 only). `learn_amortized_posterior`
 trains an NPE / FMPE / CMPE network from a prior and a `GenerativeLikelihood`
-simulator; the returned `BayesFlowPosterior` implements `SupportsConditioning`,
-so `condition_on(model, observed)` draws from `p(theta | observed)` in a
-single forward pass — the same trained instance conditions on any observation
-with no retraining.
+simulator; the returned `BayesFlowModel` represents the joint model:
+`sample(model)` draws `(params, data)` forward through the prior and
+simulator, and `condition_on(model, observed)` draws from
+`p(theta | observed)` in a single network forward pass — the same trained
+instance conditions on any observation with no retraining.
 
 ::: probpipe.learn_amortized_posterior
 
-::: probpipe.BayesFlowPosterior
+::: probpipe.BayesFlowModel
 
 ## Iterative transformations
 

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -133,6 +133,7 @@ from probpipe.inference import (
     elliptical_slice,
     condition_on_nutpie,
     MinibatchedDistribution,
+    learn_amortized_posterior,
 )
 from probpipe.modeling import ProbabilisticModel, SimpleModel, SimpleGenerativeModel
 from probpipe.validation import predictive_check
@@ -294,6 +295,7 @@ __all__ = [
     "elliptical_slice",
     "condition_on_nutpie",
     "MinibatchedDistribution",
+    "learn_amortized_posterior",
     # Validation
     "predictive_check",
     # Converters

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -134,7 +134,7 @@ from probpipe.inference import (
     condition_on_nutpie,
     MinibatchedDistribution,
     learn_amortized_posterior,
-    BayesFlowPosterior,
+    BayesFlowModel,
 )
 from probpipe.modeling import ProbabilisticModel, SimpleModel, SimpleGenerativeModel
 from probpipe.validation import predictive_check
@@ -297,7 +297,7 @@ __all__ = [
     "condition_on_nutpie",
     "MinibatchedDistribution",
     "learn_amortized_posterior",
-    "BayesFlowPosterior",
+    "BayesFlowModel",
     # Validation
     "predictive_check",
     # Converters

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -134,6 +134,7 @@ from probpipe.inference import (
     condition_on_nutpie,
     MinibatchedDistribution,
     learn_amortized_posterior,
+    BayesFlowPosterior,
 )
 from probpipe.modeling import ProbabilisticModel, SimpleModel, SimpleGenerativeModel
 from probpipe.validation import predictive_check
@@ -296,6 +297,7 @@ __all__ = [
     "condition_on_nutpie",
     "MinibatchedDistribution",
     "learn_amortized_posterior",
+    "BayesFlowPosterior",
     # Validation
     "predictive_check",
     # Converters

--- a/probpipe/core/protocols.py
+++ b/probpipe/core/protocols.py
@@ -502,9 +502,9 @@ class ConditionallyIndependentLikelihood[P, D](Likelihood[P, D], Protocol):
     Required by :class:`~probpipe.MinibatchedDistribution` for
     stochastic-gradient inference, and useful independently for held-out
     predictive log-likelihoods, leave-one-out cross-validation, and
-    PSIS-LOO. Implementations expose :meth:`per_datum_log_likelihood`; a
-    length-1-batch fallback is available for likelihoods that prefer a
-    default over an efficient override.
+    PSIS-LOO. Implementations expose :meth:`per_datum_log_likelihood`;
+    :func:`_default_per_datum_log_likelihood` is a length-1-batch fallback
+    for likelihoods that prefer a default over an efficient override.
     """
 
     def per_datum_log_likelihood(self, params: P, datum: Any) -> Any:
@@ -525,6 +525,26 @@ class ConditionallyIndependentLikelihood[P, D](Likelihood[P, D], Protocol):
             Scalar log-density of the datum under ``params``.
         """
         ...
+
+
+def _default_per_datum_log_likelihood(
+    likelihood: Likelihood,
+    params: Any,
+    datum: Any,
+) -> Any:
+    """Default per-datum log-likelihood — evaluate ``log_likelihood`` on a length-1 batch.
+
+    Fallback for :class:`ConditionallyIndependentLikelihood`
+    implementations that don't have a row-specific shortcut. Adds a
+    leading axis to ``datum`` via ``jax.tree.map(lambda x: x[None, ...], datum)``
+    and calls ``likelihood.log_likelihood(params, batch)``. Less
+    efficient than an override that evaluates the family directly on
+    the un-reshaped datum (no length-1-batch wrap, no associated
+    broadcasting overhead inside ``log_likelihood``).
+    """
+    import jax
+    batch = jax.tree.map(lambda x: x[None, ...], datum)
+    return likelihood.log_likelihood(params, batch)
 
 
 @runtime_checkable

--- a/probpipe/core/protocols.py
+++ b/probpipe/core/protocols.py
@@ -461,6 +461,100 @@ def protocols_supported_by_all(
     return tuple(p for p in candidates if all(isinstance(l, p) for l in leaves))
 
 
+# ---------------------------------------------------------------------------
+# Likelihoods and generative simulators
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Likelihood[P, D](Protocol):
+    """Protocol for computing log-likelihood of data given parameters.
+
+    Generic in ``P`` (parameter type) and ``D`` (data type).
+    Any class that defines ``log_likelihood(params, data) -> float``
+    satisfies this protocol.
+    """
+
+    def log_likelihood(self, params: P, data: D) -> float: ...
+
+
+@runtime_checkable
+class ConditionallyIndependentLikelihood[P, D](Likelihood[P, D], Protocol):
+    """Likelihood whose observations are conditionally independent given
+    the parameters.
+
+    Formally, for observations ``y_1, ..., y_N`` the joint log-density
+    factorises into a sum of per-observation log-densities:
+
+    .. math::
+
+        \\log p(y_1, \\ldots, y_N \\mid \\theta)
+            = \\sum_{i=1}^N \\log p(y_i \\mid \\theta).
+
+    The "conditionally" refers to conditioning on the parameters ``θ``:
+    the ``y_i`` are independent *given* ``θ``, not marginally. For
+    regression-style likelihoods each datum carries a covariate ``x_i``
+    that the per-observation density depends on; the factorisation then
+    reads ``Σ_i log p(y_i | x_i, θ)``, with the covariates treated as
+    fixed inputs. This is the "conditionally independent" case rather
+    than the stricter "i.i.d." (where every ``p(y_i | θ)`` is identical).
+
+    Required by :class:`~probpipe.MinibatchedDistribution` for
+    stochastic-gradient inference, and useful independently for held-out
+    predictive log-likelihoods, leave-one-out cross-validation, and
+    PSIS-LOO. Implementations expose :meth:`per_datum_log_likelihood`; a
+    length-1-batch fallback is available for likelihoods that prefer a
+    default over an efficient override.
+    """
+
+    def per_datum_log_likelihood(self, params: P, datum: Any) -> Any:
+        """Log-density of a single datum given parameters.
+
+        Parameters
+        ----------
+        params : P
+            Model parameters.
+        datum : Any
+            One observation; its shape depends on the data format the
+            likelihood was built against (a row ``(x_i, y_i)`` for a
+            regression model, a single value for a scalar response).
+
+        Returns
+        -------
+        Array
+            Scalar log-density of the datum under ``params``.
+        """
+        ...
+
+
+@runtime_checkable
+class GenerativeLikelihood[P, D](Protocol):
+    """Protocol for generating synthetic data given parameters.
+
+    Generic in ``P`` (parameter type) and ``D`` (data type).
+    Any class that defines
+    ``generate_data(params, num_observations, *, key) -> D``
+    satisfies this protocol.
+    """
+
+    def generate_data(
+        self, params: P, num_observations: int,
+        *, key: PRNGKey | None = None,
+    ) -> D:
+        """Generate ``num_observations`` synthetic data points from ``params``.
+
+        Parameters
+        ----------
+        params : P
+            Model parameters.
+        num_observations : int
+            Number of data points to generate.
+        key : PRNGKey or None
+            JAX PRNG key for reproducible generation.
+        """
+        ...
+
+
 __all__ = [
     "compute_expectation",
     "SupportsExpectation",
@@ -474,5 +568,8 @@ __all__ = [
     "SupportsRandomUnnormalizedLogProb",
     "SupportsConditioning",
     "SupportsArrayBackend",
+    "Likelihood",
+    "ConditionallyIndependentLikelihood",
+    "GenerativeLikelihood",
     "protocols_supported_by_all",
 ]

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -377,8 +377,22 @@ class ProductDistribution(
 
     @property
     def supports(self):
-        """Per-field support constraints -- each component's ``support``."""
-        return {name: comp.support for name, comp in self._components.items()}
+        """Per-leaf support constraints -- each leaf component's ``support``.
+
+        Nested components are keyed by slash-delimited paths
+        (``"outer/a"``), matching ``RecordTemplate.leaf_shapes``, so every
+        value is a ``Constraint``."""
+        out: dict = {}
+
+        def _walk(components: dict, prefix: str) -> None:
+            for name, comp in components.items():
+                if isinstance(comp, dict):
+                    _walk(comp, f"{prefix}{name}/")
+                else:
+                    out[f"{prefix}{name}"] = comp.support
+
+        _walk(self._components, "")
+        return out
 
     # -- Conditioning -------------------------------------------------------
 

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -375,6 +375,11 @@ class ProductDistribution(
             return MappingProxyType(self._components)
         return self._components
 
+    @property
+    def supports(self):
+        """Per-field support constraints -- each component's ``support``."""
+        return {name: comp.support for name, comp in self._components.items()}
+
     # -- Conditioning -------------------------------------------------------
 
     def _condition_on(self, observed=None, /, **kwargs):

--- a/probpipe/inference/__init__.py
+++ b/probpipe/inference/__init__.py
@@ -20,7 +20,7 @@ from ._minibatch import MinibatchedDistribution
 # Amortized SBI (optional ``[bayesflow]`` extra). keras/bayesflow load lazily on
 # first call, so this eager import stays cheap; the trained estimator dispatches
 # via ``SupportsConditioning`` and needs no inference-registry method.
-from ._bayesflow import BayesFlowPosterior, learn_amortized_posterior
+from ._bayesflow import BayesFlowModel, learn_amortized_posterior
 
 __all__ = [
     "ApproximateDistribution",
@@ -34,7 +34,7 @@ __all__ = [
     "condition_on_nutpie",
     "MinibatchedDistribution",
     "learn_amortized_posterior",
-    "BayesFlowPosterior",
+    "BayesFlowModel",
 ]
 
 

--- a/probpipe/inference/__init__.py
+++ b/probpipe/inference/__init__.py
@@ -17,6 +17,12 @@ from ._blackjax_rwmh import rwmh
 from ._blackjax_ess import elliptical_slice
 from ._nutpie import condition_on_nutpie
 from ._minibatch import MinibatchedDistribution
+# Amortized SBI (optional ``[bayesflow]`` extra). The module imports cheaply —
+# keras / bayesflow load lazily inside the workflow function on first call (the
+# nutpie pattern) — so this eager import does not pull keras into ``import
+# probpipe``. The trained estimator is a ``SupportsConditioning`` distribution
+# and needs no inference-registry method.
+from ._bayesflow import BayesFlowPosterior, learn_amortized_posterior
 
 __all__ = [
     "ApproximateDistribution",
@@ -29,6 +35,8 @@ __all__ = [
     "elliptical_slice",
     "condition_on_nutpie",
     "MinibatchedDistribution",
+    "learn_amortized_posterior",
+    "BayesFlowPosterior",
 ]
 
 

--- a/probpipe/inference/__init__.py
+++ b/probpipe/inference/__init__.py
@@ -17,11 +17,9 @@ from ._blackjax_rwmh import rwmh
 from ._blackjax_ess import elliptical_slice
 from ._nutpie import condition_on_nutpie
 from ._minibatch import MinibatchedDistribution
-# Amortized SBI (optional ``[bayesflow]`` extra). The module imports cheaply —
-# keras / bayesflow load lazily inside the workflow function on first call (the
-# nutpie pattern) — so this eager import does not pull keras into ``import
-# probpipe``. The trained estimator is a ``SupportsConditioning`` distribution
-# and needs no inference-registry method.
+# Amortized SBI (optional ``[bayesflow]`` extra). keras/bayesflow load lazily on
+# first call, so this eager import stays cheap; the trained estimator dispatches
+# via ``SupportsConditioning`` and needs no inference-registry method.
 from ._bayesflow import BayesFlowPosterior, learn_amortized_posterior
 
 __all__ = [

--- a/probpipe/inference/_bayesflow.py
+++ b/probpipe/inference/_bayesflow.py
@@ -33,9 +33,7 @@ from ..custom_types import Array, PRNGKey
 from ._approximate_distribution import ApproximateDistribution, make_posterior
 
 if TYPE_CHECKING:
-    # Type-only imports of the optional ``bayesflow`` dependency: stringized by
-    # ``from __future__ import annotations`` and never evaluated at runtime
-    # (bayesflow is loaded only inside ``_ensure_bayesflow``).
+    # Type-only: the optional bayesflow dependency loads at runtime in _ensure_bayesflow.
     from bayesflow import Adapter, ContinuousApproximator
     from bayesflow.networks import InferenceNetwork
 
@@ -139,8 +137,6 @@ def _field_bijectors(prior: Distribution, fields: tuple[str, ...]) -> dict[str, 
         supports = prior.supports
     except NotImplementedError:
         if len(fields) > 1:
-            # Spreading one support across heterogeneous fields would silently pick
-            # the wrong bijector; demand the per-field accessor instead.
             raise TypeError(
                 f"{type(prior).__name__} has {len(fields)} fields but does not "
                 "implement per-field `supports`; cannot infer per-field constraints "
@@ -185,17 +181,14 @@ def _simulate_offline(
     fields = template.fields
     k_theta, k_sim = jax.random.split(key)
     theta = _sample_op(prior, key=k_theta, sample_shape=(num_simulations,))
-    # ``theta.flatten()`` is the prior's canonical flat layout (record-template
-    # field order); ``unflatten`` lifts it back to named per-field arrays --
-    # uniform across record containers and single-field priors (whose raw draws
-    # are not field-indexable by name, but whose flat layout is well defined).
+    # Round-trip through the canonical flat layout: single-field priors' raw draws
+    # are not field-indexable by name, so unflatten gives uniform named access.
     theta_flat = jnp.asarray(theta.flatten()).reshape(num_simulations, -1)
     record = NumericRecordArray.unflatten(
         theta_flat, template=template, batch_shape=(num_simulations,)
     )
-    # Unconstrain each field at its *native* event shape -- matrix-valued bijectors
-    # (e.g. positive-definite: Chain([CholeskyOuterProduct, FillScaleTriL])) require
-    # (..., n, n) input, so the inverse must run before flattening for the adapter.
+    # Invert before flattening: matrix-valued bijectors (positive-definite) require
+    # the field's native (..., n, n) event shape, not the flat adapter layout.
     named = {}
     for f in fields:
         u = bijectors[f].inverse(jnp.asarray(record[f]))
@@ -203,9 +196,8 @@ def _simulate_offline(
     sim_keys = jax.random.split(k_sim, num_simulations)
 
     def _one(flat_row: Array, k: PRNGKey) -> Array:
-        # Reconstruct the prior's native per-draw structured params (a record with
-        # named fields, so the simulator may use ``params["a"]``) -- the same object
-        # SimpleGenerativeModel / PriorPredictiveCheck pass, not a raw flat vector.
+        # Per-draw structured params (named-field access), per the
+        # GenerativeLikelihood contract.
         params = NumericRecordArray.unflatten(flat_row, template=template, batch_shape=())
         return jnp.ravel(simulator.generate_data(params, 1, key=k)[0])
 
@@ -214,9 +206,8 @@ def _simulate_offline(
         y = jax.vmap(_one)(theta_flat, sim_keys)
     else:  # "sequential"
         # Non-traceable simulators (numpy / external code): one eager call per
-        # draw, so generate_data runs concretely rather than under a jax trace.
-        # Move theta to the host once, rather than indexing the device array
-        # (and paying a sync) on every draw; keys stay jax (they are PRNG keys).
+        # draw. Theta is hosted once -- per-draw device indexing would sync
+        # every iteration.
         theta_rows = np.asarray(theta_flat)
         y = jnp.stack([_one(theta_rows[i], sim_keys[i]) for i in range(num_simulations)])
     return named, np.asarray(y, dtype="float32")
@@ -260,18 +251,14 @@ class BayesFlowPosterior(Distribution, SupportsConditioning):
         self._data_dim = data_dim
         self._num_results = num_results
         self._random_seed = random_seed
-        # Per-field forward bijectors (R^d -> support) applied to the network's
-        # unconstrained draws; identity for real-valued priors. Missing/None entries
-        # are treated as identity.
+        # Forward bijectors (unconstrained -> support); missing entries mean identity.
         self._bijectors = bijectors or {}
         # The ``Distribution`` metaclass requires a non-empty name.
         self._name = f"BayesFlowPosterior({method})"
 
     def _sample(self, key: PRNGKey, sample_shape: tuple[int, ...] = ()) -> Any:
-        # Defined (rather than left absent) so callers probing sampleability --
-        # e.g. WorkflowFunction's dispatch fallback, which catches
-        # NotImplementedError but not AttributeError -- get the guarded signal
-        # plus an actionable message.
+        # Present so sampleability probes get NotImplementedError -- which
+        # WorkflowFunction's dispatch fallback catches -- not AttributeError.
         raise NotImplementedError(
             "BayesFlowPosterior is an amortized conditional estimator with no "
             "unconditional sampler; draw from it by conditioning on data: "
@@ -299,12 +286,8 @@ class BayesFlowPosterior(Distribution, SupportsConditioning):
             conditions={_OBSERVATION_KEY: obs_flat[None, :]},
             seed=random_seed,
         )
-        # ``out`` maps each field to ``(1, num_results, d_field)``; squeeze the
-        # observation axis, map each field's unconstrained draws back to its support
-        # via the forward bijector (identity for real-valued fields), flatten any
-        # matrix-valued output, and concatenate in record-template field order (the
-        # layout ``make_posterior`` lifts back to named draws). Stays in jnp
-        # end-to-end -- this is the latency-critical amortized path, so no per-field
+        # ``out`` maps each field to ``(1, num_results, d_field)``. Stays in jnp
+        # end-to-end: this is the latency-critical amortized path, so no per-field
         # host round-trips.
         cols = []
         for f in self._fields:
@@ -462,8 +445,8 @@ def learn_amortized_posterior(
             f"prior field name {_OBSERVATION_KEY!r} collides with the reserved "
             "observation key used internally by the BayesFlow adapter; rename the field."
         )
-    # Per-field unconstraining bijectors (identity for real-valued priors); this also
-    # rejects discrete / unsupported-support priors up front, before any simulation.
+    # Built up front: also rejects discrete / unsupported-support priors before
+    # any simulation runs.
     bijectors = _field_bijectors(prior, fields)
     # The network trains on *unconstrained* widths, which differ from the prior's
     # event sizes for dimension-shifting bijectors (a d-simplex contributes d-1).
@@ -476,12 +459,9 @@ def learn_amortized_posterior(
     bf = _ensure_bayesflow()
     import keras
 
-    # Seed Python / NumPy / keras RNG so keras network init + fit (weight init, batch
-    # shuffling) are reproducible for a given random_seed; jax.random already seeds the
-    # offline simulation and sampling, but keras training reads the global RNG.
-    # Snapshot the caller's Python/NumPy RNG state and restore it after training, so
-    # the (global, process-wide) seeding does not silently perturb the caller's
-    # unrelated random streams. keras keeps its own seeded generator state.
+    # keras reads the global RNG for network init + fit, so seed it -- but snapshot
+    # and restore the caller's Python/NumPy state so the process-wide seeding does
+    # not leak. keras keeps its own seeded generator state across the restore.
     py_state = random.getstate()
     np_state = np.random.get_state()
     keras.utils.set_random_seed(random_seed)

--- a/probpipe/inference/_bayesflow.py
+++ b/probpipe/inference/_bayesflow.py
@@ -50,10 +50,23 @@ AmortizedMethod = Literal["npe", "fmpe", "cmpe"]
 # dispatch names ("jax" = vmap the simulator, "sequential" = eager per-draw loop).
 SimBackend = Literal["jax", "sequential"]
 
-# Reserved key for the simulated observation in BayesFlow's named-array dicts.
+# Internal adapter key for the simulated observation. User field names never
+# enter BayesFlow's key namespace -- theta fields are re-keyed via
+# ``_adapter_field_keys`` -- so this (and BayesFlow's own ``inference_variables``
+# / ``inference_conditions`` targets) can never collide with a prior field.
 _OBSERVATION_KEY = "observation"
 
 _bayesflow_module: ModuleType | None = None
+
+
+def _adapter_field_keys(fields: tuple[str, ...]) -> tuple[str, ...]:
+    """Positional internal keys (``theta_0``, ``theta_1``, ...) for the adapter.
+
+    Both the training dict and the sample-side extraction derive these from the
+    prior's ``record_template.fields`` order, so the mapping is deterministic
+    across train and inference without storing it.
+    """
+    return tuple(f"theta_{i}" for i in range(len(fields)))
 
 
 def _ensure_bayesflow() -> ModuleType:
@@ -117,14 +130,14 @@ def _make_inference_network(
     )
 
 
-def _build_adapter(bf: ModuleType, fields: tuple[str, ...]) -> Adapter:
-    """Route named theta fields to ``inference_variables`` and the observation
-    to ``inference_conditions``. The adapter is invertible, so ``sample``
-    returns the parameters split back into named fields."""
+def _build_adapter(bf: ModuleType, internal_keys: tuple[str, ...]) -> Adapter:
+    """Route the internal theta keys to ``inference_variables`` and the
+    observation to ``inference_conditions``. The adapter is invertible, so
+    ``sample`` returns the parameters split back under the same keys."""
     return (
         bf.Adapter()
         .convert_dtype("float64", "float32")
-        .concatenate(list(fields), into="inference_variables")
+        .concatenate(list(internal_keys), into="inference_variables")
         .concatenate([_OBSERVATION_KEY], into="inference_conditions")
     )
 
@@ -330,12 +343,12 @@ class BayesFlowModel(Distribution, SupportsSampling, SupportsConditioning):
             conditions={_OBSERVATION_KEY: obs_flat[None, :]},
             seed=random_seed,
         )
-        # ``out`` maps each field to ``(1, num_results, d_field)``. Stays in jnp
-        # end-to-end: this is the latency-critical amortized path, so no per-field
-        # host round-trips.
+        # ``out`` maps each internal theta key to ``(1, num_results, d_field)``.
+        # Stays in jnp end-to-end: this is the latency-critical amortized path,
+        # so no per-field host round-trips.
         cols = []
-        for f in self._fields:
-            draws = jnp.asarray(out[f])[0]
+        for k, f in zip(_adapter_field_keys(self._fields), self._fields):
+            draws = jnp.asarray(out[k])[0]
             bij = self._bijectors.get(f)
             if bij is not None:
                 draws = bij.forward(draws)
@@ -448,9 +461,8 @@ def learn_amortized_posterior(
         If ``method`` is not one of ``"npe"`` / ``"fmpe"`` / ``"cmpe"``,
         ``sim_backend`` is not ``"jax"`` / ``"sequential"``, any of
         ``num_simulations`` / ``batch_size`` / ``epochs`` / ``num_results`` is not a
-        positive integer, a prior field collides with the reserved ``"observation"``
-        key, or a prior field's support admits no smooth bijector to ``R^d`` (e.g. a
-        discrete prior).
+        positive integer, or a prior field's support admits no smooth bijector to
+        ``R^d`` (e.g. a discrete prior).
     TypeError
         If ``simulator`` lacks ``generate_data``, ``prior`` is not a
         ``RecordDistribution`` (has no ``record_template``), or a multi-field
@@ -486,11 +498,6 @@ def learn_amortized_posterior(
             "record_template."
         )
     fields = record_template.fields
-    if _OBSERVATION_KEY in fields:
-        raise ValueError(
-            f"prior field name {_OBSERVATION_KEY!r} collides with the reserved "
-            "observation key used internally by the BayesFlow adapter; rename the field."
-        )
     # Built up front: also rejects discrete / unsupported-support priors before
     # any simulation runs.
     bijectors = _field_bijectors(prior, fields)
@@ -517,9 +524,14 @@ def learn_amortized_posterior(
             prior, simulator, num_simulations, key,
             sim_backend=sim_backend, bijectors=bijectors,
         )
-        sims = {**named, _OBSERVATION_KEY: y}
+        # Re-key theta fields to positional internal names so user field names
+        # never enter BayesFlow's key namespace (no collision with the
+        # observation key or the adapter's inference_variables/conditions).
+        internal_keys = _adapter_field_keys(fields)
+        sims = {k: named[f] for k, f in zip(internal_keys, fields)}
+        sims[_OBSERVATION_KEY] = y
 
-        adapter = _build_adapter(bf, fields)
+        adapter = _build_adapter(bf, internal_keys)
         num_batches = max(1, -(-num_simulations // batch_size))  # ceil: count partial batch
         net = inference_network or _make_inference_network(
             bf, method, total_steps=epochs * num_batches, unconstrained_size=unconstrained_size

--- a/probpipe/inference/_bayesflow.py
+++ b/probpipe/inference/_bayesflow.py
@@ -138,7 +138,15 @@ def _field_bijectors(prior: Distribution, fields: tuple[str, ...]) -> dict[str, 
     try:
         supports = prior.supports
     except NotImplementedError:
-        # RecordDistributions without per-field supports: spread the single support.
+        if len(fields) > 1:
+            # Spreading one support across heterogeneous fields would silently pick
+            # the wrong bijector; demand the per-field accessor instead.
+            raise TypeError(
+                f"{type(prior).__name__} has {len(fields)} fields but does not "
+                "implement per-field `supports`; cannot infer per-field constraints "
+                "from the single `support`. Implement `supports` on the prior."
+            ) from None
+        # Single-field priors: the whole-distribution support is the field's support.
         supports = {f: prior.support for f in fields}
     bijectors: dict[str, Any] = {}
     for f in fields:
@@ -226,9 +234,12 @@ class BayesFlowPosterior(Distribution, SupportsConditioning):
     ``condition_on(model, observed)`` draws from ``p(theta | observed)`` in one
     forward pass through the trained network.  Because the estimator is
     amortized, the same instance conditions on any observation with no
-    retraining.  The amortized path honours ``num_results`` and (best-effort)
-    ``random_seed``; ``num_warmup`` / ``num_chains`` do not apply (a forward
-    pass yields a single draw block).
+    retraining.  The network samples in unconstrained space; draws are mapped
+    back to each field's support via the per-field forward bijectors recorded
+    at training time (identity for real-valued fields).  The amortized path
+    honours ``num_results`` (a positive integer) and ``random_seed``;
+    ``num_warmup`` / ``num_chains`` do not apply (a forward pass yields a
+    single draw block).
     """
 
     def __init__(
@@ -412,8 +423,9 @@ def learn_amortized_posterior(
         key, or a prior field's support admits no smooth bijector to ``R^d`` (e.g. a
         discrete prior).
     TypeError
-        If ``simulator`` lacks ``generate_data``, or ``prior`` is not a
-        ``RecordDistribution`` (has no ``record_template``).
+        If ``simulator`` lacks ``generate_data``, ``prior`` is not a
+        ``RecordDistribution`` (has no ``record_template``), or a multi-field
+        prior implements no per-field ``supports`` accessor.
     ImportError
         If the ``[bayesflow]`` extra is not installed.
     """

--- a/probpipe/inference/_bayesflow.py
+++ b/probpipe/inference/_bayesflow.py
@@ -439,13 +439,14 @@ def learn_amortized_posterior(
     ValueError
         If ``method`` is not one of ``"npe"`` / ``"fmpe"`` / ``"cmpe"``,
         ``sim_backend`` is not ``"jax"`` / ``"sequential"``, any of
-        ``num_simulations`` / ``batch_size`` / ``epochs`` / ``num_results`` is not a
-        positive integer, or a prior field's support admits no smooth bijector to
+        ``num_simulations`` / ``batch_size`` / ``epochs`` / ``num_results`` is
+        less than one, or a prior field's support admits no smooth bijector to
         ``R^d`` (e.g. a discrete prior).
     TypeError
-        If ``simulator`` lacks ``generate_data``, ``prior`` is not a
-        ``RecordDistribution`` (has no ``record_template``), or a multi-field
-        prior implements no per-field ``supports`` accessor.
+        If a count parameter is not an integer, ``simulator`` lacks
+        ``generate_data``, ``prior`` is not a ``RecordDistribution`` (has no
+        ``record_template``), the prior is nested, or a multi-field prior
+        implements no per-field ``supports`` accessor.
     ImportError
         If the ``[bayesflow]`` extra is not installed.
     """
@@ -461,6 +462,8 @@ def learn_amortized_posterior(
         ("num_simulations", num_simulations), ("batch_size", batch_size),
         ("epochs", epochs), ("num_results", num_results),
     ):
+        if not isinstance(_val, (int, np.integer)):
+            raise TypeError(f"{_name} must be an integer, got {type(_val).__name__}.")
         if _val < 1:
             raise ValueError(f"{_name} must be a positive integer, got {_val}.")
     if not hasattr(simulator, "generate_data"):
@@ -477,12 +480,18 @@ def learn_amortized_posterior(
             "record_template."
         )
     fields = record_template.fields
+    leaf_shapes = record_template.numeric_leaf_shapes
+    if any("/" in k for k in leaf_shapes):
+        raise TypeError(
+            "learn_amortized_posterior does not support nested priors (the "
+            "per-field bijector and adapter machinery is flat); flatten the "
+            "prior into top-level named fields."
+        )
     # Built up front: also rejects discrete / unsupported-support priors before
     # any simulation runs.
     bijectors = _field_bijectors(prior, fields)
     # The network trains on *unconstrained* widths, which differ from the prior's
     # event sizes for dimension-shifting bijectors (a d-simplex contributes d-1).
-    leaf_shapes = record_template.numeric_leaf_shapes
     unconstrained_size = sum(
         int(np.prod(tuple(bijectors[f].inverse_event_shape(leaf_shapes[f])), dtype=int))
         for f in fields

--- a/probpipe/inference/_bayesflow.py
+++ b/probpipe/inference/_bayesflow.py
@@ -120,6 +120,34 @@ def _build_adapter(bf: ModuleType, fields: tuple[str, ...]) -> Adapter:
     )
 
 
+def _field_bijectors(prior: Distribution, fields: tuple[str, ...]) -> dict[str, Any]:
+    """Per-field bijector mapping each parameter's unconstrained R^d to its support.
+
+    BayesFlow's ``ContinuousApproximator`` operates in unconstrained, real space, so a
+    constrained prior (positive, an interval, ...) is trained on the *unconstrained*
+    parameters (``bijector.inverse``) and the network's draws are mapped back to the
+    support (``bijector.forward``). For a real-valued prior every bijector is the
+    identity, so the round-trip is a no-op. Discrete priors have no smooth bijector and
+    are rejected here with a clear error.
+    """
+    from ..distributions import bijector_for  # lazy: inference/ -> distributions/
+
+    components = getattr(prior, "components", None)
+    bijectors: dict[str, Any] = {}
+    for f in fields:
+        constraint = components[f].support if components is not None else prior.support
+        try:
+            bijectors[f] = bijector_for(constraint)
+        except NotImplementedError as e:
+            raise ValueError(
+                f"learn_amortized_posterior cannot handle prior field {f!r} with support "
+                f"{constraint!r}: {e}. Amortized SBI requires a continuous prior whose "
+                "support admits a smooth bijector to R^d (e.g. real, positive, an "
+                "interval); discrete priors are not supported."
+            ) from e
+    return bijectors
+
+
 def _simulate_offline(
     prior: Distribution,
     simulator: GenerativeLikelihood,
@@ -155,9 +183,12 @@ def _simulate_offline(
     }
     sim_keys = jax.random.split(k_sim, num_simulations)
 
-    def _one(p: Array, k: PRNGKey) -> Array:
-        # One simulated dataset per theta, flattened to a fixed (d_y,) vector.
-        return jnp.ravel(simulator.generate_data(p, 1, key=k)[0])
+    def _one(flat_row: Array, k: PRNGKey) -> Array:
+        # Reconstruct the prior's native per-draw structured params (a record with
+        # named fields, so the simulator may use ``params["a"]``) -- the same object
+        # SimpleGenerativeModel / PriorPredictiveCheck pass, not a raw flat vector.
+        params = NumericRecordArray.unflatten(flat_row, template=template, batch_shape=())
+        return jnp.ravel(simulator.generate_data(params, 1, key=k)[0])
 
     if sim_backend == "jax":
         # JAX-traceable simulators: vmap the whole batch (fast path).
@@ -195,6 +226,7 @@ class BayesFlowPosterior(Distribution, SupportsConditioning):
         data_dim: int,
         num_results: int = 2000,
         random_seed: int = 0,
+        bijectors: dict[str, Any] | None = None,
     ):
         self._approximator = approximator
         self._prior = prior
@@ -203,6 +235,10 @@ class BayesFlowPosterior(Distribution, SupportsConditioning):
         self._data_dim = data_dim
         self._num_results = num_results
         self._random_seed = random_seed
+        # Per-field forward bijectors (R^d -> support) applied to the network's
+        # unconstrained draws; identity for real-valued priors. Missing/None entries
+        # are treated as identity.
+        self._bijectors = bijectors or {}
         # The ``Distribution`` metaclass requires a non-empty name.
         self._name = f"BayesFlowPosterior({method})"
 
@@ -226,9 +262,17 @@ class BayesFlowPosterior(Distribution, SupportsConditioning):
             seed=random_seed,
         )
         # ``out`` maps each field to ``(1, num_results, d_field)``; squeeze the
-        # observation axis and concatenate in record-template field order (the
-        # layout ``make_posterior`` lifts back to named draws).
-        cols = [np.asarray(out[f])[0].reshape(num_results, -1) for f in self._fields]
+        # observation axis, map each field's unconstrained draws back to its support
+        # via the forward bijector (identity for real-valued fields), and concatenate
+        # in record-template field order (the layout ``make_posterior`` lifts back to
+        # named draws).
+        cols = []
+        for f in self._fields:
+            draws = np.asarray(out[f])[0]
+            bij = self._bijectors.get(f)
+            if bij is not None:
+                draws = np.asarray(bij.forward(jnp.asarray(draws)))
+            cols.append(draws.reshape(num_results, -1))
         flat = jnp.asarray(np.concatenate(cols, axis=-1))
         return make_posterior(
             [flat],
@@ -281,13 +325,18 @@ def learn_amortized_posterior(
         typically a ``ProductDistribution`` of named distributions, or a single
         named distribution for a one-parameter model.  It is sampled via the
         :func:`~probpipe.sample` op to draw training thetas; it is *not*
-        otherwise translated.
+        otherwise translated.  Constrained fields (positive, an interval, ...) are
+        trained in unconstrained space via the per-field bijector from
+        :func:`~probpipe.bijector_for` and mapped back to the support at sample time;
+        real-valued fields use the identity.  Discrete priors are not supported.
     simulator : GenerativeLikelihood
-        Must implement ``generate_data(params, num_observations, *, key)``; it
-        must be JAX-vmappable unless ``sim_backend="sequential"`` (see below). Training
-        uses one simulated dataset per ``theta``, so ``condition_on`` must be
-        given a single observation of that same flattened shape (not a stacked
-        multi-observation dataset).
+        Must implement ``generate_data(params, num_observations, *, key)``.  As with
+        ``SimpleGenerativeModel`` / ``PriorPredictiveCheck``, ``params`` is the prior's
+        native per-draw sample -- a record whose fields are accessible by name
+        (``params["a"]``), not a flattened vector.  It must be JAX-vmappable unless
+        ``sim_backend="sequential"`` (see below). Training uses one simulated dataset
+        per ``theta``, so ``condition_on`` must be given a single observation of that
+        same flattened shape (not a stacked multi-observation dataset).
     method : {"npe", "fmpe", "cmpe"}
         Amortized estimator: NPE (coupling flow), FMPE (flow matching), or CMPE
         (consistency model). NPE's coupling flow needs at least two parameters,
@@ -308,8 +357,9 @@ def learn_amortized_posterior(
     num_results : int
         Default number of posterior draws per ``condition_on`` call.
     random_seed : int
-        Seed for offline simulation, training, and sampling (sampling
-        reproducibility is best-effort via keras seeding).
+        Seed for offline simulation (``jax.random``), keras network init + training
+        (via ``keras.utils.set_random_seed``), and sampling. Note that this sets the
+        global keras / NumPy / Python RNG state.
     optimizer : str or keras.Optimizer
         Passed to ``approximator.compile``.
     **fit_kwargs
@@ -324,8 +374,11 @@ def learn_amortized_posterior(
     ------
     ValueError
         If ``method`` is not one of ``"npe"`` / ``"fmpe"`` / ``"cmpe"``,
-        ``sim_backend`` is not ``"jax"`` / ``"sequential"``, or a prior field
-        collides with the reserved ``"observation"`` key.
+        ``sim_backend`` is not ``"jax"`` / ``"sequential"``, any of
+        ``num_simulations`` / ``batch_size`` / ``epochs`` / ``num_results`` is not a
+        positive integer, a prior field collides with the reserved ``"observation"``
+        key, or a prior field's support admits no smooth bijector to ``R^d`` (e.g. a
+        discrete prior).
     TypeError
         If ``simulator`` lacks ``generate_data``, or ``prior`` is not a
         ``RecordDistribution`` (has no ``record_template``).
@@ -340,6 +393,12 @@ def learn_amortized_posterior(
         raise ValueError(
             f"Unknown sim_backend: {sim_backend!r}. Supported: 'jax', 'sequential'."
         )
+    for _name, _val in (
+        ("num_simulations", num_simulations), ("batch_size", batch_size),
+        ("epochs", epochs), ("num_results", num_results),
+    ):
+        if _val < 1:
+            raise ValueError(f"{_name} must be a positive integer, got {_val}.")
     if not hasattr(simulator, "generate_data"):
         raise TypeError(
             "simulator must be a GenerativeLikelihood with a generate_data method, "
@@ -359,10 +418,27 @@ def learn_amortized_posterior(
             f"prior field name {_OBSERVATION_KEY!r} collides with the reserved "
             "observation key used internally by the BayesFlow adapter; rename the field."
         )
+    # Per-field unconstraining bijectors (identity for real-valued priors); this also
+    # rejects discrete / unsupported-support priors up front, before any simulation.
+    bijectors = _field_bijectors(prior, fields)
+
     bf = _ensure_bayesflow()
+    import keras
+
+    # Seed Python / NumPy / keras RNG so keras network init + fit (weight init, batch
+    # shuffling) are reproducible for a given random_seed; jax.random already seeds the
+    # offline simulation and sampling, but keras training reads the global RNG.
+    keras.utils.set_random_seed(random_seed)
     key = jax.random.PRNGKey(random_seed)
     named, y = _simulate_offline(prior, simulator, num_simulations, key, sim_backend=sim_backend)
-    sims = {**named, _OBSERVATION_KEY: y}
+    # Train in unconstrained space: map each field's draws to R^d via the inverse
+    # bijector (a no-op for real-valued fields), so the continuous network never has to
+    # reproduce a constrained support; the forward map is applied to draws at sample time.
+    named_u = {
+        f: np.asarray(bijectors[f].inverse(jnp.asarray(named[f])), dtype="float32")
+        for f in fields
+    }
+    sims = {**named_u, _OBSERVATION_KEY: y}
 
     adapter = _build_adapter(bf, fields)
     num_batches = max(1, -(-num_simulations // batch_size))  # ceil: count the partial batch
@@ -377,5 +453,5 @@ def learn_amortized_posterior(
 
     return BayesFlowPosterior(
         approximator, prior, method=method, data_dim=int(y.shape[-1]),
-        num_results=num_results, random_seed=random_seed,
+        num_results=num_results, random_seed=random_seed, bijectors=bijectors,
     )

--- a/probpipe/inference/_bayesflow.py
+++ b/probpipe/inference/_bayesflow.py
@@ -3,11 +3,11 @@
 Trains amortized conditional posterior estimators -- NPE (neural posterior
 estimation), FMPE (flow-matching) and CMPE (consistency-model) -- with BayesFlow
 (keras-on-JAX) and wraps prior + simulator + trained estimator as a
-:class:`BayesFlowModel` of the joint ``p(theta, y)``: forward sampling draws
-``(params, data)`` through the simulator, and ``condition_on(model, observed)``
-draws from ``p(theta | observed)`` in a single forward pass through the trained
-network -- no MCMC, no gradient bridge, and no prior translation (the prior is
-used only to draw ``theta`` at train time via the :func:`~probpipe.sample` op).
+:class:`BayesFlowModel` of the joint ``p(theta, y)``:
+``condition_on(model, observed)`` draws from ``p(theta | observed)`` in a single
+forward pass through the trained network -- no MCMC, no gradient bridge, and no
+prior translation (the prior is used only to draw ``theta`` at train time via
+the :func:`~probpipe.sample` op).
 
 BayesFlow / keras is imported lazily on first use, so ``import probpipe`` does
 not pull keras.
@@ -28,7 +28,7 @@ from ..core._record_array import NumericRecordArray
 from ..core.distribution import Distribution
 from ..core.node import workflow_function
 from ..core.ops import sample as _sample_op
-from ..core.protocols import GenerativeLikelihood, SupportsConditioning, SupportsSampling
+from ..core.protocols import GenerativeLikelihood, SupportsConditioning
 from ..custom_types import Array, ArrayLike, PRNGKey
 from ._approximate_distribution import ApproximateDistribution, make_posterior
 
@@ -239,25 +239,22 @@ def _simulate_offline(
 # ---------------------------------------------------------------------------
 
 
-class BayesFlowModel(Distribution, SupportsSampling, SupportsConditioning):
+class BayesFlowModel(Distribution, SupportsConditioning):
     """A BayesFlow amortized model of the joint ``p(theta, y)``.
 
-    Bundles the generative model it was trained from (``prior`` + ``simulator``)
-    with the trained amortized estimator.  Sampling draws ``(params, data)``
-    from the joint via the prior and one simulator call, exactly like
-    :class:`~probpipe.SimpleGenerativeModel`.  Conditioning runs the trained
-    network: ``condition_on(model, observed)`` draws from ``p(theta | observed)``
-    in one forward pass, and -- because the estimator is amortized -- the same
-    instance conditions on any observation with no retraining.  The network
-    samples in unconstrained space; posterior draws are mapped back to each
-    field's support via the per-field forward bijectors recorded at training
-    time (identity for real-valued fields).  The amortized path honours
-    ``num_results`` (a positive integer) and ``random_seed``; ``num_warmup`` /
-    ``num_chains`` do not apply (a forward pass yields a single draw block).
+    Bundles the generative model it was trained from (``prior`` + ``simulator``,
+    exposed as properties) with the trained amortized estimator.  Conditioning
+    runs the trained network: ``condition_on(model, observed)`` draws from
+    ``p(theta | observed)`` in one forward pass, and -- because the estimator is
+    amortized -- the same instance conditions on any observation with no
+    retraining.  The network samples in unconstrained space; posterior draws are
+    mapped back to each field's support via the per-field forward bijectors
+    recorded at training time (identity for real-valued fields).  The amortized
+    path honours ``num_results`` (a positive integer) and ``random_seed``;
+    ``num_warmup`` / ``num_chains`` do not apply (a forward pass yields a single
+    draw block).  Direct sampling is not implemented; simulate from the joint
+    via the ``prior`` / ``simulator`` components.
     """
-
-    _sampling_cost: str = "medium"
-    _preferred_orchestration: str | None = None
 
     def __init__(
         self,
@@ -294,31 +291,14 @@ class BayesFlowModel(Distribution, SupportsSampling, SupportsConditioning):
         """The generative likelihood (provides ``generate_data``)."""
         return self._simulator
 
-    def _sample(self, key: PRNGKey, sample_shape: tuple[int, ...] = ()) -> tuple[Any, Any]:
-        """Draw one joint ``(params, data)`` sample from the generative model.
-
-        Samples ``params`` from the prior and one dataset from
-        ``simulator.generate_data(params, 1)`` -- forward sampling, independent
-        of the trained network.  ``params`` is the same named-field structured
-        record the simulator sees during training.  Batched draws are not
-        supported because ``GenerativeLikelihood.generate_data`` takes a single
-        params object by contract (same restriction as
-        ``SimpleGenerativeModel``).
-        """
-        if sample_shape != ():
-            raise NotImplementedError(
-                "BayesFlowModel._sample(..., sample_shape=...) with a non-empty "
-                "sample_shape is not supported. Loop over _sample(key, ()) with "
-                "independent keys instead."
-            )
-        k_prior, k_data = jax.random.split(key)
-        theta = _sample_op(self._prior, key=k_prior, sample_shape=(1,))
-        params = NumericRecordArray.unflatten(
-            jnp.reshape(jnp.asarray(theta.flatten()), (-1,)),
-            template=self._prior.record_template, batch_shape=(),
+    def _sample(self, key: PRNGKey, sample_shape: tuple[int, ...] = ()) -> Any:
+        # Present so sampleability probes get NotImplementedError -- which
+        # WorkflowFunction's dispatch fallback catches -- not AttributeError.
+        raise NotImplementedError(
+            "BayesFlowModel does not implement direct sampling; draw posterior "
+            "samples by conditioning (condition_on(model, observed)), or simulate "
+            "from the joint via the prior / simulator properties."
         )
-        data = self._simulator.generate_data(params, 1, key=k_data)[0]
-        return (params, data)
 
     def _condition_on(
         self, observed: ArrayLike | np.ndarray, /, **kwargs: Any
@@ -396,8 +376,7 @@ def learn_amortized_posterior(
     ``prior`` and a ``simulator`` and returns a :class:`BayesFlowModel` -- the
     joint model bundling prior, simulator, and the trained estimator.
     ``condition_on(result, observed)`` produces fast amortized posterior draws
-    in a single forward pass (no MCMC); ``sample(result)`` draws ``(params,
-    data)`` from the joint generative model.
+    in a single forward pass (no MCMC).
 
     Parameters
     ----------
@@ -452,8 +431,8 @@ def learn_amortized_posterior(
     Returns
     -------
     BayesFlowModel
-        The joint model: forward sampling via prior + simulator, amortized
-        conditioning via the trained estimator.
+        The joint-model wrapper: prior + simulator exposed as properties,
+        amortized conditioning via the trained estimator.
 
     Raises
     ------

--- a/probpipe/inference/_bayesflow.py
+++ b/probpipe/inference/_bayesflow.py
@@ -2,12 +2,12 @@
 
 Trains amortized conditional posterior estimators -- NPE (neural posterior
 estimation), FMPE (flow-matching) and CMPE (consistency-model) -- with BayesFlow
-(keras-on-JAX) and wraps the trained estimator as a
-:class:`~probpipe.core.protocols.SupportsConditioning` distribution.
-``condition_on(model, observed)`` then draws from ``p(theta | observed)`` in a
-single forward pass through the trained network: no MCMC, no gradient bridge,
-and no prior translation (the prior is used only to draw ``theta`` at train
-time via the :func:`~probpipe.sample` op).
+(keras-on-JAX) and wraps prior + simulator + trained estimator as a
+:class:`BayesFlowModel` of the joint ``p(theta, y)``: forward sampling draws
+``(params, data)`` through the simulator, and ``condition_on(model, observed)``
+draws from ``p(theta | observed)`` in a single forward pass through the trained
+network -- no MCMC, no gradient bridge, and no prior translation (the prior is
+used only to draw ``theta`` at train time via the :func:`~probpipe.sample` op).
 
 BayesFlow / keras is imported lazily on first use, so ``import probpipe`` does
 not pull keras.
@@ -28,14 +28,22 @@ from ..core._record_array import NumericRecordArray
 from ..core.distribution import Distribution
 from ..core.node import workflow_function
 from ..core.ops import sample as _sample_op
-from ..core.protocols import GenerativeLikelihood, SupportsConditioning
-from ..custom_types import Array, PRNGKey
+from ..core.protocols import GenerativeLikelihood, SupportsConditioning, SupportsSampling
+from ..custom_types import Array, ArrayLike, PRNGKey
 from ._approximate_distribution import ApproximateDistribution, make_posterior
 
 if TYPE_CHECKING:
-    # Type-only: the optional bayesflow dependency loads at runtime in _ensure_bayesflow.
+    # Type-only: bayesflow/keras load at runtime in _ensure_bayesflow; tfp is a
+    # hard dependency but is only needed here for bijector annotations.
+    import tensorflow_probability.substrates.jax.bijectors as tfb
     from bayesflow import Adapter, ContinuousApproximator
     from bayesflow.networks import InferenceNetwork
+    from keras.optimizers import Optimizer as KerasOptimizer
+else:
+    # ``@workflow_function`` resolves the decorated signature's hints at runtime
+    # (``get_type_hints``), so names appearing there must exist outside
+    # TYPE_CHECKING; the optional-dependency types degrade to ``Any``.
+    InferenceNetwork = KerasOptimizer = Any
 
 AmortizedMethod = Literal["npe", "fmpe", "cmpe"]
 # Offline-simulation execution backend; values mirror ``WorkflowFunction``'s
@@ -121,7 +129,7 @@ def _build_adapter(bf: ModuleType, fields: tuple[str, ...]) -> Adapter:
     )
 
 
-def _field_bijectors(prior: Distribution, fields: tuple[str, ...]) -> dict[str, Any]:
+def _field_bijectors(prior: Distribution, fields: tuple[str, ...]) -> dict[str, tfb.Bijector]:
     """Per-field bijector mapping each parameter's unconstrained R^d to its support.
 
     BayesFlow's ``ContinuousApproximator`` operates in unconstrained, real space, so a
@@ -144,7 +152,7 @@ def _field_bijectors(prior: Distribution, fields: tuple[str, ...]) -> dict[str, 
             ) from None
         # Single-field priors: the whole-distribution support is the field's support.
         supports = {f: prior.support for f in fields}
-    bijectors: dict[str, Any] = {}
+    bijectors: dict[str, tfb.Bijector] = {}
     for f in fields:
         constraint = supports[f]
         try:
@@ -166,7 +174,7 @@ def _simulate_offline(
     key: PRNGKey,
     *,
     sim_backend: SimBackend,
-    bijectors: dict[str, Any],
+    bijectors: dict[str, tfb.Bijector],
 ) -> tuple[dict[str, np.ndarray], np.ndarray]:
     """Draw ``(theta, y)`` pairs offline: ``theta ~ prior``, ``y ~ simulator(theta)``.
 
@@ -218,34 +226,41 @@ def _simulate_offline(
 # ---------------------------------------------------------------------------
 
 
-class BayesFlowPosterior(Distribution, SupportsConditioning):
-    """A trained BayesFlow amortized posterior estimator.
+class BayesFlowModel(Distribution, SupportsSampling, SupportsConditioning):
+    """A BayesFlow amortized model of the joint ``p(theta, y)``.
 
-    Implements :class:`~probpipe.core.protocols.SupportsConditioning`, so
-    ``condition_on(model, observed)`` draws from ``p(theta | observed)`` in one
-    forward pass through the trained network.  Because the estimator is
-    amortized, the same instance conditions on any observation with no
-    retraining.  The network samples in unconstrained space; draws are mapped
-    back to each field's support via the per-field forward bijectors recorded
-    at training time (identity for real-valued fields).  The amortized path
-    honours ``num_results`` (a positive integer) and ``random_seed``;
-    ``num_warmup`` / ``num_chains`` do not apply (a forward pass yields a
-    single draw block).
+    Bundles the generative model it was trained from (``prior`` + ``simulator``)
+    with the trained amortized estimator.  Sampling draws ``(params, data)``
+    from the joint via the prior and one simulator call, exactly like
+    :class:`~probpipe.SimpleGenerativeModel`.  Conditioning runs the trained
+    network: ``condition_on(model, observed)`` draws from ``p(theta | observed)``
+    in one forward pass, and -- because the estimator is amortized -- the same
+    instance conditions on any observation with no retraining.  The network
+    samples in unconstrained space; posterior draws are mapped back to each
+    field's support via the per-field forward bijectors recorded at training
+    time (identity for real-valued fields).  The amortized path honours
+    ``num_results`` (a positive integer) and ``random_seed``; ``num_warmup`` /
+    ``num_chains`` do not apply (a forward pass yields a single draw block).
     """
+
+    _sampling_cost: str = "medium"
+    _preferred_orchestration: str | None = None
 
     def __init__(
         self,
         approximator: ContinuousApproximator,
         prior: Distribution,
+        simulator: GenerativeLikelihood,
         *,
         method: AmortizedMethod,
         data_dim: int,
         num_results: int = 2000,
         random_seed: int = 0,
-        bijectors: dict[str, Any] | None = None,
+        bijectors: dict[str, tfb.Bijector] | None = None,
     ):
         self._approximator = approximator
         self._prior = prior
+        self._simulator = simulator
         self._fields = tuple(prior.record_template.fields)
         self._method = method
         self._data_dim = data_dim
@@ -254,18 +269,47 @@ class BayesFlowPosterior(Distribution, SupportsConditioning):
         # Forward bijectors (unconstrained -> support); missing entries mean identity.
         self._bijectors = bijectors or {}
         # The ``Distribution`` metaclass requires a non-empty name.
-        self._name = f"BayesFlowPosterior({method})"
+        self._name = f"BayesFlowModel({method})"
 
-    def _sample(self, key: PRNGKey, sample_shape: tuple[int, ...] = ()) -> Any:
-        # Present so sampleability probes get NotImplementedError -- which
-        # WorkflowFunction's dispatch fallback catches -- not AttributeError.
-        raise NotImplementedError(
-            "BayesFlowPosterior is an amortized conditional estimator with no "
-            "unconditional sampler; draw from it by conditioning on data: "
-            "condition_on(model, observed)."
+    @property
+    def prior(self) -> Distribution:
+        """The prior over model parameters."""
+        return self._prior
+
+    @property
+    def simulator(self) -> GenerativeLikelihood:
+        """The generative likelihood (provides ``generate_data``)."""
+        return self._simulator
+
+    def _sample(self, key: PRNGKey, sample_shape: tuple[int, ...] = ()) -> tuple[Any, Any]:
+        """Draw one joint ``(params, data)`` sample from the generative model.
+
+        Samples ``params`` from the prior and one dataset from
+        ``simulator.generate_data(params, 1)`` -- forward sampling, independent
+        of the trained network.  ``params`` is the same named-field structured
+        record the simulator sees during training.  Batched draws are not
+        supported because ``GenerativeLikelihood.generate_data`` takes a single
+        params object by contract (same restriction as
+        ``SimpleGenerativeModel``).
+        """
+        if sample_shape != ():
+            raise NotImplementedError(
+                "BayesFlowModel._sample(..., sample_shape=...) with a non-empty "
+                "sample_shape is not supported. Loop over _sample(key, ()) with "
+                "independent keys instead."
+            )
+        k_prior, k_data = jax.random.split(key)
+        theta = _sample_op(self._prior, key=k_prior, sample_shape=(1,))
+        params = NumericRecordArray.unflatten(
+            jnp.reshape(jnp.asarray(theta.flatten()), (-1,)),
+            template=self._prior.record_template, batch_shape=(),
         )
+        data = self._simulator.generate_data(params, 1, key=k_data)[0]
+        return (params, data)
 
-    def _condition_on(self, observed: Any, /, **kwargs: Any) -> ApproximateDistribution:
+    def _condition_on(
+        self, observed: ArrayLike | np.ndarray, /, **kwargs: Any
+    ) -> ApproximateDistribution:
         num_results = int(kwargs.get("num_results", self._num_results))
         if num_results < 1:
             raise ValueError(f"num_results must be a positive integer, got {num_results}.")
@@ -307,7 +351,7 @@ class BayesFlowPosterior(Distribution, SupportsConditioning):
 
     def __repr__(self) -> str:
         return (
-            f"BayesFlowPosterior(method={self._method!r}, "
+            f"BayesFlowModel(method={self._method!r}, "
             f"num_results={self._num_results})"
         )
 
@@ -327,19 +371,20 @@ def learn_amortized_posterior(
     epochs: int = 50,
     batch_size: int = 128,
     sim_backend: SimBackend = "jax",
-    inference_network: Any | None = None,
+    inference_network: InferenceNetwork | None = None,
     num_results: int = 2000,
     random_seed: int = 0,
-    optimizer: Any = "adam",
+    optimizer: str | KerasOptimizer = "adam",
     **fit_kwargs: Any,
-) -> BayesFlowPosterior:
+) -> BayesFlowModel:
     """Learn an amortized conditional posterior ``p(theta | y)`` with BayesFlow.
 
     Trains an amortized neural posterior estimator (NPE / FMPE / CMPE) from a
-    ``prior`` and a ``simulator`` and returns a :class:`BayesFlowPosterior`
-    implementing :class:`~probpipe.core.protocols.SupportsConditioning`.
-    ``condition_on(result, observed)`` then produces fast amortized draws in a
-    single forward pass -- no MCMC.
+    ``prior`` and a ``simulator`` and returns a :class:`BayesFlowModel` -- the
+    joint model bundling prior, simulator, and the trained estimator.
+    ``condition_on(result, observed)`` produces fast amortized posterior draws
+    in a single forward pass (no MCMC); ``sample(result)`` draws ``(params,
+    data)`` from the joint generative model.
 
     Parameters
     ----------
@@ -393,8 +438,9 @@ def learn_amortized_posterior(
 
     Returns
     -------
-    BayesFlowPosterior
-        A ``SupportsConditioning`` distribution wrapping the trained estimator.
+    BayesFlowModel
+        The joint model: forward sampling via prior + simulator, amortized
+        conditioning via the trained estimator.
 
     Raises
     ------
@@ -487,7 +533,7 @@ def learn_amortized_posterior(
         random.setstate(py_state)
         np.random.set_state(np_state)
 
-    return BayesFlowPosterior(
-        approximator, prior, method=method, data_dim=int(y.shape[-1]),
+    return BayesFlowModel(
+        approximator, prior, simulator, method=method, data_dim=int(y.shape[-1]),
         num_results=num_results, random_seed=random_seed, bijectors=bijectors,
     )

--- a/probpipe/inference/_bayesflow.py
+++ b/probpipe/inference/_bayesflow.py
@@ -1,0 +1,381 @@
+"""BayesFlow amortized-SBI backend for ProbPipe.
+
+Trains amortized conditional posterior estimators -- NPE (neural posterior
+estimation), FMPE (flow-matching) and CMPE (consistency-model) -- with BayesFlow
+(keras-on-JAX) and wraps the trained estimator as a
+:class:`~probpipe.core.protocols.SupportsConditioning` distribution.
+``condition_on(model, observed)`` then draws from ``p(theta | observed)`` in a
+single forward pass through the trained network: no MCMC, no gradient bridge,
+and no prior translation (the prior is used only to draw ``theta`` at train
+time via the :func:`~probpipe.sample` op).
+
+BayesFlow / keras is imported lazily on first use, so ``import probpipe`` does
+not pull keras.
+"""
+
+from __future__ import annotations
+
+import os
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, Literal
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from ..core._record_array import NumericRecordArray
+from ..core.distribution import Distribution
+from ..core.node import workflow_function
+from ..core.ops import sample as _sample_op
+from ..core.protocols import GenerativeLikelihood, SupportsConditioning
+from ..custom_types import Array, PRNGKey
+from ._approximate_distribution import ApproximateDistribution, make_posterior
+
+if TYPE_CHECKING:
+    # Type-only imports of the optional ``bayesflow`` dependency: stringized by
+    # ``from __future__ import annotations`` and never evaluated at runtime
+    # (bayesflow is loaded only inside ``_ensure_bayesflow``).
+    from bayesflow import Adapter, ContinuousApproximator
+    from bayesflow.networks import InferenceNetwork
+
+AmortizedMethod = Literal["npe", "fmpe", "cmpe"]
+# Offline-simulation execution backend; values mirror ``WorkflowFunction``'s
+# dispatch names ("jax" = vmap the simulator, "sequential" = eager per-draw loop).
+SimBackend = Literal["jax", "sequential"]
+
+# Reserved key for the simulated observation in BayesFlow's named-array dicts.
+_OBSERVATION_KEY = "observation"
+
+_bayesflow_module: ModuleType | None = None
+
+
+def _ensure_bayesflow() -> ModuleType:
+    """Import BayesFlow on the keras JAX backend, or raise a helpful error.
+
+    Imported lazily (and cached) so that ``import probpipe`` does not load keras.
+    """
+    global _bayesflow_module
+    if _bayesflow_module is not None:
+        return _bayesflow_module
+    # keras resolves its backend at import time from ``KERAS_BACKEND``; pin jax
+    # before keras / bayesflow load. ``setdefault`` leaves an explicit choice.
+    os.environ.setdefault("KERAS_BACKEND", "jax")
+    try:
+        import bayesflow as bf
+        import keras
+    except ImportError as e:
+        raise ImportError(
+            "BayesFlow is required for learn_amortized_posterior: "
+            "pip install probpipe[bayesflow]"
+        ) from e
+    if keras.backend.backend() != "jax":
+        # ``setdefault`` cannot re-bind an already-imported keras, so a process
+        # that imported keras with another backend first lands here.
+        raise ImportError(
+            "ProbPipe's BayesFlow backend requires the keras JAX backend, but "
+            f"keras reports {keras.backend.backend()!r}. Set KERAS_BACKEND=jax "
+            "before keras or bayesflow is first imported."
+        )
+    _bayesflow_module = bf
+    return bf
+
+
+# ---------------------------------------------------------------------------
+# Bridge helpers: ProbPipe prior / simulator <-> BayesFlow named-array dicts
+# ---------------------------------------------------------------------------
+
+
+def _make_inference_network(
+    bf: ModuleType, method: AmortizedMethod, total_steps: int, *, event_size: int
+) -> InferenceNetwork:
+    """The BayesFlow inference network for each amortized method.
+
+    NPE's coupling flow splits the parameter vector in two and so needs at least
+    two parameters; for a one-parameter model (``event_size < 2``) the NPE default
+    falls back to a flow-matching network, which has no such constraint (the
+    posterior is still exposed under ``method="npe"``).
+    """
+    if method == "npe":
+        if event_size < 2:
+            return bf.networks.FlowMatching()
+        return bf.networks.CouplingFlow()
+    if method == "fmpe":
+        return bf.networks.FlowMatching()
+    if method == "cmpe":
+        return bf.networks.ConsistencyModel(total_steps=total_steps)
+    raise ValueError(
+        f"Unknown amortized SBI method: {method!r}. Supported: 'npe', 'fmpe', 'cmpe'."
+    )
+
+
+def _build_adapter(bf: ModuleType, fields: tuple[str, ...]) -> Adapter:
+    """Route named theta fields to ``inference_variables`` and the observation
+    to ``inference_conditions``. The adapter is invertible, so ``sample``
+    returns the parameters split back into named fields."""
+    return (
+        bf.Adapter()
+        .convert_dtype("float64", "float32")
+        .concatenate(list(fields), into="inference_variables")
+        .concatenate([_OBSERVATION_KEY], into="inference_conditions")
+    )
+
+
+def _simulate_offline(
+    prior: Distribution,
+    simulator: GenerativeLikelihood,
+    num_simulations: int,
+    key: PRNGKey,
+    *,
+    sim_backend: SimBackend,
+) -> tuple[dict[str, np.ndarray], np.ndarray]:
+    """Draw ``(theta, y)`` pairs offline: ``theta ~ prior``, ``y ~ simulator(theta)``.
+
+    Returns ``(named_theta, y)`` where ``named_theta`` maps each prior
+    record-template field to a ``(num_simulations, d_field)`` float32 array and
+    ``y`` is the ``(num_simulations, d_y)`` float32 array of flattened
+    simulated observations.
+    """
+    template = prior.record_template
+    fields = template.fields
+    k_theta, k_sim = jax.random.split(key)
+    theta = _sample_op(prior, key=k_theta, sample_shape=(num_simulations,))
+    # ``theta.flatten()`` is the prior's canonical flat layout (record-template
+    # field order); the simulator's ``generate_data(params, ...)`` consumes it
+    # positionally, and ``unflatten`` splits it back into per-field arrays for
+    # the adapter via the same canonical layout -- uniform across record
+    # containers and single-field priors (whose raw draws are not field-indexable
+    # by name, but whose flat layout is well defined).
+    theta_flat = jnp.asarray(theta.flatten()).reshape(num_simulations, -1)
+    record = NumericRecordArray.unflatten(
+        theta_flat, template=template, batch_shape=(num_simulations,)
+    )
+    named = {
+        f: np.asarray(jnp.asarray(record[f]).reshape(num_simulations, -1), dtype="float32")
+        for f in fields
+    }
+    sim_keys = jax.random.split(k_sim, num_simulations)
+
+    def _one(p: Array, k: PRNGKey) -> Array:
+        # One simulated dataset per theta, flattened to a fixed (d_y,) vector.
+        return jnp.ravel(simulator.generate_data(p, 1, key=k)[0])
+
+    if sim_backend == "jax":
+        # JAX-traceable simulators: vmap the whole batch (fast path).
+        y = jax.vmap(_one)(theta_flat, sim_keys)
+    else:  # "sequential"
+        # Non-traceable simulators (numpy / external code): one eager call per
+        # draw, so generate_data runs concretely rather than under a jax trace.
+        y = jnp.stack([_one(theta_flat[i], sim_keys[i]) for i in range(num_simulations)])
+    return named, np.asarray(y, dtype="float32")
+
+
+# ---------------------------------------------------------------------------
+# Trained-model wrapper: a SupportsConditioning direct sampler
+# ---------------------------------------------------------------------------
+
+
+class BayesFlowPosterior(Distribution, SupportsConditioning):
+    """A trained BayesFlow amortized posterior estimator.
+
+    Implements :class:`~probpipe.core.protocols.SupportsConditioning`, so
+    ``condition_on(model, observed)`` draws from ``p(theta | observed)`` in one
+    forward pass through the trained network.  Because the estimator is
+    amortized, the same instance conditions on any observation with no
+    retraining.  The amortized path honours ``num_results`` and (best-effort)
+    ``random_seed``; ``num_warmup`` / ``num_chains`` do not apply (a forward
+    pass yields a single draw block).
+    """
+
+    def __init__(
+        self,
+        approximator: ContinuousApproximator,
+        prior: Distribution,
+        *,
+        method: AmortizedMethod,
+        data_dim: int,
+        num_results: int = 2000,
+        random_seed: int = 0,
+    ):
+        self._approximator = approximator
+        self._prior = prior
+        self._fields = tuple(prior.record_template.fields)
+        self._method = method
+        self._data_dim = data_dim
+        self._num_results = num_results
+        self._random_seed = random_seed
+        # The ``Distribution`` metaclass requires a non-empty name.
+        self._name = f"BayesFlowPosterior({method})"
+
+    def _condition_on(self, observed: Any, /, **kwargs: Any) -> ApproximateDistribution:
+        num_results = int(kwargs.get("num_results", self._num_results))
+        random_seed = int(kwargs.get("random_seed", self._random_seed))
+
+        # One observation -> a length-1 condition batch, matching the flattened
+        # ``(d_y,)`` layout the network was trained on.
+        obs_flat = np.ravel(np.asarray(observed, dtype="float32"))
+        if obs_flat.size != self._data_dim:
+            raise ValueError(
+                f"observation has {obs_flat.size} values but the estimator was "
+                f"trained on observations of size {self._data_dim} (one simulated "
+                "dataset); pass a single observation of the simulator's output "
+                "shape, not a stacked multi-observation dataset."
+            )
+        out = self._approximator.sample(
+            num_samples=num_results,
+            conditions={_OBSERVATION_KEY: obs_flat[None, :]},
+            seed=random_seed,
+        )
+        # ``out`` maps each field to ``(1, num_results, d_field)``; squeeze the
+        # observation axis and concatenate in record-template field order (the
+        # layout ``make_posterior`` lifts back to named draws).
+        cols = [np.asarray(out[f])[0].reshape(num_results, -1) for f in self._fields]
+        flat = jnp.asarray(np.concatenate(cols, axis=-1))
+        return make_posterior(
+            [flat],
+            parents=(self._prior,),
+            algorithm=f"bayesflow_{self._method}",
+            record_template=self._prior.record_template,
+            num_results=num_results,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"BayesFlowPosterior(method={self._method!r}, "
+            f"num_results={self._num_results})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Workflow function
+# ---------------------------------------------------------------------------
+
+
+@workflow_function
+def learn_amortized_posterior(
+    prior: Distribution,
+    simulator: GenerativeLikelihood,
+    *,
+    method: AmortizedMethod = "npe",
+    num_simulations: int = 10_000,
+    epochs: int = 50,
+    batch_size: int = 128,
+    sim_backend: SimBackend = "jax",
+    inference_network: Any | None = None,
+    num_results: int = 2000,
+    random_seed: int = 0,
+    optimizer: Any = "adam",
+    **fit_kwargs: Any,
+) -> BayesFlowPosterior:
+    """Learn an amortized conditional posterior ``p(theta | y)`` with BayesFlow.
+
+    Trains an amortized neural posterior estimator (NPE / FMPE / CMPE) from a
+    ``prior`` and a ``simulator`` and returns a :class:`BayesFlowPosterior`
+    implementing :class:`~probpipe.core.protocols.SupportsConditioning`.
+    ``condition_on(result, observed)`` then produces fast amortized draws in a
+    single forward pass -- no MCMC.
+
+    Parameters
+    ----------
+    prior : Distribution
+        Prior over the model parameters.  Must be a ``RecordDistribution`` --
+        typically a ``ProductDistribution`` of named distributions, or a single
+        named distribution for a one-parameter model.  It is sampled via the
+        :func:`~probpipe.sample` op to draw training thetas; it is *not*
+        otherwise translated.
+    simulator : GenerativeLikelihood
+        Must implement ``generate_data(params, num_observations, *, key)``; it
+        must be JAX-vmappable unless ``sim_backend="sequential"`` (see below). Training
+        uses one simulated dataset per ``theta``, so ``condition_on`` must be
+        given a single observation of that same flattened shape (not a stacked
+        multi-observation dataset).
+    method : {"npe", "fmpe", "cmpe"}
+        Amortized estimator: NPE (coupling flow), FMPE (flow matching), or CMPE
+        (consistency model). NPE's coupling flow needs at least two parameters,
+        so for a one-parameter prior the NPE default falls back to a flow-matching
+        network (still reported as ``method="npe"``).
+    num_simulations : int
+        Number of ``(theta, y)`` pairs simulated offline for training.
+    epochs, batch_size : int
+        keras training schedule.
+    sim_backend : {"jax", "sequential"}
+        How the offline simulation is executed. ``"jax"`` (default) vmaps the
+        simulator and requires it to be JAX-traceable; ``"sequential"`` runs an
+        eager per-draw loop, supporting non-JAX simulators (numpy / external
+        code) at the cost of speed. Mirrors ``WorkflowFunction``'s dispatch names.
+    inference_network : bayesflow.networks.InferenceNetwork or None
+        Overrides the method default (``CouplingFlow`` / ``FlowMatching`` /
+        ``ConsistencyModel``).
+    num_results : int
+        Default number of posterior draws per ``condition_on`` call.
+    random_seed : int
+        Seed for offline simulation, training, and sampling (sampling
+        reproducibility is best-effort via keras seeding).
+    optimizer : str or keras.Optimizer
+        Passed to ``approximator.compile``.
+    **fit_kwargs
+        Forwarded to ``approximator.fit`` (e.g. ``callbacks``, ``verbose``).
+
+    Returns
+    -------
+    BayesFlowPosterior
+        A ``SupportsConditioning`` distribution wrapping the trained estimator.
+
+    Raises
+    ------
+    ValueError
+        If ``method`` is not one of ``"npe"`` / ``"fmpe"`` / ``"cmpe"``,
+        ``sim_backend`` is not ``"jax"`` / ``"sequential"``, or a prior field
+        collides with the reserved ``"observation"`` key.
+    TypeError
+        If ``simulator`` lacks ``generate_data``, or ``prior`` is not a
+        ``RecordDistribution`` (has no ``record_template``).
+    ImportError
+        If the ``[bayesflow]`` extra is not installed.
+    """
+    if method not in ("npe", "fmpe", "cmpe"):
+        raise ValueError(
+            f"Unknown amortized SBI method: {method!r}. Supported: 'npe', 'fmpe', 'cmpe'."
+        )
+    if sim_backend not in ("jax", "sequential"):
+        raise ValueError(
+            f"Unknown sim_backend: {sim_backend!r}. Supported: 'jax', 'sequential'."
+        )
+    if not hasattr(simulator, "generate_data"):
+        raise TypeError(
+            "simulator must be a GenerativeLikelihood with a generate_data method, "
+            f"got {type(simulator).__name__}"
+        )
+    record_template = getattr(prior, "record_template", None)
+    if record_template is None:
+        raise TypeError(
+            "learn_amortized_posterior requires a RecordDistribution prior with "
+            "named parameter fields -- typically a ProductDistribution of named "
+            f"distributions -- but got {type(prior).__name__}, which has no "
+            "record_template."
+        )
+    fields = record_template.fields
+    if _OBSERVATION_KEY in fields:
+        raise ValueError(
+            f"prior field name {_OBSERVATION_KEY!r} collides with the reserved "
+            "observation key used internally by the BayesFlow adapter; rename the field."
+        )
+    bf = _ensure_bayesflow()
+    key = jax.random.PRNGKey(random_seed)
+    named, y = _simulate_offline(prior, simulator, num_simulations, key, sim_backend=sim_backend)
+    sims = {**named, _OBSERVATION_KEY: y}
+
+    adapter = _build_adapter(bf, fields)
+    num_batches = max(1, -(-num_simulations // batch_size))  # ceil: count the partial batch
+    net = inference_network or _make_inference_network(
+        bf, method, total_steps=epochs * num_batches, event_size=prior.event_size
+    )
+
+    approximator = bf.ContinuousApproximator(inference_network=net, adapter=adapter)
+    approximator.compile(optimizer=optimizer)
+    dataset = bf.OfflineDataset(data=sims, batch_size=batch_size, adapter=adapter)
+    approximator.fit(dataset=dataset, epochs=epochs, **fit_kwargs)
+
+    return BayesFlowPosterior(
+        approximator, prior, method=method, data_dim=int(y.shape[-1]),
+        num_results=num_results, random_seed=random_seed,
+    )

--- a/probpipe/inference/_bayesflow.py
+++ b/probpipe/inference/_bayesflow.py
@@ -16,6 +16,7 @@ not pull keras.
 from __future__ import annotations
 
 import os
+import random
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -86,17 +87,19 @@ def _ensure_bayesflow() -> ModuleType:
 
 
 def _make_inference_network(
-    bf: ModuleType, method: AmortizedMethod, total_steps: int, *, event_size: int
+    bf: ModuleType, method: AmortizedMethod, total_steps: int, *, unconstrained_size: int
 ) -> InferenceNetwork:
     """The BayesFlow inference network for each amortized method.
 
     NPE's coupling flow splits the parameter vector in two and so needs at least
-    two parameters; for a one-parameter model (``event_size < 2``) the NPE default
-    falls back to a flow-matching network, which has no such constraint (the
-    posterior is still exposed under ``method="npe"``).
+    two dimensions. The network operates in *unconstrained* space, so the relevant
+    count is the unconstrained width, not the prior's event size -- e.g. a 2-simplex
+    field contributes one dimension, not two. Below two unconstrained dimensions the
+    NPE default falls back to a flow-matching network, which has no such constraint
+    (the posterior is still exposed under ``method="npe"``).
     """
     if method == "npe":
-        if event_size < 2:
+        if unconstrained_size < 2:
             return bf.networks.FlowMatching()
         return bf.networks.CouplingFlow()
     if method == "fmpe":
@@ -132,10 +135,14 @@ def _field_bijectors(prior: Distribution, fields: tuple[str, ...]) -> dict[str, 
     """
     from ..distributions import bijector_for  # lazy: inference/ -> distributions/
 
-    components = getattr(prior, "components", None)
+    try:
+        supports = prior.supports
+    except NotImplementedError:
+        # RecordDistributions without per-field supports: spread the single support.
+        supports = {f: prior.support for f in fields}
     bijectors: dict[str, Any] = {}
     for f in fields:
-        constraint = components[f].support if components is not None else prior.support
+        constraint = supports[f]
         try:
             bijectors[f] = bijector_for(constraint)
         except NotImplementedError as e:
@@ -155,32 +162,36 @@ def _simulate_offline(
     key: PRNGKey,
     *,
     sim_backend: SimBackend,
+    bijectors: dict[str, Any],
 ) -> tuple[dict[str, np.ndarray], np.ndarray]:
     """Draw ``(theta, y)`` pairs offline: ``theta ~ prior``, ``y ~ simulator(theta)``.
 
     Returns ``(named_theta, y)`` where ``named_theta`` maps each prior
-    record-template field to a ``(num_simulations, d_field)`` float32 array and
-    ``y`` is the ``(num_simulations, d_y)`` float32 array of flattened
-    simulated observations.
+    record-template field to a ``(num_simulations, d_field)`` float32 array of
+    *unconstrained* parameters (each field's draws pushed through its inverse
+    bijector at the field's native event shape, then flattened) and ``y`` is the
+    ``(num_simulations, d_y)`` float32 array of flattened simulated observations.
+    The simulator itself always sees the constrained, structured draws.
     """
     template = prior.record_template
     fields = template.fields
     k_theta, k_sim = jax.random.split(key)
     theta = _sample_op(prior, key=k_theta, sample_shape=(num_simulations,))
     # ``theta.flatten()`` is the prior's canonical flat layout (record-template
-    # field order); the simulator's ``generate_data(params, ...)`` consumes it
-    # positionally, and ``unflatten`` splits it back into per-field arrays for
-    # the adapter via the same canonical layout -- uniform across record
-    # containers and single-field priors (whose raw draws are not field-indexable
-    # by name, but whose flat layout is well defined).
+    # field order); ``unflatten`` lifts it back to named per-field arrays --
+    # uniform across record containers and single-field priors (whose raw draws
+    # are not field-indexable by name, but whose flat layout is well defined).
     theta_flat = jnp.asarray(theta.flatten()).reshape(num_simulations, -1)
     record = NumericRecordArray.unflatten(
         theta_flat, template=template, batch_shape=(num_simulations,)
     )
-    named = {
-        f: np.asarray(jnp.asarray(record[f]).reshape(num_simulations, -1), dtype="float32")
-        for f in fields
-    }
+    # Unconstrain each field at its *native* event shape -- matrix-valued bijectors
+    # (e.g. positive-definite: Chain([CholeskyOuterProduct, FillScaleTriL])) require
+    # (..., n, n) input, so the inverse must run before flattening for the adapter.
+    named = {}
+    for f in fields:
+        u = bijectors[f].inverse(jnp.asarray(record[f]))
+        named[f] = np.asarray(jnp.reshape(u, (num_simulations, -1)), dtype="float32")
     sim_keys = jax.random.split(k_sim, num_simulations)
 
     def _one(flat_row: Array, k: PRNGKey) -> Array:
@@ -196,7 +207,10 @@ def _simulate_offline(
     else:  # "sequential"
         # Non-traceable simulators (numpy / external code): one eager call per
         # draw, so generate_data runs concretely rather than under a jax trace.
-        y = jnp.stack([_one(theta_flat[i], sim_keys[i]) for i in range(num_simulations)])
+        # Move theta to the host once, rather than indexing the device array
+        # (and paying a sync) on every draw; keys stay jax (they are PRNG keys).
+        theta_rows = np.asarray(theta_flat)
+        y = jnp.stack([_one(theta_rows[i], sim_keys[i]) for i in range(num_simulations)])
     return named, np.asarray(y, dtype="float32")
 
 
@@ -242,8 +256,21 @@ class BayesFlowPosterior(Distribution, SupportsConditioning):
         # The ``Distribution`` metaclass requires a non-empty name.
         self._name = f"BayesFlowPosterior({method})"
 
+    def _sample(self, key: PRNGKey, sample_shape: tuple[int, ...] = ()) -> Any:
+        # Defined (rather than left absent) so callers probing sampleability --
+        # e.g. WorkflowFunction's dispatch fallback, which catches
+        # NotImplementedError but not AttributeError -- get the guarded signal
+        # plus an actionable message.
+        raise NotImplementedError(
+            "BayesFlowPosterior is an amortized conditional estimator with no "
+            "unconditional sampler; draw from it by conditioning on data: "
+            "condition_on(model, observed)."
+        )
+
     def _condition_on(self, observed: Any, /, **kwargs: Any) -> ApproximateDistribution:
         num_results = int(kwargs.get("num_results", self._num_results))
+        if num_results < 1:
+            raise ValueError(f"num_results must be a positive integer, got {num_results}.")
         random_seed = int(kwargs.get("random_seed", self._random_seed))
 
         # One observation -> a length-1 condition batch, matching the flattened
@@ -263,17 +290,19 @@ class BayesFlowPosterior(Distribution, SupportsConditioning):
         )
         # ``out`` maps each field to ``(1, num_results, d_field)``; squeeze the
         # observation axis, map each field's unconstrained draws back to its support
-        # via the forward bijector (identity for real-valued fields), and concatenate
-        # in record-template field order (the layout ``make_posterior`` lifts back to
-        # named draws).
+        # via the forward bijector (identity for real-valued fields), flatten any
+        # matrix-valued output, and concatenate in record-template field order (the
+        # layout ``make_posterior`` lifts back to named draws). Stays in jnp
+        # end-to-end -- this is the latency-critical amortized path, so no per-field
+        # host round-trips.
         cols = []
         for f in self._fields:
-            draws = np.asarray(out[f])[0]
+            draws = jnp.asarray(out[f])[0]
             bij = self._bijectors.get(f)
             if bij is not None:
-                draws = np.asarray(bij.forward(jnp.asarray(draws)))
-            cols.append(draws.reshape(num_results, -1))
-        flat = jnp.asarray(np.concatenate(cols, axis=-1))
+                draws = bij.forward(draws)
+            cols.append(jnp.reshape(draws, (num_results, -1)))
+        flat = jnp.concatenate(cols, axis=-1)
         return make_posterior(
             [flat],
             parents=(self._prior,),
@@ -325,9 +354,10 @@ def learn_amortized_posterior(
         typically a ``ProductDistribution`` of named distributions, or a single
         named distribution for a one-parameter model.  It is sampled via the
         :func:`~probpipe.sample` op to draw training thetas; it is *not*
-        otherwise translated.  Constrained fields (positive, an interval, ...) are
-        trained in unconstrained space via the per-field bijector from
-        :func:`~probpipe.bijector_for` and mapped back to the support at sample time;
+        otherwise translated.  Constrained fields (positive, an interval, a simplex,
+        positive-definite matrices, ...) are trained in unconstrained space via the
+        per-field bijector from :func:`~probpipe.bijector_for` -- applied at the
+        field's native event shape -- and mapped back to the support at sample time;
         real-valued fields use the identity.  Discrete priors are not supported.
     simulator : GenerativeLikelihood
         Must implement ``generate_data(params, num_observations, *, key)``.  As with
@@ -339,8 +369,9 @@ def learn_amortized_posterior(
         same flattened shape (not a stacked multi-observation dataset).
     method : {"npe", "fmpe", "cmpe"}
         Amortized estimator: NPE (coupling flow), FMPE (flow matching), or CMPE
-        (consistency model). NPE's coupling flow needs at least two parameters,
-        so for a one-parameter prior the NPE default falls back to a flow-matching
+        (consistency model). NPE's coupling flow needs at least two *unconstrained*
+        parameter dimensions (a one-parameter prior has one; so does a single
+        2-simplex), below which the NPE default falls back to a flow-matching
         network (still reported as ``method="npe"``).
     num_simulations : int
         Number of ``(theta, y)`` pairs simulated offline for training.
@@ -358,8 +389,9 @@ def learn_amortized_posterior(
         Default number of posterior draws per ``condition_on`` call.
     random_seed : int
         Seed for offline simulation (``jax.random``), keras network init + training
-        (via ``keras.utils.set_random_seed``), and sampling. Note that this sets the
-        global keras / NumPy / Python RNG state.
+        (via ``keras.utils.set_random_seed``), and sampling. The caller's global
+        NumPy / Python RNG state is snapshotted and restored after training, so the
+        call does not perturb unrelated random streams.
     optimizer : str or keras.Optimizer
         Passed to ``approximator.compile``.
     **fit_kwargs
@@ -421,6 +453,13 @@ def learn_amortized_posterior(
     # Per-field unconstraining bijectors (identity for real-valued priors); this also
     # rejects discrete / unsupported-support priors up front, before any simulation.
     bijectors = _field_bijectors(prior, fields)
+    # The network trains on *unconstrained* widths, which differ from the prior's
+    # event sizes for dimension-shifting bijectors (a d-simplex contributes d-1).
+    leaf_shapes = record_template.numeric_leaf_shapes
+    unconstrained_size = sum(
+        int(np.prod(tuple(bijectors[f].inverse_event_shape(leaf_shapes[f])), dtype=int))
+        for f in fields
+    )
 
     bf = _ensure_bayesflow()
     import keras
@@ -428,28 +467,33 @@ def learn_amortized_posterior(
     # Seed Python / NumPy / keras RNG so keras network init + fit (weight init, batch
     # shuffling) are reproducible for a given random_seed; jax.random already seeds the
     # offline simulation and sampling, but keras training reads the global RNG.
+    # Snapshot the caller's Python/NumPy RNG state and restore it after training, so
+    # the (global, process-wide) seeding does not silently perturb the caller's
+    # unrelated random streams. keras keeps its own seeded generator state.
+    py_state = random.getstate()
+    np_state = np.random.get_state()
     keras.utils.set_random_seed(random_seed)
-    key = jax.random.PRNGKey(random_seed)
-    named, y = _simulate_offline(prior, simulator, num_simulations, key, sim_backend=sim_backend)
-    # Train in unconstrained space: map each field's draws to R^d via the inverse
-    # bijector (a no-op for real-valued fields), so the continuous network never has to
-    # reproduce a constrained support; the forward map is applied to draws at sample time.
-    named_u = {
-        f: np.asarray(bijectors[f].inverse(jnp.asarray(named[f])), dtype="float32")
-        for f in fields
-    }
-    sims = {**named_u, _OBSERVATION_KEY: y}
+    try:
+        key = jax.random.PRNGKey(random_seed)
+        named, y = _simulate_offline(
+            prior, simulator, num_simulations, key,
+            sim_backend=sim_backend, bijectors=bijectors,
+        )
+        sims = {**named, _OBSERVATION_KEY: y}
 
-    adapter = _build_adapter(bf, fields)
-    num_batches = max(1, -(-num_simulations // batch_size))  # ceil: count the partial batch
-    net = inference_network or _make_inference_network(
-        bf, method, total_steps=epochs * num_batches, event_size=prior.event_size
-    )
+        adapter = _build_adapter(bf, fields)
+        num_batches = max(1, -(-num_simulations // batch_size))  # ceil: count partial batch
+        net = inference_network or _make_inference_network(
+            bf, method, total_steps=epochs * num_batches, unconstrained_size=unconstrained_size
+        )
 
-    approximator = bf.ContinuousApproximator(inference_network=net, adapter=adapter)
-    approximator.compile(optimizer=optimizer)
-    dataset = bf.OfflineDataset(data=sims, batch_size=batch_size, adapter=adapter)
-    approximator.fit(dataset=dataset, epochs=epochs, **fit_kwargs)
+        approximator = bf.ContinuousApproximator(inference_network=net, adapter=adapter)
+        approximator.compile(optimizer=optimizer)
+        dataset = bf.OfflineDataset(data=sims, batch_size=batch_size, adapter=adapter)
+        approximator.fit(dataset=dataset, epochs=epochs, **fit_kwargs)
+    finally:
+        random.setstate(py_state)
+        np.random.set_state(np_state)
 
     return BayesFlowPosterior(
         approximator, prior, method=method, data_dim=int(y.shape[-1]),

--- a/probpipe/inference/_blackjax_sgmcmc.py
+++ b/probpipe/inference/_blackjax_sgmcmc.py
@@ -107,7 +107,7 @@ class _BlackJAXSGMCMCMethod(InferenceMethod):
 
     def check(self, dist: Any, observed: Any, **kwargs: Any) -> MethodInfo:
         """Require SimpleModel + ConditionallyIndependentLikelihood + batch_size."""
-        from ..modeling._likelihood import ConditionallyIndependentLikelihood
+        from ..core.protocols import ConditionallyIndependentLikelihood
 
         if not is_simple_model(dist):
             return MethodInfo(

--- a/probpipe/inference/_minibatch.py
+++ b/probpipe/inference/_minibatch.py
@@ -53,7 +53,7 @@ from ..core.record import Record
 from ..custom_types import Array, ArrayLike, PRNGKey
 
 if TYPE_CHECKING:
-    from ..modeling._likelihood import ConditionallyIndependentLikelihood
+    from ..core.protocols import ConditionallyIndependentLikelihood
 
 __all__ = ["MinibatchedDistribution"]
 
@@ -195,8 +195,7 @@ class MinibatchedDistribution(
         with_replacement: bool = False,
         name: str | None = None,
     ):
-        # Lazy import: inference can't import modeling at module load.
-        from ..modeling._likelihood import ConditionallyIndependentLikelihood
+        from ..core.protocols import ConditionallyIndependentLikelihood
 
         if not isinstance(prior, SupportsLogProb):
             raise TypeError(

--- a/probpipe/modeling/_likelihood.py
+++ b/probpipe/modeling/_likelihood.py
@@ -25,30 +25,11 @@ __all__ = [
 ]
 
 
-# ``Likelihood``, ``ConditionallyIndependentLikelihood`` and
-# ``GenerativeLikelihood`` are defined in ``core.protocols`` (pure structural
-# protocols importable by both modeling/ and inference/ without a cycle) and
-# re-exported above for backward compatibility.
-
-
-def _default_per_datum_log_likelihood(
-    likelihood: "Likelihood",
-    params: Any,
-    datum: Any,
-) -> Any:
-    """Default per-datum log-likelihood — evaluate ``log_likelihood`` on a length-1 batch.
-
-    Fallback for :class:`ConditionallyIndependentLikelihood`
-    implementations that don't have a row-specific shortcut. Adds a
-    leading axis to ``datum`` via ``jax.tree.map(lambda x: x[None, ...], datum)``
-    and calls ``likelihood.log_likelihood(params, batch)``. Less
-    efficient than an override that evaluates the family directly on
-    the un-reshaped datum (no length-1-batch wrap, no associated
-    broadcasting overhead inside ``log_likelihood``).
-    """
-    import jax
-    batch = jax.tree.map(lambda x: x[None, ...], datum)
-    return likelihood.log_likelihood(params, batch)
+# ``Likelihood``, ``ConditionallyIndependentLikelihood``,
+# ``GenerativeLikelihood``, and the ``_default_per_datum_log_likelihood``
+# fallback are defined in ``core.protocols`` (pure structural protocols
+# importable by both modeling/ and inference/ without a cycle); the protocols
+# are re-exported above for backward compatibility.
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/modeling/_likelihood.py
+++ b/probpipe/modeling/_likelihood.py
@@ -51,11 +51,6 @@ def _default_per_datum_log_likelihood(
     return likelihood.log_likelihood(params, batch)
 
 
-# ``GenerativeLikelihood`` now lives in ``core.protocols`` (a pure structural
-# protocol with no modeling dependency, so the inference/ layer can import it
-# without a cycle). Re-exported above for backward compatibility.
-
-
 # ---------------------------------------------------------------------------
 # _ConditioningStep — private WorkflowFunction for IncrementalConditioner
 # ---------------------------------------------------------------------------

--- a/probpipe/modeling/_likelihood.py
+++ b/probpipe/modeling/_likelihood.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Protocol, runtime_checkable
+from typing import Any
 
 from ..core.distribution import Distribution
 from ..core.node import Module, WorkflowFunction
+from ..core.protocols import ConditionallyIndependentLikelihood, GenerativeLikelihood, Likelihood
 from ..core.transition import iterate
-from ..custom_types import PRNGKey
 
 logger = logging.getLogger(__name__)
 
@@ -25,75 +25,10 @@ __all__ = [
 ]
 
 
-# ---------------------------------------------------------------------------
-# Protocol interfaces
-# ---------------------------------------------------------------------------
-
-
-@runtime_checkable
-class Likelihood[P, D](Protocol):
-    """Protocol for computing log-likelihood of data given parameters.
-
-    Generic in ``P`` (parameter type) and ``D`` (data type).
-    Any class that defines ``log_likelihood(params, data) -> float``
-    satisfies this protocol.
-    """
-
-    def log_likelihood(self, params: P, data: D) -> float: ...
-
-
-@runtime_checkable
-class ConditionallyIndependentLikelihood[P, D](Likelihood[P, D], Protocol):
-    """Likelihood whose observations are conditionally independent given
-    the parameters.
-
-    Formally, for observations ``y_1, ..., y_N`` the joint log-density
-    factorises into a sum of per-observation log-densities:
-
-    .. math::
-
-        \\log p(y_1, \\ldots, y_N \\mid \\theta)
-            = \\sum_{i=1}^N \\log p(y_i \\mid \\theta).
-
-    The "conditionally" refers to the conditioning on the parameters
-    ``θ``: the ``y_i`` are independent *given* ``θ``, not marginally.
-    For regression-style likelihoods each datum carries a covariate
-    ``x_i`` that the per-observation density depends on; the
-    factorisation then reads ``Σ_i log p(y_i | x_i, θ)``, with the
-    covariates treated as fixed inputs rather than random variables.
-    This is the "conditionally independent" case rather than the
-    stricter "i.i.d." (where every ``p(y_i | θ)`` is the same density).
-
-    Required by :class:`~probpipe.MinibatchedDistribution` for
-    stochastic-gradient inference, and useful independently for
-    held-out predictive log-likelihoods, leave-one-out
-    cross-validation, and PSIS-LOO.
-
-    Implementations expose :meth:`per_datum_log_likelihood`; the helper
-    :func:`_default_per_datum_log_likelihood` provides a length-1-batch
-    fallback for likelihoods that want a default rather than an
-    efficient override.
-    """
-
-    def per_datum_log_likelihood(self, params: P, datum: Any) -> Any:
-        """Log-density of a single datum given parameters.
-
-        Parameters
-        ----------
-        params : P
-            Model parameters.
-        datum : Any
-            One observation. The exact shape depends on the data format
-            the likelihood was constructed against — for a regression
-            model that's a single row ``(x_i, y_i)``; for a scalar
-            response, it's a single value. Subclasses define the shape.
-
-        Returns
-        -------
-        Array
-            Scalar log-density of the datum under ``params``.
-        """
-        ...
+# ``Likelihood``, ``ConditionallyIndependentLikelihood`` and
+# ``GenerativeLikelihood`` are defined in ``core.protocols`` (pure structural
+# protocols importable by both modeling/ and inference/ without a cycle) and
+# re-exported above for backward compatibility.
 
 
 def _default_per_datum_log_likelihood(
@@ -116,32 +51,9 @@ def _default_per_datum_log_likelihood(
     return likelihood.log_likelihood(params, batch)
 
 
-@runtime_checkable
-class GenerativeLikelihood[P, D](Protocol):
-    """Protocol for generating synthetic data given parameters.
-
-    Generic in ``P`` (parameter type) and ``D`` (data type).
-    Any class that defines
-    ``generate_data(params, num_observations, *, key) -> D``
-    satisfies this protocol.
-    """
-
-    def generate_data(
-        self, params: P, num_observations: int,
-        *, key: PRNGKey | None = None,
-    ) -> D:
-        """Generate ``num_observations`` synthetic data points from ``params``.
-
-        Parameters
-        ----------
-        params : P
-            Model parameters.
-        num_observations : int
-            Number of data points to generate.
-        key : PRNGKey or None
-            JAX PRNG key for reproducible generation.
-        """
-        ...
+# ``GenerativeLikelihood`` now lives in ``core.protocols`` (a pure structural
+# protocol with no modeling dependency, so the inference/ layer can import it
+# without a cycle). Re-exported above for backward compatibility.
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ stan = ["bridgestan>=2.0", "cmdstanpy>=1.2"]
 # arviz<1.0); matplotlib is required by the pymc 6 sampler progress bar.
 pymc = ["pymc>=6", "matplotlib"]
 nutpie = ["nutpie>=0.12"]
+# Amortized neural SBI (NPE/FMPE/CMPE), jax-native via keras (KERAS_BACKEND=jax).
+# BayesFlow 2.x requires Python <3.14 and numpy>=2.2.6, so this extra is
+# Python 3.12-3.13 only; bare core stays 3.14-capable.
+bayesflow = ["bayesflow>=2.0,<3"]
 dev = [
   "probpipe[prefect,viz,docs]",
   "pytest>=7",

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -193,19 +193,20 @@ class TestProductDistribution:
         assert sup["g"] != sup["x"]  # positive vs real
 
     def test_supports_nested_components(self):
-        """``supports`` walks nested dict components, keying leaves by
-        slash-delimited paths -- the same keying as ``leaf_shapes`` -- so every
-        value is a leaf Constraint."""
+        """``supports`` walks nested dict components recursively (two levels
+        here), keying leaves by slash-delimited paths -- the same keying as
+        ``leaf_shapes`` -- so every value is a leaf Constraint."""
         joint = ProductDistribution(
             name="joint",
             outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
-                   "g": Gamma(2.0, 1.0, name="g")},
+                   "deep": {"g": Gamma(2.0, 1.0, name="g")}},
             m=Normal(loc=0.0, scale=1.0, name="m"),
         )
         sup = joint.supports
         assert set(sup.keys()) == set(joint.record_template.leaf_shapes.keys())
-        assert sup["outer/g"] != sup["outer/a"]  # positive vs real
-        assert sup["outer/a"] == sup["m"]        # both real
+        assert "outer/deep/g" in sup
+        assert sup["outer/deep/g"] != sup["outer/a"]  # positive vs real
+        assert sup["outer/a"] == sup["m"]             # both real
 
 
 # ===========================================================================

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -192,6 +192,21 @@ class TestProductDistribution:
         assert sup["x"] == joint.components["x"].support
         assert sup["g"] != sup["x"]  # positive vs real
 
+    def test_supports_nested_components(self):
+        """``supports`` walks nested dict components, keying leaves by
+        slash-delimited paths -- the same keying as ``leaf_shapes`` -- so every
+        value is a leaf Constraint."""
+        joint = ProductDistribution(
+            name="joint",
+            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
+                   "g": Gamma(2.0, 1.0, name="g")},
+            m=Normal(loc=0.0, scale=1.0, name="m"),
+        )
+        sup = joint.supports
+        assert set(sup.keys()) == set(joint.record_template.leaf_shapes.keys())
+        assert sup["outer/g"] != sup["outer/a"]  # positive vs real
+        assert sup["outer/a"] == sup["m"]        # both real
+
 
 # ===========================================================================
 # 2. TestFlattenUnflatten

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -181,6 +181,17 @@ class TestProductDistribution:
         assert set(items.keys()) == {"x", "y"}
         assert all(isinstance(v, _RecordDistributionView) for v in items.values())
 
+    def test_supports_per_field(self):
+        """``supports`` maps each field to its component's support constraint
+        (heterogeneous constraints preserved per field)."""
+        joint = ProductDistribution(Gamma(2.0, 1.0, name="g"),
+                                    Normal(loc=0.0, scale=1.0, name="x"))
+        sup = joint.supports
+        assert set(sup.keys()) == {"g", "x"}
+        assert sup["g"] == joint.components["g"].support
+        assert sup["x"] == joint.components["x"].support
+        assert sup["g"] != sup["x"]  # positive vs real
+
 
 # ===========================================================================
 # 2. TestFlattenUnflatten

--- a/tests/inference/test_bayesflow.py
+++ b/tests/inference/test_bayesflow.py
@@ -493,6 +493,22 @@ class TestBayesFlowMethods:
         assert np.isfinite(r).all()
         assert (r > 0).all()        # forward bijector (Exp) keeps every draw in support
 
+    def test_interval_prior_draws_respect_support(self):
+        """A bounded-interval prior field (Beta, unit-interval support) rounds
+        through the Sigmoid bijector: trained unconstrained, every posterior
+        draw lands strictly inside (0, 1)."""
+        import probpipe as pp
+        prior = ProductDistribution(pp.Beta(2.0, 2.0, name="q"),
+                                    Normal(loc=0.0, scale=1.0, name="m"))
+        model = learn_amortized_posterior(
+            prior, _ConjugateGaussianLikelihood(), method="npe",
+            num_simulations=800, epochs=2, batch_size=256,
+            num_results=300, random_seed=0, verbose=0,
+        )
+        q = np.asarray(condition_on(model, jnp.array([0.5, 0.0])).draws()["q"]).reshape(-1)
+        assert np.isfinite(q).all()
+        assert ((q > 0) & (q < 1)).all()   # Sigmoid forward keeps draws in (0, 1)
+
     def test_wishart_matrix_prior_round_trip(self):
         """A matrix-valued constrained field (Wishart, positive-definite support)
         round-trips: the inverse bijector runs at the field's native (n, n) event

--- a/tests/inference/test_bayesflow.py
+++ b/tests/inference/test_bayesflow.py
@@ -630,6 +630,31 @@ class TestBayesFlowValidation:
         with pytest.raises(ValueError, match="positive integer"):
             learn_amortized_posterior(_prior(), _ToyLikelihood(), **kwargs)
 
+    @pytest.mark.parametrize(
+        "override",
+        [{"num_simulations": 100.5}, {"batch_size": "64"}, {"epochs": 2.0},
+         {"num_results": None}],
+    )
+    def test_rejects_non_integer_counts(self, override):
+        """Count parameters must be integers -- floats (even integral ones),
+        strings, and None are rejected with a TypeError rather than truncating
+        or failing deep inside keras."""
+        kwargs = {"num_simulations": 8, "epochs": 1, **override}
+        with pytest.raises(TypeError, match="must be an integer"):
+            learn_amortized_posterior(_prior(), _ToyLikelihood(), **kwargs)
+
+    def test_rejects_nested_prior(self):
+        """A nested prior (dict components) is rejected up front: the per-field
+        bijector and adapter machinery is flat."""
+        nested = ProductDistribution(
+            name="joint",
+            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
+                   "b": Normal(loc=0.0, scale=1.0, name="b")},
+            m=Normal(loc=0.0, scale=1.0, name="m"),
+        )
+        with pytest.raises(TypeError, match="nested"):
+            learn_amortized_posterior(nested, _ToyLikelihood(), num_simulations=8, epochs=1)
+
     def test_rejects_discrete_prior(self):
         """A discrete prior field has no smooth bijector to R^d and is rejected up
         front with a clear error (here a Poisson count parameter)."""

--- a/tests/inference/test_bayesflow.py
+++ b/tests/inference/test_bayesflow.py
@@ -1,0 +1,456 @@
+"""Tests for the BayesFlow amortized-SBI backend (NPE / FMPE / CMPE).
+
+Requires the ``[bayesflow]`` extra (Python 3.12-3.13); skipped otherwise. Uses a
+small, fast-training toy fixture so the suite stays tractable.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("bayesflow")
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from probpipe import (
+    ApproximateDistribution,
+    Normal,
+    ProductDistribution,
+    condition_on,
+    learn_amortized_posterior,
+)
+from probpipe.modeling import GenerativeLikelihood, Likelihood
+
+
+class _ToyLikelihood(Likelihood, GenerativeLikelihood):
+    """Identifiable 2-parameter model: ``y = [a + b, a - b] + small noise``."""
+
+    # ``log_likelihood`` is unused by the amortized path (only ``generate_data``
+    # is called); stubbed here just to satisfy the ``Likelihood`` protocol.
+    def log_likelihood(self, params, data):
+        return jnp.array(0.0)
+
+    def generate_data(self, params, num_observations, *, key=None):
+        a, b = params[0], params[1]
+        key = key if key is not None else jax.random.PRNGKey(0)
+        mean = jnp.stack([a + b, a - b])
+        return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
+
+
+def _prior():
+    return ProductDistribution(
+        Normal(loc=0.0, scale=1.0, name="a"),
+        Normal(loc=0.0, scale=1.0, name="b"),
+    )
+
+
+def _observe(a, b, seed):
+    return _ToyLikelihood().generate_data(jnp.array([a, b]), 1, key=jax.random.PRNGKey(seed))[0]
+
+
+class _VecLikelihood(Likelihood, GenerativeLikelihood):
+    """Vector + scalar params [m0, m1, s]; y = [m0 + s, m1 - s] + small noise."""
+
+    # ``log_likelihood`` is unused by the amortized path (see ``_ToyLikelihood``).
+    def log_likelihood(self, params, data):
+        return jnp.array(0.0)
+
+    def generate_data(self, params, num_observations, *, key=None):
+        m0, m1, s = params[0], params[1], params[2]
+        key = key if key is not None else jax.random.PRNGKey(0)
+        mean = jnp.stack([m0 + s, m1 - s])
+        return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
+
+
+def _vec_prior():
+    import probpipe as pp
+
+    return ProductDistribution(
+        pp.MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="m"),
+        Normal(loc=0.0, scale=1.0, name="s"),
+    )
+
+
+class _SingleFieldLikelihood(Likelihood, GenerativeLikelihood):
+    """Single (vector) parameter field: ``y = theta + small noise``."""
+
+    # ``log_likelihood`` is unused by the amortized path (see ``_ToyLikelihood``).
+    def log_likelihood(self, params, data):
+        return jnp.array(0.0)
+
+    def generate_data(self, params, num_observations, *, key=None):
+        key = key if key is not None else jax.random.PRNGKey(0)
+        return params[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
+
+
+class _NonJaxLikelihood(Likelihood, GenerativeLikelihood):
+    """A deliberately non-vmappable simulator: it concretizes the parameters
+    (``float(...)``) and draws noise with numpy, so it runs only on the eager
+    path (``sim_backend="sequential"``) -- ``jax.vmap`` would raise a tracer error."""
+
+    def log_likelihood(self, params, data):
+        return jnp.array(0.0)
+
+    def generate_data(self, params, num_observations, *, key=None):
+        a, b = float(params[0]), float(params[1])
+        seed = 0 if key is None else int(jax.random.randint(key, (), 0, 2**16))
+        noise = np.random.default_rng(seed).standard_normal((num_observations, 2))
+        return np.array([a + b, a - b]) + 0.1 * noise
+
+
+class _ScalarLikelihood(Likelihood, GenerativeLikelihood):
+    """One-parameter model: ``y = a + small noise`` (a single scalar param)."""
+
+    # ``log_likelihood`` is unused by the amortized path (see ``_ToyLikelihood``).
+    def log_likelihood(self, params, data):
+        return jnp.array(0.0)
+
+    def generate_data(self, params, num_observations, *, key=None):
+        a = params[0]
+        key = key if key is not None else jax.random.PRNGKey(0)
+        return a + 0.1 * jax.random.normal(key, (num_observations, 1))
+
+
+class _MultiFieldLikelihood(Likelihood, GenerativeLikelihood):
+    """Three-field params (flat ``[a, b0, b1, c]``) -> an 8-d observation built
+    from several param combinations, to exercise multiple mixed-shape parameter
+    fields and higher-dimensional data."""
+
+    # ``log_likelihood`` is unused by the amortized path (see ``_ToyLikelihood``).
+    def log_likelihood(self, params, data):
+        return jnp.array(0.0)
+
+    def generate_data(self, params, num_observations, *, key=None):
+        a, b0, b1, c = params[0], params[1], params[2], params[3]
+        key = key if key is not None else jax.random.PRNGKey(0)
+        mean = jnp.stack([a + b0, a - b0, b1 + c, b1 - c, a + c, b0 * b1, a, c])
+        return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, mean.shape[0]))
+
+
+def _multi_field_prior():
+    import probpipe as pp
+
+    return ProductDistribution(
+        Normal(loc=0.0, scale=1.0, name="a"),
+        pp.MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="b"),
+        Normal(loc=0.0, scale=1.0, name="c"),
+    )
+
+
+# Conjugate Gaussian with an analytic posterior, used to check calibration.
+_CONJ_SIGMA = 0.5
+
+
+class _ConjugateGaussianLikelihood(Likelihood, GenerativeLikelihood):
+    """Conjugate model (any dimension): prior ``theta ~ N(0, I)``, ``y = theta +
+    sigma * noise``. The posterior is analytic -- ``N(y / (1 + sigma^2), sigma^2 /
+    (1 + sigma^2) I)`` -- so the amortized posterior's mean *and* spread can be
+    checked against it. The observation dimension follows the parameter dimension,
+    so one likelihood serves both the 2-D and 1-D calibration tests."""
+
+    def log_likelihood(self, params, data):
+        return jnp.array(0.0)
+
+    def generate_data(self, params, num_observations, *, key=None):
+        key = key if key is not None else jax.random.PRNGKey(0)
+        dim = params.shape[-1]
+        return params[None, :] + _CONJ_SIGMA * jax.random.normal(key, (num_observations, dim))
+
+
+@pytest.fixture(scope="module")
+def npe_model():
+    """A briefly-trained NPE estimator, shared across the NPE tests."""
+    return learn_amortized_posterior(
+        _prior(), _ToyLikelihood(), method="npe",
+        num_simulations=3000, epochs=6, batch_size=256,
+        num_results=500, random_seed=0, verbose=0,
+    )
+
+
+class TestBayesFlowNPE:
+    def test_recovery(self, npe_model):
+        """The amortized posterior concentrates near the truth -- in *both*
+        parameters. Both truths sit >0.5 from the prior mean (0), so neither
+        assertion passes without the model actually learning the parameter."""
+        post = condition_on(npe_model, _observe(0.6, -0.6, seed=7))
+        draws = post.draws()
+        a = float(np.mean(np.asarray(draws["a"])))
+        b = float(np.mean(np.asarray(draws["b"])))
+        # Loose, calibration-style tolerance (brief training, stochastic).
+        assert abs(a - 0.6) < 0.5
+        assert abs(b - (-0.6)) < 0.5
+
+    def test_amortization(self, npe_model):
+        """The same trained model conditions on distinct observations, and the
+        posterior means land on the correct side of zero (the defining property
+        of amortized inference)."""
+        mean_a_hi = float(np.mean(np.asarray(condition_on(npe_model, _observe(1.0, 0.0, 2)).draws()["a"])))
+        mean_a_lo = float(np.mean(np.asarray(condition_on(npe_model, _observe(-1.0, 0.0, 3)).draws()["a"])))
+        assert mean_a_hi > 0 > mean_a_lo
+
+    def test_contract(self, npe_model):
+        """``condition_on`` honours ``num_results`` (and its model default) and
+        ignores the MCMC-only kwargs; the result is a named
+        ``ApproximateDistribution``."""
+        post = condition_on(npe_model, _observe(0.0, 0.0, 1),
+                            num_results=300, num_warmup=99, num_chains=4)
+        assert isinstance(post, ApproximateDistribution)
+        assert post.algorithm == "bayesflow_npe"
+        draws = post.draws()
+        # Named fields (record_template lifting), 300 draws, no warmup/chains effect.
+        assert np.asarray(draws["a"]).reshape(-1).shape[0] == 300
+        assert np.isfinite(np.asarray(draws["b"])).all()
+        # Omitting num_results falls back to the model default (500 here).
+        default_post = condition_on(npe_model, _observe(0.0, 0.0, 1))
+        assert np.asarray(default_post.draws()["a"]).reshape(-1).shape[0] == 500
+
+    def test_observation_dim_mismatch(self, npe_model):
+        """Conditioning on a wrong-size observation raises a clear error rather
+        than an opaque keras shape failure."""
+        with pytest.raises(ValueError, match="trained on observations of size"):
+            condition_on(npe_model, np.zeros(5, dtype="float32"))
+
+    def test_repr(self, npe_model):
+        """``repr`` surfaces the method and the default draw count."""
+        r = repr(npe_model)
+        assert "method='npe'" in r
+        assert "num_results=500" in r
+
+
+class TestBayesFlowMethods:
+    @pytest.mark.parametrize("method", ["npe", "fmpe", "cmpe"])
+    def test_methods_smoke(self, method):
+        """Each amortized method trains and conditions, returning named draws."""
+        model = learn_amortized_posterior(
+            _prior(), _ToyLikelihood(), method=method,
+            num_simulations=1500, epochs=3, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        post = condition_on(model, _observe(0.5, 0.0, 0))
+        assert post.algorithm == f"bayesflow_{method}"
+        draws = post.draws()
+        assert np.isfinite(np.asarray(draws["a"])).all()
+        assert np.asarray(draws["a"]).reshape(-1).shape[0] == 200
+
+    def test_vector_valued_field(self):
+        """A vector-valued parameter field round-trips through the per-field
+        reshape/concatenate and returns named draws of the right shape."""
+        model = learn_amortized_posterior(
+            _vec_prior(), _VecLikelihood(), method="npe",
+            num_simulations=2000, epochs=4, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        obs = _VecLikelihood().generate_data(jnp.array([0.5, -0.5, 0.2]), 1,
+                                             key=jax.random.PRNGKey(5))[0]
+        draws = condition_on(model, obs).draws()
+        m = np.asarray(draws["m"]).reshape(200, -1)
+        s = np.asarray(draws["s"]).reshape(200, -1)
+        assert m.shape == (200, 2)  # the (2,)-vector field is preserved
+        assert s.shape == (200, 1)
+        assert np.isfinite(m).all() and np.isfinite(s).all()
+
+    def test_custom_inference_network(self):
+        """A caller-supplied ``inference_network`` overrides the method default
+        and is the network actually wired into the trained approximator."""
+        import bayesflow as bf
+
+        net = bf.networks.CouplingFlow()
+        model = learn_amortized_posterior(
+            _prior(), _ToyLikelihood(), method="npe", inference_network=net,
+            num_simulations=1500, epochs=3, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        # The exact instance passed in is the one used (not a method default).
+        assert model._approximator.inference_network is net
+        post = condition_on(model, _observe(0.5, 0.0, 0))
+        assert np.asarray(post.draws()["a"]).reshape(-1).shape[0] == 200
+
+    def test_single_field_prior(self):
+        """A single-field prior (not a ProductDistribution) is supported: its
+        draws are not field-indexable, but the canonical flat layout drives the
+        per-field split, so it round-trips end-to-end to named draws."""
+        import probpipe as pp
+
+        prior = pp.MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="theta")
+        model = learn_amortized_posterior(
+            prior, _SingleFieldLikelihood(), method="npe",
+            num_simulations=1500, epochs=3, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        obs = _SingleFieldLikelihood().generate_data(jnp.array([0.5, -0.5]), 1,
+                                                     key=jax.random.PRNGKey(4))[0]
+        draws = condition_on(model, obs).draws()
+        assert np.asarray(draws["theta"]).reshape(200, -1).shape == (200, 2)
+        assert np.isfinite(np.asarray(draws["theta"])).all()
+
+    def test_non_jax_simulator(self):
+        """A non-vmappable (non-JAX) simulator trains via the eager path
+        (``sim_backend="sequential"``) and conditions to named draws -- ``vmap``
+        would fail on it, so success proves the eager loop ran."""
+        model = learn_amortized_posterior(
+            _prior(), _NonJaxLikelihood(), method="npe", sim_backend="sequential",
+            num_simulations=800, epochs=2, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        post = condition_on(model, _observe(0.5, 0.0, 0))
+        assert post.algorithm == "bayesflow_npe"
+        draws = post.draws()
+        assert np.asarray(draws["a"]).reshape(-1).shape[0] == 200
+        assert np.isfinite(np.asarray(draws["a"])).all()
+
+    def test_scalar_prior_fmpe(self):
+        """A one-parameter (scalar) prior round-trips with FMPE: the single-field
+        split handles ``event_shape=()``, and flow matching (unlike NPE's
+        coupling flow) has no >= 2-parameter requirement."""
+        model = learn_amortized_posterior(
+            Normal(loc=0.0, scale=1.0, name="a"), _ScalarLikelihood(), method="fmpe",
+            num_simulations=1500, epochs=3, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        obs = _ScalarLikelihood().generate_data(jnp.array([0.7]), 1,
+                                                key=jax.random.PRNGKey(4))[0]
+        draws = condition_on(model, obs).draws()
+        assert np.asarray(draws["a"]).reshape(-1).shape[0] == 200
+        assert np.isfinite(np.asarray(draws["a"])).all()
+
+    def test_npe_one_param_fallback_calibration(self):
+        """The NPE one-parameter fallback is held to the same calibration standard
+        as the multi-parameter path. A coupling flow can't split a 1-D vector, so
+        NPE at d=1 falls back to a flow-matching network; here, against a 1-D
+        conjugate Gaussian (analytic posterior), the amortized posterior mean and
+        spread are checked against the analytic mean and std. The bounds are looser
+        than ``test_calibration_against_conjugate_gaussian`` because flow matching
+        at d=1 is a measurably noisier estimator -- its ODE sampling is less exact
+        than a coupling flow's density, and more training does not reliably tighten
+        it (mean error ranges ~0.04-0.19 posterior-std and the std ratio ~0.92-1.18
+        across training seeds)."""
+        prior = Normal(loc=0.0, scale=1.0, name="a")   # event_size 1 -> FlowMatching
+        model = learn_amortized_posterior(
+            prior, _ConjugateGaussianLikelihood(), method="npe",
+            num_simulations=5000, epochs=40, batch_size=256,
+            num_results=2000, random_seed=0, verbose=0,
+        )
+        s2 = _CONJ_SIGMA**2
+        post_std = (s2 / (1 + s2)) ** 0.5          # analytic posterior std
+        sim = _ConjugateGaussianLikelihood()
+        mean_errs, std_ratios = [], []
+        for i in range(6):
+            theta = jax.random.normal(jax.random.PRNGKey(100 + i), (1,))
+            obs = sim.generate_data(theta, 1, key=jax.random.PRNGKey(900 + i))[0]
+            x = np.asarray(condition_on(model, obs).draws()["a"]).reshape(-1)
+            mean_errs.append(abs(float(x.mean()) - float(obs[0]) / (1 + s2)))
+            std_ratios.append(float(x.std()) / post_std)
+        # Estimate: mean posterior-mean error under 0.5 posterior-std.
+        assert np.mean(mean_errs) < 0.5 * post_std
+        # Uncertainty: mean std ratio in [0.7, 1.4] (flow matching at d=1 tends to
+        # slightly under-disperse; band bounds the measured cross-seed spread).
+        assert 0.7 < np.mean(std_ratios) < 1.4
+
+    def test_multi_field_prior_and_data(self):
+        """A richer scenario: three parameter fields (scalar + 2-vector + scalar)
+        and a higher-dimensional (8-d) observation. Exercises the per-field
+        split, adapter routing, and posterior assembly with multiple mixed-shape
+        fields and bigger data, and checks the posterior responds to the data."""
+        model = learn_amortized_posterior(
+            _multi_field_prior(), _MultiFieldLikelihood(), method="npe",
+            num_simulations=2500, epochs=5, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        sim = _MultiFieldLikelihood()
+        obs = sim.generate_data(jnp.array([0.5, -0.5, 0.3, -0.2]), 1,
+                                key=jax.random.PRNGKey(6))[0]
+        assert obs.shape == (8,)  # higher-dimensional observation
+        draws = condition_on(model, obs).draws()
+        assert np.asarray(draws["a"]).reshape(200, -1).shape == (200, 1)
+        assert np.asarray(draws["b"]).reshape(200, -1).shape == (200, 2)  # 2-vector field
+        assert np.asarray(draws["c"]).reshape(200, -1).shape == (200, 1)
+        assert all(np.isfinite(np.asarray(draws[f])).all() for f in ("a", "b", "c"))
+        # Amortized response: the posterior mean of `a` tracks the observation.
+        obs_hi = sim.generate_data(jnp.array([1.0, 0.0, 0.0, 0.0]), 1, key=jax.random.PRNGKey(1))[0]
+        obs_lo = sim.generate_data(jnp.array([-1.0, 0.0, 0.0, 0.0]), 1, key=jax.random.PRNGKey(2))[0]
+        mean_a_hi = float(np.mean(np.asarray(condition_on(model, obs_hi).draws()["a"])))
+        mean_a_lo = float(np.mean(np.asarray(condition_on(model, obs_lo).draws()["a"])))
+        assert mean_a_hi > mean_a_lo
+
+    def test_calibration_against_conjugate_gaussian(self):
+        """Estimate *and* uncertainty are roughly correct: against a conjugate
+        Gaussian whose posterior is analytic, the amortized posterior mean tracks
+        the analytic mean and its std matches the analytic std (averaged over
+        several observations). Trains a bit longer than the smoke tests so the
+        estimator is near-converged."""
+        prior = ProductDistribution(Normal(loc=0.0, scale=1.0, name="a"),
+                                    Normal(loc=0.0, scale=1.0, name="b"))
+        model = learn_amortized_posterior(
+            prior, _ConjugateGaussianLikelihood(), method="npe",
+            num_simulations=5000, epochs=40, batch_size=256,
+            num_results=4000, random_seed=0, verbose=0,
+        )
+        s2 = _CONJ_SIGMA**2
+        post_std = (s2 / (1 + s2)) ** 0.5          # analytic posterior std
+        sim = _ConjugateGaussianLikelihood()
+        mean_errs, std_ratios = [], []
+        for i in range(6):
+            theta = jax.random.normal(jax.random.PRNGKey(100 + i), (2,))
+            obs = sim.generate_data(theta, 1, key=jax.random.PRNGKey(900 + i))[0]
+            draws = condition_on(model, obs).draws()
+            for j, f in enumerate(("a", "b")):
+                x = np.asarray(draws[f]).reshape(-1)
+                analytic_mean = float(obs[j]) / (1 + s2)
+                mean_errs.append(abs(float(x.mean()) - analytic_mean))
+                std_ratios.append(float(x.std()) / post_std)
+        # Estimate: mean posterior-mean error under 0.3 posterior-std (observed ~0.03-0.11
+        # across training seeds; keras training is not fully seeded, hence the margin).
+        assert np.mean(mean_errs) < 0.3 * post_std
+        # Uncertainty: mean std ratio in [0.8, 1.25] (observed ~1.01-1.03 across seeds).
+        assert 0.8 < np.mean(std_ratios) < 1.25
+
+
+class TestBayesFlowValidation:
+    """Train-time input validation -- each raises before any simulation runs."""
+
+    def test_rejects_reserved_field_name(self):
+        """A prior field named like the reserved observation key is rejected."""
+        bad_prior = ProductDistribution(
+            Normal(loc=0.0, scale=1.0, name="observation"),
+            Normal(loc=0.0, scale=1.0, name="b"),
+        )
+        with pytest.raises(ValueError, match="reserved"):
+            learn_amortized_posterior(bad_prior, _ToyLikelihood(), num_simulations=8, epochs=1)
+
+    def test_rejects_non_generative_simulator(self):
+        """A simulator without ``generate_data`` is rejected with a clear TypeError."""
+
+        class _NoGenerate:
+            pass
+
+        with pytest.raises(TypeError, match="generate_data"):
+            learn_amortized_posterior(_prior(), _NoGenerate(), num_simulations=8, epochs=1)
+
+    def test_rejects_non_record_prior(self):
+        """A prior that is not a RecordDistribution (here a raw array, with no
+        ``record_template``) is rejected with a clear TypeError."""
+        with pytest.raises(TypeError, match="RecordDistribution"):
+            learn_amortized_posterior(
+                jnp.zeros(2), _ToyLikelihood(), num_simulations=8, epochs=1,
+            )
+
+    def test_rejects_unknown_method(self):
+        """An unsupported amortized method is rejected up front."""
+        with pytest.raises(ValueError, match="Unknown amortized SBI method"):
+            learn_amortized_posterior(
+                _prior(), _ToyLikelihood(), method="bogus",
+                num_simulations=8, epochs=1,
+            )
+
+    def test_rejects_unknown_sim_backend(self):
+        """An unsupported simulation backend is rejected up front."""
+        with pytest.raises(ValueError, match="Unknown sim_backend"):
+            learn_amortized_posterior(
+                _prior(), _ToyLikelihood(), sim_backend="bogus",
+                num_simulations=8, epochs=1,
+            )

--- a/tests/inference/test_bayesflow.py
+++ b/tests/inference/test_bayesflow.py
@@ -257,12 +257,19 @@ class TestBayesFlowNPE:
         with pytest.raises(ValueError, match="positive integer"):
             condition_on(npe_model, _observe(0.0, 0.0, 2), num_results=bad)
 
-    def test_unconditioned_sample_raises_not_implemented(self, npe_model):
-        """An unconditioned BayesFlowPosterior has no unconditional sampler:
-        ``_sample`` raises NotImplementedError -- the signal WorkflowFunction's
-        dispatch fallback catches -- with a pointer to condition_on."""
-        with pytest.raises(NotImplementedError, match="condition_on"):
-            npe_model._sample(jax.random.PRNGKey(0))
+    def test_forward_sampling_from_joint(self, npe_model):
+        """The model represents the joint p(theta, y): sampling draws
+        (params, data) via prior + simulator -- params carry the prior's named
+        fields, data has the simulator's output shape. Batched draws are
+        rejected like SimpleGenerativeModel's."""
+        from probpipe import SupportsSampling
+        assert isinstance(npe_model, SupportsSampling)
+        params, data = npe_model._sample(jax.random.PRNGKey(0))
+        assert np.isfinite(float(params["a"]))
+        assert np.isfinite(float(params["b"]))
+        assert np.asarray(data).shape == (2,)   # _ToyLikelihood's per-dataset shape
+        with pytest.raises(NotImplementedError, match="sample_shape"):
+            npe_model._sample(jax.random.PRNGKey(0), (3,))
 
     def test_repr(self, npe_model):
         """``repr`` surfaces the method and the default draw count."""

--- a/tests/inference/test_bayesflow.py
+++ b/tests/inference/test_bayesflow.py
@@ -251,6 +251,22 @@ class TestBayesFlowNPE:
         with pytest.raises(ValueError, match="trained on observations of size"):
             condition_on(npe_model, np.zeros(5, dtype="float32"))
 
+    @pytest.mark.parametrize("bad", [0, -5])
+    def test_condition_rejects_nonpositive_num_results(self, npe_model, bad):
+        """Sample-time num_results is validated like the train-time one: 0 or
+        negative fails fast at the ProbPipe boundary, not as a cryptic JAX
+        reduction/broadcast error inside the flow network."""
+        with pytest.raises(ValueError, match="positive integer"):
+            condition_on(npe_model, _observe(0.0, 0.0, 2), num_results=bad)
+
+    def test_unconditioned_sample_raises_not_implemented(self, npe_model):
+        """An unconditioned BayesFlowPosterior has no unconditional sampler; the
+        ``_sample`` probe raises NotImplementedError (the signal WorkflowFunction's
+        dispatch fallback catches -- an absent method would surface as an unguarded
+        AttributeError) with a pointer to condition_on."""
+        with pytest.raises(NotImplementedError, match="condition_on"):
+            npe_model._sample(jax.random.PRNGKey(0))
+
     def test_repr(self, npe_model):
         """``repr`` surfaces the method and the default draw count."""
         r = repr(npe_model)
@@ -476,6 +492,60 @@ class TestBayesFlowMethods:
         r = np.asarray(condition_on(model, jnp.array([3.0, 1.0])).draws()["r"]).reshape(-1)
         assert np.isfinite(r).all()
         assert (r > 0).all()        # forward bijector (Exp) keeps every draw in support
+
+    def test_wishart_matrix_prior_round_trip(self):
+        """A matrix-valued constrained field (Wishart, positive-definite support)
+        round-trips: the inverse bijector runs at the field's native (n, n) event
+        shape at train time -- a flattened input would crash the
+        CholeskyOuterProduct chain -- and the forward map at sample time returns
+        draws that are symmetric positive definite."""
+        import probpipe as pp
+        prior = ProductDistribution(pp.Wishart(df=4.0, scale=jnp.eye(2), name="cov"),
+                                    Normal(loc=0.0, scale=1.0, name="m"))
+        model = learn_amortized_posterior(
+            prior, _ConjugateGaussianLikelihood(), method="fmpe",
+            num_simulations=600, epochs=2, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        obs = jnp.array([1.5, 0.3, 0.3, 1.2, 0.5])    # flattened (cov, m) observation
+        cov = np.asarray(condition_on(model, obs).draws()["cov"]).reshape(-1, 2, 2)
+        assert np.isfinite(cov).all()
+        assert np.allclose(cov, np.swapaxes(cov, -1, -2), atol=1e-5)   # symmetric
+        assert np.linalg.eigvalsh(cov).min() > 0                       # positive definite
+
+    def test_dirichlet_simplex_prior_npe(self):
+        """A single 2-simplex (Dirichlet) prior under method='npe': the coupling-flow
+        guard counts *unconstrained* dimensions (one here, not the constrained
+        event_size of two), so NPE falls back to flow matching instead of building a
+        units=0 coupling flow; draws land on the simplex."""
+        import probpipe as pp
+        model = learn_amortized_posterior(
+            pp.Dirichlet(jnp.ones(2), name="p"), _ConjugateGaussianLikelihood(),
+            method="npe", num_simulations=600, epochs=2, batch_size=256,
+            num_results=300, random_seed=0, verbose=0,
+        )
+        p = np.asarray(condition_on(model, jnp.array([0.7, 0.3])).draws()["p"]).reshape(-1, 2)
+        assert np.allclose(p.sum(axis=-1), 1.0, atol=1e-5)
+        assert ((p > 0) & (p < 1)).all()
+
+    def test_global_rng_state_restored(self):
+        """Training seeds keras via the global RNG but snapshots and restores the
+        caller's NumPy / Python random state, so a call does not silently make the
+        caller's unrelated random streams deterministic."""
+        import random as pyrandom
+        np.random.seed(123)
+        pyrandom.seed(7)
+        expected_np = np.random.random()
+        expected_py = pyrandom.random()
+        np.random.seed(123)
+        pyrandom.seed(7)
+        learn_amortized_posterior(
+            _prior(), _ToyLikelihood(), method="fmpe",
+            num_simulations=256, epochs=1, batch_size=256,
+            num_results=50, random_seed=0, verbose=0,
+        )
+        assert np.random.random() == expected_np
+        assert pyrandom.random() == expected_py
 
 
 class TestBayesFlowValidation:

--- a/tests/inference/test_bayesflow.py
+++ b/tests/inference/test_bayesflow.py
@@ -10,8 +10,8 @@ import os
 
 import pytest
 
-pytest.importorskip("bayesflow")
 os.environ.setdefault("KERAS_BACKEND", "jax")
+pytest.importorskip("bayesflow")
 
 import jax
 import jax.numpy as jnp
@@ -36,7 +36,8 @@ class _ToyLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        a, b = params[0], params[1]
+        t = params.flatten()        # structured record (training) or raw array (direct)
+        a, b = t[0], t[1]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([a + b, a - b])
         return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
@@ -61,7 +62,8 @@ class _VecLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        m0, m1, s = params[0], params[1], params[2]
+        t = params.flatten()
+        m0, m1, s = t[0], t[1], t[2]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([m0 + s, m1 - s])
         return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
@@ -84,8 +86,9 @@ class _SingleFieldLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
+        t = params.flatten()
         key = key if key is not None else jax.random.PRNGKey(0)
-        return params[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
+        return t[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
 
 
 class _NonJaxLikelihood(Likelihood, GenerativeLikelihood):
@@ -97,7 +100,8 @@ class _NonJaxLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        a, b = float(params[0]), float(params[1])
+        t = np.asarray(params.flatten())
+        a, b = float(t[0]), float(t[1])
         seed = 0 if key is None else int(jax.random.randint(key, (), 0, 2**16))
         noise = np.random.default_rng(seed).standard_normal((num_observations, 2))
         return np.array([a + b, a - b]) + 0.1 * noise
@@ -111,7 +115,7 @@ class _ScalarLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        a = params[0]
+        a = params.flatten()[0]
         key = key if key is not None else jax.random.PRNGKey(0)
         return a + 0.1 * jax.random.normal(key, (num_observations, 1))
 
@@ -126,7 +130,8 @@ class _MultiFieldLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        a, b0, b1, c = params[0], params[1], params[2], params[3]
+        t = params.flatten()
+        a, b0, b1, c = t[0], t[1], t[2], t[3]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([a + b0, a - b0, b1 + c, b1 - c, a + c, b0 * b1, a, c])
         return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, mean.shape[0]))
@@ -158,8 +163,39 @@ class _ConjugateGaussianLikelihood(Likelihood, GenerativeLikelihood):
 
     def generate_data(self, params, num_observations, *, key=None):
         key = key if key is not None else jax.random.PRNGKey(0)
-        dim = params.shape[-1]
-        return params[None, :] + _CONJ_SIGMA * jax.random.normal(key, (num_observations, dim))
+        t = params.flatten()
+        return t[None, :] + _CONJ_SIGMA * jax.random.normal(key, (num_observations, t.shape[-1]))
+
+
+class _NamedFieldLikelihood(Likelihood, GenerativeLikelihood):
+    """Accesses params strictly by field name (``params["a"]``), never positionally.
+    Under the previous implementation -- which flattened theta to a raw array before
+    calling the simulator -- this would raise; it works only because the structured
+    per-draw record is now passed, per the ``GenerativeLikelihood`` contract."""
+
+    def log_likelihood(self, params, data):
+        return jnp.array(0.0)
+
+    def generate_data(self, params, num_observations, *, key=None):
+        a, b = params["a"], params["b"]        # strict named access -- the contract
+        key = key if key is not None else jax.random.PRNGKey(0)
+        mean = jnp.stack([a + b, a - b])
+        return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
+
+
+class _PositiveLikelihood(Likelihood, GenerativeLikelihood):
+    """Simulator for a constrained prior (positive ``r``, real ``m``):
+    ``y = [r + m, r - m] + small noise``."""
+
+    def log_likelihood(self, params, data):
+        return jnp.array(0.0)
+
+    def generate_data(self, params, num_observations, *, key=None):
+        t = params.flatten()
+        r, m = t[0], t[1]
+        key = key if key is not None else jax.random.PRNGKey(0)
+        mean = jnp.stack([r + m, r - m])
+        return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
 
 
 @pytest.fixture(scope="module")
@@ -326,9 +362,10 @@ class TestBayesFlowMethods:
         spread are checked against the analytic mean and std. The bounds are looser
         than ``test_calibration_against_conjugate_gaussian`` because flow matching
         at d=1 is a measurably noisier estimator -- its ODE sampling is less exact
-        than a coupling flow's density, and more training does not reliably tighten
-        it (mean error ranges ~0.04-0.19 posterior-std and the std ratio ~0.92-1.18
-        across training seeds)."""
+        than a coupling flow's density (across training seeds the mean error spans
+        ~0.04-0.19 posterior-std and the std ratio ~0.92-1.18). Training is seeded,
+        so a given run is reproducible; the band absorbs that estimator imprecision
+        plus cross-platform / library-version drift."""
         prior = Normal(loc=0.0, scale=1.0, name="a")   # event_size 1 -> FlowMatching
         model = learn_amortized_posterior(
             prior, _ConjugateGaussianLikelihood(), method="npe",
@@ -403,11 +440,42 @@ class TestBayesFlowMethods:
                 analytic_mean = float(obs[j]) / (1 + s2)
                 mean_errs.append(abs(float(x.mean()) - analytic_mean))
                 std_ratios.append(float(x.std()) / post_std)
-        # Estimate: mean posterior-mean error under 0.3 posterior-std (observed ~0.03-0.11
-        # across training seeds; keras training is not fully seeded, hence the margin).
+        # Training is seeded (reproducible); the margins absorb cross-platform /
+        # library-version numerical drift. Estimate: mean posterior-mean error under
+        # 0.3 posterior-std (observed ~0.03-0.11 across training seeds).
         assert np.mean(mean_errs) < 0.3 * post_std
         # Uncertainty: mean std ratio in [0.8, 1.25] (observed ~1.01-1.03 across seeds).
         assert 0.8 < np.mean(std_ratios) < 1.25
+
+    def test_simulator_receives_named_record(self):
+        """generate_data receives the prior's structured per-draw sample (named
+        fields), per the GenerativeLikelihood contract -- not a flattened vector. The
+        simulator uses params["a"]/["b"] exclusively, so training succeeds only when
+        the structured record is passed (it would raise under the old flattening)."""
+        model = learn_amortized_posterior(
+            _prior(), _NamedFieldLikelihood(), method="npe",
+            num_simulations=800, epochs=2, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        draws = condition_on(model, jnp.array([0.8, 0.2])).draws()
+        assert np.asarray(draws["a"]).reshape(-1).shape[0] == 200
+        assert np.isfinite(np.asarray(draws["a"])).all()
+
+    def test_constrained_prior_draws_respect_support(self):
+        """A constrained (positive) prior field is trained in unconstrained space and
+        its draws are mapped back through the forward bijector, so they land in the
+        support -- here all positive. The accompanying real-valued field is unaffected."""
+        import probpipe as pp
+        prior = ProductDistribution(pp.Gamma(3.0, 1.0, name="r"),
+                                    Normal(loc=0.0, scale=1.0, name="m"))
+        model = learn_amortized_posterior(
+            prior, _PositiveLikelihood(), method="npe",
+            num_simulations=1500, epochs=5, batch_size=256,
+            num_results=400, random_seed=0, verbose=0,
+        )
+        r = np.asarray(condition_on(model, jnp.array([3.0, 1.0])).draws()["r"]).reshape(-1)
+        assert np.isfinite(r).all()
+        assert (r > 0).all()        # forward bijector (Exp) keeps every draw in support
 
 
 class TestBayesFlowValidation:
@@ -454,3 +522,22 @@ class TestBayesFlowValidation:
                 _prior(), _ToyLikelihood(), sim_backend="bogus",
                 num_simulations=8, epochs=1,
             )
+
+    @pytest.mark.parametrize(
+        "override",
+        [{"num_simulations": 0}, {"batch_size": 0}, {"epochs": 0}, {"num_results": 0}],
+    )
+    def test_rejects_nonpositive_counts(self, override):
+        """num_simulations / batch_size / epochs / num_results must be positive."""
+        kwargs = {"num_simulations": 8, "epochs": 1, **override}
+        with pytest.raises(ValueError, match="positive integer"):
+            learn_amortized_posterior(_prior(), _ToyLikelihood(), **kwargs)
+
+    def test_rejects_discrete_prior(self):
+        """A discrete prior field has no smooth bijector to R^d and is rejected up
+        front with a clear error (here a Poisson count parameter)."""
+        import probpipe as pp
+        bad_prior = ProductDistribution(pp.Poisson(3.0, name="k"),
+                                        Normal(loc=0.0, scale=1.0, name="m"))
+        with pytest.raises(ValueError, match="discrete"):
+            learn_amortized_posterior(bad_prior, _ToyLikelihood(), num_simulations=8, epochs=1)

--- a/tests/inference/test_bayesflow.py
+++ b/tests/inference/test_bayesflow.py
@@ -497,6 +497,26 @@ class TestBayesFlowMethods:
         assert np.isfinite(r).all()
         assert (r > 0).all()        # forward bijector (Exp) keeps every draw in support
 
+    def test_adapter_internal_names_avoid_collisions(self):
+        """No reserved field names: theta fields are re-keyed to internal adapter
+        names, so even fields named like BayesFlow's own keys ("observation",
+        "inference_variables") train and condition, with draws returned under the
+        user's names."""
+        prior = ProductDistribution(
+            Normal(loc=0.0, scale=1.0, name="observation"),
+            Normal(loc=0.0, scale=1.0, name="inference_variables"),
+        )
+        model = learn_amortized_posterior(
+            prior, _ToyLikelihood(), method="npe",
+            num_simulations=800, epochs=2, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        draws = condition_on(model, jnp.array([0.5, 0.1])).draws()
+        for f in ("observation", "inference_variables"):
+            x = np.asarray(draws[f]).reshape(-1)
+            assert x.shape[0] == 200
+            assert np.isfinite(x).all()
+
     def test_interval_prior_draws_respect_support(self):
         """A bounded-interval prior field (Beta, unit-interval support) rounds
         through the Sigmoid bijector: trained unconstrained, every posterior
@@ -570,15 +590,6 @@ class TestBayesFlowMethods:
 
 class TestBayesFlowValidation:
     """Train-time input validation -- each raises before any simulation runs."""
-
-    def test_rejects_reserved_field_name(self):
-        """A prior field named like the reserved observation key is rejected."""
-        bad_prior = ProductDistribution(
-            Normal(loc=0.0, scale=1.0, name="observation"),
-            Normal(loc=0.0, scale=1.0, name="b"),
-        )
-        with pytest.raises(ValueError, match="reserved"):
-            learn_amortized_posterior(bad_prior, _ToyLikelihood(), num_simulations=8, epochs=1)
 
     def test_rejects_non_generative_simulator(self):
         """A simulator without ``generate_data`` is rejected with a clear TypeError."""

--- a/tests/inference/test_bayesflow.py
+++ b/tests/inference/test_bayesflow.py
@@ -17,10 +17,12 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+import probpipe as pp
 from probpipe import (
     ApproximateDistribution,
     Normal,
     ProductDistribution,
+    RecordTemplate,
     condition_on,
     learn_amortized_posterior,
 )
@@ -70,8 +72,6 @@ class _VecLikelihood(Likelihood, GenerativeLikelihood):
 
 
 def _vec_prior():
-    import probpipe as pp
-
     return ProductDistribution(
         pp.MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="m"),
         Normal(loc=0.0, scale=1.0, name="s"),
@@ -138,8 +138,6 @@ class _MultiFieldLikelihood(Likelihood, GenerativeLikelihood):
 
 
 def _multi_field_prior():
-    import probpipe as pp
-
     return ProductDistribution(
         Normal(loc=0.0, scale=1.0, name="a"),
         pp.MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="b"),
@@ -260,12 +258,23 @@ class TestBayesFlowNPE:
     def test_direct_sampling_not_implemented(self, npe_model):
         """BayesFlowModel has no direct sampler: ``_sample`` raises
         NotImplementedError -- the signal WorkflowFunction's dispatch fallback
-        catches -- pointing to condition_on and the prior/simulator components
-        (which remain accessible for forward simulation)."""
+        catches -- pointing to condition_on and the prior/simulator components.
+        The properties pass the training inputs through (which remain available
+        for forward simulation by hand)."""
         with pytest.raises(NotImplementedError, match="condition_on"):
             npe_model._sample(jax.random.PRNGKey(0))
-        assert npe_model.prior is not None
-        assert hasattr(npe_model.simulator, "generate_data")
+        assert npe_model.prior.record_template.fields == ("a", "b")
+        assert isinstance(npe_model.simulator, _ToyLikelihood)
+
+    def test_condition_random_seed_reproducible(self, npe_model):
+        """The amortized path honours ``random_seed`` at condition time: the same
+        seed reproduces the draws exactly; a different seed changes them."""
+        obs = _observe(0.3, 0.1, 4)
+        d1 = np.asarray(condition_on(npe_model, obs, random_seed=11).draws()["a"]).reshape(-1)
+        d2 = np.asarray(condition_on(npe_model, obs, random_seed=11).draws()["a"]).reshape(-1)
+        d3 = np.asarray(condition_on(npe_model, obs, random_seed=12).draws()["a"]).reshape(-1)
+        np.testing.assert_array_equal(d1, d2)
+        assert not np.array_equal(d1, d3)
 
     def test_repr(self, npe_model):
         """``repr`` surfaces the method and the default draw count."""
@@ -326,7 +335,6 @@ class TestBayesFlowMethods:
         """A single-field prior (not a ProductDistribution) is supported: its
         draws are not field-indexable, but the canonical flat layout drives the
         per-field split, so it round-trips end-to-end to named draws."""
-        import probpipe as pp
 
         prior = pp.MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="theta")
         model = learn_amortized_posterior(
@@ -382,12 +390,14 @@ class TestBayesFlowMethods:
         ~0.04-0.19 posterior-std and the std ratio ~0.92-1.18). Training is seeded,
         so a given run is reproducible; the band absorbs that estimator imprecision
         plus cross-platform / library-version drift."""
+        import bayesflow as bf
         prior = Normal(loc=0.0, scale=1.0, name="a")   # event_size 1 -> FlowMatching
         model = learn_amortized_posterior(
             prior, _ConjugateGaussianLikelihood(), method="npe",
             num_simulations=5000, epochs=40, batch_size=256,
             num_results=2000, random_seed=0, verbose=0,
         )
+        assert isinstance(model._approximator.inference_network, bf.networks.FlowMatching)
         s2 = _CONJ_SIGMA**2
         post_std = (s2 / (1 + s2)) ** 0.5          # analytic posterior std
         sim = _ConjugateGaussianLikelihood()
@@ -481,7 +491,6 @@ class TestBayesFlowMethods:
         """A constrained (positive) prior field is trained in unconstrained space and
         its draws are mapped back through the forward bijector, so they land in the
         support -- here all positive. The accompanying real-valued field is unaffected."""
-        import probpipe as pp
         prior = ProductDistribution(pp.Gamma(3.0, 1.0, name="r"),
                                     Normal(loc=0.0, scale=1.0, name="m"))
         model = learn_amortized_posterior(
@@ -517,7 +526,6 @@ class TestBayesFlowMethods:
         """A bounded-interval prior field (Beta, unit-interval support) rounds
         through the Sigmoid bijector: trained unconstrained, every posterior
         draw lands strictly inside (0, 1)."""
-        import probpipe as pp
         prior = ProductDistribution(pp.Beta(2.0, 2.0, name="q"),
                                     Normal(loc=0.0, scale=1.0, name="m"))
         model = learn_amortized_posterior(
@@ -535,7 +543,6 @@ class TestBayesFlowMethods:
         shape at train time -- a flattened input would crash the
         CholeskyOuterProduct chain -- and the forward map at sample time returns
         draws that are symmetric positive definite."""
-        import probpipe as pp
         prior = ProductDistribution(pp.Wishart(df=4.0, scale=jnp.eye(2), name="cov"),
                                     Normal(loc=0.0, scale=1.0, name="m"))
         model = learn_amortized_posterior(
@@ -546,23 +553,39 @@ class TestBayesFlowMethods:
         obs = jnp.array([1.5, 0.3, 0.3, 1.2, 0.5])    # flattened (cov, m) observation
         cov = np.asarray(condition_on(model, obs).draws()["cov"]).reshape(-1, 2, 2)
         assert np.isfinite(cov).all()
-        assert np.allclose(cov, np.swapaxes(cov, -1, -2), atol=1e-5)   # symmetric
-        assert np.linalg.eigvalsh(cov).min() > 0                       # positive definite
+        np.testing.assert_allclose(cov, np.swapaxes(cov, -1, -2), atol=1e-5)  # symmetric
+        assert np.linalg.eigvalsh(cov).min() > 0                              # positive definite
 
     def test_dirichlet_simplex_prior_npe(self):
         """A single 2-simplex (Dirichlet) prior under method='npe': the coupling-flow
         guard counts *unconstrained* dimensions (one here, not the constrained
         event_size of two), so NPE falls back to flow matching instead of building a
         units=0 coupling flow; draws land on the simplex."""
-        import probpipe as pp
+        import bayesflow as bf
         model = learn_amortized_posterior(
             pp.Dirichlet(jnp.ones(2), name="p"), _ConjugateGaussianLikelihood(),
             method="npe", num_simulations=600, epochs=2, batch_size=256,
             num_results=300, random_seed=0, verbose=0,
         )
+        assert isinstance(model._approximator.inference_network, bf.networks.FlowMatching)
         p = np.asarray(condition_on(model, jnp.array([0.7, 0.3])).draws()["p"]).reshape(-1, 2)
-        assert np.allclose(p.sum(axis=-1), 1.0, atol=1e-5)
+        np.testing.assert_allclose(p.sum(axis=-1), 1.0, atol=1e-5)
         assert ((p > 0) & (p < 1)).all()
+
+    def test_training_deterministic_for_seed(self):
+        """Two same-seed trainings produce bit-identical models: keras init + fit
+        are seeded via ``keras.utils.set_random_seed`` (the calibration tests'
+        tolerance rationale relies on this reproducibility)."""
+        def _fit():
+            return learn_amortized_posterior(
+                _prior(), _ToyLikelihood(), method="npe",
+                num_simulations=400, epochs=1, batch_size=256,
+                num_results=100, random_seed=0, verbose=0,
+            )
+        obs = _observe(0.4, -0.2, 5)
+        d1 = np.asarray(condition_on(_fit(), obs).draws()["a"]).reshape(-1)
+        d2 = np.asarray(condition_on(_fit(), obs).draws()["a"]).reshape(-1)
+        np.testing.assert_array_equal(d1, d2)
 
     def test_global_rng_state_restored(self):
         """Training seeds keras via the global RNG but snapshots and restores the
@@ -658,8 +681,23 @@ class TestBayesFlowValidation:
     def test_rejects_discrete_prior(self):
         """A discrete prior field has no smooth bijector to R^d and is rejected up
         front with a clear error (here a Poisson count parameter)."""
-        import probpipe as pp
         bad_prior = ProductDistribution(pp.Poisson(3.0, name="k"),
                                         Normal(loc=0.0, scale=1.0, name="m"))
         with pytest.raises(ValueError, match="discrete"):
             learn_amortized_posterior(bad_prior, _ToyLikelihood(), num_simulations=8, epochs=1)
+
+    def test_rejects_multifield_prior_without_supports(self):
+        """A multi-field prior implementing no per-field ``supports`` accessor is
+        rejected: spreading the single whole-distribution ``support`` across
+        heterogeneous fields could silently pick the wrong bijector."""
+
+        class _NoSupports:
+            record_template = RecordTemplate(a=(), b=())
+
+            @property
+            def supports(self):
+                raise NotImplementedError
+
+        with pytest.raises(TypeError, match="per-field"):
+            learn_amortized_posterior(_NoSupports(), _ToyLikelihood(),
+                                      num_simulations=8, epochs=1)

--- a/tests/inference/test_bayesflow.py
+++ b/tests/inference/test_bayesflow.py
@@ -168,16 +168,15 @@ class _ConjugateGaussianLikelihood(Likelihood, GenerativeLikelihood):
 
 
 class _NamedFieldLikelihood(Likelihood, GenerativeLikelihood):
-    """Accesses params strictly by field name (``params["a"]``), never positionally.
-    Under the previous implementation -- which flattened theta to a raw array before
-    calling the simulator -- this would raise; it works only because the structured
-    per-draw record is now passed, per the ``GenerativeLikelihood`` contract."""
+    """Accesses params strictly by field name (``params["a"]``), never positionally
+    -- locks the ``GenerativeLikelihood`` contract that training passes the prior's
+    structured per-draw record (a flattened-vector regression raises here)."""
 
     def log_likelihood(self, params, data):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        a, b = params["a"], params["b"]        # strict named access -- the contract
+        a, b = params["a"], params["b"]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([a + b, a - b])
         return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
@@ -253,17 +252,15 @@ class TestBayesFlowNPE:
 
     @pytest.mark.parametrize("bad", [0, -5])
     def test_condition_rejects_nonpositive_num_results(self, npe_model, bad):
-        """Sample-time num_results is validated like the train-time one: 0 or
-        negative fails fast at the ProbPipe boundary, not as a cryptic JAX
-        reduction/broadcast error inside the flow network."""
+        """Sample-time num_results is validated like the train-time one: zero or
+        negative fails fast at the ProbPipe boundary."""
         with pytest.raises(ValueError, match="positive integer"):
             condition_on(npe_model, _observe(0.0, 0.0, 2), num_results=bad)
 
     def test_unconditioned_sample_raises_not_implemented(self, npe_model):
-        """An unconditioned BayesFlowPosterior has no unconditional sampler; the
-        ``_sample`` probe raises NotImplementedError (the signal WorkflowFunction's
-        dispatch fallback catches -- an absent method would surface as an unguarded
-        AttributeError) with a pointer to condition_on."""
+        """An unconditioned BayesFlowPosterior has no unconditional sampler:
+        ``_sample`` raises NotImplementedError -- the signal WorkflowFunction's
+        dispatch fallback catches -- with a pointer to condition_on."""
         with pytest.raises(NotImplementedError, match="condition_on"):
             npe_model._sample(jax.random.PRNGKey(0))
 
@@ -465,9 +462,9 @@ class TestBayesFlowMethods:
 
     def test_simulator_receives_named_record(self):
         """generate_data receives the prior's structured per-draw sample (named
-        fields), per the GenerativeLikelihood contract -- not a flattened vector. The
-        simulator uses params["a"]/["b"] exclusively, so training succeeds only when
-        the structured record is passed (it would raise under the old flattening)."""
+        fields), per the GenerativeLikelihood contract -- the simulator uses
+        params["a"]/["b"] exclusively, so training succeeds only when the
+        structured record is passed."""
         model = learn_amortized_posterior(
             _prior(), _NamedFieldLikelihood(), method="npe",
             num_simulations=800, epochs=2, batch_size=256,

--- a/tests/inference/test_bayesflow.py
+++ b/tests/inference/test_bayesflow.py
@@ -257,19 +257,15 @@ class TestBayesFlowNPE:
         with pytest.raises(ValueError, match="positive integer"):
             condition_on(npe_model, _observe(0.0, 0.0, 2), num_results=bad)
 
-    def test_forward_sampling_from_joint(self, npe_model):
-        """The model represents the joint p(theta, y): sampling draws
-        (params, data) via prior + simulator -- params carry the prior's named
-        fields, data has the simulator's output shape. Batched draws are
-        rejected like SimpleGenerativeModel's."""
-        from probpipe import SupportsSampling
-        assert isinstance(npe_model, SupportsSampling)
-        params, data = npe_model._sample(jax.random.PRNGKey(0))
-        assert np.isfinite(float(params["a"]))
-        assert np.isfinite(float(params["b"]))
-        assert np.asarray(data).shape == (2,)   # _ToyLikelihood's per-dataset shape
-        with pytest.raises(NotImplementedError, match="sample_shape"):
-            npe_model._sample(jax.random.PRNGKey(0), (3,))
+    def test_direct_sampling_not_implemented(self, npe_model):
+        """BayesFlowModel has no direct sampler: ``_sample`` raises
+        NotImplementedError -- the signal WorkflowFunction's dispatch fallback
+        catches -- pointing to condition_on and the prior/simulator components
+        (which remain accessible for forward simulation)."""
+        with pytest.raises(NotImplementedError, match="condition_on"):
+            npe_model._sample(jax.random.PRNGKey(0))
+        assert npe_model.prior is not None
+        assert hasattr(npe_model.simulator, "generate_data")
 
     def test_repr(self, npe_model):
         """``repr`` surfaces the method and the default draw count."""

--- a/tests/modeling/test_conditionally_independent_likelihood.py
+++ b/tests/modeling/test_conditionally_independent_likelihood.py
@@ -19,7 +19,7 @@ from probpipe import (
     Likelihood,
     Record,
 )
-from probpipe.modeling._likelihood import _default_per_datum_log_likelihood
+from probpipe.core.protocols import _default_per_datum_log_likelihood
 
 
 # -- Protocol structure --------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -379,6 +379,25 @@ wheels = [
 ]
 
 [[package]]
+name = "bayesflow"
+version = "2.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "keras" },
+    { name = "matplotlib" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "seaborn" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/72/85259caf0339d37f558b96ba27a533d7db34f4dd1b7a300f5f6c5a49d4d3/bayesflow-2.0.12.tar.gz", hash = "sha256:9a5d46389cc4cb6f0923669c24b074df6d8e6b8cf8b1e78674279818dc03e7a3", size = 327701, upload-time = "2026-05-08T21:52:43.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e4/478efa5f63270a706e0970e9ea7daf4c1900528a516580967bd8751800bd/bayesflow-2.0.12-py3-none-any.whl", hash = "sha256:6dec1fa022ef9366d21250291d52c474d93f8a654cad9a7cd89ba9599cc0681f", size = 511224, upload-time = "2026-05-08T21:52:42.262Z" },
+]
+
+[[package]]
 name = "beartype"
 version = "0.22.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1365,6 +1384,49 @@ wheels = [
 ]
 
 [[package]]
+name = "h5py"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c0/5d4119dba94093bbafede500d3defd2f5eab7897732998c04b54021e530b/h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d", size = 3685604, upload-time = "2026-03-06T13:48:04.198Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/c84efcc1d4caebafb1ecd8be4643f39c85c47a80fe254d92b8b43b1eadaf/h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d", size = 3061940, upload-time = "2026-03-06T13:48:05.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/84/06281c82d4d1686fde1ac6b0f307c50918f1c0151062445ab3b6fa5a921d/h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527", size = 5198852, upload-time = "2026-03-06T13:48:07.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/1a19e42cd43cc1365e127db6aae85e1c671da1d9a5d746f4d34a50edb577/h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e", size = 5405250, upload-time = "2026-03-06T13:48:09.628Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/9790c1655eabeb85b92b1ecab7d7e62a2069e53baefd58c98f0909c7a948/h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794", size = 5190108, upload-time = "2026-03-06T13:48:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d7/ab693274f1bd7e8c5f9fdd6c7003a88d59bedeaf8752716a55f532924fbb/h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074", size = 5419216, upload-time = "2026-03-06T13:48:13.322Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/0976b235cf29ead553e22f2fb6385a8252b533715e00d0ae52ed7b900582/h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6", size = 3182868, upload-time = "2026-03-06T13:48:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/866b7e570b39070f92d47b0ff1800f0f8239b6f9e45f02363d7112336c1f/h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db", size = 2653286, upload-time = "2026-03-06T13:48:17.279Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/9e/6142ebfda0cb6e9349c091eae73c2e01a770b7659255248d637bec54a88b/h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9", size = 3671808, upload-time = "2026-03-06T13:48:19.737Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/65/5e088a45d0f43cd814bc5bec521c051d42005a472e804b1a36c48dada09b/h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb", size = 3045837, upload-time = "2026-03-06T13:48:21.854Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/6172269e18cc5a484e2913ced33339aad588e02ba407fafd00d369e22ef3/h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524", size = 5193860, upload-time = "2026-03-06T13:48:24.071Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/ef2b6fe2903e377cbe870c3b2800d62552f1e3dbe81ce49e1923c53d1c5c/h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402", size = 5400417, upload-time = "2026-03-06T13:48:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/81/5b62d760039eed64348c98129d17061fdfc7839fc9c04eaaad6dee1004e4/h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7", size = 5185214, upload-time = "2026-03-06T13:48:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c4/532123bcd9080e250696779c927f2cb906c8bf3447df98f5ceb8dcded539/h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff", size = 5414598, upload-time = "2026-03-06T13:48:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/a27997f84341fc0dfcdd1fe4179b6ba6c32a7aa880fdb8c514d4dad6fba3/h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad", size = 3175509, upload-time = "2026-03-06T13:48:31.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/bb8647521d4fd770c30a76cfc6cb6a2f5495868904054e92f2394c5a78ff/h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4", size = 2647362, upload-time = "2026-03-06T13:48:33.411Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3c/7fcd9b4c9eed82e91fb15568992561019ae7a829d1f696b2c844355d95dd/h5py-3.16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9c9d307c0ef862d1cd5714f72ecfafe0a5d7529c44845afa8de9f46e5ba8bd65", size = 3678608, upload-time = "2026-03-06T13:48:35.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b7/9366ed44ced9b7ef357ab48c94205280276db9d7f064aa3012a97227e966/h5py-3.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c1eff849cdd53cbc73c214c30ebdb6f1bb8b64790b4b4fc36acdb5e43570210", size = 3054773, upload-time = "2026-03-06T13:48:37.139Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/4964bc0e91e86340c2bbda83420225b2f770dcf1eb8a39464871ad769436/h5py-3.16.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2c04d129f180019e216ee5f9c40b78a418634091c8782e1f723a6ca3658b965", size = 5198886, upload-time = "2026-03-06T13:48:38.879Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/16/d905e7f53e661ce2c24686c38048d8e2b750ffc4350009d41c4e6c6c9826/h5py-3.16.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e4360f15875a532bc7b98196c7592ed4fc92672a57c0a621355961cafb17a6dd", size = 5404883, upload-time = "2026-03-06T13:48:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f2/58f34cb74af46d39f4cd18ea20909a8514960c5a3e5b92fd06a28161e0a8/h5py-3.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3fae9197390c325e62e0a1aa977f2f62d994aa87aab182abbea85479b791197c", size = 5192039, upload-time = "2026-03-06T13:48:43.117Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ca/934a39c24ce2e2db017268c08da0537c20fa0be7e1549be3e977313fc8f5/h5py-3.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:43259303989ac8adacc9986695b31e35dba6fd1e297ff9c6a04b7da5542139cc", size = 5421526, upload-time = "2026-03-06T13:48:44.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/14/615a450205e1b56d16c6783f5ccd116cde05550faad70ae077c955654a75/h5py-3.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:fa48993a0b799737ba7fd21e2350fa0a60701e58180fae9f2de834bc39a147ab", size = 3183263, upload-time = "2026-03-06T13:48:47.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/48/a6faef5ed632cae0c65ac6b214a6614a0b510c3183532c521bdb0055e117/h5py-3.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:1897a771a7f40d05c262fc8f37376ec37873218544b70216872876c627640f63", size = 2663450, upload-time = "2026-03-06T13:48:48.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/32/0c8bb8aedb62c772cf7c1d427c7d1951477e8c2835f872bc0a13d1f85f86/h5py-3.16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15922e485844f77c0b9d275396d435db3baa58292a9c2176a386e072e0cf2491", size = 3760693, upload-time = "2026-03-06T13:48:50.453Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1f/fcc5977d32d6387c5c9a694afee716a5e20658ac08b3ff24fdec79fb05f2/h5py-3.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:df02dd29bd247f98674634dfe41f89fd7c16ba3d7de8695ec958f58404a4e618", size = 3181305, upload-time = "2026-03-06T13:48:52.221Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a1/af87f64b9f986889884243643621ebbd4ac72472ba8ec8cec891ac8e2ca1/h5py-3.16.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0f456f556e4e2cebeebd9d66adf8dc321770a42593494a0b6f0af54a7567b242", size = 5074061, upload-time = "2026-03-06T13:48:54.089Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d0/146f5eaff3dc246a9c7f6e5e4f42bd45cc613bce16693bcd4d1f7c958bf5/h5py-3.16.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3e6cb3387c756de6a9492d601553dffea3fe11b5f22b443aac708c69f3f55e16", size = 5279216, upload-time = "2026-03-06T13:48:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9d/12a13424f1e604fc7df9497b73c0356fb78c2fb206abd7465ce47226e8fd/h5py-3.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8389e13a1fd745ad2856873e8187fd10268b2d9677877bb667b41aebd771d8b7", size = 5070068, upload-time = "2026-03-06T13:48:59.169Z" },
+    { url = "https://files.pythonhosted.org/packages/41/8c/bbe98f813722b4873818a8db3e15aa3e625b59278566905ac439725e8070/h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725", size = 5300253, upload-time = "2026-03-06T13:49:02.033Z" },
+    { url = "https://files.pythonhosted.org/packages/32/9e/87e6705b4d6890e7cecdf876e2a7d3e40654a2ae37482d79a6f1b87f7b92/h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e", size = 3381671, upload-time = "2026-03-06T13:49:04.351Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/9fad90cfc5f9b2489c7c26ad897157bce82f0e9534a986a221b99760b23b/h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1", size = 2740706, upload-time = "2026-03-06T13:49:06.347Z" },
+]
+
+[[package]]
 name = "hpack"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1894,6 +1956,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/2d/15624c3d9440d85a280ff13d2d23afd989802f25470ac59932f4fef6f0c6/jupytext-1.19.3.tar.gz", hash = "sha256:713c3ed4441afe0f31474d28ea2e6b61a268c04c40fd78e5ccfd7f7ac9e9f766", size = 4305350, upload-time = "2026-05-17T09:09:29.294Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/ec/d9be3bd1db141e76b2f525c265f70e66edd30a51a3307d8edf0ef1909c54/jupytext-1.19.3-py3-none-any.whl", hash = "sha256:acf75492f80895ad8e664fd8db1708b617008dd0e71c341a1abc3d0d07310ed0", size = 170579, upload-time = "2026-05-17T09:09:27.478Z" },
+]
+
+[[package]]
+name = "keras"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "h5py" },
+    { name = "ml-dtypes" },
+    { name = "namex" },
+    { name = "numpy" },
+    { name = "optree" },
+    { name = "packaging" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/e7/97a7664581b73e4f9ff1d3a767a493b6ac5d3e0ed1926bd2b6b2c8bbccd7/keras-3.14.1.tar.gz", hash = "sha256:ef479173102ad29db89b53c232efdc3fb5ad57c28bc27ead59f3e78a1eecd05b", size = 1263647, upload-time = "2026-05-07T21:43:35.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/03/184267c1d09783dd070f1ddfd0d4beb7503139dfc7bd75b422867cf282fd/keras-3.14.1-py3-none-any.whl", hash = "sha256:ebd2c14d2af3c9de18083604d408483996407fc7d2f9ebd1d565961f96608c29", size = 1628606, upload-time = "2026-05-07T21:43:32.737Z" },
 ]
 
 [[package]]
@@ -2440,6 +2521,15 @@ wheels = [
 ]
 
 [[package]]
+name = "namex"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/c0/ee95b28f029c73f8d49d8f52edaed02a1d4a9acb8b69355737fdb1faa191/namex-0.1.0.tar.gz", hash = "sha256:117f03ccd302cc48e3f5c58a296838f6b89c83455ab8683a1e85f2a430aa4306", size = 6649, upload-time = "2025-05-26T23:17:38.918Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/bc/465daf1de06409cdd4532082806770ee0d8d7df434da79c76564d0f69741/namex-0.1.0-py3-none-any.whl", hash = "sha256:e2012a474502f1e2251267062aae3114611f07df4224b6e06334c57b0f2ce87c", size = 5905, upload-time = "2025-05-26T23:17:37.695Z" },
+]
+
+[[package]]
 name = "nbclient"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2501,6 +2591,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -2776,6 +2875,78 @@ wheels = [
 ]
 
 [[package]]
+name = "optree"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/63/92328a17ab7836562fe0129e605f685a88db35ce98427c34ff48ee4ec157/optree-0.19.1.tar.gz", hash = "sha256:4497d1c9197b8c6842e511368163d318ce536521ebdcff8bebb7551dcdfac532", size = 177531, upload-time = "2026-05-06T02:32:39.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/a7/cb5567029a608a296b0ca224025d03bba0365b41df19085b9b580191f6f2/optree-0.19.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:96e5c7c3b9144f08ae40c3d9848cfbcfa36b6bead0f8215ad071d5922ee6c4a5", size = 424023, upload-time = "2026-05-06T02:30:57.732Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a1/3651fb32fa8617108204aa4056d283af742020e0987d106f41402005d800/optree-0.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5d9d198343e1e6ced18bef0cbff84091c1877964fc4a121df33f18840e073a01", size = 394782, upload-time = "2026-05-06T02:30:59.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/1e/676470909aa64d7aba7c5edf83b171dc83b7af901d9ebb8e6d7512fe913a/optree-0.19.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a1202371d9fe3aa75f3e886b1f871aac4991a655aadb65e54f58a3ae9388ab2", size = 413157, upload-time = "2026-05-06T02:31:00.339Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/41/1a4c58f2af5742b9d9e21ea9e45c6c3c49463b5e2a0537e84ead1e9597ca/optree-0.19.1-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:d41ccc4c20bfeae01d1d221c057a6d026e84e32229664952eddcdbe4b9b71417", size = 476923, upload-time = "2026-05-06T02:31:01.492Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c1/f62167bd9d6f6c948b191a0943923404678d47100f777f4a8fb37816e6f8/optree-0.19.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d934f240b109c6891dd06b2e30400b123b8a4b6ed31dcd0db2ae2378d30a6e8", size = 475385, upload-time = "2026-05-06T02:31:02.836Z" },
+    { url = "https://files.pythonhosted.org/packages/30/5e/5323c5fa3024fdd900bdd8f14621139ed844c2247bf1a26e7cf5c1116188/optree-0.19.1-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ddeefb7ca799c09647e332ebc1a5f6c09888a5a0e51f2dff4ca55e65b42a8c14", size = 474406, upload-time = "2026-05-06T02:31:04.023Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/54e4c47e61a51504a5224c933722e0c8a69925aacec4c08175e9675aeb81/optree-0.19.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0ce49f64f804f7f35f2f9c2a21e3ba94c090199fccdcfd40e3ded4426c5c175", size = 457596, upload-time = "2026-05-06T02:31:05.695Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/12/bba07c0b769586c6bd54e81f1f734cad103dbe30abbadee940fe7d3e330e/optree-0.19.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e0f02600832ab8d0f6c934dcb5c339e17a36938d477641a45798e02625ebe107", size = 417900, upload-time = "2026-05-06T02:31:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/8f/6ae994bb47f9394b33912a14593f9247737dd6c3303811550e5a3e918107/optree-0.19.1-cp312-cp312-win32.whl", hash = "sha256:f10d58c1a17e1b32f9d9b5e1b9d1ad964d99c1113d9df0b9f62f2fe7dde19909", size = 317302, upload-time = "2026-05-06T02:31:08.627Z" },
+    { url = "https://files.pythonhosted.org/packages/31/97/d7e3ec79dcdde81f785a0446acf75fea77723f5ca4b98556350d7877986f/optree-0.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:06f5c8a4cf356a1a276ce5cec1be44719ed260690f79c036d04b4d427e801258", size = 341362, upload-time = "2026-05-06T02:31:09.689Z" },
+    { url = "https://files.pythonhosted.org/packages/33/97/813afb84a81fd8ae65444730907c05f0775fd6c79d3359c9e84bd3370445/optree-0.19.1-cp312-cp312-win_arm64.whl", hash = "sha256:a33bd23fc5c67ecb9ff491b75fde10cd9b53f47f8a876de842090e8c7a2437e1", size = 351838, upload-time = "2026-05-06T02:31:11.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/7b/0f2f3c9d55dda5127624daf68ff802ab624b739dd4b32aef505dac0c8e02/optree-0.19.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:f144cfd65fb17c6aa2c51818614eb009e6052d3d6ace91f7e570b1318cdcac4c", size = 929090, upload-time = "2026-05-06T02:31:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/670d260dfd0532d64272dd6f7edd540a09d7040c0342b6cc6cf773568ea4/optree-0.19.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:39a006735d2a0a68751a3bc33d670184fddcd86db63b0293e1e819739e8105e4", size = 391528, upload-time = "2026-05-06T02:31:14.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/96/46c15e80b0c97e2ba6aba11339008a37cabc5ccf55c31c6c60aecdb79638/optree-0.19.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:d2cb43c36638f469f5d8f4cf638e914de90c62242d8bed29f1b4487e0346ab94", size = 398231, upload-time = "2026-05-06T02:31:15.519Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/39/9d7d22cdaeb9a40ace2485f91c5b7c5f3a7f688575e2621e436561211cc1/optree-0.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e70faa00ab69331f49f8337d45021bed09ae2265d1db72eea9d7817af2b73c64", size = 429852, upload-time = "2026-05-06T02:31:16.992Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4c/1da9e8375e7b7fd9671dc5987682b042f6412c4d6fd9da03296403818d9f/optree-0.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1c5d21176b670407f4555aae40711668832599c4fb0627000c5ce3ed0d6e2dae", size = 398688, upload-time = "2026-05-06T02:31:18.113Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/50/cd2d178099618093f5a9fd1c9de80af2b428879922eae1e9f27f1002c8be/optree-0.19.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f658fa46305b2bdccdc5bb2cb07818aeaef88a1085499deda5be48a0a58d2971", size = 417560, upload-time = "2026-05-06T02:31:19.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b0/f22ff5632083b5032caa80208dd202f8e963ed4aac11afa0a0f6a307fd68/optree-0.19.1-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:e757079d44a00319447f43df5c51e55bf9b62d9f05eea0e2db5ff7c7ca5ec71d", size = 482937, upload-time = "2026-05-06T02:31:20.799Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d4/7499d28be8b11eb40668262d27802119fe7e6ec4cd8816b76a1acd7b08f5/optree-0.19.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9690c132822d9dee479cf7dff8cc52a67c8af42a4f7529d21f0f4f1d99e4c84e", size = 477864, upload-time = "2026-05-06T02:31:22.077Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6e/6c6fa6f1159ac68f4ee7666610127fb4c14d47a2fa7a0a48de3aecc24d4b/optree-0.19.1-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:544b70958dbd7e732bc6874e0180c609c9052115937d0ec28123bb49c1a574aa", size = 478319, upload-time = "2026-05-06T02:31:23.266Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b5/8a2427bbe4ee59e2ce26a14125728e3b48c7030c80984ba07d0e5d804d37/optree-0.19.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9dde5b756946c1f1458aeab248a7a9b0c01bb06b5787de9f06d52ad38b745557", size = 462379, upload-time = "2026-05-06T02:31:24.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0c/a073eeaea4d4f68e02d5883ed8268746a296e6749e3c46e0124ca45f306c/optree-0.19.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:f1d7838e8b1b62258abd73a5911afad1153ed76822070558c3ba7e0bb5b44192", size = 423061, upload-time = "2026-05-06T02:31:25.652Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/34/637b151d071ca94aea0087322f470ce84c5828ef6b9c0de7dc7b4420a1cf/optree-0.19.1-cp313-cp313-win32.whl", hash = "sha256:9870d33ec50cca0c46c2b431cea24c6247457da15fd4ad66ccb8ab78145c1490", size = 317439, upload-time = "2026-05-06T02:31:27.304Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/49b8a8d9e94c57c6fa5008953f84a1c36a4119a3b90dcb7df745f1f05a00/optree-0.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:aa0845b725bcd0029e179cf9b4bc2cc016c7358e56fc7c0d2c43bf4d514c96cf", size = 343906, upload-time = "2026-05-06T02:31:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a9/1ae0a9685f5301f454f01d2490065b98df6956f90b1b2fd1cea9daa6d820/optree-0.19.1-cp313-cp313-win_arm64.whl", hash = "sha256:6f0b1efc177bed6495f78d39d5aa495ccb31cc20bcf64bb1b806ca4c919f4049", size = 353146, upload-time = "2026-05-06T02:31:29.976Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/77/4c8108cbce2c8ae2aa4b6adc7874082882e32cf131cb64b3a4411f50dec4/optree-0.19.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:b964bcdb5cfe367cdf56447e80ba5a49123098d8c4e8e68b41c20890eec6e58e", size = 469723, upload-time = "2026-05-06T02:31:31.425Z" },
+    { url = "https://files.pythonhosted.org/packages/64/33/ce9b54646ed4ab5773a9dc59767dadfe3de8bb2e97a3ed19205b995a7a31/optree-0.19.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:08ccec0ee5a565eb5aa4fe30383016a358627ea23d968ec8ab28b1f2ce4ce3d8", size = 437071, upload-time = "2026-05-06T02:31:33.027Z" },
+    { url = "https://files.pythonhosted.org/packages/79/55/04260128a726e3550b49467a65bff859452897144b68bae54b2f2e5c27f1/optree-0.19.1-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:672588408906051d3e9a99aca6c0af93c6e0b638137a701418088eaa0bb6c719", size = 433503, upload-time = "2026-05-06T02:31:34.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/99/6a4cc29389667efa089a0c476b7c36b7d0a66e10dd2d8c2d19c776977566/optree-0.19.1-cp313-cp313t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:d16cef4d0555d49ce221d80249f1285a2d3faf932e451c3ce6cb8ccb6a846767", size = 496305, upload-time = "2026-05-06T02:31:35.835Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/506aa1a64abce69e2f4cec9cdac3da0cae207cf04c5e70e7f143bf8b29d8/optree-0.19.1-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dc2db0b449baff53aa7e583306101de0ade5e5ae9e6fce78400eb2319bbd23dc", size = 492759, upload-time = "2026-05-06T02:31:37.265Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/28/2210de9a68722007fe007da3cae1a5971b92fc8113b5eecef66a04637959/optree-0.19.1-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:76b3e9e5d37e6b05ec82fff91758c8c0e27e159b35faea4b33d5eb975d720257", size = 495447, upload-time = "2026-05-06T02:31:38.505Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/61/40c3463e52914d552c66c760ae15e673137c4cc1d1d9f8da0d745656193a/optree-0.19.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03faa8e23fdaf3a18f9a1568c2c0eb0641a6aa05baf3a20639bd11fb34664700", size = 475564, upload-time = "2026-05-06T02:31:39.732Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/66/1603680fa924e68e5697c1229510c0645db0a9c633a12d1a9bfdbfc9cb74/optree-0.19.1-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:a9b9c7e9148ec470124dc4c1d1cd1485dbeb35973357b5911b181a79090426d2", size = 442414, upload-time = "2026-05-06T02:31:40.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/58/34820bab11f28ba6b03fe9e151880ad591b43f26648f058c94451fbdfc3a/optree-0.19.1-cp313-cp313t-win32.whl", hash = "sha256:ab8ad9803376d553a2958471b6bb6842b7e15888e19cc6aeb76da96c6afd948d", size = 348644, upload-time = "2026-05-06T02:31:42.038Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2b/0be3f8b9765f366e3e12d0590e9c6514de110d0c5b3b9002f49e56bf15b1/optree-0.19.1-cp313-cp313t-win_amd64.whl", hash = "sha256:afd4abeb2783b2367093287bc6268ac9af244b20c8d9b01696ccfe817483b66c", size = 382445, upload-time = "2026-05-06T02:31:43.166Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/8c0882cdd42e28a23c1998297c8ad1202194510cbba8b050251429c641c0/optree-0.19.1-cp313-cp313t-win_arm64.whl", hash = "sha256:b9120510d3f951e268e417a3f64f335bc1c539e1e80bff2129ddc6fb60ac7b56", size = 388040, upload-time = "2026-05-06T02:31:44.661Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/da/4e16e26375c56c9e40760697af4e2b72f196c2099e96cc783b63dcc862a8/optree-0.19.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:e1951ddc870f67430310fd17393971c30510ee9fd290525b44c12afe25f3c307", size = 927808, upload-time = "2026-05-06T02:31:45.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/87/ff1c6bb6b79a5d0b70b83f7ae8b78811a406a749b3ae4478a2122a7afb66/optree-0.19.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:ae9d42718ebf985cdad3182364b5cf829193b8fd2c6d993fbb4111d38e2bdf96", size = 390981, upload-time = "2026-05-06T02:31:47.38Z" },
+    { url = "https://files.pythonhosted.org/packages/82/25/fc648710102960f87d18cd8fc8a24afe14a5ec7827c64dfb1340230c0794/optree-0.19.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:930268ebfdebca43a8808f6293910d6ade2fe7c84fa784692017d7120d285226", size = 397756, upload-time = "2026-05-06T02:31:48.76Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f6/a7bf5d75a6481038bbb61846d87d43124d63741385796ef7b37d326f46bd/optree-0.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:b2757c5d922aab76cfc9b870c373fb35209c2094e3c912733b326c043e85a0c6", size = 427424, upload-time = "2026-05-06T02:31:49.838Z" },
+    { url = "https://files.pythonhosted.org/packages/49/cc/14dd93887295859457e507fc46a847b68ae8f20c42b2fde4d8a749c94bbc/optree-0.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b17a7b70ff8bd406c2142914c5ab0a57f8bcfb9f52181f7012e32406bbdbfdda", size = 398242, upload-time = "2026-05-06T02:31:51.262Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b5/ac51aa118dd918761519fbc031865b1d6f850453e9a7ac0c3da21109c4f0/optree-0.19.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:987bba55366917d9829f45b5ee86499ecc87a30e9103072db9ab8d67f9958179", size = 419568, upload-time = "2026-05-06T02:31:52.349Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/41/25144e61f76278b9e0a5d4189c7083fe853164c5f7328a1f5aac43d964c2/optree-0.19.1-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:d3bba2af7a5fce0c25e99024688e68dfe9be41e3d6e92720febbefdc879fba38", size = 482797, upload-time = "2026-05-06T02:31:53.471Z" },
+    { url = "https://files.pythonhosted.org/packages/22/47/2c76c7ce937323988770c41126e0e380bcb73a816f68a767f23b5c33aced/optree-0.19.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dae6c247cc8751bd2f167951468769f5c98f8cfdae31c0db0f2eb4145a6ec560", size = 479794, upload-time = "2026-05-06T02:31:54.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ca/bd9553f94bec0bc7860f10ae177c14ca265ab19ddb463122be22fa335ee8/optree-0.19.1-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:17a986fd91ccdc18bb7b587ca1f508c1761580a93517e6db33a13b22e46acb9b", size = 481084, upload-time = "2026-05-06T02:31:56.261Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/1a/4834b1f2fb1847412353d7342eb7a1d001a4f3bd9d24155e057135a4aa44/optree-0.19.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d0e1493429ae1d1a5e34855774ee604c974a8f76656bd0e562cdbf9466c9b1f", size = 462955, upload-time = "2026-05-06T02:31:57.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/88/598fb91c06fee3d8b08568779b011225dc2b66140927bd0b2b2d9b40a566/optree-0.19.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:f61a01ed9991193ed6f3db8e956ede05218190a32ca2ddfb71cfc40c8daba1d5", size = 423754, upload-time = "2026-05-06T02:31:59.291Z" },
+    { url = "https://files.pythonhosted.org/packages/20/8a/83c64ecadc686e08310fc9c20bc0bbe6453e89b69257e08887818dac7886/optree-0.19.1-cp314-cp314-win32.whl", hash = "sha256:b0c920579bddc3b18a0e051850f017618e24efcc19ba83dcd415cf74db5fd904", size = 325214, upload-time = "2026-05-06T02:32:00.802Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c3/4f2f318b98465376bbb7a06a33da553c688b3ed39dafbb8307f824eef74a/optree-0.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:50d77b91a8cd01adf422472b7edf39fc445b0268816176a868a385d28f8367c2", size = 351654, upload-time = "2026-05-06T02:32:01.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ab/55d7508e87055c730fe7207cfd0c45183a07ddf1f91d9e73d017a7f8c1f4/optree-0.19.1-cp314-cp314-win_arm64.whl", hash = "sha256:c682ab6711b7a623503711fa661a2bba7886e1c21dc06c3b7febba101b458051", size = 361610, upload-time = "2026-05-06T02:32:03.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/2d/4f7facd482d56079b7adb8ce3fede19f41629bc0463e8ee25907f1dba36c/optree-0.19.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:068edb89fadd94f6f57fdb51f4ad2c764b5a0bfd00903c55ffe433c2863a8037", size = 469130, upload-time = "2026-05-06T02:32:04.395Z" },
+    { url = "https://files.pythonhosted.org/packages/92/60/f7539012aa8a7488c1e34f66b76eadc384c3152dd9800973f1b5fe045dfd/optree-0.19.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a609c90e4f64e4f3e2b5b3cc022210314834737e0e61a745485e33b33eae773b", size = 437286, upload-time = "2026-05-06T02:32:05.527Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3f/a5f8fb3ec3840f885de52d7a793ba57ace17990e3a9b3797218425ffe842/optree-0.19.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfae64c4c371640a4b3e2a9e3e6aa3a3e8cdf2da5247a88fef5b632614b948a6", size = 431954, upload-time = "2026-05-06T02:32:06.83Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dc/6d0ef14bc82bd54046c1a066d25fa6854123a6b29fd691f1f95dec3ab45f/optree-0.19.1-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:470742544ff2d4b63843023f38dcfb83e82c3a9877c783dee0e69cbb974de6d1", size = 494631, upload-time = "2026-05-06T02:32:08.038Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/9a/9e183c610c414cba581f9afda7610589d89cae229d627b14f8480425d975/optree-0.19.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1a74e0656ccef45b1fec07b9d964ce97f3def8bab73711f56175076c4259884f", size = 491786, upload-time = "2026-05-06T02:32:09.363Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/73/266b9de8eb5b16bfe7010c90c55840517d5d61ee6e0ca64901440296d97a/optree-0.19.1-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f55841132ba8a34dbbd85e0c2cf990602384eea0e4638df986cd3266482f4a17", size = 490876, upload-time = "2026-05-06T02:32:11.388Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8d/42a8ca6277ef93d47ab0986e30a25134206afe0c6e6c3425c8736b2677ba/optree-0.19.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5f8383952f18d5a4ec6b248d8ae6fe27012434ad9750aa33a821ad4846da5af", size = 475079, upload-time = "2026-05-06T02:32:12.768Z" },
+    { url = "https://files.pythonhosted.org/packages/63/91/e363f4adda292f891ca0cf5748010fea955737bdf494cc11d4c3bcda6935/optree-0.19.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:de8acbed5965beae6f6b0456fcb8d1afaea1fe300810739e88645e22138849bc", size = 440119, upload-time = "2026-05-06T02:32:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/eb/489d22ef3cadb2f5f3bbd6e6099d17b5a521ff533e086f78f005c3358017/optree-0.19.1-cp314-cp314t-win32.whl", hash = "sha256:312048e69dc88de26915674f961bf38980a765a6b48ead2f1672858a39402c41", size = 357465, upload-time = "2026-05-06T02:32:15.424Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/7f48b7034ff75d2eb3e94e2196709ddbf762798fb621f9508899fa66b44e/optree-0.19.1-cp314-cp314t-win_amd64.whl", hash = "sha256:60e9345405d7b06cafdf1b1dd2e2261ceddddce10f35729240f90e2bab845a0b", size = 397783, upload-time = "2026-05-06T02:32:16.853Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/6d6f93416c66820cb8753e65b5ff43c47480af9c4911bd2b8406ff0f7f27/optree-0.19.1-cp314-cp314t-win_arm64.whl", hash = "sha256:4e103e212d1e8fe0399ed076eff80a905fb14929729bbd994d3660110a27a252", size = 396064, upload-time = "2026-05-06T02:32:18.077Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2973,7 +3144,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3148,6 +3319,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+bayesflow = [
+    { name = "bayesflow" },
+]
 dev = [
     { name = "graphviz" },
     { name = "ipykernel" },
@@ -3190,6 +3364,7 @@ viz = [
 [package.metadata]
 requires-dist = [
     { name = "arviz", specifier = ">=1.1,<2.0" },
+    { name = "bayesflow", marker = "extra == 'bayesflow'", specifier = ">=2.0,<3" },
     { name = "blackjax", specifier = ">=1.4" },
     { name = "bridgestan", marker = "extra == 'stan'", specifier = ">=2.0" },
     { name = "cmdstanpy", marker = "extra == 'stan'", specifier = ">=1.2" },
@@ -3214,7 +3389,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "tfp-nightly", specifier = ">=0.26.0.dev20260318" },
 ]
-provides-extras = ["prefect", "viz", "docs", "stan", "pymc", "nutpie", "dev"]
+provides-extras = ["prefect", "viz", "docs", "stan", "pymc", "nutpie", "bayesflow", "dev"]
 
 [[package]]
 name = "prometheus-client"
@@ -4261,6 +4436,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
     { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
     { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "seaborn"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Step 5 of the SBI-backend replacement: a **BayesFlow amortized-SBI backend**, restoring the amortized half of the SBI layer dropped with sbijax — now jax-native (keras-on-JAX, no TensorFlow/PyTorch). `learn_amortized_posterior` trains an amortized neural posterior estimator and returns a `SupportsConditioning` distribution, so `condition_on(model, observed)` draws from `p(theta | observed)` in a single forward pass with **no MCMC, no gradient bridge, and no prior translation**.

Based on `main`; review feedback (@SoymilkWinsAgain's five comments), a max-effort code-review pass, and a conventions review are addressed in follow-up commits so each delta is reviewable in isolation.

## What's added

**`probpipe/inference/_bayesflow.py`:**

- `learn_amortized_posterior(prior, simulator, *, method="npe"|"fmpe"|"cmpe", num_simulations=, epochs=, batch_size=, sim_backend="jax", inference_network=None, num_results=, random_seed=, optimizer="adam", **fit_kwargs)` — simulates `(theta, y)` pairs offline (`theta` via the `sample` op, `y` via `simulator.generate_data`), builds a BayesFlow `Adapter` from the prior's `record_template`, trains a `ContinuousApproximator`, and returns a `BayesFlowModel`.
- `BayesFlowModel(Distribution, SupportsConditioning)` — the **joint model** `p(theta, y)`: bundles prior + simulator + trained estimator (`prior`/`simulator` exposed as properties; no direct sampler — `_sample` raises a guarded `NotImplementedError` pointing to `condition_on`). `_condition_on` runs one network forward pass and returns **named** draws via `make_posterior(record_template=, ...)`. Amortized: the same instance conditions on any observation with no retraining; honours `num_results`/`random_seed`, ignores MCMC-only kwargs. Exported at the `probpipe` top level alongside `learn_amortized_posterior`.
- The prior needs **no** TFP translation — it is only sampled to draw `theta`.

## Design points worth a look

- **Simulator contract.** `generate_data(params, ...)` receives the prior's **native per-draw structured sample** (named fields, `params["a"]`) — matching `SimpleGenerativeModel` / `PriorPredictiveCheck` — reconstructed per draw via `NumericRecordArray.unflatten`; the `jax.vmap` fast path is preserved.
- **Constrained priors via per-field bijectors.** Each field is trained in unconstrained space (`bijector_for(support).inverse`, applied at the field's *native event shape*) and draws are mapped back through `forward` at sample time. Identity for real-valued fields; handles positive (Gamma), intervals (Beta), simplexes (Dirichlet), and positive-definite matrices (Wishart). Discrete priors have no smooth bijector and are rejected with a clear error. NPE's coupling-flow ≥2-dimension minimum is counted in **unconstrained** dimensions (a 2-simplex contributes one), falling back to flow matching below it.
- **`sim_backend` (not a bool).** `"jax"` (default) vmaps a traceable simulator; `"sequential"` runs an eager per-draw loop for **non-JAX simulators**. Values mirror `WorkflowFunction`'s dispatch vocabulary, so future parallel backends slot in as `Literal` members.
- **Likelihood protocols relocated to `core/protocols.py`.** `Likelihood`, `ConditionallyIndependentLikelihood`, `GenerativeLikelihood` moved from `modeling/_likelihood.py` (re-exported for back-compat) so `inference/` can depend on them without a cycle; removes two reverse import edges. Documented in `STYLE_GUIDE.md` §7.2; the lazy `inference/ → distributions/` edge (`bijector_for`) is now documented in §6's exceptions.
- **`ProductDistribution.supports`** — new per-field constraint accessor (`{field: component.support}`), implementing the canonical `RecordDistribution` API that previously raised `NotImplementedError`; the backend consumes it rather than reaching into `.components`.
- **RNG hygiene.** Training seeds keras (`keras.utils.set_random_seed`) for full reproducibility, but snapshots and **restores the caller's global NumPy/Python RNG state**, so a call does not silently perturb unrelated random streams.
- **Lazy import:** `import probpipe` loads neither keras nor bayesflow; `KERAS_BACKEND=jax` pinned with a post-import backend assertion.

## Robustness guards

Train-time, each raising before any simulation: non-`RecordDistribution` prior (`TypeError`); unknown `method`/`sim_backend`, non-positive `num_simulations`/`batch_size`/`epochs`/`num_results`, discrete/unsupported-support prior (`ValueError`); multi-field prior lacking per-field `supports` (`TypeError`). Condition-time: observation-size mismatch and non-positive `num_results` (`ValueError`). `_sample` raises `NotImplementedError` pointing to `condition_on` (the probe-able signal `WorkflowFunction`'s dispatch fallback catches).

## Tests (`tests/inference/test_bayesflow.py`, 35 passing)

Recovery near truth, amortization across observations, the no-direct-sampler guard, the `ApproximateDistribution` contract, repr, npe/fmpe/cmpe smoke, vector-valued field, caller-supplied `inference_network`, single-field and one-parameter priors, a multi-field (scalar+vector+scalar) prior with 8-d observations, a strict **named-field-access simulator** (fails under flattening), **constrained-support round-trips** for positive (Gamma), interval (Beta), simplex (Dirichlet under NPE), and positive-definite (Wishart — draws verified symmetric PSD), a non-JAX simulator on the `sequential` path, **global-RNG-restoration**, the condition-time guards, **adapter-namespace isolation** (fields literally named `observation` / `inference_variables` train and condition — theta fields are re-keyed to positional internal adapter names, so no field name is reserved), and six train-time validation rejections.

**Calibration against a conjugate Gaussian** (analytic posterior) checks the posterior mean **and spread** for both network paths:

| Path | Mean error | Std ratio |
|------|-----------|-----------|
| 2-D coupling flow | ≤ 0.11 post-std | 1.01–1.03 |
| 1-D flow-matching fallback | ≤ 0.19 post-std | 0.92–1.18 |

Training is fully seeded (same-seed runs are bit-identical); tolerance margins cover cross-platform numerical drift.

## Packaging / CI / docs

- `[bayesflow] = ["bayesflow>=2.0,<3"]`, **Python 3.12–3.13 only** (BayesFlow caps `<3.14`); resolved into `uv.lock` behind a `python_version < 3.14` marker, leaving the verified jax/jaxlib `0.10.1` + tfp pins untouched.
- A separate **`bayesflow` CI leg** (3.12 & 3.13) syncs `dev,nutpie,bayesflow` via `uv sync --frozen`, runs the suite, and uploads its coverage (the test job doesn't install the extra, so the union keeps `_bayesflow.py` — ~96% — in the patch metric).
- New **"Amortized SBI"** section in `docs/api/inference.md` (strict mkdocs build verified); CHANGELOG, STYLE_GUIDE §6/§7.2, and CONTRIBUTING updated.

## Verification

Local: bayesflow 2.0.12 / keras 3.14.1 (jax) / jax 0.10.1 — **35 bayesflow tests** plus `tests/distributions` + `tests/core` (2056) pass; `import probpipe` stays lazy; `uv lock --check` consistent; ruff clean on changed files; strict docs build green.



