### PR TITLE
feat(core): nested-record flatten + canonical batched sample + slash indexing (#262 PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Nested `ProductDistribution` support in the record layer (#262).**
+  `RecordArray` accepts slash-delimited paths in string indexing
+  (`arr["outer/a"]`) and integer-indexes a nested array into a nested record
+  element; `flatten` / `unflatten` recurse into nested record fields in
+  depth-first leaf order; and a batched draw from a nested `ProductDistribution`
+  is a canonical, flattenable nested record array.
+
 - **Citation metadata and a "Cite" / "Help" docs section.** A
   `CITATION.cff` enables GitHub's "Cite this repository" button; the
   README gains a "Citing ProbPipe" section with a BibTeX entry; and the

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -157,6 +157,14 @@ class RecordArray(Record):
     # -- Field access -------------------------------------------------------
 
     def __getitem__(self, key: str | int) -> Any:
+        """Index a field by name, or extract one element by integer batch index.
+
+        A string ``key`` selects a field; slash-delimited paths descend into
+        nested record fields (``arr["outer/a"]``, per the path convention). An
+        integer ``key`` returns the element at that flat batch index as a
+        (possibly nested) ``Record``. A missing field -- or a path that descends
+        into a leaf -- raises ``KeyError``; a non-str/int key raises ``TypeError``.
+        """
         if isinstance(key, str):
             if _PATH_SEP in key:
                 head, _, rest = key.partition(_PATH_SEP)

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -19,7 +19,7 @@ import numpy as np
 from ..custom_types import ArrayLike
 from ._numeric_record import _NUMERIC_DTYPE_KINDS, NumericRecord
 from .provenance import Provenance
-from .record import Record, RecordTemplate, _spec_size
+from .record import _PATH_SEP, Record, RecordTemplate, _spec_size
 
 __all__ = [
     "RecordArray",
@@ -158,6 +158,14 @@ class RecordArray(Record):
 
     def __getitem__(self, key: str | int) -> Any:
         if isinstance(key, str):
+            if _PATH_SEP in key:
+                head, _, rest = key.partition(_PATH_SEP)
+                if head not in self._store:
+                    raise KeyError(key)
+                try:
+                    return self._store[head][rest]
+                except (KeyError, TypeError) as e:
+                    raise KeyError(key) from e
             if key not in self._store:
                 raise KeyError(key)
             return self._store[key]
@@ -420,16 +428,25 @@ class NumericRecordArray(RecordArray):
     def flatten(self) -> jnp.ndarray:
         """Flatten event dimensions into a single trailing axis.
 
-        Returns array of shape ``(*batch_shape, flat_event_size)``.
+        Returns array of shape ``(*batch_shape, flat_event_size)``. Nested
+        record fields are flattened depth-first in field order, matching
+        :meth:`unflatten` and :meth:`NumericRecord.flatten`.
         """
         n_batch = len(self._batch_shape)
-        parts = []
-        for name in self._store:
-            val = self._store[name]
-            event_shape = val.shape[n_batch:]
-            field_size = prod(event_shape)
-            new_shape = self._batch_shape + (field_size,)
-            parts.append(jnp.reshape(val, new_shape))
+
+        def _flat_field(val: Any) -> jnp.ndarray:
+            # A nested record-array field (from unflatten, or a batched _sample)
+            # carries the same batch axis and flattens its own leaves.
+            if isinstance(val, RecordArray):
+                return val.flatten()
+            # A nested plain Record whose leaves still carry the batch axis
+            # (a non-canonical batched draw): flatten each leaf and concatenate.
+            if isinstance(val, Record):
+                return jnp.concatenate(
+                    [_flat_field(val[f]) for f in val.fields], axis=-1)
+            return jnp.reshape(val, self._batch_shape + (prod(val.shape[n_batch:]),))
+
+        parts = [_flat_field(self._store[name]) for name in self._store]
         return jnp.concatenate(parts, axis=-1)
 
     @classmethod

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -197,12 +197,23 @@ class RecordArray(Record):
     """
 
     def _get_record(self, index: int) -> Record:
-        """Extract a single Record at a flat batch index."""
+        """Extract a single Record at a flat batch index.
+
+        Nested record fields (a co-batched ``RecordArray`` or a plain
+        ``Record`` with batch-shaped leaves) are descended recursively so
+        the element is itself a (nested) record, not indexed by the raw
+        batch tuple.
+        """
         nd_index = np.unravel_index(index, self._batch_shape)
-        fields: dict[str, Any] = {}
-        for name in self._store:
-            fields[name] = self._store[name][nd_index]
-        return self._record_cls(fields)
+
+        def _elem(val: Any) -> Any:
+            if isinstance(val, RecordArray):
+                return val._get_record(index)
+            if isinstance(val, Record):
+                return type(val)({k: _elem(val[k]) for k in val.fields})
+            return val[nd_index]
+
+        return self._record_cls({name: _elem(self._store[name]) for name in self._store})
 
     def __contains__(self, name: str) -> bool:
         return name in self._store

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -210,7 +210,11 @@ class RecordArray(Record):
             if isinstance(val, RecordArray):
                 return val._get_record(index)
             if isinstance(val, Record):
-                return type(val)({k: _elem(val[k]) for k in val.fields})
+                # A NumericRecord requires NumericRecord children, so a plain-Record
+                # nested field (the pre-canonical shape) is promoted; a non-numeric
+                # parent keeps the child's own type.
+                cls = NumericRecord if isinstance(self, NumericRecordArray) else type(val)
+                return cls({k: _elem(val[k]) for k in val.fields})
             return val[nd_index]
 
         return self._record_cls({name: _elem(self._store[name]) for name in self._store})

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -16,7 +16,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from ..custom_types import ArrayLike
+from ..custom_types import Array
 from ._numeric_record import _NUMERIC_DTYPE_KINDS, NumericRecord
 from .provenance import Provenance
 from .record import _PATH_SEP, Record, RecordTemplate, _spec_size
@@ -206,7 +206,7 @@ class RecordArray(Record):
         """
         nd_index = np.unravel_index(index, self._batch_shape)
 
-        def _elem(val: Any) -> Any:
+        def _elem(val: Record | Array) -> Record | Array:
             if isinstance(val, RecordArray):
                 return val._get_record(index)
             if isinstance(val, Record):

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -276,11 +276,17 @@ class ProductDistribution(
         from ..core._record_array import NumericRecordArray, RecordArray
         names = list(self._components.keys())
         keys = jax.random.split(key, len(names))
+        numeric = isinstance(self, NumericRecordDistribution)
         fields: dict[str, jnp.ndarray | Record] = {}
         for subkey, name in zip(keys, names):
             comp = self._components[name]
             if isinstance(comp, dict):
-                fields[name] = _sample_nested(comp, subkey, sample_shape)
+                # Pass the sub-template so a batched nested draw is a nested
+                # record-array (canonical, flattenable), not a plain Record.
+                sub_template = self.record_template[name] if sample_shape else None
+                fields[name] = _sample_nested(
+                    comp, subkey, sample_shape,
+                    template=sub_template, numeric=numeric)
             else:
                 fields[name] = comp._sample(subkey, sample_shape)
         if sample_shape:
@@ -504,17 +510,30 @@ class TFPProductDistribution(ProductDistribution):
 # -- Helpers for nested component pytrees ----------------------------------
 
 
-def _sample_nested(components: dict, key, sample_shape) -> Record:
-    """Recursively sample from nested component dicts, returning nested Record."""
+def _sample_nested(components: dict, key, sample_shape, template=None, numeric=False):
+    """Recursively sample from nested component dicts.
+
+    For an **unbatched** draw (``sample_shape == ()``) returns a plain nested
+    ``Record``. For a **batched** draw returns a nested record-array
+    (``NumericRecordArray`` when ``numeric`` else ``RecordArray``) carrying the
+    sub-``template`` and ``batch_shape``, so the result is canonical and
+    flattenable rather than a plain ``Record`` with batch-shaped leaves.
+    """
     names = list(components.keys())
     keys = jax.random.split(key, len(names))
     fields: dict = {}
     for subkey, name in zip(keys, names):
         comp = components[name]
         if isinstance(comp, dict):
-            fields[name] = _sample_nested(comp, subkey, sample_shape)
+            sub_template = template[name] if template is not None else None
+            fields[name] = _sample_nested(
+                comp, subkey, sample_shape, template=sub_template, numeric=numeric)
         else:
             fields[name] = comp._sample(subkey, sample_shape)
+    if sample_shape and template is not None:
+        from ..core._record_array import NumericRecordArray, RecordArray
+        cls = NumericRecordArray if numeric else RecordArray
+        return cls(fields, batch_shape=sample_shape, template=template)
     return Record(fields)
 
 

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -340,6 +340,11 @@ class TestNumericRecordArrayNested:
         np.testing.assert_allclose(flat[:, 0], inner["a"])
         np.testing.assert_allclose(flat[:, 1], inner["b"])
         np.testing.assert_allclose(flat[:, 2], nra["m"])
+        # Integer-indexing descends the plain-Record nested field (the Record
+        # branch of _get_record), returning a nested record element.
+        elem = nra[2]
+        np.testing.assert_allclose(elem["outer"]["a"], inner["a"][2])
+        np.testing.assert_allclose(elem["outer"]["b"], inner["b"][2])
 
     def test_flatten_nested_depth2_roundtrip(self):
         tpl = RecordTemplate(
@@ -349,13 +354,29 @@ class TestNumericRecordArrayNested:
         np.testing.assert_allclose(nra.flatten(), flat)
         np.testing.assert_allclose(nra["outer/deep/g"], flat[:, 0])
 
+    def test_flatten_nested_vector_leaf(self):
+        # A non-scalar (vector) leaf under nesting: flatten lays out its columns
+        # at the leaf's event size, in canonical leaf order, and round-trips.
+        tpl = RecordTemplate(outer=RecordTemplate(a=(2,), b=()), m=())
+        flat = jnp.arange(20.0).reshape(5, 4)  # outer/a (2), outer/b (1), m (1)
+        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(5,))
+        assert np.asarray(nra["outer/a"]).shape == (5, 2)
+        np.testing.assert_allclose(nra["outer/a"], flat[:, 0:2])
+        np.testing.assert_allclose(nra["outer/b"], flat[:, 2])
+        np.testing.assert_allclose(nra["m"], flat[:, 3])
+        np.testing.assert_allclose(nra.flatten(), flat)
+
     def test_getitem_slash_path(self):
         tpl = self._nested_tpl()
         nra = NumericRecordArray.unflatten(
             jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,))
         np.testing.assert_allclose(nra["outer/a"], nra["outer"]["a"])
         with pytest.raises(KeyError):
-            nra["outer/missing"]
+            nra["outer/missing"]    # leaf missing inside the sub-record
+        with pytest.raises(KeyError):
+            nra["nope/a"]           # head field not in the store
+        with pytest.raises(KeyError):
+            nra["m/x"]              # slash descends into a (scalar) leaf
 
     def test_getitem_int_nested_element(self):
         # Integer indexing of a nested record array descends into the nested

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -305,6 +305,60 @@ class TestNumericRecordArrayFlatten:
 
 
 # ---------------------------------------------------------------------------
+# Nested-record flatten / slash indexing (issue #262)
+# ---------------------------------------------------------------------------
+
+
+class TestNumericRecordArrayNested:
+    """flatten() recurses into nested record fields, in depth-first leaf order,
+    and round-trips through unflatten; slash paths index leaves."""
+
+    @staticmethod
+    def _nested_tpl():
+        return RecordTemplate(outer=RecordTemplate(a=(), b=()), m=())
+
+    def test_flatten_nested_record_array_field(self):
+        # The unflatten / canonical-_sample shape: the nested field is itself a
+        # NumericRecordArray (exercises the RecordArray branch).
+        tpl = self._nested_tpl()
+        flat = jnp.arange(15.0).reshape(5, 3)  # columns = outer/a, outer/b, m
+        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(5,))
+        assert isinstance(nra["outer"], NumericRecordArray)
+        np.testing.assert_allclose(nra.flatten(), flat)  # round-trips exactly
+
+    def test_flatten_nested_record_field(self):
+        # The pre-canonical shape: the nested field is a plain Record holding
+        # batch-shaped leaves (exercises the Record branch).
+        tpl = self._nested_tpl()
+        inner = Record(a=jnp.arange(5.0), b=jnp.arange(5.0) + 10)
+        nra = NumericRecordArray(
+            {"outer": inner, "m": jnp.arange(5.0) + 100},
+            batch_shape=(5,), template=tpl,
+        )
+        flat = nra.flatten()
+        assert flat.shape == (5, 3)
+        np.testing.assert_allclose(flat[:, 0], inner["a"])
+        np.testing.assert_allclose(flat[:, 1], inner["b"])
+        np.testing.assert_allclose(flat[:, 2], nra["m"])
+
+    def test_flatten_nested_depth2_roundtrip(self):
+        tpl = RecordTemplate(
+            outer=RecordTemplate(deep=RecordTemplate(g=(), h=()), a=()), m=())
+        flat = jnp.arange(20.0).reshape(5, 4)  # outer/deep/g, outer/deep/h, outer/a, m
+        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(5,))
+        np.testing.assert_allclose(nra.flatten(), flat)
+        np.testing.assert_allclose(nra["outer/deep/g"], flat[:, 0])
+
+    def test_getitem_slash_path(self):
+        tpl = self._nested_tpl()
+        nra = NumericRecordArray.unflatten(
+            jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,))
+        np.testing.assert_allclose(nra["outer/a"], nra["outer"]["a"])
+        with pytest.raises(KeyError):
+            nra["outer/missing"]
+
+
+# ---------------------------------------------------------------------------
 # NumericRecordArray mean / var
 # ---------------------------------------------------------------------------
 

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -357,6 +357,25 @@ class TestNumericRecordArrayNested:
         with pytest.raises(KeyError):
             nra["outer/missing"]
 
