### PR TITLE
fix(modeling): preserve named record fields across IncrementalConditioner batches

### DIFF
--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -798,21 +798,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "n=80: mean = NumericRecord(posterior=array(shape=(2,)))\n"
+      "n=80: mean = NumericRecord(intercept=Array(0.6788004, dtype=float32), slope=Array(0.86441153, dtype=float32))\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "n=130: mean = NumericRecord(posterior=array(shape=(2,)))\n"
+      "n=130: mean = NumericRecord(intercept=Array(0.51428884, dtype=float32), slope=Array(0.9303026, dtype=float32))\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "n=172: mean = NumericRecord(posterior=array(shape=(2,)))\n",
+      "n=172: mean = NumericRecord(intercept=Array(0.53039783, dtype=float32), slope=Array(0.88493264, dtype=float32))\n",
       "\n",
       "Full-data posterior mean: NumericRecord(intercept=Array(0.55128115, dtype=float32), slope=Array(0.89175206, dtype=float32))\n"
      ]

--- a/probpipe/converters/_probpipe.py
+++ b/probpipe/converters/_probpipe.py
@@ -447,12 +447,12 @@ def _convert_to_empirical(source, key, **kw):
 def _convert_to_kde(source, key, **kw):
     """Convert any distribution to a KDEDistribution.
 
-    For a ``RecordEmpiricalDistribution`` source the stored samples
-    and weights are reused directly: single-field empiricals pass the
-    field's stacked array straight to KDE; multi-field empiricals
-    pass ``source.flat_samples`` (the ``(n, total_dim)`` flat-matrix
-    view) so KDE sees one row per sample with all parameters
-    concatenated. Other sources fall back to drawing fresh samples.
+    For a ``RecordEmpiricalDistribution`` source (including its
+    subclasses such as :class:`~probpipe.inference.ApproximateDistribution`),
+    the stored samples, weights, and ``record_template`` are reused
+    directly via :meth:`KDEDistribution.from_empirical` — which
+    preserves named-field structure end-to-end. Other sources fall
+    back to drawing fresh samples (single-field auto-template).
 
     Raises
     ------
@@ -471,17 +471,10 @@ def _convert_to_kde(source, key, **kw):
     name = kw.get("name") or source.name
 
     if isinstance(source, RecordEmpiricalDistribution):
-        # Single-field: pass the field array directly so KDE keeps the
-        # original event shape. Multi-field: collapse to the
-        # ``(n, total_dim)`` flat-matrix view.
-        if len(source.samples.fields) == 1:
-            field = source.samples.fields[0]
-            arr = source.samples[field]
-        else:
-            arr = source.flat_samples
-        r = KDEDistribution(
-            arr, weights=source._w, bandwidth=bandwidth, name=name,
-        )
+        # Single-field and multi-field paths both route through
+        # ``from_empirical``, which threads the source's
+        # ``record_template`` so KDE preserves named fields (issue #267).
+        r = KDEDistribution.from_empirical(source, bandwidth=bandwidth, name=name)
         r.with_source(_mm_provenance(source))
         return r
 

--- a/probpipe/distributions/kde.py
+++ b/probpipe/distributions/kde.py
@@ -9,14 +9,24 @@ that supports density evaluation.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
-from ._tfp_base import TFPDistribution
 from .._dtype import _as_float_array
-from ..core.constraints import Constraint, real
-from ..custom_types import ArrayLike
 from .._weights import Weights
+from ..core._empirical import RecordEmpiricalDistribution
+from ..core._numeric_record import NumericRecord
+from ..core._numeric_record_distribution import NumericRecordDistribution
+from ..core._record_array import NumericRecordArray
+from ..core.constraints import Constraint, real
+from ..core.record import NumericRecordTemplate, Record
+from ..custom_types import Array, ArrayLike
+from ._tfp_base import TFPDistribution
+
+if TYPE_CHECKING:
+    from ..core.record import RecordTemplate
 
 __all__ = ["KDEDistribution"]
 
@@ -44,6 +54,16 @@ class KDEDistribution(TFPDistribution):
         Per-dimension bandwidth (standard deviation of each Gaussian
         kernel), shape ``(d,)`` or scalar.  If ``None``, Silverman's
         rule is used: ``n^{-1/(d+4)} * std_j`` for each dimension *j*.
+    record_template : RecordTemplate or None
+        Structural template for the KDE's value type. When ``None`` (the
+        default) a single-field template keyed by ``name`` is auto-built,
+        matching the historical behavior. When supplied with multiple
+        fields, the template defines how the flat ``(n, d)`` sample matrix
+        maps back to a structured ``NumericRecord`` / ``NumericRecordArray``
+        — preserving named fields end-to-end across e.g. an MCMC posterior
+        being routed through KDE as the new prior in
+        :class:`~probpipe.modeling.IncrementalConditioner`. The template's
+        ``flat_size`` must equal ``samples.shape[1]``.
     name : str or None
         Distribution name for provenance.
     """
