### PR TITLE
refactor(core): Remove the support for `workflow_kind` in string or None type & remove the check or old keywords in `WorkflowFunction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (breaking)
 
+- **`WorkflowFunction.workflow_kind` and `Module.workflow_kind` now require
+  `WorkflowKind` enum members.** String aliases such as `"task"` / `"flow"`
+  and `None` are no longer accepted and now raise `TypeError`; use
+  `WorkflowKind.TASK`, `WorkflowKind.FLOW`, or `WorkflowKind.OFF` explicitly.
+  The old `parallel=` / `vectorize=` keyword guard on `WorkflowFunction` was
+  also removed, so those names are no longer specially reserved by the
+  constructor.
 - **`tfp_rwmh` removed.** The hand-rolled Python-loop RWMH that sat
   behind ``method="tfp_rwmh"`` is gone; ``blackjax_rwmh`` is the only
   RWMH backend. Callers must rename ``method="tfp_rwmh"`` →
@@ -631,8 +638,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Or via the new `PROBPIPE_WORKFLOW_KIND` environment variable
   (`off` / `task` / `flow` / `default`, case-insensitive), which is
-  read once at import time. Per-call overrides via
-  `@workflow_function(workflow_kind="task")` are unchanged.
+  read once at import time. Per-workflow overrides remain available via
+  `@workflow_function(workflow_kind=probpipe.WorkflowKind.TASK)`; string
+  aliases are no longer accepted in this release (see the
+  `workflow_kind` breaking entry above).
   Migration: production callers that relied on the implicit
   "Prefect importable → tasks enabled" path must add the one-line
   assignment or env var above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,9 +198,11 @@ probpipe.prefect_config.workflow_kind = probpipe.WorkflowKind.TASK
 export PROBPIPE_WORKFLOW_KIND=task   # or flow / off / default
 ```
 
-Per-call overrides via `@workflow_function(workflow_kind="task")` and
-explicit `WorkflowFunction(..., workflow_kind=WorkflowKind.FLOW)`
-continue to work and are unaffected by either of the above.
+Per-workflow overrides via
+`@workflow_function(workflow_kind=probpipe.WorkflowKind.TASK)` and
+explicit `WorkflowFunction(..., workflow_kind=probpipe.WorkflowKind.FLOW)`
+are unaffected by either of the above. String aliases such as `"task"` /
+`"flow"` are not accepted; use `WorkflowKind` enum members explicitly.
 
 The off-by-default behaviour exists because the prior auto-detect path
 ("Prefect importable → tasks enabled") confused notebook and REPL

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -171,8 +171,7 @@ class WorkflowFunction(Node):
         set via the ``PROBPIPE_WORKFLOW_KIND`` environment variable
         or explicit assignment).  ``TASK`` / ``FLOW`` explicitly
         request Prefect orchestration.  ``OFF`` disables
-        orchestration.  Legacy strings (``"task"``, ``"flow"``) and
-        ``None`` are auto-converted.
+        orchestration.
     name : str or None
         Display name; defaults to ``func.__name__``.
     bind : dict or None
@@ -210,7 +209,7 @@ class WorkflowFunction(Node):
         self,
         *,
         func: Callable,
-        workflow_kind: WorkflowKind | str | None = WorkflowKind.DEFAULT,  # TODO: remove str | None in follow-up issue
+        workflow_kind: WorkflowKind = WorkflowKind.DEFAULT,
         name: str | None = None,
         bind: dict[str, Any] | None = None,         # construction-time bindings (defaults/config)
         module: Any | None = None,                  # typically a Module; kept as Any to avoid import cycles
@@ -221,13 +220,7 @@ class WorkflowFunction(Node):
         include_inputs: bool = False,                # True → return BroadcastDistribution (joint over inputs+outputs)
         **kwargs: Any,                              # convenience bindings (merged into bind)
     ):
-        removed_keywords = {"parallel", "vectorize"} & set(kwargs)
-        if removed_keywords:
-            names = ", ".join(sorted(removed_keywords))
-            raise TypeError(
-                f"WorkflowFunction no longer accepts {names}; use dispatch= instead."
-            )
-
+        # Validate arguments before setting any instance state.
         if dispatch not in _VALID_DISPATCH_STRATEGIES:
             raise ValueError(
                 f"dispatch must be one of {_VALID_DISPATCH_STRATEGIES}; got {dispatch!r}"
@@ -240,16 +233,15 @@ class WorkflowFunction(Node):
                 stacklevel=2,
             )
 