+    def test_getitem_int_nested_element(self):
+        # Integer indexing of a nested record array descends into the nested
+        # field, returning a (nested) record element — not an indexing error.
+        tpl = self._nested_tpl()
+        nra = NumericRecordArray.unflatten(
+            jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,))
+        elem = nra[2]
+        assert isinstance(elem, Record)
+        np.testing.assert_allclose(elem["outer"]["a"], nra["outer"]["a"][2])
+        np.testing.assert_allclose(elem.flatten(), nra.flatten()[2])
+
+    def test_getitem_int_nested_multidim_batch(self):
+        tpl = self._nested_tpl()
+        nra = NumericRecordArray.unflatten(
+            jnp.arange(24.0).reshape(2, 4, 3), template=tpl, batch_shape=(2, 4))
+        elem = nra[5]  # flat index into the (2, 4) batch
+        np.testing.assert_allclose(
+            elem["outer"]["a"], np.asarray(nra["outer"]["a"]).reshape(-1)[5])
+
 
 # ---------------------------------------------------------------------------
 # NumericRecordArray mean / var

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -304,10 +304,39 @@ class TestNestedSampleFlatten:
         leaves = list(nested.record_template.numeric_leaf_shapes)
         flat = s.flatten()
         assert flat.shape == (6, len(leaves))  # ('outer/a', 'outer/b', 'm')
