### PR TITLE
docs(tutorials): add "Open in Colab" badges and guarded setup cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ask questions / file issues). The Zenodo DOI is minted from the first
   tagged release and is dropped into the BibTeX/CFF once available.
 
+- **"Open in Colab" badges on the tutorials.** Both tutorial notebooks
+  (Getting Started, Flexible Inference) gain an "Open in Colab" badge and a
+  guarded setup cell that, *only when run on Colab*, installs ProbPipe with
+  the extras the notebook uses (and, for Getting Started, fetches the
+  dataset). The cell is a no-op in local Jupyter, the docs build, and CI, so
+  notebook execution elsewhere is unaffected.
+
 ### Changed
 
 - **Install docs: a "New to Python?" two-route fork.** The README and docs

--- a/docs/tutorials/flexible_inference.ipynb
+++ b/docs/tutorials/flexible_inference.ipynb
@@ -23,6 +23,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "aa22edf6",
+   "source": "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/TARPS-group/prob-pipe/blob/main/docs/tutorials/flexible_inference.ipynb)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "916d7069",
+   "source": "# Colab setup — installs ProbPipe with the neural-SBI extra. Runs only on Google\n# Colab; on local Jupyter, the docs build, and CI this block is skipped, so it\n# never affects execution elsewhere.\ntry:\n    import google.colab  # noqa: F401\n    _IN_COLAB = True\nexcept ImportError:\n    _IN_COLAB = False\n\nif _IN_COLAB:\n    import subprocess, sys\n\n    subprocess.run(\n        [sys.executable, \"-m\", \"pip\", \"install\",\n         \"probpipe[viz,bayesflow] @ git+https://github.com/TARPS-group/prob-pipe@main\"],\n        check=True,\n    )",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "imports",
@@ -1176,13 +1190,13 @@
        "description": "",
        "description_allow_html": false,
        "layout": "IPY_MODEL_7b78052f797b453abee27a07369d0c2c",
-       "max": 1.0,
-       "min": 0.0,
+       "max": 1,
+       "min": 0,
        "orientation": "horizontal",
        "style": "IPY_MODEL_93ab68cfec5a4b1e96d104fffdb20582",
        "tabbable": null,
        "tooltip": null,