+        if not isinstance(workflow_kind, WorkflowKind):
+            raise TypeError(
+                f"workflow_kind must be a WorkflowKind enum member, "
+                f"got {type(workflow_kind).__name__}"
+            )
+
         self._func = func
         self._signature_info = _workflow_call.make_signature_info(func)
-        # Convert legacy string / None values to WorkflowKind enum
-        # TODO: remove this legacy conversion in follow-up issue
-        if workflow_kind is None:
-            self._workflow_kind_raw = WorkflowKind.OFF
-        elif isinstance(workflow_kind, str) and not isinstance(workflow_kind, WorkflowKind):
-            self._workflow_kind_raw = WorkflowKind(workflow_kind)
-        else:
-            self._workflow_kind_raw = workflow_kind
+        self._workflow_kind_raw = workflow_kind
         self._name = name or getattr(func, "__name__", self.__class__.__name__)
 
         # Expose wrapped function's metadata for introspection (help(),
@@ -576,14 +568,18 @@ class Module(Node):
         - everything else becomes inputs
     """
 
-    def __init__(self, *, workflow_kind: WorkflowKind | str | None = WorkflowKind.DEFAULT, **kwargs: Any):
-        # Convert legacy string / None values to WorkflowKind enum
-        if workflow_kind is None:
-            self._workflow_kind = WorkflowKind.OFF
-        elif isinstance(workflow_kind, str) and not isinstance(workflow_kind, WorkflowKind):
-            self._workflow_kind = WorkflowKind(workflow_kind)
-        else:
-            self._workflow_kind = workflow_kind
+    def __init__(
+        self,
+        *,
+        workflow_kind: WorkflowKind = WorkflowKind.DEFAULT,
+        **kwargs: Any,
+    ):
+        if not isinstance(workflow_kind, WorkflowKind):
+            raise TypeError(
+                f"workflow_kind must be a WorkflowKind enum member, "
+                f"got {type(workflow_kind).__name__}"
+            )
+        self._workflow_kind = workflow_kind
         super().__init__(**kwargs)
         # validate abstract workflow implementations before wrapping
         self._validate_abstract_workflow_implementations()

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -202,6 +202,11 @@ class WorkflowFunction(Node):
         use this setting.
     seed : int
         Random seed for JAX PRNG key management during broadcasting.
+
+    Raises
+    ------
+    TypeError
+        If ``workflow_kind`` is not a ``WorkflowKind`` enum member.
     """
 
     DEFAULT_N_BROADCAST_SAMPLES: int = 128
@@ -566,6 +571,19 @@ class Module(Node):
     Internally:
         - kwargs whose values are Node instances become child_nodes
         - everything else becomes inputs
+
+    Parameters
+    ----------
+    workflow_kind : WorkflowKind
+        Prefect orchestration mode propagated to workflow methods built
+        from this module.
+    **kwargs : Any
+        Shared child nodes and inputs available to workflow methods.
+
+    Raises
+    ------
+    TypeError
+        If ``workflow_kind`` is not a ``WorkflowKind`` enum member.
     """
 
     def __init__(

--- a/probpipe/modeling/_likelihood.py
+++ b/probpipe/modeling/_likelihood.py
@@ -7,9 +7,10 @@ step function, and a stateful module for sequential Bayesian updating.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable
 from typing import Any, Protocol, runtime_checkable
 
+from ..core.config import WorkflowKind
 from ..core.distribution import Distribution
 from ..core.node import Module, WorkflowFunction
 from ..core.transition import iterate
@@ -18,10 +19,10 @@ from ..custom_types import PRNGKey
 logger = logging.getLogger(__name__)
 
 __all__ = [
-    "Likelihood",
     "ConditionallyIndependentLikelihood",
     "GenerativeLikelihood",
     "IncrementalConditioner",
+    "Likelihood",
 ]
 
 
@@ -97,7 +98,7 @@ class ConditionallyIndependentLikelihood[P, D](Likelihood[P, D], Protocol):
 
 
 def _default_per_datum_log_likelihood(
-    likelihood: "Likelihood",
+    likelihood: Likelihood,
     params: Any,
     datum: Any,
 ) -> Any:
@@ -180,7 +181,7 @@ class _ConditioningStep[P, D](WorkflowFunction):
         likelihood: Likelihood[P, D],
         *,
         condition_fn: Callable[..., Distribution[P]] | None = None,
-        workflow_kind: str | None = None,
+        workflow_kind: WorkflowKind = WorkflowKind.OFF,
         **condition_kwargs: Any,
     ):
         if condition_fn is None:
@@ -203,8 +204,8 @@ class _ConditioningStep[P, D](WorkflowFunction):
         dist: Distribution,
         data: Any,
     ) -> Distribution:
-        from ._simple import SimpleModel
         from ..core.protocols import SupportsLogProb
+        from ._simple import SimpleModel
 
         prior = dist
         if not isinstance(prior, SupportsLogProb):

--- a/tests/core/test_prefect_config.py
+++ b/tests/core/test_prefect_config.py
@@ -6,7 +6,7 @@ Exercises:
 - effective_workflow_kind resolution (per-instance vs global)
 - Graceful fallback when Prefect is not installed
 - Task runner auto-detection and explicit override
-- Legacy string / None conversion
+- Strict WorkflowFunction / Module workflow_kind validation
 - Module inherits global config
 - PROBPIPE_WORKFLOW_KIND environment-variable override
 """
