### PR TITLE
docs(contributing): codify comment, naming, test, and PR-hygiene conventions

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -21,10 +21,13 @@ are made.
 
 ### 1a. Read project conventions (do this first)
 
-Read the following files in full. These are the **authoritative source of truth**
-for all naming, style, architecture, and API conventions. Every check you perform
-in Step 2 must be grounded in what these documents say — do not rely on your own
-prior knowledge of ProbPipe conventions, as they may have changed.
+Read the following files in full, **from the PR's base ref** — e.g.
+`git show origin/main:STYLE_GUIDE.md` after `git fetch origin main` — not from
+the local checkout: a worktree copy may be stale relative to the branch the PR
+merges into. These are the **authoritative source of truth** for all naming,
+style, architecture, and API conventions. Every check you perform in Step 2
+must be grounded in what these documents say — do not rely on your own prior
+knowledge of ProbPipe conventions, as they may have changed.
 
 - `STYLE_GUIDE.md` — naming, imports, types, protocols, testing, module layout
 - `CONTRIBUTING.md` — architecture overview, design principles, package
@@ -65,7 +68,10 @@ the docs actually say over this summary:
 - **Design principles** — immutability, ops-not-methods, protocol-based dispatch,
   private method convention, etc. (see CONTRIBUTING.md "Design principles")
 - **Naming** — protocols, ops, implementation functions, classes, modules,
-  reserved parameter names, the `.n` property convention (see STYLE_GUIDE.md)
+  reserved parameter names, the `num_atoms` / `replicate_size` property
+  convention, and **naming accuracy** (STYLE_GUIDE.md §1.12): names describe
+  what the object *is* (semantic accuracy), align with numpy/JAX vocabulary,
+  pair symmetrically, and renames sweep all analogous symbols + test files
 - **Imports** — `from __future__ import annotations`, relative internals, import
   order, optional dependency patterns, `TYPE_CHECKING` guards
 - **Type annotations** — modern Python 3.12+ syntax, project type aliases.
@@ -107,6 +113,13 @@ the docs actually say over this summary:
 - Have any existing tests become stale — testing behavior that no longer matches
   the implementation?
 - Do tests follow project conventions (see STYLE_GUIDE.md section 8)?
+- Are correctness tolerances as tight as they can reliably be? Loose tolerances
+  — or shape-only assertions on inference output where a statistical sanity
+  check is feasible — are findings.
+- Do tests cover structured cases (multi-field Records, mixed scalar/vector
+  parameters), not just scalar happy paths?
+- If the change touches dispatch (jax vs sequential paths), is there an
+  equivalence test guarding against silent path divergence?
 
 ### 2.4 Duplicate and redundant code
 
@@ -132,7 +145,14 @@ documentation:
 - Overly verbose explainer comments that restate what the code obviously does
 - `# TODO` or `# FIXME` comments that were not in the original code and seem
   like AI planning artifacts rather than genuine action items
-- Comments that narrate the development process rather than explain the code
+- Comments that narrate the development process or provenance rather than
+  explain the code — which PR/plan phase introduced a line, which review
+  comment prompted it ("addressed in review", "previously this was...")
+- Negative documentation — comments or docstrings describing what something
+  *isn't* ("this is not a mixture"); usually a naming or design smell
+  (CONTRIBUTING.md "Code comments & docstrings")
+- Public docstrings that explain implementation internals rather than
+  behavior and usage
 
 ### 2.6 General concerns
 
@@ -150,6 +170,22 @@ documentation:
 - Is there dead code, unused imports, or unreachable branches?
 - Are there opportunities to use JAX idioms more effectively (e.g., `vmap`
   instead of Python loops, `jnp` instead of `np` where JIT is intended)?
+
+### 2.8 PR body and branch hygiene
+
+- Does the PR title/description match the **final** diff? Flag drift in either
+  direction: features described but not present, changes present but
+  undescribed.
+- Is the body free of internal process jargon ("Phase 1b", plan-file
+  references, review-round narration) that an outside reader cannot follow?
+- Is there a CHANGELOG entry for user-visible changes, and a
+  `kind:breaking-change` label where the public API changes?
+- Did scratch artifacts leak into the diff — `*_plan.md` files, references to
+  local plan directories, leftover debug scripts?
+- When the PR pins a version (CI action, tool), is the pin consistent with the
+  same pin elsewhere in the repo, and reachable by the automated bumpers
+  (Dependabot, `pre-commit autoupdate`)? An inline pin no bumper parses will
+  silently drift.
 
 ## Step 3: Present findings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Contributor conventions for comments, naming, tests, and PR hygiene.**