-       "value": 1.0
+       "value": 1
       }
      },
      "06d573d59ca44f4eba2f4ffe4b9e1740": {
@@ -1527,13 +1541,13 @@
        "description": "",
        "description_allow_html": false,
        "layout": "IPY_MODEL_8a143a7cd9514245ae08c05e8be348f8",
-       "max": 1.0,
-       "min": 0.0,
+       "max": 1,
+       "min": 0,
        "orientation": "horizontal",
        "style": "IPY_MODEL_d9e343fdbf8340d8a6b966b65ce53c21",
        "tabbable": null,
        "tooltip": null,
-       "value": 1.0
+       "value": 1
       }
      },
      "35e33c77e2834a4fa0187329079bb282": {
@@ -1734,13 +1748,13 @@
        "description": "",
        "description_allow_html": false,
        "layout": "IPY_MODEL_e13f5257cfc14fbbb1207f0e944dd4a4",
-       "max": 1.0,
-       "min": 0.0,
+       "max": 1,
+       "min": 0,
        "orientation": "horizontal",
        "style": "IPY_MODEL_56e490a1620e451bb6edc7779add2642",
        "tabbable": null,
        "tooltip": null,
-       "value": 1.0
+       "value": 1
       }
      },
      "7b78052f797b453abee27a07369d0c2c": {

--- a/docs/tutorials/flexible_inference.ipynb
+++ b/docs/tutorials/flexible_inference.ipynb
@@ -2,6 +2,12 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "513fac8d",
+   "source": "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/TARPS-group/prob-pipe/blob/main/docs/tutorials/flexible_inference.ipynb)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "intro",
    "metadata": {},
    "source": [
@@ -21,12 +27,6 @@
     "\n",
     "> **Prerequisites:** [Getting Started tutorial](getting_started.ipynb). The neural SBI engines (NPE/NLE/NRE) require `pip install probpipe[bayesflow]`; SMC-ABC requires the `pyabc` backend (a later release)."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "aa22edf6",
-   "source": "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/TARPS-group/prob-pipe/blob/main/docs/tutorials/flexible_inference.ipynb)",
-   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -29,6 +29,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e2a947ad",
+   "source": "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/TARPS-group/prob-pipe/blob/main/docs/tutorials/getting_started.ipynb)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "e10b00e6",
+   "source": "# Colab setup — installs ProbPipe (plus the extras this tutorial uses) and\n# fetches the dataset. Runs only on Google Colab; on local Jupyter, the docs\n# build, and CI this block is skipped, so it never affects execution elsewhere.\ntry:\n    import google.colab  # noqa: F401\n    _IN_COLAB = True\nexcept ImportError:\n    _IN_COLAB = False\n\nif _IN_COLAB:\n    import os, subprocess, sys, urllib.request\n\n    subprocess.run(\n        [sys.executable, \"-m\", \"pip\", \"install\",\n         \"probpipe[viz,pymc,nutpie] @ git+https://github.com/TARPS-group/prob-pipe@main\"],\n        check=True,\n    )\n    os.makedirs(\"data\", exist_ok=True)\n    urllib.request.urlretrieve(\n        \"https://raw.githubusercontent.com/TARPS-group/prob-pipe/main/\"\n        \"docs/tutorials/data/horseshoe_crabs.csv\",\n        \"data/horseshoe_crabs.csv\",\n    )",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "9fe1dab1",
    "metadata": {},
    "source": [

--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -2,6 +2,12 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "e29e12e4",
+   "source": "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/TARPS-group/prob-pipe/blob/main/docs/tutorials/getting_started.ipynb)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "85f9fb83",
    "metadata": {},
    "source": [
@@ -26,12 +32,6 @@
     "\n",
     "The benefits of ProbPipe are nicely illustrated when you need to revise an analysis pipeline many times. Applied Bayesian analysis is iterative: start simple, check the model against data, revise, and repeat (see [Gelman et al. 2020, *Bayesian Workflow*](https://arxiv.org/abs/2011.01808)). Each iteration follows the same steps: prior predictive check, fit, computational diagnostics, posterior predictive check, then decide what to change and repeat as needed. Across iterations you may need to try different likelihood models, swap inference algorithms, or feed posteriors into downstream predictions. This tutorial walks through an example of this process where the obvious first model fails its posterior predictive checks and we revise it. Later sections present tools you might need on more challenging problems."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e2a947ad",
-   "source": "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/TARPS-group/prob-pipe/blob/main/docs/tutorials/getting_started.ipynb)",
-   "metadata": {}
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Both tutorial notebooks now carry an **"Open in Colab"** badge and a guarded
setup cell, so a reader can open either tutorial in Colab and run it end to end
without a local install.

- **Badge** (markdown cell at the very top, above the title) links to the
  notebook on Colab via GitHub (`main`).
- **Setup cell** (code, right after the badge) installs ProbPipe with the
  extras the notebook uses and, for Getting Started, fetches the dataset.

The setup cell runs **only on Colab** — it probes for `google.colab` and skips
the install/fetch otherwise — so local Jupyter, the docs build, and the CI
notebook-execution job are unaffected.

| Notebook | Colab install | Data fetch |
|---|---|---|
| Getting Started | `probpipe[viz,pymc,nutpie]` | `horseshoe_crabs.csv` |
| Flexible Inference | `probpipe[viz,bayesflow]` | none (moose series is inline) |

## Test plan

- `mkdocs build --strict` passes (notebooks render from stored outputs;
  `execute: false`).
- Guard verified a no-op off Colab: `import google.colab` raises `ImportError`
  locally, so the install/fetch block is skipped.
- Diffs are additive — two new cells per notebook; no existing cell or its
  stored outputs were modified. (The only other change is a benign
  re-serialization of the embedded ipywidgets progress-bar state, `1.0` → `1`.)
- Inserted code follows the notebooks' existing packed-import idiom; the
  `google.colab` probe carries `# noqa: F401`.

## Notes

Binder is intentionally deferred — Colab needs no extra repo configuration,
whereas Binder would require an environment spec and adds little for these two
notebooks right now.

Refs #239.

## Checklist

- [x] Title `<type>(<scope>): <subject>` — `docs(tutorials): ...`.
- [x] `area:docs` auto-label applies (docs-only paths).
- [x] CHANGELOG updated under [Unreleased] → Added.
