### PR TITLE
ci: fix Codecov misreporting on targeted PRs (#261)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,11 +310,18 @@ jobs:
           uv run pytest --cov-fail-under=88 --cov-report=xml --cov-report=html
 
       - name: Upload coverage reports to Codecov
-        if: matrix.python-version == '3.12' && steps.changed.outputs.run_all == 'true'
+        # Upload on 3.12 for BOTH the targeted and full-suite paths (gated only
+        # on the test step having run). The targeted run covers exactly the
+        # changed files — which is what Codecov *patch* coverage needs — so the
+        # patch gate is accurate even on targeted PRs. The full-suite path
+        # additionally gives the authoritative *project* number. Tagged `unit`
+        # so the flag carries forward when a PR doesn't run it (see codecov.yml).
+        if: matrix.python-version == '3.12' && steps.changed.outputs.skip != 'true'
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: TARPS-group/prob-pipe
+          flags: unit
 
       - name: Upload coverage HTML report
         if: always() && matrix.python-version == '3.12' && steps.changed.outputs.run_all == 'true'
@@ -337,13 +344,52 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need full history for git diff
+
+      - name: Check if BayesFlow-relevant files changed
+        id: bf_check
+        # Gate the leg with the same logic the test job uses for RUN_ALL: run
+        # on pushes to main, on foundational changes (deps / this workflow),
+        # or when a BayesFlow file itself changed. Otherwise skip — and the
+        # `bayesflow` coverage flag carries forward from base (codecov.yml),
+        # so a skipped leg doesn't drag the coverage union down.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/${{ github.base_ref }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          CHANGED=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD \
+            -- 'probpipe/inference/_bayesflow.py' 'tests/inference/test_bayesflow.py' || true)
+          CHANGED_ALL=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD || true)
+          RUN_BF=false
+          if [ "${{ github.event_name }}" = "push" ]; then
+            RUN_BF=true
+          else
+            for f in $CHANGED_ALL; do
+              case "$f" in
+                pyproject.toml|uv.lock|.github/workflows/ci.yml) RUN_BF=true ;;
+              esac
+            done
+            [ -n "$CHANGED" ] && RUN_BF=true
+          fi
+          if [ "$RUN_BF" = "true" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Running the BayesFlow leg."
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No BayesFlow-relevant changes — skipping (coverage flag carries forward)."
+          fi
 
       - name: Install uv
+        if: steps.bf_check.outputs.skip != 'true'
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
 
       - name: Install dependencies
+        if: steps.bf_check.outputs.skip != 'true'
         # Versions (jax/jaxlib/tfp-nightly/keras/bayesflow) are pinned in uv.lock;
         # --frozen fails if the lockfile drifts. --python pins the interpreter to
         # the matrix leg. The bayesflow extra is locked behind a python_version
@@ -351,18 +397,20 @@ jobs:
         run: uv sync --frozen --python ${{ matrix.python-version }} --extra dev --extra nutpie --extra bayesflow
 
       - name: Run BayesFlow backend tests
+        if: steps.bf_check.outputs.skip != 'true'
         run: uv run pytest tests/inference/test_bayesflow.py --cov-report=xml
 
       - name: Upload coverage reports to Codecov
-        # The test job's upload measures the BayesFlow backend as uncovered: it
-        # does not install [bayesflow], so these tests importorskip out there.
-        # Upload this leg's report too — Codecov's per-commit union then counts
-        # _bayesflow.py toward patch coverage. 3.12 only, matching the test job.
-        if: matrix.python-version == '3.12'
+        # The main test job does not install [bayesflow], so its run measures
+        # _bayesflow.py as uncovered. Upload this leg under the `bayesflow`
+        # flag so Codecov's union counts _bayesflow.py toward coverage. 3.12
+        # only, matching the test job's upload.
+        if: steps.bf_check.outputs.skip != 'true' && matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: TARPS-group/prob-pipe
+          flags: bayesflow
 
   notebooks:
     # Execute every docs/examples notebook to keep the reference set

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,16 +360,21 @@ jobs:
           else
             BASE="${{ github.event.before }}"
           fi
+          # Globs, not single files: the BayesFlow backend is being split into
+          # multiple modules (NLE/NRE), so match the whole family.
           CHANGED=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD \
-            -- 'probpipe/inference/_bayesflow.py' 'tests/inference/test_bayesflow.py' || true)
+            -- 'probpipe/inference/_bayesflow*.py' 'tests/inference/test_bayesflow*.py' || true)
           CHANGED_ALL=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD || true)
           RUN_BF=false
           if [ "${{ github.event_name }}" = "push" ]; then
             RUN_BF=true
           else