+  CONTRIBUTING.md gains "Code comments & docstrings" (no process narration,
+  no negative documentation, public docstrings describe behavior) and "Test
+  quality" (tightest reliable tolerances, structured cases, dispatch-path
+  equivalence) sections, a description-equals-final-state PR rule, and a
+  docs-ship-with-the-change rule. STYLE_GUIDE.md gains §1.12 "Naming
+  accuracy" (semantic accuracy, ecosystem alignment, symmetry, complete
+  rename sweeps). The `review-pr` skill now checks all of these and reads
+  the convention docs from the PR's base ref.
+
 - **BayesFlow amortized-SBI backend (`[bayesflow]` extra).** New
   `learn_amortized_posterior(prior, simulator, method="npe"|"fmpe"|"cmpe",
   ...)` trains a jax-native (keras-on-JAX) amortized neural posterior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,14 @@ A few conventions keep PRs consistent; the PR template
   `docs(contributing): document PR conventions`. Common types are `feat`,
   `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, and `ci`; the scope is
   the affected subpackage or area.
+- **Description = final state.** The title and body describe the change as
+  it stands, and are updated whenever the scope shifts during review — a
+  stale description is a review blocker. No internal process jargon
+  ("Phase 1b", plan-file references, review-round narration): an outside
+  reader must be able to follow the description on its own. User-visible
+  changes get a CHANGELOG entry, and scratch planning artifacts
+  (`*_plan.md` files, references to local plan directories) never land on
+  the branch.
 - **Labels** — `area:*` labels are auto-applied from the changed paths (see
   [Labels](#labels) below); set `kind:*` / `status:*` by hand, and always add
   `kind:breaking-change` if the PR changes a user-visible API.
@@ -131,6 +139,18 @@ uv run pytest tests/test_foo.py -x -v      # single file, stop on first failure
 can also `source .venv/bin/activate` once per shell and then just type
 `pytest`.
 
+### Test quality
+
+- Correctness tests use the **tightest tolerances that pass reliably** —
+  a loose tolerance is a review flag, not a convenience.
+- Cover structured cases (multi-field Records, mixed scalar/vector
+  parameters), error paths, and **equivalence across dispatch paths**
+  (jax vs sequential) — path divergence has produced real
+  silently-wrong-results bugs.
+- Inference code gets a statistical sanity check (parameter estimates and
+  uncertainty roughly correct on a known target), not just shape
+  assertions.
+
 ### Coverage
 
 ```bash
@@ -204,6 +224,26 @@ layout helps readability there even when the call would fit on one
 line.
 
 This applies equally to source files and notebook code cells.
+
+### Code comments & docstrings
+
+Comments state constraints and contracts the code cannot express — not
+the development process. Match the comment density of the surrounding
+code, and when in doubt, delete: an over-explained obvious line is worse
+than no comment.
+
+- **No process narration.** Never record provenance in code — which PR
+  or plan phase introduced a line, which review comment prompted it
+  ("addressed in review", "previously this was..."). Such comments are
+  noise the moment the PR merges. (Citing an issue that documents a
+  known limitation or a non-obvious rationale is fine — that is a
+  constraint, not history.)
+- **Describe what something *is*, not what it *isn't*.** Negative
+  documentation ("this is not a mixture") usually signals that the name
+  or design needs fixing instead.
+- **Public docstrings describe behavior and usage, not implementation
+  internals.** Internals discussion belongs on private helpers, or
+  nowhere.
 
 ### Linting & pre-commit
 
@@ -279,6 +319,12 @@ uv run mkdocs serve            # local preview
 
 API docs use `mkdocstrings` directives in `docs/api/*.md` referencing
 fully-qualified Python paths.