@@ -55,6 +75,7 @@ class KDEDistribution(TFPDistribution):
         *,
         log_weights: ArrayLike | Weights | None = None,
         bandwidth: ArrayLike | None = None,
+        record_template: "RecordTemplate | None" = None,
         name: str | None = None,
     ):
         samples = _as_float_array(samples)
@@ -71,6 +92,28 @@ class KDEDistribution(TFPDistribution):
         self._d = d
         if name is None:
             name = "kde"
+
+        # Multi-field template support: when the caller supplies a template
+        # with more than one field, preset ``_record_template`` so that
+        # ``NumericRecordDistribution.record_template`` (parent) skips its
+        # single-field auto-build keyed by ``name``. Validate that the
+        # template's flat width matches the samples' trailing dimension.
+        if record_template is not None and len(record_template.fields) > 1:
+            if isinstance(record_template, NumericRecordTemplate):
+                expected = record_template.flat_size
+            else:
+                expected = sum(
+                    int(jnp.prod(jnp.array(shape))) if shape else 1
+                    for shape in record_template.leaf_shapes.values()
+                )
+            if expected != d:
+                raise ValueError(
+                    f"record_template flat_size ({expected}) does not match "
+                    f"samples flat dimension ({d}); template fields="
+                    f"{record_template.fields}"
+                )
+            object.__setattr__(self, "_record_template", record_template)
+
         super().__init__(name=name)
 
         # Weights