+            # Same foundational set as the test job's RUN_ALL — these can affect
+            # the test environment or the public surface, so they run every leg.
             for f in $CHANGED_ALL; do
               case "$f" in
-                pyproject.toml|uv.lock|.github/workflows/ci.yml) RUN_BF=true ;;
+                pyproject.toml|uv.lock|setup.cfg|setup.py|tests/conftest.py|probpipe/__init__.py|.github/workflows/ci.yml)
+                  RUN_BF=true ;;
               esac
             done
             [ -n "$CHANGED" ] && RUN_BF=true
@@ -398,7 +403,8 @@ jobs:
 
       - name: Run BayesFlow backend tests
         if: steps.bf_check.outputs.skip != 'true'
-        run: uv run pytest tests/inference/test_bayesflow.py --cov-report=xml
+        # Glob to pick up the split BayesFlow test files (NLE/NRE) as they land.
+        run: uv run pytest tests/inference/test_bayesflow*.py --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         # The main test job does not install [bayesflow], so its run measures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Codecov no longer misreports coverage on targeted PRs (#261).**
+  On a PR that ran only the changed-files test path, the main test job
+  skipped its Codecov upload while the BayesFlow job still uploaded, so
+  Codecov computed project/patch from the BayesFlow report alone —
+  yielding spuriously low numbers and a "HEAD has 1 upload less than
+  BASE" warning even though every Actions job passed. Now: the main
+  test job uploads coverage on the targeted path too (tagged `unit`),
+  so **patch** coverage is accurate and stays an enforced PR gate;
+  Codecov **project** is `informational` on PRs (the real 88% floor is
+  enforced in-CI on the full-suite run via `--cov-fail-under`); the
+  BayesFlow leg is gated to run only on BayesFlow-relevant changes; and
+  per-flag `carryforward` keeps the project number sane when a flag
+  isn't uploaded.
+
 - **Package license metadata corrected to Apache-2.0 (was MIT).**
   `pyproject.toml` declared `license = { text = "MIT" }` while the
   repository's `LICENSE` is Apache License 2.0 — and the metadata field is

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,31 @@ coverage:
   status:
     project:
       default:
+        # Informational on PRs: a targeted PR uploads only a partial report
+        # (the changed-files test subset), so Codecov's project number is not
+        # authoritative here and must not gate. The real project floor (88%)
+        # is enforced in-CI on the full-suite run — `pytest --cov-fail-under`
+        # in .github/workflows/ci.yml, which fires on pushes to main and on
+        # foundational PRs. `informational` makes this status report-only.
+        informational: true
         # Allow small drops during large refactors. Absolute coverage
         # should still land in the 80s.
         threshold: 2%
     patch:
       default:
+        # Enforced on every PR. The main test job uploads coverage of exactly
+        # the changed files (targeted run), so patch — "did you cover your new
+        # lines" — is a meaningful, accurate gate even on targeted PRs.
         target: 70%
+
+# Carry each flag's coverage forward from the base commit when a PR doesn't
+# upload it, so the project number stays sane and Codecov stops reporting
+# "HEAD has N uploads less than BASE":
+#   - unit: the main pytest suite (probpipe, minus the BayesFlow backend).
+#   - bayesflow: the keras-on-jax BayesFlow leg, which only runs when
+#     BayesFlow-relevant files change (see the bayesflow job's gating).
+flags:
+  unit:
+    carryforward: true
+  bayesflow:
+    carryforward: true


### PR DESCRIPTION
Closes #261.

## Investigation verdict (the issue is half-right)

The mechanism is **real and reproducible**, but it's a **coverage-misreporting defect, not a merge-blocking bug**:

