### PR TITLE
chore(infra): CI hygiene bundle (3.14 matrix, concurrency, coverage floor, auto-labeling, dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # GitHub Actions only — keeps actions/checkout, actions/setup-uv,
+  # astral-sh/setup-uv, codecov/codecov-action, actions/labeler, etc.
+  # current as upstream releases. Deliberately NOT enabled for pip/uv:
+  # the dependency tree is tightly pinned (jax/tfp-nightly resolver
+  # interaction), and lockfile updates need to be intentional, not
+  # auto-PRed.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "area:infrastructure"
+    commit-message:
+      prefix: "chore(infra)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,21 @@
 version: 2
 updates:
-  # GitHub Actions only — keeps actions/checkout, actions/setup-uv,
-  # astral-sh/setup-uv, codecov/codecov-action, actions/labeler, etc.
-  # current as upstream releases. Deliberately NOT enabled for pip/uv:
-  # the dependency tree is tightly pinned (jax/tfp-nightly resolver
-  # interaction), and lockfile updates need to be intentional, not
-  # auto-PRed.
+  # GitHub Actions only — keeps actions/checkout, astral-sh/setup-uv,
+  # codecov/codecov-action, actions/labeler, etc. current as upstream
+  # releases. Deliberately NOT enabled for pip/uv: the dependency tree is
+  # tightly pinned (jax/tfp-nightly resolver interaction), and lockfile
+  # updates need to be intentional, not auto-PRed.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Batch all action bumps into a single weekly PR rather than one per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "area:infrastructure"
     commit-message:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -96,3 +96,13 @@
           - "codecov.yml"
           - ".gitignore"
           - "STYLE_GUIDE.md"
+
+"area:core":
+  - changed-files:
+      - any-glob-to-any-file:
+          # Root-level foundational modules + root tests that no subpackage
+          # area glob matches: type aliases (custom_types.py), Weights,
+          # dtype/array helpers, and the package surface (__init__.py).
+          # `*` does not cross `/`, so these match only top-level files.
+          - "probpipe/*.py"
+          - "tests/*.py"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,98 @@
+# Path → area:* label mappings used by .github/workflows/labeler.yml.
+# Multiple labels apply when a PR touches multiple areas — that's intentional.
+# `kind:*` and `status:*` labels are NOT auto-applied; humans set those.
+
+"area:distributions":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "probpipe/distributions/**"
+          - "probpipe/converters/**"
+          - "probpipe/linalg/**"
+          - "probpipe/core/distribution.py"
+          - "probpipe/core/_distribution_*.py"
+          - "probpipe/core/_empirical.py"
+          - "probpipe/core/_random_measures.py"
+          - "probpipe/core/_random_functions.py"
+          - "probpipe/core/_array_backend.py"
+          - "probpipe/core/constraints.py"
+          - "tests/distributions/**"
+          - "tests/converters/**"
+          - "tests/linalg/**"
+          - "tests/core/test_distribution*.py"
+          - "tests/core/test_empirical*.py"
+          - "tests/core/test_random*.py"
+
+"area:records":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "probpipe/record/**"
+          - "probpipe/core/record.py"
+          - "probpipe/core/_record_*.py"
+          - "probpipe/core/_numeric_record*.py"
+          - "tests/record/**"
+          - "tests/core/test_record*.py"
+
+"area:inference":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "probpipe/inference/**"
+          - "probpipe/modeling/**"
+          - "tests/inference/**"
+          - "tests/modeling/**"
+
+"area:workflow":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "probpipe/core/node.py"
+          - "probpipe/core/_workflow_*.py"
+          - "probpipe/core/_broadcast_distributions.py"
+          - "probpipe/core/ops.py"
+          - "probpipe/core/protocols.py"
+          - "probpipe/core/_registry.py"
+          - "probpipe/core/transition.py"
+          - "tests/core/test_workflow*.py"
+          - "tests/core/test_broadcast*.py"
+          - "tests/core/test_ops*.py"
+          - "tests/core/test_protocols*.py"
+
+"area:orchestration":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "example_scripts/run_prefect_demo.py"
+          - "example_scripts/run_ray_demo.py"
+          - "probpipe/core/config.py"
+          - "tests/core/test_prefect*.py"
+          - "tests/core/test_workflow_kind*.py"
+          - "docs/orchestration/**"
+
+"area:diagnostics":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "probpipe/validation/**"
+          - "tests/validation/**"
+
+"area:provenance":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "probpipe/core/provenance.py"
+          - "tests/core/test_provenance*.py"
+
+"area:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "mkdocs.yml"
+          - "mkdocs_hooks.py"
+          - "*.md"
+          - "AUTHORS"
+
+"area:infrastructure":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "pyproject.toml"
+          - "uv.lock"
+          - "setup.py"
+          - "codecov.yml"
+          - ".gitignore"
+          - "STYLE_GUIDE.md"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0   # need full history for git diff
 
@@ -186,7 +186,7 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0   # need full history for git diff
 
@@ -438,7 +438,7 @@ jobs:
 
       - name: Install uv
         if: steps.nb_check.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -438,7 +438,7 @@ jobs:
 
       - name: Install uv
         if: steps.nb_check.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,19 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs on PR pushes (saves CI minutes during iteration).
+# Pushes to main keep running — never cancel work that gates the merged history.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,21 +195,29 @@ jobs:
         # in uv.lock. --frozen makes the resolver fail if the lockfile is
         # out of sync, so CI never silently drifts from the committed pins.
         # --python pins the interpreter to the matrix leg: uv fetches a managed
-        # CPython when the runner lacks it, so the "3.13" leg genuinely runs
-        # 3.13. (setup-uv's python-version input was silently ignored on @v3,
-        # which let both legs fall back to the system 3.12.) [pymc] is included
-        # so pymc 6 is exercised on both matrix legs.
+        # CPython when the runner lacks it, so the "3.13" and "3.14" legs
+        # genuinely run those versions. (setup-uv's python-version input was
+        # silently ignored on @v3, which let every leg fall back to the system
+        # 3.12.) [pymc] is included so pymc 6 is exercised on all matrix legs.
         run: uv sync --frozen --python ${{ matrix.python-version }} --extra dev --extra nutpie --extra pymc
 
       - name: Run tests (changed files only)
         if: steps.changed.outputs.skip != 'true' && steps.changed.outputs.run_all == 'false'
+        # A targeted run executes a subset of tests but still measures
+        # --cov=probpipe (the whole package), so a global coverage floor
+        # would always fail here. The floor is enforced on the full-suite
+        # run below; keep partial runs exempt with --cov-fail-under=0.
         run: |
-          uv run pytest ${{ steps.changed.outputs.test_files }} --cov-report=xml --cov-report=html
+          uv run pytest ${{ steps.changed.outputs.test_files }} --cov-fail-under=0 --cov-report=xml --cov-report=html
 
       - name: Run tests (full suite)
         if: steps.changed.outputs.skip != 'true' && steps.changed.outputs.run_all == 'true'
+        # The 88% coverage floor is enforced here (full suite only): a
+        # foundational change or any push to main runs every test, so the
+        # whole-package measurement is meaningful. This overrides the
+        # --cov-fail-under=0 in pyproject's addopts.
         run: |
-          uv run pytest --cov-report=xml --cov-report=html
+          uv run pytest --cov-fail-under=88 --cov-report=xml --cov-report=html
 
       - name: Upload coverage reports to Codecov
         if: matrix.python-version == '3.12' && steps.changed.outputs.run_all == 'true'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           python-version: "3.12"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version: "3.12"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           python-version: "3.12"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,8 +13,12 @@ permissions:
   deployments: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  # For pushes to main: keep the 'pages' group + no cancellation so back-to-back
+  # deploys serialize cleanly (gh-pages allows only one in-flight deploy).
+  # For PRs: scope by ref and cancel superseded builds — they only need to
+  # verify `mkdocs build --strict`, not race for a deploy slot.
+  group: ${{ github.event_name == 'pull_request' && format('docs-pr-{0}', github.ref) || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,34 @@
+name: Auto-label PRs
+
+# Applies `area:*` labels to PRs based on the file paths they touch.
+# Path → label mapping lives in .github/labeler.yml. The `kind:*` and
+# `status:*` labels are intentionally NOT auto-applied — humans set
+# those based on intent, which paths can't tell us.
+
+on:
+  # `pull_request_target` runs in the BASE-branch context (so the labeler
+  # config is the one already merged, not whatever the PR proposes — a
+  # PR can't grant itself a custom label vocabulary). It also has write
+  # access to PR metadata, which `pull_request` from forks does not.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          # Don't remove labels that aren't in the config — preserves
+          # manual labels like `kind:breaking-change`, `priority`, and
+          # any `status:*` a maintainer applied.
+          sync-labels: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -25,7 +25,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           # Don't remove labels that aren't in the config — preserves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Python 3.14 to the CI test matrix.** The matrix is now
   `[3.12, 3.13, 3.14]`. `requires-python = ">=3.12"` is unchanged.
-- **Coverage floor enforced at 88%** (`--cov-fail-under=88`). Current
-  measured coverage on `main` is ~91%; the floor is set conservatively
-  within the beta plan's ≥85–90% commitment to leave headroom for normal
-  fluctuation.
+- **Coverage floor enforced at 88%** on the full-suite CI run
+  (`--cov-fail-under=88`). The changed-files-only PR path and local
+  single-file runs are exempt (`--cov-fail-under=0`), since a global floor
+  is only meaningful when the whole suite executes. Current measured
+  coverage on `main` is ~91%; the floor is set conservatively within the
+  beta plan's ≥85–90% commitment to leave headroom for normal fluctuation.
 - **Concurrency cancellation on CI for PR pushes.** A new push to a PR
   branch cancels the prior in-progress CI run. Pushes to `main` are
   unaffected (no cancellation — the merge-history gate stays solid).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Python 3.14 to the CI test matrix.** The matrix is now
+  `[3.12, 3.13, 3.14]`. `requires-python = ">=3.12"` is unchanged.
+- **Coverage floor enforced at 88%** (`--cov-fail-under=88`). Current
+  measured coverage on `main` is ~91%; the floor is set conservatively
+  within the beta plan's ≥85–90% commitment to leave headroom for normal
+  fluctuation.
+- **Concurrency cancellation on CI for PR pushes.** A new push to a PR
+  branch cancels the prior in-progress CI run. Pushes to `main` are
+  unaffected (no cancellation — the merge-history gate stays solid).
+  Same pattern added to the docs build (PR builds cancel; pages deploys
+  still serialize via the original `pages` group).
+- **PR auto-labeling.** `.github/workflows/labeler.yml` +
+  `.github/labeler.yml` apply `area:*` labels to PRs based on changed
+  file paths. `kind:*` and `status:*` labels are still applied by
+  humans.
+- **Dependabot for GitHub Actions.** `.github/dependabot.yml` opens
+  weekly PRs that bump pinned action versions (`actions/checkout`,
+  `astral-sh/setup-uv`, `codecov/codecov-action`, `actions/labeler`).
+  Auto-labeled `area:infrastructure`. Pip/uv dependency bumps are NOT
+  enabled — the JAX/TFP resolver interaction means lockfile updates
+  must be intentional.
+
 ### Changed
 
 - **Dev tooling: migrated to [uv](https://docs.astral.sh/uv/) for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,9 @@ A few conventions keep PRs consistent; the PR template
   `docs(contributing): document PR conventions`. Common types are `feat`,
   `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, and `ci`; the scope is
   the affected subpackage or area.
-- **Labels** — apply at least one `area:*` label for the affected subsystem,
-  plus `kind:breaking-change` if the PR changes a user-visible API.
+- **Labels** — `area:*` labels are auto-applied from the changed paths (see
+  [Labels](#labels) below); set `kind:*` / `status:*` by hand, and always add
+  `kind:breaking-change` if the PR changes a user-visible API.
 - **Linked issue** — reference the plan/tracking issue (`Refs #N` on stage
   PRs, `Closes #N` on the final one). A small standalone fix that skipped the
   plan step (above) has no issue to link; leave that section and its checklist
@@ -72,6 +73,26 @@ Claude Code auto-generates branch names like
 open PRs to the new branch — it silently closes them
 (see [#157](https://github.com/TARPS-group/prob-pipe/pull/157) for an
 example). If you must rename after a PR is open, use the web UI.
+
+### Labels
+
+ProbPipe uses three label families:
+
+- **`area:*`** — the affected subsystem (`area:core`, `area:distributions`,
+  `area:records`, `area:inference`, `area:workflow`, `area:orchestration`,
+  `area:diagnostics`, `area:provenance`, `area:docs`,
+  `area:infrastructure`). On PRs these are **applied automatically** by
+  `.github/workflows/labeler.yml` from the changed file paths (mapping in
+  `.github/labeler.yml`), so a PR that touches several areas gets several
+  `area:*` labels. On *issues*, apply them by hand — the auto-labeler runs
+  on PRs only.
+- **`kind:*`** — the nature of the change (`kind:refactor`,
+  `kind:breaking-change`, `kind:deprecation`, `kind:tracking`). Always
+  human-set; paths cannot infer intent.
+- **`status:*`** — workflow state (`status:blocked`, `status:needs-design`,
+  `status:needs-review`). Human-set.
+
+`enhancement` and `documentation` remain the catch-all tags for issues.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,7 +216,7 @@ full rationale.
 
 GitHub Actions (`.github/workflows/ci.yml`):
 
-- Tests on Python 3.12 and 3.13
+- Tests on Python 3.12, 3.13, and 3.14
 - Installs via `uv sync --frozen` from `uv.lock` (single source of truth
   for pinned dependency versions, shared between local dev and CI)
 - Test job uses extras `dev,nutpie,pymc`; the notebooks job uses

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ plt.xlabel('Temperature (°F)'); plt.ylabel('P(O-ring damage)'); plt.legend()
 
 ## Installation
 
-Requires Python >= 3.12 (tested on 3.12 and 3.13).
+Requires Python >= 3.12 (tested on 3.12, 3.13, and 3.14).
 
 ```bash
 git clone https://github.com/TARPS-group/prob-pipe.git

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ ProbPipe provides a set of built-in **ops**, which are workflow functions that c
 
 ## Installation
 
-ProbPipe requires Python ≥ 3.12 (tested on 3.12 and 3.13).
+ProbPipe requires Python ≥ 3.12 (tested on 3.12, 3.13, and 3.14).
 
 ```bash
 git clone https://github.com/TARPS-group/prob-pipe.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ exclude = ["tests*", "docs*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-n auto --dist worksteal -v --cov=probpipe --cov-report=term-missing --cov-fail-under=0"
+addopts = "-n auto --dist worksteal -v --cov=probpipe --cov-report=term-missing --cov-fail-under=88"
 markers = [
     "prefect: marks tests requiring prefect (deselect with '-m \"not prefect\"')",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ exclude = ["tests*", "docs*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-n auto --dist worksteal -v --cov=probpipe --cov-report=term-missing --cov-fail-under=88"
+addopts = "-n auto --dist worksteal -v --cov=probpipe --cov-report=term-missing --cov-fail-under=0"
 markers = [
     "prefect: marks tests requiring prefect (deselect with '-m \"not prefect\"')",
 ]


### PR DESCRIPTION
## Summary

Five small, independent CI-hygiene additions bundled in one PR. Each is a few lines on its own; bundling keeps review costs low.

## What's in this PR

### Python 3.14 in the CI matrix

`.github/workflows/ci.yml` matrix becomes `[3.12, 3.13, 3.14]`. `requires-python = ">=3.12"` in `pyproject.toml` is unchanged. README, `docs/index.md`, and CONTRIBUTING.md updated to reflect "tested on 3.12, 3.13, and 3.14".

Per SPEC 0 (the successor to NEP 29) — as of mid-2026, 3.12, 3.13, and 3.14 are all within the supported window:

| Python | Released | Age | SPEC 0 |
|---|---|---|---|
| 3.12 | Oct 2023 | 32 mo | support |
| 3.13 | Oct 2024 | 20 mo | support |
| 3.14 | Oct 2025 | 8 mo | support |

Verified before bundling: `uv lock` resolves all 255 packages cleanly on 3.14.5 — wheels exist for every dep (jax, jaxlib, tfp-nightly, pymc 6, nutpie, arviz 1.x, blackjax, etc.).

### Concurrency cancellation for PR runs

`.github/workflows/ci.yml` gets:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```
A new push to a PR cancels the prior in-progress CI run (saves CI minutes during iteration). Pushes to `main` are **never** cancelled — the merge-history gate stays solid.

`.github/workflows/docs.yml` gets the same pattern, but the original `concurrency: group: pages, cancel-in-progress: false` block is preserved for pushes to `main` (gh-pages allows only one in-flight deploy and that serialization is intentional). The new expression scopes PR builds by ref and cancels them:
```yaml
group: ${{ github.event_name == 'pull_request' && format('docs-pr-{0}', github.ref) || 'pages' }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

`docs.yml`'s `astral-sh/setup-uv` is also bumped `@v3` → `@v5` to match `ci.yml` (the `@v3` step silently ignored its `python-version` input).

### Coverage floor enforced at 88% (full-suite runs)

The 88% floor is enforced on the **full-suite** CI run only. `pyproject.toml` `addopts` keeps `--cov-fail-under=0`; the `Run tests (full suite)` step passes `--cov-fail-under=88` (which overrides it). This scoping matters because `ci.yml` runs a **changed-files-only** subset on most PRs while still measuring `--cov=probpipe` (the whole package) — a global floor in `addopts` would fail every targeted run, and every local `pytest tests/test_foo.py`. The changed-files step pins `--cov-fail-under=0` explicitly to stay exempt. The full suite runs on every push to `main` and on any PR touching a foundational file (`pyproject.toml`, `uv.lock`, `ci.yml`, `conftest.py`, `probpipe/__init__.py`), so the floor still gates the merged history.

Current measured coverage on `main` is ~91% per the Codecov badge; 88% leaves a 3-point buffer within the beta plan's ≥85–90% commitment.

### PR auto-labeling

Two new files:

- `.github/labeler.yml` — path → label mapping. `area:distributions` for files under `probpipe/distributions/`, `probpipe/converters/`, `probpipe/linalg/`, plus distribution-shaped files in `probpipe/core/`. Similar mappings for `area:records`, `area:inference`, `area:workflow`, `area:orchestration`, `area:diagnostics`, `area:provenance`, `area:docs`, `area:infrastructure`, and `area:core` (root-level `probpipe/*.py` and `tests/*.py` — type aliases, weights, dtype/array helpers, the package surface — that no subpackage glob matches).
- `.github/workflows/labeler.yml` — runs `actions/labeler@v5` on `pull_request_target` (so the label config is read from the base branch, not the PR — a PR can't grant itself a custom label vocabulary). `sync-labels: false` preserves manually-applied labels.

Only `area:*` labels are auto-applied. `kind:*` (refactor / breaking-change / tracking / deprecation) and `status:*` (blocked / needs-design / needs-review) stay human-set — paths can't tell us intent.

### Dependabot for GitHub Actions

`.github/dependabot.yml` — a weekly Monday PR that bumps pinned action versions (`actions/checkout`, `astral-sh/setup-uv`, `codecov/codecov-action`, `actions/labeler`), grouped so all bumps arrive in one PR rather than one per action. Auto-labeled `area:infrastructure` with commit-message prefix `chore(infra)`.

Pip/uv ecosystem **not** enabled — the JAX/TFP resolver interaction means lockfile updates must be intentional (e.g., via `uv lock --upgrade-package <name>` in a deliberate PR).

## Linked issue(s)

Refs the beta-hygiene line in `probpipe-0.2.0-beta-plan.md` §2 ("issue/PR templates, logo, **enforced coverage floor**"). No issue to link beyond that — this is the CI cleanup we discussed.

## Test plan

- YAML validated locally on all 5 workflow/config files.
- CI run on this PR is the actual verification: it touches foundational files (`pyproject.toml`, `ci.yml`), so it takes the **full-suite** path on all three legs (3.12 / 3.13 / 3.14) and enforces the 88% floor. The changed-files-only path — and its `--cov-fail-under=0` exemption — gets its first real exercise on the next subpackage-scoped PR.

## Breaking changes

None. `requires-python` is unchanged; pip + uv both continue to work; existing PRs' labels and milestones are unaffected.

## Documentation

- [x] No docstrings touched (no code changes).
- [x] README, `docs/index.md`, CONTRIBUTING.md updated for 3.14; CONTRIBUTING.md gains a "Labels" section documenting the `area:` / `kind:` / `status:` taxonomy.
- [x] CHANGELOG entry under `[Unreleased] / ### Added`.

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>` — `chore(infra): ...`.
- [x] `area:infrastructure` label applied.
- [x] No linked issue — small standalone hygiene work; following the CONTRIBUTING.md exception for cohesive small-fix PRs.

## Notes for reviewers

- The five items are independent — you can mentally verify each in isolation. They're bundled for review-cost amortization, not because they share logic.
- The `pull_request_target` choice for the labeler is deliberate (security-aware default for actions that need write access to PR metadata). The labeler runs with the base-branch config, not the PR's proposed config, so it can't be hijacked by a forked-PR config change.
- Once this merges, the next time anyone opens a PR, they should see `area:*` labels auto-applied based on changed paths.
- **`area:core` is a new repo label** created alongside this PR (the labeler skips labels that don't exist), using the same color as the other `area:*` labels.
- The coverage floor is deliberately scoped to the full-suite run — a global `--cov-fail-under` in `addopts` would red-light every changed-files-only PR (and local single-file runs), which measure whole-package coverage while running only a subset.