@@ -117,6 +160,73 @@ class KDEDistribution(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return real
+
+    # -- sampling & density (template-aware overrides) ------------------------
+    #
+    # When ``_record_template`` is multi-field, sample output is unflattened
+    # back into ``NumericRecord`` / ``NumericRecordArray`` keyed by the
+    # template, and log_prob accepts both structured and flat inputs. Single-
+    # field auto-templates fall through to the TFP base class behaviour, so
+    # existing call sites are unchanged.
+
+    def _sample(self, key: Any, sample_shape: tuple[int, ...] = ()) -> Any:
+        flat = self._tfp_dist.sample(seed=key, sample_shape=sample_shape)
+        tpl = getattr(self, "_record_template", None)
+        if tpl is None or len(tpl.fields) <= 1:
+            return flat
+        return NumericRecordDistribution.unflatten_value(flat, template=tpl)
+
+    def _log_prob(self, value: Any) -> Array:
+        tpl = getattr(self, "_record_template", None)
+        if tpl is not None and len(tpl.fields) > 1:
+            if isinstance(value, (Record, NumericRecord, NumericRecordArray)):
+                value = NumericRecordDistribution.flatten_value(value)
+        return self._tfp_dist.log_prob(jnp.asarray(value))
+
+    # -- factories ------------------------------------------------------------
+
+    @classmethod
+    def from_empirical(
+        cls,
+        source: Any,
+        *,
+        bandwidth: ArrayLike | None = None,
+        name: str | None = None,
+    ) -> "KDEDistribution":
+        """Build a KDE from a :class:`RecordEmpiricalDistribution` source.
+
+        Reuses the source's stored samples, weights, and record template,
+        so the resulting KDE preserves the source's named-field structure
+        end-to-end. Works for any subclass (notably
+        :class:`~probpipe.inference.ApproximateDistribution`).
+
+        Parameters
+        ----------
+        source : RecordEmpiricalDistribution
+            Empirical or approximate distribution with stored samples.
+        bandwidth : array-like or None
+            Per-dimension bandwidth (see :class:`KDEDistribution`).
+        name : str or None
+            Distribution name; defaults to ``source.name``.
+        """
+        if not isinstance(source, RecordEmpiricalDistribution):
+            raise TypeError(
+                f"from_empirical requires a RecordEmpiricalDistribution "
+                f"(or subclass); got {type(source).__name__}"
+            )
+        name = name or source.name
+        tpl = source.record_template
+        if len(tpl.fields) == 1:
+            field = tpl.fields[0]
+            arr = source.samples[field]
+            return cls(arr, weights=source._w, bandwidth=bandwidth, name=name)
+        return cls(
+            source.flat_samples,
+            weights=source._w,
+            bandwidth=bandwidth,
+            record_template=tpl,
+            name=name,
+        )
 
     def __repr__(self) -> str:
         return (

--- a/tests/converters/test_converters.py
+++ b/tests/converters/test_converters.py
@@ -790,6 +790,51 @@ class TestProtocolConversion:
         assert result.source is not None
         assert emp in result.source.parents
 
+    def test_multi_field_empirical_preserves_template_through_kde(self):
+        """Multi-field RecordEmpirical → KDE preserves the named template
+        (issue #267). Regression: previously the converter passed
+        ``flat_samples`` to KDE without the template, so the resulting
+        KDE collapsed to a single-field auto-template keyed by ``name``.
+        """
+        from probpipe import Record
+        from probpipe.distributions.kde import KDEDistribution
+
+        n = 200
+        rec = Record(
+            intercept=jax.random.normal(jax.random.PRNGKey(0), (n,)),
+            slope=jax.random.normal(jax.random.PRNGKey(1), (n,)),
+        )
+        emp = RecordEmpiricalDistribution(rec)
+        result = converter_registry.convert(emp, SupportsLogProb)
+        assert isinstance(result, KDEDistribution)
+        assert result.record_template.fields == ("intercept", "slope")
+
+    def test_approximate_distribution_preserves_template_through_kde(self):
+        """``ApproximateDistribution`` (inherits from RecordEmpirical) →
+        KDE must preserve the parameter-field structure so that
+        :class:`IncrementalConditioner` updates beyond batch 1 don't
+        collapse to a flat ``posterior`` field (issue #267).
+        """
+        from probpipe.core.record import NumericRecordTemplate
+        from probpipe.distributions.kde import KDEDistribution
+        from probpipe.inference._approximate_distribution import (
+            ApproximateDistribution,
+        )
+
+        n_draws = 100
+        chain_intercept = jax.random.normal(jax.random.PRNGKey(0), (n_draws,))
+        chain_slope = jax.random.normal(jax.random.PRNGKey(1), (n_draws,))
+        # Stack into per-chain (num_draws, total_dim) layout
+        chains = [jnp.stack([chain_intercept, chain_slope], axis=-1)]
+        approx = ApproximateDistribution(
+            chains,
+            name="posterior",
+            record_template=NumericRecordTemplate(intercept=(), slope=()),
+        )
+        result = converter_registry.convert(approx, SupportsLogProb)
+        assert isinstance(result, KDEDistribution)
+        assert result.record_template.fields == ("intercept", "slope")
+
 
 # ---------------------------------------------------------------------------
 # KDEDistribution

--- a/tests/distributions/test_kde.py
+++ b/tests/distributions/test_kde.py
@@ -1,0 +1,193 @@
+"""Tests for KDEDistribution's template-aware sampling and log-density.
+
+The single-field auto-template path is exercised throughout the
+converter tests in ``tests/converters/test_converters.py``; this file
+focuses on the multi-field ``record_template=`` constructor parameter
+(issue #267) and the :meth:`KDEDistribution.from_empirical` factory.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import (
+    EmpiricalDistribution,
+    NumericRecord,
+    NumericRecordTemplate,
+    Record,
+    RecordTemplate,
+)
+from probpipe.core._empirical import RecordEmpiricalDistribution
+from probpipe.core._numeric_record import NumericRecord as _NumericRecord
+from probpipe.core._record_array import NumericRecordArray
+from probpipe.distributions.kde import KDEDistribution
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def two_field_template():
+    return RecordTemplate(intercept=(), slope=())
+
+
+@pytest.fixture
+def flat_samples():
+    rng = np.random.RandomState(0)
+    return jnp.asarray(rng.randn(200, 2).astype("float32"))
+
+
+# ---------------------------------------------------------------------------
+# Constructor + validation
+# ---------------------------------------------------------------------------
+
+class TestRecordTemplateConstructor:
+    def test_multi_field_template_preserved(self, two_field_template, flat_samples):
+        kde = KDEDistribution(
+            flat_samples, record_template=two_field_template, name="post",
+        )
+        assert kde.record_template is two_field_template
+        assert kde.record_template.fields == ("intercept", "slope")
+
+    def test_mismatched_flat_size_raises(self, flat_samples):
+        bad_tpl = RecordTemplate(a=(), b=(), c=())  # flat_size=3, samples flat dim=2
+        with pytest.raises(ValueError, match="flat_size"):
+            KDEDistribution(flat_samples, record_template=bad_tpl, name="bad")
+
+    def test_single_field_template_unchanged(self, flat_samples):
+        """A single-field template falls through to the auto-build path
+        (the existing single-field behaviour is the baseline)."""
+        single = RecordTemplate(theta=(2,))
+        kde = KDEDistribution(
+            flat_samples, record_template=single, name="post",
+        )
+        # Single-field template still gets stored — but the special-case
+        # multi-field path isn't taken.
+        assert kde.record_template is not None
+
+    def test_no_template_keeps_auto_build(self, flat_samples):
+        """Without record_template= the auto-build keyed by name still
+        fires — backward compatible with every existing call site."""
+        kde = KDEDistribution(flat_samples, name="kde")
+        assert kde.record_template.fields == ("kde",)
+
+
+# ---------------------------------------------------------------------------
+# _sample round-trip
+# ---------------------------------------------------------------------------
+
+class TestSampleRoundTrip:
+    def test_sample_scalar_returns_numeric_record(self, two_field_template, flat_samples):
+        kde = KDEDistribution(
+            flat_samples, record_template=two_field_template, name="post",
+        )
+        s = kde._sample(jax.random.PRNGKey(0), ())
+        assert isinstance(s, _NumericRecord)
+        assert s.fields == ("intercept", "slope")
+
+    def test_sample_batched_returns_record_array(self, two_field_template, flat_samples):
+        kde = KDEDistribution(
+            flat_samples, record_template=two_field_template, name="post",
+        )
+        s = kde._sample(jax.random.PRNGKey(1), (8,))
+        assert isinstance(s, NumericRecordArray)
+        assert s.batch_shape == (8,)
+        assert s.fields == ("intercept", "slope")
+
+    def test_sample_no_template_returns_raw_array(self, flat_samples):
+        """With auto-build single-field template the sample stays a raw
+        array (existing TFP-base behaviour)."""
+        kde = KDEDistribution(flat_samples, name="post")
+        s = kde._sample(jax.random.PRNGKey(2), (4,))
+        assert isinstance(s, jnp.ndarray)
+        assert s.shape == (4, 2)
+
+
+# ---------------------------------------------------------------------------
+# _log_prob dual input
+# ---------------------------------------------------------------------------
+
+class TestLogProbDualInput:
+    def test_structured_and_flat_inputs_agree(self, two_field_template, flat_samples):
+        kde = KDEDistribution(
+            flat_samples, record_template=two_field_template, name="post",
+        )
+        nr = NumericRecord(intercept=jnp.array(0.5), slope=jnp.array(-0.3))
+        lp_struct = kde._log_prob(nr)
+        lp_flat = kde._log_prob(jnp.array([0.5, -0.3]))
+        assert jnp.allclose(lp_struct, lp_flat)
+
+    def test_record_accepted(self, two_field_template, flat_samples):
+        """Plain Record (not NumericRecord) also accepted."""
+        kde = KDEDistribution(
+            flat_samples, record_template=two_field_template, name="post",
+        )
+        rec = Record(intercept=jnp.array(0.5), slope=jnp.array(-0.3))
+        lp = kde._log_prob(rec)
+        assert jnp.isfinite(lp)
+
+    def test_batched_record_array(self, two_field_template, flat_samples):
+        """A NumericRecordArray input is flattened to (batch, d) and the
+        TFP mixture log-prob returns a (batch,) array."""
+        kde = KDEDistribution(
+            flat_samples, record_template=two_field_template, name="post",
+        )
+        # Build a 3-row NumericRecordArray
+        nra = NumericRecordArray(
+            {"intercept": jnp.array([0.5, 0.6, 0.7]),
+             "slope": jnp.array([-0.3, -0.4, -0.5])},
+            batch_shape=(3,),
+            template=NumericRecordTemplate(intercept=(), slope=()),
+        )
+        lp = kde._log_prob(nra)
+        assert lp.shape == (3,)
+        # Matches the flat form
+        lp_flat = kde._log_prob(jnp.stack([
+            jnp.array([0.5, -0.3]),
+            jnp.array([0.6, -0.4]),
+            jnp.array([0.7, -0.5]),
+        ]))
+        assert jnp.allclose(lp, lp_flat)
+
+
+# ---------------------------------------------------------------------------
+# from_empirical factory
+# ---------------------------------------------------------------------------
+
+class TestFromEmpirical:
+    def test_multi_field_record_empirical(self, two_field_template):
+        n = 200
+        rec = Record(
+            intercept=jax.random.normal(jax.random.PRNGKey(0), (n,)),
+            slope=jax.random.normal(jax.random.PRNGKey(1), (n,)),
+        )
+        emp = RecordEmpiricalDistribution(rec)
+        kde = KDEDistribution.from_empirical(emp, name="post")
+        assert isinstance(kde, KDEDistribution)
+        # Template preserved
+        assert kde.record_template.fields == ("intercept", "slope")
+        # Samples come back structured
+        s = kde._sample(jax.random.PRNGKey(2), ())
+        assert isinstance(s, _NumericRecord)
+        assert s.fields == ("intercept", "slope")
+
+    def test_single_field_record_empirical(self):
+        """Single-field empirical → single-field KDE (no multi-field
+        template threading)."""
+        samples = jax.random.normal(jax.random.PRNGKey(0), (200, 3))
+        emp = RecordEmpiricalDistribution(samples, name="theta")
+        kde = KDEDistribution.from_empirical(emp)
+        assert isinstance(kde, KDEDistribution)
+        # Single-field template
+        assert kde.record_template.fields == ("theta",)
+
+    def test_rejects_non_record_empirical(self):
+        """Generic (object-array) EmpiricalDistribution is rejected."""
+        emp_generic = EmpiricalDistribution(
+            np.array([{"a": 1}, {"a": 2}], dtype=object), name="x",
+        )
+        with pytest.raises(TypeError, match="RecordEmpiricalDistribution"):
+            KDEDistribution.from_empirical(emp_generic)

--- a/tests/modeling/test_modeling.py
+++ b/tests/modeling/test_modeling.py
@@ -201,3 +201,37 @@ class TestIncrementalConditioner:
         assert isinstance(post, EmpiricalDistribution)
         # Internal state unchanged because we bypassed update().
         assert conditioner.curr_posterior is prior
+
+    def test_multi_batch_preserves_named_record_fields(self):
+        """Multi-batch IncrementalConditioner over a named ProductDistribution
+        prior preserves field names on every batch (issue #267).
+
+        Previously batches 2+ collapsed to a single unnamed ``posterior``
+        field of shape ``(d,)`` because the samples→KDE conversion at the
+        start of each subsequent step dropped the ``record_template``.
+        """
+        import tensorflow_probability.substrates.jax.glm as tfp_glm
+
+        from probpipe import (
+            GLMLikelihood,
+            Normal,
+            ProductDistribution,
+            mean,
+        )
+
+        rng = np.random.RandomState(0)
+        X = rng.randn(120).astype("float32")
+        y = rng.poisson(np.exp(0.3 + 0.5 * X)).astype("float32")
+
+        prior = ProductDistribution(
+            Normal(0.0, np.sqrt(5.0), name="intercept"),
+            Normal(0.0, np.sqrt(5.0), name="slope"),
+        )
+        cond = IncrementalConditioner(prior, GLMLikelihood(tfp_glm.NegativeBinomial()))
+        for s, e in [(0, 40), (40, 80), (80, 120)]:
+            cond.update(X=X[s:e], y=y[s:e])
+            posterior_mean = mean(cond.curr_posterior)
+            assert posterior_mean.fields == ("intercept", "slope"), (
+                f"named fields lost after batch ending at {e}: "
+                f"got {posterior_mean.fields}"
+            )


### PR DESCRIPTION
## Summary

`IncrementalConditioner` lost the named parameter fields after the first batch when the parameter space is a record (e.g. a `ProductDistribution` of named `Normal`s). The first `update` returned a posterior keyed by the prior's fields; every subsequent `update` collapsed to a single unnamed `posterior` field of shape `(d,)`. The draws were still numerically correct, but the named structure that downstream code, plotting, and `mean(...)["intercept"]` rely on was gone.

Root cause: from batch 2 onward, the current distribution is an `ApproximateDistribution` (not `SupportsLogProb`), so `_ConditioningStep` converts it to a `KDEDistribution` before building the next `SimpleModel`. That samples→KDE conversion dropped the source `record_template`, so the KDE became a density over a flat `(d,)` vector with no named fields, and `make_posterior` then wrapped the result as a single unnamed `posterior` field.

## Linked issue(s)

Closes #267
Closes #166 — the `KDEDistribution.from_empirical(...)` shortcut is the natural home for the template-threading logic, so it is added here.

## What changed

- **`KDEDistribution` gains a `record_template=` parameter.** When the template has multiple fields, `_sample` unflattens draws back into `NumericRecord` / `NumericRecordArray` keyed by the template, and `_log_prob` accepts both structured (`Record` / `NumericRecord` / `NumericRecordArray`) and flat-vector inputs. Single-field / no-template behaviour is unchanged (validated by a regression test), so every existing call site is backward compatible. The template's `flat_size` is checked against the sample matrix width at construction.
- **New `KDEDistribution.from_empirical(source)` factory** reuses a `RecordEmpiricalDistribution`'s stored samples, weights, and `record_template`, preserving named structure end-to-end. Works for any subclass, notably `ApproximateDistribution`.
- **`_convert_to_kde` threads the source template through** via `from_empirical`, collapsing the previous single-field / multi-field branches into one path that covers both `RecordEmpiricalDistribution` and `ApproximateDistribution`.
- **`getting_started.ipynb` §9 (Sequential updating)** re-executed so every batch now renders named `intercept` / `slope` fields, matching the section's "one conditioner for all batches" claim.

## Test plan

New tests:
- `tests/distributions/test_kde.py` (new file) — `record_template=` constructor + `flat_size` validation, `_sample` round-trip (single + batched), `_log_prob` dual input (Record / NumericRecord / NumericRecordArray / flat agree), and the `from_empirical` factory.
- `tests/converters/test_converters.py::TestProtocolConversion` — added `test_multi_field_empirical_preserves_template_through_kde` and `test_approximate_distribution_preserves_template_through_kde`.
- `tests/modeling/test_modeling.py::TestIncrementalConditioner::test_multi_batch_preserves_named_record_fields` — the issue #267 repro, asserting named fields survive all three batches.

Verification:
- Targeted: `pytest tests/distributions/test_kde.py tests/converters/test_converters.py tests/modeling/test_modeling.py` → 147 passed.
- Broader sweep (`distributions/ converters/ modeling/ inference/test_inference.py core/test_transition.py`) → 1202 passed, 6 skipped, no regressions.
- The #267 minimal repro now prints named `intercept` / `slope` on every batch.

## Breaking changes

None. `KDEDistribution(samples, ...)` without `record_template=` keeps the single-field auto-template; `log_prob(kde, value)` with a positional value is unchanged; `condition_on` behaviour is unchanged. The new `record_template=` parameter and `from_empirical` classmethod are purely additive.

## Documentation

- [x] Docstrings updated for changed public APIs (`KDEDistribution.__init__`, `from_empirical`, `_convert_to_kde`)
- [x] User Guide / tutorials updated where relevant (`getting_started.ipynb` §9 re-executed)
- [ ] CHANGELOG (or release-notes entry) noted in the linked issue

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`
- [x] At least one `area:*` label applied
- [x] Linked to an issue above