@@ -314,47 +314,51 @@ class TestEffectiveWorkflowKind:
 
 
 # ---------------------------------------------------------------------------
-# Legacy string / None conversion
+# Strict constructor workflow_kind validation
 # ---------------------------------------------------------------------------
 
-class TestLegacyConversion:
-    """Verify old-style workflow_kind values are auto-converted."""
+class TestWorkflowKindConstructorValidation:
+    """Verify constructors reject old-style workflow_kind values."""
 
-    def test_string_task_converts(self):
+    def test_workflow_function_rejects_string(self):
         from probpipe.core.node import WorkflowFunction
 
         def noop(x):
             return x
 
-        wf = WorkflowFunction(func=noop, workflow_kind="task", dispatch="sequential", seed=0)
-        assert wf._workflow_kind_raw is WorkflowKind.TASK
+        with pytest.raises(TypeError, match="WorkflowKind enum member"):
+            WorkflowFunction(
+                func=noop,
+                workflow_kind="task",
+                dispatch="sequential",
+                seed=0,
+            )
 
-    def test_string_flow_converts(self):
+    def test_workflow_function_rejects_none(self):
         from probpipe.core.node import WorkflowFunction
 
         def noop(x):
             return x
 
-        wf = WorkflowFunction(func=noop, workflow_kind="flow", dispatch="sequential", seed=0)
-        assert wf._workflow_kind_raw is WorkflowKind.FLOW
+        with pytest.raises(TypeError, match="WorkflowKind enum member"):
+            WorkflowFunction(
+                func=noop,
+                workflow_kind=None,
+                dispatch="sequential",
+                seed=0,
+            )
 
-    def test_none_converts_to_off(self):
-        from probpipe.core.node import WorkflowFunction
+    def test_module_rejects_string(self):
+        from probpipe.core.node import Module
 
-        def noop(x):
-            return x
+        with pytest.raises(TypeError, match="WorkflowKind enum member"):
+            Module(workflow_kind="task")
 
-        wf = WorkflowFunction(func=noop, workflow_kind=None, dispatch="sequential", seed=0)
-        assert wf._workflow_kind_raw is WorkflowKind.OFF
+    def test_module_rejects_none(self):
+        from probpipe.core.node import Module
 
-    def test_invalid_string_raises(self):
-        from probpipe.core.node import WorkflowFunction
-
-        def noop(x):
-            return x
-
-        with pytest.raises(ValueError):
-            WorkflowFunction(func=noop, workflow_kind="banana", dispatch="sequential", seed=0)
+        with pytest.raises(TypeError, match="WorkflowKind enum member"):
+            Module(workflow_kind=None)
 
 
 # ---------------------------------------------------------------------------
@@ -394,7 +398,7 @@ class TestModuleInheritsConfig:
         mod = MyModule(workflow_kind=WorkflowKind.OFF)
         assert mod.step._workflow_kind_raw is WorkflowKind.OFF
 
-    def test_module_legacy_string_converts(self):
+    def test_module_explicit_task_passes_task_to_children(self):
         from probpipe.core.node import Module, workflow_method
 
         class MyModule(Module):
@@ -402,7 +406,7 @@ class TestModuleInheritsConfig:
             def step(self, x):
                 return x + 1
 