- **Confirmed in config:** the main test job uploads coverage only on `run_all=='true'`, while the BayesFlow job uploaded on every `3.12` run. So a *targeted* PR sent Codecov **only** the BayesFlow report (which runs `test_bayesflow.py` under `--cov=probpipe` → ~38% project), and "HEAD has 1 upload less than BASE" is literally `2 − 1`.
- **Reproduced by #260:** every Actions job green, only `codecov/patch` (60.93%) + `codecov/project` (38.53%) red. #260's diff is pure core/workflow code (`node.py`, `ops.py`, `_workflow_call.py`, `_glm.py`) with **zero** BayesFlow — yet the only uploaded report was BayesFlow's, so the diff read as uncovered.
- **Not blocking:** there are no required status checks and no rulesets on `main` (verified via the API), so the red `codecov/*` X's can't block a merge — #260's `BLOCKED` state is from the PR-review requirement, not Codecov. So the real cost is **trust erosion** (scary numbers on healthy PRs), not a broken gate.

**On the patch question specifically:** patch coverage was *not* correct either. Patch is scoped to the diff lines, but "covered" still comes from the uploaded reports — and the BayesFlow-only report doesn't exercise a non-BayesFlow diff, so those lines read uncovered (hence #260's 60.93%). Carryforward alone wouldn't fix patch, because the base commit has no coverage for newly-added lines; you need the report from the run that actually exercised the changed lines.

## Fix (preserves the changed-files-only speedup — no full suite on every PR)

1. **Main test job uploads coverage on the targeted path too** (gate relaxed `run_all=='true'` → `skip!='true'`), tagged flag `unit`. The targeted run covers exactly the changed files → **patch is accurate** and stays the enforced PR gate (`target: 70%`).
2. **`codecov.yml` project → `informational: true`.** A targeted PR's partial report can't give an authoritative project number, so it must not gate. The real **88% project floor is still enforced in-CI** on the full-suite run (`pytest --cov-fail-under=88`), which fires on pushes to `main` and on foundational PRs — i.e., coverage is enforced exactly when the full suite runs, as requested.
3. **BayesFlow leg gated** with the same RUN_ALL-style logic as the test job (push to main / foundational change / a BayesFlow file changed); otherwise skipped, and its flag carries forward.
4. **Per-flag `carryforward`** for `unit` and `bayesflow` so the project number stays sane and the "uploads less than BASE" warning stops.

Net: **patch** is the accurate, enforced PR gate; **project** is informational on PRs and a hard in-CI gate on full-suite runs.

## Test plan

- `ci.yml` and `codecov.yml` YAML validated locally.
- The in-job `--cov-fail-under=88` (full suite) / `=0` (targeted) split is preserved unchanged.
- Real verification is this PR's own Codecov checks: as a targeted PR, `codecov/patch` should now reflect the changed files accurately and `codecov/project` should appear as an informational (non-failing) status.

## Breaking changes

None — CI/coverage-reporting only.

## Documentation

- [x] CHANGELOG entry under `[Unreleased] / ### Fixed`.
- [x] Rationale captured inline in `codecov.yml` and the workflow comments.

## Checklist

- [x] Title `<type>(<scope>): <subject>` — `ci: ...`.
- [x] `area:infrastructure` auto-label applies (touches `.github/**`, `codecov.yml`).
- [x] Closes #261.

## Notes for reviewers

- **Honest caveat:** on a *targeted* PR the partial `unit` upload means Codecov's **project** number still shows low — that's why project is `informational`. It's not "fixed to look right" on targeted PRs; it's correctly marked non-authoritative there, with the real enforcement on full-suite runs. Patch is the metric that's both correct and gating per-PR.
- If you'd additionally like the full-suite coverage to be a **hard merge-blocker** (not just a failing job), that's a one-time branch-protection change (add the `test (3.12/3.13/3.14)` checks to required status checks) — say the word and I'll set it via `gh api`; it's outside this PR since it's a repo setting, not a file.
- `@SoymilkWinsAgain`'s original recommendation (run the full 3.12 suite on every PR) also works and gives a real project number per PR, but costs the full-suite run on every PR; this approach keeps the targeted-test speedup and makes patch the per-PR gate instead.