+
+A behavior or API change and its documentation ship in the **same PR**:
+docstrings, the user-guide notebooks, README / `docs/index.md`, the
+CHANGELOG, and STYLE_GUIDE.md / CONTRIBUTING.md when conventions change.
+Examples and notebooks show idiomatic usage — never add a compat shim to
+keep an example running against an old API.
 
 ### Prefect orchestration
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -242,6 +242,28 @@ WF-output classes (`BroadcastDistribution`, `_RecordMarginal`,
 their bases and aren't directly parametrised; if you add a new such
 class, verify non-iterability via the parent class's contract.
 
+### 1.12 Naming accuracy
+
+Names describe what the object *is*, not its history or one of its
+uses:
+
+- **Semantic accuracy.** A class representing a joint model is not a
+  `*Posterior`; a distribution is not a `*LogDensity`; a helper that
+  imports and returns a module is not adequately described by
+  `_ensure_*` alone. If documenting a class honestly requires saying
+  what it is *not*, rename it.
+- **Ecosystem alignment.** Where numpy/JAX have an established
+  convention (`shape`, `__len__` over the leading axis, `size` as the
+  total element count), follow it rather than inventing a parallel
+  vocabulary.
+- **Symmetry.** Paired APIs get symmetric names — e.g.,
+  `as_flat_distribution` / `as_record_distribution` produce
+  `FlattenedDistributionView` / `NumericRecordDistributionView`.
+- **Rename sweeps are complete.** Renaming a symbol includes every
+  analogous symbol (fixing `_ensure_bayesflow` means fixing
+  `_ensure_cmdstanpy` too), the test files named after the old symbol,
+  and the docs that mention it.
+
 ---
 
 ## 2. Module Granularity


### PR DESCRIPTION
## Summary

Codifies review feedback that has recurred across recent PRs into the convention docs (CONTRIBUTING.md, STYLE_GUIDE.md) and the `review-pr` skill, so the conventions are enforced at review time instead of re-litigated PR by PR. The skill lives in-repo (`.claude/skills/review-pr/`), so it ships here too.

## What's in this PR

### CONTRIBUTING.md

- **New "Code comments & docstrings"** (after *Code formatting*): comments state constraints the code cannot express — never process narration or provenance ("addressed in review", which PR/phase introduced a line); describe what something *is*, not what it *isn't* (negative documentation signals a naming/design problem); public docstrings describe behavior and usage, not implementation internals.
- **New "Test quality"** (after *Running Tests*): correctness tests use the tightest tolerances that pass reliably; cover structured cases (multi-field Records, mixed scalar/vector parameters) and error paths; dispatch-touching changes get a jax-vs-sequential equivalence test; inference code gets a statistical sanity check, not just shape assertions.
- **"Description = final state"** bullet under *Opening the PR*: the title/body track the change as it stands and are updated when scope shifts during review; no internal process jargon; user-visible changes get a CHANGELOG entry; scratch planning artifacts (`*_plan.md`, references to local plan directories) never land on the branch.
- **Docs ship with the change** (under *Documentation*): a behavior/API change and its documentation land in the same PR — docstrings, notebooks, README / `docs/index.md`, CHANGELOG, and the convention docs when conventions change. Examples show idiomatic usage; no compat shims.

### STYLE_GUIDE.md

- **New §1.12 "Naming accuracy"**: names describe what the object *is* (a joint model is not a `*Posterior`); align with numpy/JAX vocabulary (`shape`, `__len__`, `size`); paired APIs get symmetric names; rename sweeps are complete (analogous symbols, test files, docs).

### `review-pr` skill (`.claude/skills/review-pr/SKILL.md`)

- **Step 1a**: read STYLE_GUIDE.md / CONTRIBUTING.md from the **PR's base ref** (`git show origin/main:...`) rather than the local checkout, which can be stale.
- **§2.1**: naming check extended with §1.12 (semantic accuracy, ecosystem alignment, symmetry, rename sweeps); fixed the stale `.n`-property reference to `num_atoms` / `replicate_size`.
- **§2.3**: test-tightness checks (tolerances, structured cases, dispatch-path equivalence).
- **§2.5**: extended AI-artifact patterns — provenance-narrating comments, negative documentation, internals in public docstrings.
- **New §2.8 "PR body and branch hygiene"**: body matches the final diff; no process jargon; CHANGELOG entry + `kind:breaking-change` label where applicable; scratch-file leakage; version pins consistent and reachable by automated bumpers (Dependabot, `pre-commit autoupdate`).

## Linked issue(s)

None — documentation/convention change per the CONTRIBUTING.md small-fix exception.

## Test plan

Docs-only (+ skill markdown): `git diff --check` clean; section anchors verified; no code or CI behavior touched. The mkdocs build does not include these files.

## Breaking changes

None.

## Documentation

- [x] CHANGELOG entry under `[Unreleased]` / `Added`.
- [x] This PR *is* the convention-docs update.

## Notes for reviewers

- The conventions are written to be checkable: each maps to a concrete review-pr skill item, so future reviews flag violations mechanically.
- Examples in the new sections (e.g., `*Posterior` naming, `_ensure_*` helpers, jax-vs-loop divergence) are drawn from patterns that actually came up in past ProbPipe reviews — they are illustrative, not hypothetical.
