### PR TITLE
ci: add advisory pyright type-check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,14 @@ jobs:
   # unrelated work; advisory surfaces it without forcing a cleanup. Syncs
   # the full dependency env first so imports resolve against the real
   # jax/tfp/pymc. Config + scope live in pyrightconfig.json. To enforce
-  # later: drop continue-on-error and tighten typeCheckingMode. Pyright is
-  # pinned for a reproducible baseline; `[nodejs]` bundles the Node runtime
-  # so CI doesn't depend on a runtime download.
+  # later: drop continue-on-error and tighten typeCheckingMode.
+  #
+  # Pyright runs as an ephemeral `uv run --with` tool rather than a locked
+  # [dev] dependency: that keeps its per-platform Node binaries out of
+  # uv.lock. The version is pinned here (and referenced in CONTRIBUTING.md)
+  # for a reproducible baseline; `[nodejs]` bundles the Node runtime so CI
+  # doesn't depend on a runtime download. The final summary line is lifted
+  # into the job summary so the count is visible without opening the log.
   typecheck:
     name: typecheck (advisory)
     runs-on: ubuntu-latest
@@ -33,7 +38,20 @@ jobs:
 
       - name: Pyright (advisory — does not gate merges)
         continue-on-error: true
-        run: uv run --with 'pyright[nodejs]==1.1.410' pyright
+        run: |
+          set -o pipefail
+          uv run --frozen --with 'pyright[nodejs]==1.1.410' pyright | tee pyright-output.txt
+
+      - name: Surface pyright summary
+        if: always()
+        run: |
+          {
+            echo "### Pyright (advisory — does not gate merges)"
+            echo '```'
+            grep -E '[0-9]+ error' pyright-output.txt | tail -n 1 || echo "no summary line found"
+            echo '```'
+            echo "_Full report in the \"Pyright\" step log above. Type checking is advisory; see CONTRIBUTING.md § Type checking._"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,34 @@ on:
     branches: [main]
 
 jobs:
+  # Advisory pyright type check. Reports but does NOT gate merges
+  # (continue-on-error). The source carries a type-debt baseline (much of
+  # it JAX/TFP untyped-attribute noise), so enforcing now would block
+  # unrelated work; advisory surfaces it without forcing a cleanup. Syncs
+  # the full dependency env first so imports resolve against the real
+  # jax/tfp/pymc. Config + scope live in pyrightconfig.json. To enforce
+  # later: drop continue-on-error and tighten typeCheckingMode. Pyright is
+  # pinned for a reproducible baseline; `[nodejs]` bundles the Node runtime
+  # so CI doesn't depend on a runtime download.
+  typecheck:
+    name: typecheck (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev --extra nutpie --extra pymc
+
+      - name: Pyright (advisory — does not gate merges)
+        continue-on-error: true
+        run: uv run --with 'pyright[nodejs]==1.1.410' pyright
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ __pycache__/
 .DS_Store
 .claude/scheduled_tasks.lock
 .agents
+
+# transient CI artifact (pyright advisory job tees its output here)
+pyright-output.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Pyright type checking (advisory).** A `typecheck (advisory)` CI job
+  runs [pyright](https://microsoft.github.io/pyright/) over the `probpipe`
+  package and reports type issues; it is **advisory for now** (does not
+  gate merges) while the type-debt baseline — largely JAX/TFP
+  untyped-attribute noise — is burned down. Config lives in
+  `pyrightconfig.json` (`basic` mode, `reportMissingTypeStubs` off). Run
+  locally with `uv run --with 'pyright[nodejs]' pyright`. To enforce
+  later: drop the job's `continue-on-error` and tighten
+  `typeCheckingMode`. See [CONTRIBUTING.md](CONTRIBUTING.md#type-checking).
+
 - **Dev tooling: migrated to [uv](https://docs.astral.sh/uv/) for
   environment + dependency management.** `uv.lock` is committed and used
   by CI (`uv sync --frozen`), making the install reproducible and lifting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,13 +181,23 @@ Run it locally in the synced environment:
 uv run --with 'pyright[nodejs]' pyright
 ```
 
+CI pins a specific pyright version for a reproducible baseline, so a
+local run on a newer pyright may report a slightly different count — pin
+to match CI (`pyright[nodejs]==<version from ci.yml>`) if you need exact
+parity.
+
 Like ruff, **pyright is advisory in CI for now** — the `typecheck
-(advisory)` job reports type issues but does not gate merges. The source
-carries a type-debt baseline (much of it noise from JAX/TFP untyped
-attributes), so enforcing immediately would block unrelated work. The
-plan is to burn the baseline down, then tighten `typeCheckingMode` in
-`pyrightconfig.json` and make the gate blocking. New code should be
-clean under the current `basic` mode where practical.
+(advisory)` job reports type issues (and surfaces the count in the run's
+job summary) but does not gate merges. The source carries a type-debt
+baseline (much of it noise from JAX/TFP untyped attributes), so enforcing
+immediately would block unrelated work. The plan is to burn the baseline
+down, then tighten `typeCheckingMode` in `pyrightconfig.json` and make the
+gate blocking. New code should be clean under the current `basic` mode
+where practical.
+
+ProbPipe ships a `py.typed` marker, so the package's annotations are
+consumed by downstream users' type checkers — keeping the public surface
+well-typed is user-facing quality, not just an internal nicety.
 
 ### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,24 @@ line.
 
 This applies equally to source files and notebook code cells.
 
+### Type checking
+
+Type checking uses [pyright](https://microsoft.github.io/pyright/)
+(configured in `pyrightconfig.json`, scoped to the `probpipe` package).
+Run it locally in the synced environment:
+
+```bash
+uv run --with 'pyright[nodejs]' pyright
+```
+
+Like ruff, **pyright is advisory in CI for now** — the `typecheck
+(advisory)` job reports type issues but does not gate merges. The source
+carries a type-debt baseline (much of it noise from JAX/TFP untyped
+attributes), so enforcing immediately would block unrelated work. The
+plan is to burn the baseline down, then tighten `typeCheckingMode` in
+`pyrightconfig.json` and make the gate blocking. New code should be
+clean under the current `basic` mode where practical.
+
 ### Documentation
 
 ```bash

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -471,6 +471,11 @@ ArrayLike: TypeAlias = jnp.ndarray | list | tuple | float | int
 PRNGKey: TypeAlias = jax.Array
 ```
 
+These conventions are checked (advisorily) by pyright in CI — see
+[CONTRIBUTING.md § Type checking](CONTRIBUTING.md#type-checking). The
+check does not gate merges yet, but new code should type-check cleanly
+under the project's `basic` pyright mode where practical.
+
 ---
 
 ## 6. Subpackage Dependencies

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,10 @@
+{
+  "//": "Pyright config. Type checking is ADVISORY for now — the CI 'typecheck (advisory)' job reports but does not gate merges (see CONTRIBUTING.md). Scoped to the shipped package; tests/docs are out of scope until the source baseline is clean. Tighten typeCheckingMode toward 'standard'/'strict' and add report* rules as the type-debt burns down.",
+  "include": ["probpipe"],
+  "pythonVersion": "3.12",
+  "typeCheckingMode": "basic",
+  "venvPath": ".",
+  "venv": ".venv",
+  "//reportMissingTypeStubs": "jax / tfp-nightly / pymc ship incomplete or absent type stubs; their missing-stub noise is not actionable here.",
+  "reportMissingTypeStubs": "none"
+}


### PR DESCRIPTION
## Summary

Adds **pyright type checking in advisory mode** — C6 from the CI-tightening plan, the separate follow-up to #250 (ruff + pre-commit).

Same finding as ruff: the source carries a type-debt baseline — **324 issues** at pyright's `basic` mode with the scoped config — much of it JAX/TFP untyped-attribute noise (`reportAttributeAccessIssue` 121, `reportOperatorIssue` 39, `reportArgumentType` 76) rather than real bugs. So pyright lands **advisory** (reports, doesn't gate), to be tightened as the baseline burns down.

## What's in this PR

### CI: `typecheck (advisory)` job (`.github/workflows/ci.yml`)
```yaml
- name: Install dependencies
  run: uv sync --frozen --extra dev --extra nutpie --extra pymc
- name: Pyright (advisory — does not gate merges)
  continue-on-error: true
  run: uv run --with 'pyright[nodejs]==1.1.410' pyright
```
- Syncs the full dependency env first so imports resolve against the **real** jax/tfp/pymc (otherwise pyright drowns in unresolved-import noise).
- `pyright[nodejs]` bundles the Node runtime → no dependency on a runtime download in CI.
- Version pinned (`1.1.410`) for a reproducible baseline.
- `continue-on-error: true` → advisory. **To enforce later:** drop that line and tighten `typeCheckingMode`.

### `pyrightconfig.json` (new)
- `include: ["probpipe"]` — scoped to shipped code; tests/docs out of scope until the source baseline is clean.
- `typeCheckingMode: "basic"`, `pythonVersion: "3.12"`.
- `reportMissingTypeStubs: "none"` — jax / tfp-nightly / pymc ship incomplete or absent stubs; that noise isn't actionable (drops the count 366 → 324).
- `venvPath`/`venv` point at uv's `.venv` so import resolution works locally and in CI.

### Docs
- CONTRIBUTING.md: new **"Type checking"** subsection.
- CHANGELOG: entry under `[Unreleased]`.

## Linked issue(s)

Follows #250 (ruff + pre-commit) — the agreed "C6 as a separate PR" split. Same advisory-now/enforce-later philosophy.

## Test plan

Verified locally:
- `uv run --with 'pyright[nodejs]==1.1.410' pyright` resolves imports against the synced env and reports **324** issues with this config (vs 366 unscoped / stubs-on) — confirms the config applies and pyright reads it.
- `uv.lock` is **unchanged** — pyright is an ephemeral `--with` tool, not a project dependency.
- ci.yml YAML validated.
- CI on this PR runs the job end-to-end (goes green with the report, by design).

## Breaking changes

None. The job doesn't gate; no runtime/API change; pyright is not added to the locked dependency set.

## Documentation

- [x] No docstrings touched (no source changes).
- [x] CONTRIBUTING.md "Type checking" subsection.
- [x] CHANGELOG entry.

## Checklist

- [x] PR title `<type>(<scope>): <subject>` — `ci: ...`.
- [x] `area:infrastructure` label.
- [x] No linked issue — standalone CI hygiene (CONTRIBUTING small-fix exception); follows #250.

## Notes for reviewers

- **Expected trivial conflicts with #250**, since both are branched from `main` and touch the same three files additively:
  - `ci.yml`: #250 adds a `lint` job, this adds a `typecheck` job, both right after `jobs:`. Resolution: keep both.
  - `CONTRIBUTING.md`: #250 adds "Linting & pre-commit", this adds "Type checking", both before "### Documentation". Keep both.
  - `CHANGELOG.md`: both add a bullet under `[Unreleased]`. Keep both.

  Whichever merges second takes a ~30-second keep-both rebase. Kept independent (rather than stacked) so they can merge in either order.
- **Why scope to `probpipe` only:** type-checking tests adds noise with little safety value; the shipped package is what users type against. Expand to tests later if desired.
- **Why basic mode:** `standard`/`strict` would multiply the baseline. Start permissive, ratchet — the same path scikit-learn and others took.
