### PR TITLE
docs(tutorials): consistent float dtype for the moose data array

### DIFF
--- a/docs/tutorials/flexible_inference.ipynb
+++ b/docs/tutorials/flexible_inference.ipynb
@@ -1026,7 +1026,7 @@
    "source": [
     "# Annual moose counts, 1967-1988 (gap-free window of the `alcesdata` census).\n",
     "moose = jnp.array([33, 49, 68, 54, 101, 109, 102, 114, 143, 171, 198, 209,\n",
-    "                   178, 170, 198, 272, 258, 247, 212, 296, 259, 279.0])\n",
+    "                   178, 170, 198, 272, 258, 247, 212, 296, 259, 279], dtype=jnp.float32)\n",
     "moose_years = np.arange(1967, 1989)\n",
     "moose_ricker = RickerObservationModel(T=moose.size, N0=50.0, sigma_p=0.1)\n",
     "\n",


### PR DESCRIPTION
## Summary

The moose census array in §6 of the flexible-inference tutorial was written as all integer literals except a lone `279.0`:

```python
moose = jnp.array([33, 49, 68, 54, 101, ..., 259, 279.0])
```

That single float forces the whole array to `float32` (a common one-element trick), but it reads as a typo. This makes the intent explicit and the literals consistent:

```python
moose = jnp.array([33, 49, 68, 54, 101, ..., 259, 279],
                  dtype=jnp.float32)
```

Same `float32` dtype as before, so **no behavior change** — just a cleaner, non-surprising literal.

## Test plan

- One-token source change; cell outputs preserved (verified the diff is a single line and `realdata-fit`'s stored outputs are intact).
- `mkdocs build --strict` passes.

## Breaking changes

None — docs only; dtype unchanged.

## Checklist

- [x] Title `<type>(<scope>): <subject>` — `docs(tutorials): ...`.
- [x] `area:docs` auto-label applies.
- [x] Small standalone fix — no linked issue (per CONTRIBUTING).