+        # Primary check: flatten places each sampled leaf into its own column in
+        # canonical leaf order -- compared against the sample's own slash leaves.
+        # A permuted column order would fail here; the unflatten round-trip below
+        # cannot catch one, since flatten and unflatten share the leaf ordering.
+        for i, leaf in enumerate(leaves):
+            np.testing.assert_allclose(flat[:, i], s[leaf], atol=1e-6)
+        # Secondary: the columns round-trip back to the same leaves via unflatten.
         rec = NumericRecordArray.unflatten(
             flat, template=nested.record_template, batch_shape=(6,))
-        for i, leaf in enumerate(leaves):
-            np.testing.assert_allclose(rec[leaf], flat[:, i], atol=1e-6)
+        for leaf in leaves:
+            np.testing.assert_allclose(rec[leaf], s[leaf], atol=1e-6)
+
+    def test_batched_nested_non_numeric_field_is_plain_record_array(self):
+        # A non-numeric joint (an object-dtype JointEmpirical leaf) makes the
+        # batched nested field a plain RecordArray, not a NumericRecordArray
+        # (the else branch of _sample_nested); such a field is not flattenable.
+        from probpipe import JointEmpirical
+        from probpipe.core._record_array import NumericRecordArray, RecordArray
+        je = JointEmpirical(
+            labels=np.array(["a", "b", "c"], dtype=object),
+            ids=np.array([0, 1, 2]), name="je",
+        )
+        joint = ProductDistribution(
+            name="joint",
+            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
+                   "b": Normal(loc=2.0, scale=0.5, name="b")},
+            je=je,
+        )
+        assert not isinstance(joint, NumericRecordDistribution)
+        s = sample(joint, key=jax.random.PRNGKey(0), sample_shape=(4,))
+        assert isinstance(s, RecordArray) and not isinstance(s, NumericRecordArray)
+        assert isinstance(s["outer"], RecordArray)
+        assert not isinstance(s["outer"], NumericRecordArray)
 
 
 # ===========================================================================

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -270,6 +270,47 @@ class TestFlattenUnflatten:
 
 
 # ===========================================================================