-        mod = MyModule(workflow_kind="task")
+        mod = MyModule(workflow_kind=WorkflowKind.TASK)
         assert mod.step._workflow_kind_raw is WorkflowKind.TASK
 
 

--- a/tests/core/test_prefect_orchestration.py
+++ b/tests/core/test_prefect_orchestration.py
@@ -1,8 +1,8 @@
 """Tests for Prefect orchestration in WorkflowFunction.
 
 Exercises all Prefect dispatch paths:
-- workflow_kind="task" with sequential and JAX dispatch
-- workflow_kind="flow" with sequential and JAX dispatch
+- workflow_kind=WorkflowKind.TASK with sequential and JAX dispatch
+- workflow_kind=WorkflowKind.FLOW with sequential and JAX dispatch
 - Import guard when Prefect is unavailable
 - Provenance metadata includes orchestration info
 
@@ -16,7 +16,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import Normal
+from probpipe import Normal, WorkflowKind
 from probpipe.core.node import WorkflowFunction
 
 prefect_testing = pytest.importorskip("prefect.testing.utilities")
@@ -65,7 +65,7 @@ def sum_xy(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
 
 
 # ---------------------------------------------------------------------------
-# workflow_kind="task" with sequential dispatch
+# workflow_kind=WorkflowKind.TASK with sequential dispatch
 # ---------------------------------------------------------------------------
 
 class TestPrefectTaskRowWise:
@@ -74,7 +74,7 @@ class TestPrefectTaskRowWise:
     def test_returns_empirical_distribution(self, normal_dist):
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind="task",
+            workflow_kind=WorkflowKind.TASK,
             dispatch="sequential",
             n_broadcast_samples=30,
             seed=0,
@@ -86,7 +86,7 @@ class TestPrefectTaskRowWise:
     def test_output_values_correct(self, normal_dist):
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind="task",
+            workflow_kind=WorkflowKind.TASK,
             dispatch="sequential",
             n_broadcast_samples=200,
             seed=1,
@@ -100,7 +100,7 @@ class TestPrefectTaskRowWise:
     def test_multiple_broadcast_args(self, normal_dist):
         wf = WorkflowFunction(
             func=sum_xy,
-            workflow_kind="task",
+            workflow_kind=WorkflowKind.TASK,
             dispatch="sequential",
             n_broadcast_samples=30,
             seed=2,
@@ -112,7 +112,7 @@ class TestPrefectTaskRowWise:
 
 
 # ---------------------------------------------------------------------------
-# workflow_kind="flow" with sequential dispatch
+# workflow_kind=WorkflowKind.FLOW with sequential dispatch
 # ---------------------------------------------------------------------------
 
 class TestPrefectFlowRowWise:
@@ -121,7 +121,7 @@ class TestPrefectFlowRowWise:
     def test_returns_empirical_distribution(self, normal_dist):
         wf = WorkflowFunction(
             func=double_it,
-            workflow_kind="flow",
+            workflow_kind=WorkflowKind.FLOW,
             dispatch="sequential",
             n_broadcast_samples=25,
             seed=10,
@@ -133,7 +133,7 @@ class TestPrefectFlowRowWise:
     def test_output_values_correct(self, normal_dist):
         wf = WorkflowFunction(
             func=double_it,
-            workflow_kind="flow",
+            workflow_kind=WorkflowKind.FLOW,
             dispatch="sequential",
             n_broadcast_samples=200,
             seed=11,
@@ -146,7 +146,7 @@ class TestPrefectFlowRowWise:
 
 
 # ---------------------------------------------------------------------------
-# workflow_kind="task" with JAX dispatch
+# workflow_kind=WorkflowKind.TASK with JAX dispatch
 # ---------------------------------------------------------------------------
 
 class TestPrefectTaskJax:
@@ -155,7 +155,7 @@ class TestPrefectTaskJax:
     def test_returns_empirical_distribution(self, normal_dist):
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind="task",
+            workflow_kind=WorkflowKind.TASK,
             dispatch="jax",
             n_broadcast_samples=30,
             seed=20,
@@ -167,7 +167,7 @@ class TestPrefectTaskJax:
     def test_output_values_correct(self, normal_dist):
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind="task",
+            workflow_kind=WorkflowKind.TASK,
             dispatch="jax",
             n_broadcast_samples=200,
             seed=21,
@@ -179,7 +179,7 @@ class TestPrefectTaskJax:
 
 
 # ---------------------------------------------------------------------------
-# workflow_kind="flow" with JAX dispatch
+# workflow_kind=WorkflowKind.FLOW with JAX dispatch
 # ---------------------------------------------------------------------------
 
 class TestPrefectFlowJax:
@@ -188,7 +188,7 @@ class TestPrefectFlowJax:
     def test_returns_empirical_distribution(self, normal_dist):
         wf = WorkflowFunction(
             func=double_it,
-            workflow_kind="flow",
+            workflow_kind=WorkflowKind.FLOW,
             dispatch="jax",
             n_broadcast_samples=25,
             seed=30,
@@ -200,7 +200,7 @@ class TestPrefectFlowJax:
     def test_output_values_correct(self, normal_dist):
         wf = WorkflowFunction(
             func=double_it,
-            workflow_kind="flow",
+            workflow_kind=WorkflowKind.FLOW,
             dispatch="jax",
             n_broadcast_samples=200,
             seed=31,
@@ -221,7 +221,7 @@ class TestPrefectProvenance:
     def test_task_provenance(self, normal_dist):
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind="task",
+            workflow_kind=WorkflowKind.TASK,
             dispatch="sequential",
             n_broadcast_samples=20,
             seed=40,
@@ -235,7 +235,7 @@ class TestPrefectProvenance:
     def test_flow_provenance(self, normal_dist):
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind="flow",
+            workflow_kind=WorkflowKind.FLOW,
             dispatch="sequential",
             n_broadcast_samples=20,
             seed=41,
@@ -247,7 +247,7 @@ class TestPrefectProvenance:
     def test_no_orchestration_provenance(self, normal_dist):
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind=None,
+            workflow_kind=WorkflowKind.OFF,
             dispatch="sequential",
             n_broadcast_samples=20,
             seed=42,
@@ -267,7 +267,7 @@ class TestPrefectNonBroadcast:
     def test_task_no_broadcast(self):
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind="task",
+            workflow_kind=WorkflowKind.TASK,
             dispatch="sequential",
             seed=50,
         )
@@ -278,7 +278,7 @@ class TestPrefectNonBroadcast:
     def test_flow_no_broadcast(self):
         wf = WorkflowFunction(
             func=double_it,
-            workflow_kind="flow",
+            workflow_kind=WorkflowKind.FLOW,
             dispatch="sequential",
             seed=51,
         )
@@ -300,7 +300,7 @@ class TestPrefectImportGuard:
 
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind="task",
+            workflow_kind=WorkflowKind.TASK,
             dispatch="sequential",
             n_broadcast_samples=10,
             seed=60,
@@ -316,7 +316,7 @@ class TestPrefectImportGuard:
 
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind="flow",
+            workflow_kind=WorkflowKind.FLOW,
             dispatch="sequential",
             n_broadcast_samples=10,
             seed=61,
@@ -332,7 +332,7 @@ class TestPrefectImportGuard:
 
         wf = WorkflowFunction(
             func=add_one,
-            workflow_kind="task",
+            workflow_kind=WorkflowKind.TASK,
             dispatch="jax",
             n_broadcast_samples=10,
             seed=62,

--- a/tests/core/test_workflow_parallel.py
+++ b/tests/core/test_workflow_parallel.py
@@ -304,11 +304,6 @@ class TestWorkflowFunctionExecutionConfig:
         assert execution.mode == "sequential"
         assert execution.max_workers is None
 
-    @pytest.mark.parametrize("removed_keyword", ["parallel", "vectorize"])
-    def test_workflow_function_rejects_removed_keywords(self, removed_keyword):
-        with pytest.raises(TypeError, match="no longer accepts"):
-            WorkflowFunction(func=add_one, **{removed_keyword: True})
-
     @pytest.mark.parametrize("dispatch", ["loop", "python", "map", None, 1])
     def test_workflow_function_rejects_invalid_dispatch(self, dispatch):
         with pytest.raises(ValueError, match="dispatch must be one of"):


### PR DESCRIPTION
## Summary

1. Remove support for `workflow_kind` is `str` or `None` in `WorkflowFunction`.
2. Add validation to ensure `workflow_kind` is a `WorkflowKind` enum member.
3. Remove deprecated `parallel` and `vectorize` kwargs from `WorkflowFunction` and add validation to prevent their use. This check is introduced in #213 to prevent user from using old keywords.
