### PR TITLE
docs: add citation metadata and a Help page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Citation metadata and a "Cite" / "Help" docs section.** A
+  `CITATION.cff` enables GitHub's "Cite this repository" button; the
+  README gains a "Citing ProbPipe" section with a BibTeX entry; and the
+  docs site adds a [Cite](https://tarps-group.github.io/prob-pipe/cite/)
+  page (software citation + how to cite the inference backends) and a
+  [Help](https://tarps-group.github.io/prob-pipe/help/) page (where to
+  ask questions / file issues). The Zenodo DOI is minted from the first
+  tagged release and is dropped into the BibTeX/CFF once available.
+
 ### Fixed
 
 - **Codecov no longer misreports coverage on targeted PRs (#261).**

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,36 @@
+cff-version: 1.2.0
+message: "If you use ProbPipe in your research, please cite it using the metadata below."
+title: "ProbPipe"
+abstract: "A Python framework for building scalable probabilistic pipelines with automated uncertainty quantification."
+type: software
+authors:
+  - given-names: Jonathan
+    family-names: Huggins
+    email: huggins@bu.edu
+    affiliation: Boston University
+  - given-names: Andrew
+    family-names: Roberts
+    email: arober@bu.edu
+    affiliation: Boston University
+  - given-names: Yongho
+    family-names: Lim
+    email: ylim2@bu.edu
+    affiliation: Boston University
+  - given-names: Can
+    family-names: Erozer
+    email: caner@bu.edu
+    affiliation: Boston University
+  - given-names: Jiaqiang
+    family-names: Zhu
+    email: julian25@bu.edu
+    affiliation: Boston University
+repository-code: "https://github.com/TARPS-group/prob-pipe"
+url: "https://tarps-group.github.io/prob-pipe/"
+license: Apache-2.0
+version: "0.1.0"
+date-released: "2026-06-12"
+# Once Zenodo mints the DOI for the v0.1.0 release, add the *concept* DOI
+# (the version-independent one, which always resolves to the latest release)
+# here. GitHub's "Cite this repository" panel and citation tooling then
+# surface it automatically:
+# doi: "10.5281/zenodo.XXXXXXX"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,5 +29,5 @@ url: "https://tarps-group.github.io/prob-pipe/"
 license: Apache-2.0
 version: "0.1.0"
 date-released: "2026-06-12"
-# Version-independent concept DOI (always resolves to the latest release):
+# Zenodo concept DOI (all versions):
 doi: "10.5281/zenodo.20683559"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,8 +29,5 @@ url: "https://tarps-group.github.io/prob-pipe/"
 license: Apache-2.0
 version: "0.1.0"
 date-released: "2026-06-12"
-# Once Zenodo mints the DOI for the v0.1.0 release, add the *concept* DOI
-# (the version-independent one, which always resolves to the latest release)
-# here. GitHub's "Cite this repository" panel and citation tooling then
-# surface it automatically:
-# doi: "10.5281/zenodo.XXXXXXX"
+# Version-independent concept DOI (always resolves to the latest release):
+doi: "10.5281/zenodo.20683559"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,6 +28,6 @@ repository-code: "https://github.com/TARPS-group/prob-pipe"
 url: "https://tarps-group.github.io/prob-pipe/"
 license: Apache-2.0
 version: "0.1.0"
-date-released: "2026-06-12"
+date-released: "2026-06-13"
 # Zenodo concept DOI (all versions):
 doi: "10.5281/zenodo.20683559"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/TARPS-group/prob-pipe/branch/main/graph/badge.svg)](https://codecov.io/gh/TARPS-group/prob-pipe)
 [![docs](https://img.shields.io/badge/docs-tarps--group.github.io%2Fprob--pipe-blue)](https://tarps-group.github.io/prob-pipe/)
 
-**[Installation Guide](#installation)** | **[Getting Started](https://tarps-group.github.io/prob-pipe/tutorials/getting_started/)** | **[Full Documentation](https://tarps-group.github.io/prob-pipe/)**
+**[Installation Guide](#installation)** | **[Getting Started](https://tarps-group.github.io/prob-pipe/tutorials/getting_started/)** | **[Full Documentation](https://tarps-group.github.io/prob-pipe/)** | **[Help](https://tarps-group.github.io/prob-pipe/help/)**
 
 ProbPipe is a Python framework for building scalable probabilistic pipelines with automated uncertainty quantification.
 
@@ -156,5 +156,28 @@ for setup details, deployment notes, and current support boundaries.
 - For a more detailed overview of ProbPipe, see the **[Getting Started Tutorial](https://tarps-group.github.io/prob-pipe/tutorials/getting_started/)**
 - For all the details of the ProbPipe API, see the **[Reference Documentation](https://tarps-group.github.io/prob-pipe/)**
 - For getting started as a ProbPipe developer, see the **[Contributing Guide](CONTRIBUTING.md)**.
+
+## Citing ProbPipe
+
+If you use ProbPipe in your research, please cite it. The project is archived
+on Zenodo, which provides a version-independent concept DOI:
+
+<!-- Replace XXXXXXX with the Zenodo concept-DOI suffix once the v0.1.0
+     release is processed (then drop this comment). -->
+
+```bibtex
+@software{probpipe,
+  author  = {Huggins, Jonathan and Roberts, Andrew and Lim, Yongho and
+             Erozer, Can and Zhu, Jiaqiang},
+  title   = {{ProbPipe}: Probabilistic pipelines with automated uncertainty quantification},
+  year    = {2026},
+  version = {0.1.0},
+  doi     = {10.5281/zenodo.XXXXXXX},
+  url     = {https://github.com/TARPS-group/prob-pipe}
+}
+```
+
+See the **[citation page](https://tarps-group.github.io/prob-pipe/cite/)** for
+the concept DOI and for how to cite the inference backends ProbPipe builds on.
 
 

--- a/README.md
+++ b/README.md
@@ -160,10 +160,7 @@ for setup details, deployment notes, and current support boundaries.
 
 ## Citing ProbPipe
 
-If you use ProbPipe in your research, please cite it. The project is archived
-on Zenodo under the version-independent concept DOI
-[10.5281/zenodo.20683559](https://doi.org/10.5281/zenodo.20683559), which
-always resolves to the latest release:
+If you use ProbPipe in your research, please cite it:
 
 ```bibtex
 @software{probpipe,
@@ -178,6 +175,6 @@ always resolves to the latest release:
 ```
 
 See the **[citation page](https://tarps-group.github.io/prob-pipe/cite/)** for
-the concept DOI and for how to cite the inference backends ProbPipe builds on.
+version-specific DOIs and how to cite the inference backends ProbPipe builds on.
 
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/TARPS-group/prob-pipe/actions/workflows/ci.yml/badge.svg)](https://github.com/TARPS-group/prob-pipe/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/TARPS-group/prob-pipe/branch/main/graph/badge.svg)](https://codecov.io/gh/TARPS-group/prob-pipe)
 [![docs](https://img.shields.io/badge/docs-tarps--group.github.io%2Fprob--pipe-blue)](https://tarps-group.github.io/prob-pipe/)
+[![DOI](https://zenodo.org/badge/1041525504.svg)](https://doi.org/10.5281/zenodo.20683559)
 
 **[Installation Guide](#installation)** | **[Getting Started](https://tarps-group.github.io/prob-pipe/tutorials/getting_started/)** | **[Full Documentation](https://tarps-group.github.io/prob-pipe/)** | **[Help](https://tarps-group.github.io/prob-pipe/help/)**
 
@@ -160,10 +161,9 @@ for setup details, deployment notes, and current support boundaries.
 ## Citing ProbPipe
 
 If you use ProbPipe in your research, please cite it. The project is archived
-on Zenodo, which provides a version-independent concept DOI:
-
-<!-- Replace XXXXXXX with the Zenodo concept-DOI suffix once the v0.1.0
-     release is processed (then drop this comment). -->
+on Zenodo under the version-independent concept DOI
+[10.5281/zenodo.20683559](https://doi.org/10.5281/zenodo.20683559), which
+always resolves to the latest release:
 
 ```bibtex
 @software{probpipe,
@@ -172,7 +172,7 @@ on Zenodo, which provides a version-independent concept DOI:
   title   = {{ProbPipe}: Probabilistic pipelines with automated uncertainty quantification},
   year    = {2026},
   version = {0.1.0},
-  doi     = {10.5281/zenodo.XXXXXXX},
+  doi     = {10.5281/zenodo.20683559},
   url     = {https://github.com/TARPS-group/prob-pipe}
 }
 ```

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -1,0 +1,52 @@
+# Citing ProbPipe
+
+If you use ProbPipe in your research, we would appreciate a citation.
+
+## Citing the software
+
+ProbPipe is archived on [Zenodo](https://zenodo.org/), which mints a
+version-independent **concept DOI** (always resolving to the latest release)
+alongside a per-version DOI. Cite the concept DOI unless you need to pin a
+specific version.
+
+<!-- Fill in once the v0.1.0 release is processed by Zenodo: replace
+     XXXXXXX with the concept-DOI suffix and remove this comment. -->
+
+```bibtex
+@software{probpipe,
+  author  = {Huggins, Jonathan and Roberts, Andrew and Lim, Yongho and
+             Erozer, Can and Zhu, Jiaqiang},
+  title   = {{ProbPipe}: Probabilistic pipelines with automated uncertainty quantification},
+  year    = {2026},
+  version = {0.1.0},
+  doi     = {10.5281/zenodo.XXXXXXX},
+  url     = {https://github.com/TARPS-group/prob-pipe}
+}
+```
+
+The repository's `CITATION.cff` carries the same metadata, so GitHub's
+**"Cite this repository"** button (top-right of the repo page) produces an
+up-to-date APA or BibTeX entry.
+
+## Citing the inference backends
+
+ProbPipe is an orchestration and conversion layer — the actual inference is
+performed by established libraries. If your results depend on a particular
+backend, please also cite it:
+
+- **BlackJAX** (the default gradient-MCMC backend; NUTS, HMC, SGLD, SGHMC) —
+  see the [BlackJAX citation guidance](https://blackjax-devs.github.io/blackjax/).
+- **nutpie** (NUTS for Stan / PyMC models).
+- **Stan** / **CmdStanPy** / **BridgeStan** (`StanModel` targets).
+- **PyMC** (`PyMCModel` targets; ADVI).
+- **TensorFlow Probability** (distribution implementations and TFP NUTS/HMC).
+- **BayesFlow** (amortized simulation-based inference).
+
+Cite the specific algorithm's paper where one exists (e.g., the NUTS paper
+for NUTS sampling); the backends' own documentation lists the canonical
+references.
+
+## Citing method papers
+
+As ProbPipe-specific methods are published, their references will be listed
+here.

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -4,13 +4,11 @@ If you use ProbPipe in your research, we would appreciate a citation.
 
 ## Citing the software
 
-ProbPipe is archived on [Zenodo](https://zenodo.org/), which mints a
-version-independent **concept DOI** (always resolving to the latest release)
-alongside a per-version DOI. Cite the concept DOI unless you need to pin a
-specific version.
-
-<!-- Fill in once the v0.1.0 release is processed by Zenodo: replace
-     XXXXXXX with the concept-DOI suffix and remove this comment. -->
+ProbPipe is archived on [Zenodo](https://zenodo.org/) under the
+version-independent **concept DOI**
+[10.5281/zenodo.20683559](https://doi.org/10.5281/zenodo.20683559), which
+always resolves to the latest release. Cite the concept DOI unless you need
+to pin a specific version (each release also gets its own version DOI).
 
 ```bibtex
 @software{probpipe,
@@ -19,7 +17,7 @@ specific version.
   title   = {{ProbPipe}: Probabilistic pipelines with automated uncertainty quantification},
   year    = {2026},
   version = {0.1.0},
-  doi     = {10.5281/zenodo.XXXXXXX},
+  doi     = {10.5281/zenodo.20683559},
   url     = {https://github.com/TARPS-group/prob-pipe}
 }
 ```

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,0 +1,27 @@
+# Help & Community
+
+## Questions and bug reports
+
+Open an issue on GitHub:
+[github.com/TARPS-group/prob-pipe/issues](https://github.com/TARPS-group/prob-pipe/issues).
+
+- **Bug?** Use the **Bug report** template — a minimal reproducer plus your
+  ProbPipe, Python, and JAX versions makes it much faster to diagnose.
+- **Feature idea or question?** Use the **Feature request** template, or open
+  a blank issue for an open-ended question.
+
+Questions are welcome as issues — there is no separate forum, and "how do I
+…?" issues help us find gaps in the documentation.
+
+## Contributing
+
+If you would like to contribute, start with the
+[Contributing Guide](https://github.com/TARPS-group/prob-pipe/blob/main/CONTRIBUTING.md),
+which covers the development setup, the PR workflow, and the project's
+coding conventions.
+
+## Contact
+
+ProbPipe is developed by the [TARPS group](https://github.com/TARPS-group)
+at Boston University. For collaboration inquiries that don't fit a GitHub
+issue, contact Jonathan Huggins (huggins@bu.edu).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,3 +111,5 @@ nav:
     - Provenance: api/provenance.md
     - Extending ProbPipe: api/extending.md
     - Internals: api/internals.md
+  - Cite: cite.md
+  - Help: help.md


### PR DESCRIPTION
Adds citation metadata and front-door help docs.

## What's included

- **`CITATION.cff`** — enables GitHub's "Cite this repository" button; authors from `AUTHORS`, version 0.1.0, and the Zenodo concept DOI `10.5281/zenodo.20683559`.
- **README** — a DOI badge in the header, a "Citing ProbPipe" section with a ready-to-use BibTeX entry, and a "Help" link in the header nav row.
- **`docs/cite.md`** — how to cite the software (concept DOI + BibTeX) and how to cite the inference backends ProbPipe builds on (BlackJAX, nutpie, Stan, PyMC, TFP, BayesFlow), since ProbPipe is an orchestration layer over them.
- **`docs/help.md`** — where to ask questions and file issues (pointing at the issue templates), plus the Contributing guide and a contact.
- **`mkdocs.yml`** — `Cite` and `Help` added to the top-level nav.

The DOI is the version-independent **concept DOI**, which always resolves to the latest release; the v0.1.0 release seeds it and each future release gets its own version DOI under the same concept.

## Linked issue

Refs #239.

## Test plan

- `mkdocs build --strict` passes (the new pages render, nav resolves, no broken links).
- `CITATION.cff` validates against CFF schema 1.2.0 (`cffconvert --validate`).
- After merge + docs deploy, the `/cite/` and `/help/` pages and the README "Cite this repository" button should resolve.

## Breaking changes

None — additive docs/metadata only.

## Documentation

- [x] New docs pages (`cite.md`, `help.md`) added to the nav and build clean under `--strict`.
- [x] CHANGELOG entry under `[Unreleased] / ### Added`.

## Checklist

- [x] Title follows `<type>(<scope>): <subject>` — `docs: ...`.
- [x] `area:docs` / `area:infrastructure` auto-labels apply.
- [x] Refs #239.