+# 3b. TestNestedSampleFlatten (issue #262)
+# ===========================================================================
+
+class TestNestedSampleFlatten:
+    """A batched draw from a nested ProductDistribution is a canonical, nested
+    NumericRecordArray that flattens and round-trips; the unbatched draw stays
+    a plain Record."""
+
+    @pytest.fixture
+    def nested(self):
+        return ProductDistribution(
+            name="joint",
+            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
+                   "b": Normal(loc=2.0, scale=0.5, name="b")},
+            m=Normal(loc=-1.0, scale=1.0, name="m"),
+        )
+
+    def test_batched_nested_field_is_record_array(self, nested):
+        from probpipe.core._record_array import NumericRecordArray
+        s = sample(nested, key=jax.random.PRNGKey(0), sample_shape=(6,))
+        assert isinstance(s, NumericRecordArray)
+        assert isinstance(s["outer"], NumericRecordArray)  # not a plain Record
+
+    def test_unbatched_nested_field_stays_record(self, nested):
+        s = sample(nested, key=jax.random.PRNGKey(0))
+        assert isinstance(s, Record) and not isinstance(s, RecordArray)
+        assert isinstance(s["outer"], Record) and not isinstance(s["outer"], RecordArray)
+
+    def test_batched_nested_flatten_roundtrip(self, nested):
+        from probpipe.core._record_array import NumericRecordArray
+        s = sample(nested, key=jax.random.PRNGKey(1), sample_shape=(6,))
+        leaves = list(nested.record_template.numeric_leaf_shapes)
+        flat = s.flatten()
+        assert flat.shape == (6, len(leaves))  # ('outer/a', 'outer/b', 'm')
+        rec = NumericRecordArray.unflatten(
+            flat, template=nested.record_template, batch_shape=(6,))
+        for i, leaf in enumerate(leaves):
+            np.testing.assert_allclose(rec[leaf], flat[:, i], atol=1e-6)
+
+
+# ===========================================================================
 # 4. TestDistributionView (RecordDistributionView for ProductDistribution)
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

