### PR TITLE
docs: add a "New to Python?" install fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ask questions / file issues). The Zenodo DOI is minted from the first
   tagged release and is dropped into the BibTeX/CFF once available.
 
+### Changed
+
+- **Install docs: a "New to Python?" two-route fork.** The README and docs
+  landing now split installation into a newcomer path (uv manages Python and
+  the environment — no prior Python needed) and an experienced-user pip path,
+  and note that ProbPipe installs from source (not yet on PyPI). The optional-
+  extras list also gains the previously-missing `bayesflow` extra.
+
 ### Fixed
 
 - **Codecov no longer misreports coverage on targeted PRs (#261).**

--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ Core dependencies: JAX, [BlackJAX](https://blackjax-devs.github.io/blackjax/), a
 Optional extras (append to the `pip install .` / `uv pip install .` above, e.g. `pip install ".[dev]"`):
 
 ```bash
-pip install .[dev]        # pytest, jupyter, matplotlib, graphviz
-pip install .[prefect]    # Prefect orchestration backend
-pip install .[stan]       # Stan models via BridgeStan + CmdStanPy
-pip install .[pymc]       # PyMC model integration
-pip install .[nutpie]     # nutpie Markov chain Monte Carlo (MCMC) sampler
-pip install .[bayesflow]  # BayesFlow amortized simulation-based inference (Python 3.12-3.13)
+pip install ".[dev]"        # pytest, jupyter, matplotlib, graphviz
+pip install ".[prefect]"    # Prefect orchestration backend
+pip install ".[stan]"       # Stan models via BridgeStan + CmdStanPy
+pip install ".[pymc]"       # PyMC model integration
+pip install ".[nutpie]"     # nutpie Markov chain Monte Carlo (MCMC) sampler
+pip install ".[bayesflow]"  # BayesFlow amortized simulation-based inference (Python 3.12-3.13)
 ```
 
 ### Ray via Prefect

--- a/README.md
+++ b/README.md
@@ -109,7 +109,31 @@ plt.xlabel('Temperature (°F)'); plt.ylabel('P(O-ring damage)'); plt.legend()
 
 ## Installation
 
-Requires Python >= 3.12 (tested on 3.12, 3.13, and 3.14).
+Requires Python >= 3.12 (tested on 3.12, 3.13, and 3.14). ProbPipe is not yet
+on PyPI, so installation is from source.
+
+### New to Python?
+
+You do **not** need an existing Python installation. [uv](https://docs.astral.sh/uv/)
+manages both Python and the environment for you. First
+[install uv](https://docs.astral.sh/uv/getting-started/installation/) (on
+macOS/Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh`), then:
+
+```bash
+git clone https://github.com/TARPS-group/prob-pipe.git
+cd prob-pipe
+uv venv                 # create an isolated environment (uv fetches a compatible Python)
+uv pip install .        # install ProbPipe into it
+source .venv/bin/activate   # activate it; now `python` and `probpipe` are available
+```
+
+Then work through the
+**[Getting Started tutorial](https://tarps-group.github.io/prob-pipe/tutorials/getting_started/)**.
+(Prefer not to activate? Prefix commands with `uv run`, e.g. `uv run python`.)
+
+### Already have a Python environment?
+
+Install from source with pip into your active environment:
 
 ```bash
 git clone https://github.com/TARPS-group/prob-pipe.git
@@ -117,18 +141,23 @@ cd prob-pipe
 pip install .
 ```
 
-ProbPipe also installs cleanly with [uv](https://docs.astral.sh/uv/). For a lockfile-managed dev environment, run `uv sync` (see [CONTRIBUTING.md](CONTRIBUTING.md#installation)). To use `uv pip install` in place of the `pip install` examples below, first create and activate an environment with `uv venv && source .venv/bin/activate` — `uv pip` installs into the active (or an explicitly targeted) environment, not a global one.
+uv users can substitute `uv pip install .` (into an active `uv venv`), or
+`uv sync` for a lockfile-managed dev environment — see
+[CONTRIBUTING.md](CONTRIBUTING.md#installation).
+
+### Dependencies and optional extras
 
 Core dependencies: JAX, [BlackJAX](https://blackjax-devs.github.io/blackjax/), and TensorFlow Probability. JAX provides arrays and autodiff; BlackJAX is the default backend for gradient MCMC (`condition_on(model, data)` auto-dispatches to `blackjax_nuts`); TFP supplies the distribution implementations the wrappers in `probpipe.Normal`, `probpipe.Gamma`, etc. delegate to. ProbPipe uses [tfp-nightly](https://pypi.org/project/tfp-nightly/), which is the [recommended approach](https://github.com/tensorflow/probability/issues/1994#issuecomment-3129033043) for TFP on JAX since stable TFP releases are tied to TensorFlow and often lag behind JAX.
 
-Optional extras:
+Optional extras (append to the `pip install .` / `uv pip install .` above, e.g. `pip install ".[dev]"`):
 
 ```bash
-pip install .[dev]       # pytest, jupyter, matplotlib, graphviz
-pip install .[prefect]   # Prefect orchestration backend
-pip install .[stan]      # Stan models via BridgeStan + CmdStanPy
-pip install .[pymc]      # PyMC model integration
-pip install .[nutpie]    # nutpie Markov chain Monte Carlo (MCMC) sampler
+pip install .[dev]        # pytest, jupyter, matplotlib, graphviz
+pip install .[prefect]    # Prefect orchestration backend
+pip install .[stan]       # Stan models via BridgeStan + CmdStanPy
+pip install .[pymc]       # PyMC model integration
+pip install .[nutpie]     # nutpie Markov chain Monte Carlo (MCMC) sampler
+pip install .[bayesflow]  # BayesFlow amortized simulation-based inference (Python 3.12-3.13)
 ```
 
 ### Ray via Prefect

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,12 +69,12 @@ Core dependencies: JAX and TensorFlow Probability. ProbPipe uses [tfp-nightly](h
 Optional extras (append to the `pip install .` / `uv pip install .` above, e.g. `pip install ".[dev]"`):
 
 ```bash
-pip install .[dev]        # pytest, jupyter, matplotlib, graphviz
-pip install .[prefect]    # Prefect orchestration backend
-pip install .[stan]       # Stan models via BridgeStan + CmdStanPy
-pip install .[pymc]       # PyMC model integration
-pip install .[nutpie]     # nutpie Markov chain Monte Carlo (MCMC) sampler
-pip install .[bayesflow]  # BayesFlow amortized simulation-based inference (Python 3.12-3.13)
+pip install ".[dev]"        # pytest, jupyter, matplotlib, graphviz
+pip install ".[prefect]"    # Prefect orchestration backend
+pip install ".[stan]"       # Stan models via BridgeStan + CmdStanPy
+pip install ".[pymc]"       # PyMC model integration
+pip install ".[nutpie]"     # nutpie Markov chain Monte Carlo (MCMC) sampler
+pip install ".[bayesflow]"  # BayesFlow amortized simulation-based inference (Python 3.12-3.13)
 ```
 
 ### Ray via Prefect

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,30 @@ ProbPipe provides a set of built-in **ops**, which are workflow functions that c
 
 ## Installation
 
-ProbPipe requires Python ≥ 3.12 (tested on 3.12, 3.13, and 3.14).
+ProbPipe requires Python ≥ 3.12 (tested on 3.12, 3.13, and 3.14). ProbPipe is
+not yet on PyPI, so installation is from source.
+
+### New to Python?
+
+You do **not** need an existing Python installation. [uv](https://docs.astral.sh/uv/)
+manages both Python and the environment for you. First
+[install uv](https://docs.astral.sh/uv/getting-started/installation/) (on
+macOS/Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh`), then:
+
+```bash
+git clone https://github.com/TARPS-group/prob-pipe.git
+cd prob-pipe
+uv venv                 # create an isolated environment (uv fetches a compatible Python)
+uv pip install .        # install ProbPipe into it
+source .venv/bin/activate   # activate it; now `python` and `probpipe` are available
+```
+
+Then work through the [Getting Started tutorial](tutorials/getting_started.ipynb).
+(Prefer not to activate? Prefix commands with `uv run`, e.g. `uv run python`.)
+
+### Already have a Python environment?
+
+Install from source with pip into your active environment:
 
 ```bash
 git clone https://github.com/TARPS-group/prob-pipe.git
@@ -35,18 +58,23 @@ cd prob-pipe
 pip install .
 ```
 
-ProbPipe also installs cleanly with [uv](https://docs.astral.sh/uv/). For a lockfile-managed dev environment, run `uv sync` (see [CONTRIBUTING.md](https://github.com/TARPS-group/prob-pipe/blob/main/CONTRIBUTING.md#installation)). To use `uv pip install` in place of the `pip install` examples below, first create and activate an environment with `uv venv && source .venv/bin/activate` — `uv pip` installs into the active (or an explicitly targeted) environment, not a global one.
+uv users can substitute `uv pip install .` (into an active `uv venv`), or
+`uv sync` for a lockfile-managed dev environment (see
+[CONTRIBUTING.md](https://github.com/TARPS-group/prob-pipe/blob/main/CONTRIBUTING.md#installation)).
+
+### Dependencies and optional extras
 
 Core dependencies: JAX and TensorFlow Probability. ProbPipe uses [tfp-nightly](https://pypi.org/project/tfp-nightly/), which is the [recommended approach](https://github.com/tensorflow/probability/issues/1994#issuecomment-3129033043) for TFP on JAX since stable TFP releases are tied to TensorFlow and often lag behind JAX.
 
-Optional extras:
+Optional extras (append to the `pip install .` / `uv pip install .` above, e.g. `pip install ".[dev]"`):
 
 ```bash
-pip install .[dev]       # pytest, jupyter, matplotlib, graphviz
-pip install .[prefect]   # Prefect orchestration backend
-pip install .[stan]      # Stan models via BridgeStan + CmdStanPy
-pip install .[pymc]      # PyMC model integration
-pip install .[nutpie]    # nutpie Markov chain Monte Carlo (MCMC) sampler
+pip install .[dev]        # pytest, jupyter, matplotlib, graphviz
+pip install .[prefect]    # Prefect orchestration backend
+pip install .[stan]       # Stan models via BridgeStan + CmdStanPy
+pip install .[pymc]       # PyMC model integration
+pip install .[nutpie]     # nutpie Markov chain Monte Carlo (MCMC) sampler
+pip install .[bayesflow]  # BayesFlow amortized simulation-based inference (Python 3.12-3.13)
 ```
 
 ### Ray via Prefect


### PR DESCRIPTION
Splits the installation instructions into two routes, so a domain scientist without a Python setup has a clear path that doesn't assume an existing environment.

## What changed (README + docs landing)

- **New to Python?** — uv manages both Python *and* the environment, so no prior Python install is required: install uv → clone → `uv venv` → `uv pip install .` → activate → Getting Started tutorial.
- **Already have a Python environment?** — install from source with pip (with the uv `uv pip install .` / `uv sync` variants noted).
- Both routes note that **ProbPipe installs from source** (not yet on PyPI).
- The optional-extras list gains the previously-**missing `bayesflow` extra** (Python 3.12–3.13).

The same fork is mirrored in `README.md` and `docs/index.md` so the GitHub landing and the docs site agree.

## Linked issue

Refs #239.

## Test plan

- `mkdocs build --strict` passes (docs landing renders, nav/links resolve).
- Both install routes use only `git clone` + `uv`/`pip` from source, matching the current (pre-PyPI) reality.

## Breaking changes

None — docs only.

## Documentation

- [x] CHANGELOG entry under `[Unreleased] / ### Changed`.

## Checklist

- [x] Title `<type>(<scope>): <subject>` — `docs: ...`.
- [x] `area:docs` auto-label applies.
- [x] Refs #239.

## Note

When ProbPipe ships to PyPI (0.2.0), the "from source / clone" framing in both routes should be simplified to `pip install probpipe` / `uv pip install probpipe`.
