### PR TITLE
fix(packaging): declare Apache-2.0 license to match LICENSE file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Package license metadata corrected to Apache-2.0 (was MIT).**
+  `pyproject.toml` declared `license = { text = "MIT" }` while the
+  repository's `LICENSE` is Apache License 2.0 — and the metadata field is
+  what PyPI displays. The field is now a PEP 639 SPDX expression
+  (`license = "Apache-2.0"` with `license-files = ["LICENSE", "AUTHORS"]`),
+  so built distributions carry `License-Expression: Apache-2.0` (core
+  metadata 2.4). The setuptools build floor rises from 61 to 77.0.3 — PEP
+  639 support landed in 77.0.0, which also deprecated the old
+  `license = { text = ... }` table form, and 77.0.3 relaxed the new
+  `license-files` validation from errors to warnings — and the redundant
+  `wheel` build requirement is dropped (`bdist_wheel` ships inside
+  setuptools since 70.1). Build-time changes only; runtime dependencies
+  are unchanged.
+
 ### Added
 
 - **BayesFlow amortized-SBI backend (`[bayesflow]` extra).** New

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Tools for probabilistic data-processing pipelines"
 readme = "README.md"
 requires-python = ">=3.12"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
   { name = "Jonathan Huggins", email = "huggins@bu.edu" },
   { name = "Andrew Roberts",   email = "arober@bu.edu" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ version = "0.1.0"
 description = "Tools for probabilistic data-processing pipelines"
 readme = "README.md"
 requires-python = ">=3.12"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE", "AUTHORS"]
 authors = [
   { name = "Jonathan Huggins", email = "huggins@bu.edu" },
   { name = "Andrew Roberts",   email = "arober@bu.edu" },


### PR DESCRIPTION
## Summary

The `LICENSE` file at the repo root is Apache License 2.0, but `pyproject.toml` declared `license = { text = "MIT" }`. The package metadata is what PyPI displays, so the upcoming 0.2.0 release would have been shown as MIT-licensed. This PR corrects the metadata and modernizes it to PEP 639 in one go:

- `license = "Apache-2.0"` (SPDX expression) with `license-files = ["LICENSE", "AUTHORS"]` — built distributions now carry `License-Expression: Apache-2.0` under core metadata 2.4. Listing `AUTHORS` preserves what setuptools' default license-file globs already shipped.
- The setuptools build floor rises from `>=61.0` to `>=77.0.3`: PEP 639 support landed in 77.0.0 (which also deprecated the `license = { text = ... }` table form), and 77.0.3 relaxed the new `license-files` validation from errors to warnings.
- The redundant `wheel` build requirement is dropped — `bdist_wheel` ships inside setuptools since 70.1.

Build-time changes only; runtime dependencies are unchanged. A grep across the repo (README, CONTRIBUTING, docs/, mkdocs.yml) found no other MIT mentions to align. A CHANGELOG entry is added under `[Unreleased]` / `Fixed`.

## Linked issue(s)

N/A — small standalone fix.

## Test plan

- `uv lock --check` passes (resolves cleanly, lock unchanged).
- `uv build` succeeds for both sdist and wheel — the wheel build also exercises the dropped `wheel` requirement.
- Built metadata verified: sdist `PKG-INFO` and wheel `METADATA` both read `Metadata-Version: 2.4`, `License-Expression: Apache-2.0`, with `License-File: LICENSE` and `License-File: AUTHORS`; the wheel ships both files under `.dist-info/licenses/`.

## Breaking changes

None. Installing from sdist provisions `setuptools>=77.0.3` in the isolated build environment automatically; no user-visible API changes.

## Documentation

- [ ] Docstrings updated for changed public APIs — N/A
- [ ] User Guide / tutorials updated where relevant — N/A
- [x] CHANGELOG (or release-notes entry) noted in the linked issue — entry added directly under `[Unreleased]` / `Fixed`

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`
- [x] At least one `area:*` label applied (`area:infrastructure`)
- [x] Linked to an issue above — or N/A for a small standalone fix (see CONTRIBUTING.md)