**PR 1 of #262** — core support for nested `ProductDistribution` priors. Standalone and mergeable on its own; it unblocks the amortized-SBI bridge lift (PR 2) but is useful to any nested-record user. No public-API removals; flat priors are unchanged.

Closes the core half of #262: batched draws from a nested prior could not be flattened, which is the real blocker behind the SBI learners' nested-prior rejection.

## Changes

- **`NumericRecordArray.flatten()` recurses into nested record fields** (depth-first, field order — matching `unflatten` and `NumericRecord.flatten`). It handles both shapes a nested field can take: a nested `NumericRecordArray` (from `unflatten`, or a batched `_sample` after this PR) and a plain `Record` whose leaves still carry the batch axis. Before, it did `val.shape[n_batch:]` per field and raised `AttributeError: 'Record' object has no attribute 'shape'` (`_record_array.py:429`) — the #262 blocker.
- **`ProductDistribution._sample` / `_sample_nested` canonicalize a *batched* nested draw** to a nested `NumericRecordArray` (carrying the sub-template + `batch_shape`), so the in-memory batched type is uniformly numeric and flattenable. The **unbatched** draw stays a plain `Record`, preserving the existing contract.
- **`NumericRecordArray.__getitem__` gains slash-path leaf indexing** (`record['outer/a']`), mirroring `Record`; the PR-2 bridge uses it instead of split-and-walk.

## Tests

`tests/core/test_record_array.py::TestNumericRecordArrayNested` — nested `flatten` for both field shapes, a depth-2 nested case, a `flatten → unflatten` round-trip, and slash indexing (incl. a missing-leaf `KeyError`). `tests/distributions/test_product.py::TestNestedSampleFlatten` — batched nested draw is a nested `NumericRecordArray`, the unbatched draw stays a `Record`, and the batched draw flattens/round-trips in `numeric_leaf_shapes` order.

## Verification

`2074 passed, 4 skipped` across `tests/core` + `tests/distributions` (the blast radius of the `flatten`/`__getitem__`/`_sample` changes); zero new ruff findings on the touched files (the advisory backlog is unchanged). Flat-prior `flatten`/sample shapes and values are unchanged (explicit regression test).

## Next

**PR 2** (depends on this) lifts the BayesFlow bridge to iterate leaf paths (`numeric_leaf_shapes`), removes the nested-prior guard, keys NPE/NLE/NRE by leaves, and adds the analytic round-trip test — per the plan in #262.
