### PR TITLE
feat(inference): support nested priors in the BayesFlow SBI bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Amortized SBI learners accept nested priors (#262).**
+  `learn_amortized_posterior` / `learn_amortized_likelihood` /
+  `learn_amortized_ratio` now train on nested `ProductDistribution` priors,
+  iterating the prior's numeric leaves; for NPE, per-leaf bijectors run at each
+  leaf's native event shape, and posterior draws come back under their nested
+  leaf names. Previously a nested prior was rejected up front.
+
 - **Install docs: a "New to Python?" two-route fork.** The README and docs
   landing now split installation into a newcomer path (uv manages Python and
   the environment — no prior Python needed) and an experienced-user pip path,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Nested `ProductDistribution` support in the record layer (#262).**
+  `RecordArray` accepts slash-delimited paths in string indexing
+  (`arr["outer/a"]`) and integer-indexes a nested array into a nested record
+  element; `flatten` / `unflatten` recurse into nested record fields in
+  depth-first leaf order; and a batched draw from a nested `ProductDistribution`
+  is a canonical, flattenable nested record array.
+
 - **Citation metadata and a "Cite" / "Help" docs section.** A
   `CITATION.cff` enables GitHub's "Cite this repository" button; the
   README gains a "Citing ProbPipe" section with a BibTeX entry; and the

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -157,6 +157,14 @@ class RecordArray(Record):
     # -- Field access -------------------------------------------------------
 
     def __getitem__(self, key: str | int) -> Any:
+        """Index a field by name, or extract one element by integer batch index.
+
+        A string ``key`` selects a field; slash-delimited paths descend into
+        nested record fields (``arr["outer/a"]``, per the path convention). An
+        integer ``key`` returns the element at that flat batch index as a
+        (possibly nested) ``Record``. A missing field -- or a path that descends
+        into a leaf -- raises ``KeyError``; a non-str/int key raises ``TypeError``.
+        """
         if isinstance(key, str):
             if _PATH_SEP in key:
                 head, _, rest = key.partition(_PATH_SEP)

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -19,7 +19,7 @@ import numpy as np
 from ..custom_types import ArrayLike
 from ._numeric_record import _NUMERIC_DTYPE_KINDS, NumericRecord
 from .provenance import Provenance
-from .record import Record, RecordTemplate, _spec_size
+from .record import _PATH_SEP, Record, RecordTemplate, _spec_size
 
 __all__ = [
     "RecordArray",
@@ -158,6 +158,14 @@ class RecordArray(Record):
 
     def __getitem__(self, key: str | int) -> Any:
         if isinstance(key, str):
+            if _PATH_SEP in key:
+                head, _, rest = key.partition(_PATH_SEP)
+                if head not in self._store:
+                    raise KeyError(key)
+                try:
+                    return self._store[head][rest]
+                except (KeyError, TypeError) as e:
+                    raise KeyError(key) from e
             if key not in self._store:
                 raise KeyError(key)
             return self._store[key]
@@ -420,16 +428,25 @@ class NumericRecordArray(RecordArray):
     def flatten(self) -> jnp.ndarray:
         """Flatten event dimensions into a single trailing axis.
 
-        Returns array of shape ``(*batch_shape, flat_event_size)``.
+        Returns array of shape ``(*batch_shape, flat_event_size)``. Nested
+        record fields are flattened depth-first in field order, matching
+        :meth:`unflatten` and :meth:`NumericRecord.flatten`.
         """
         n_batch = len(self._batch_shape)
-        parts = []
-        for name in self._store:
-            val = self._store[name]
-            event_shape = val.shape[n_batch:]
-            field_size = prod(event_shape)
-            new_shape = self._batch_shape + (field_size,)
-            parts.append(jnp.reshape(val, new_shape))
+
+        def _flat_field(val: Any) -> jnp.ndarray:
+            # A nested record-array field (from unflatten, or a batched _sample)
+            # carries the same batch axis and flattens its own leaves.
+            if isinstance(val, RecordArray):
+                return val.flatten()
+            # A nested plain Record whose leaves still carry the batch axis
+            # (a non-canonical batched draw): flatten each leaf and concatenate.
+            if isinstance(val, Record):
+                return jnp.concatenate(
+                    [_flat_field(val[f]) for f in val.fields], axis=-1)
+            return jnp.reshape(val, self._batch_shape + (prod(val.shape[n_batch:]),))
+
+        parts = [_flat_field(self._store[name]) for name in self._store]
         return jnp.concatenate(parts, axis=-1)
 
     @classmethod

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -197,12 +197,23 @@ class RecordArray(Record):
     """
 
     def _get_record(self, index: int) -> Record:
-        """Extract a single Record at a flat batch index."""
+        """Extract a single Record at a flat batch index.
+
+        Nested record fields (a co-batched ``RecordArray`` or a plain
+        ``Record`` with batch-shaped leaves) are descended recursively so
+        the element is itself a (nested) record, not indexed by the raw
+        batch tuple.
+        """
         nd_index = np.unravel_index(index, self._batch_shape)
-        fields: dict[str, Any] = {}
-        for name in self._store:
-            fields[name] = self._store[name][nd_index]
-        return self._record_cls(fields)
+
+        def _elem(val: Any) -> Any:
+            if isinstance(val, RecordArray):
+                return val._get_record(index)
+            if isinstance(val, Record):
+                return type(val)({k: _elem(val[k]) for k in val.fields})
+            return val[nd_index]
+
+        return self._record_cls({name: _elem(self._store[name]) for name in self._store})
 
     def __contains__(self, name: str) -> bool:
         return name in self._store

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -210,7 +210,11 @@ class RecordArray(Record):
             if isinstance(val, RecordArray):
                 return val._get_record(index)
             if isinstance(val, Record):
-                return type(val)({k: _elem(val[k]) for k in val.fields})
+                # A NumericRecord requires NumericRecord children, so a plain-Record
+                # nested field (the pre-canonical shape) is promoted; a non-numeric
+                # parent keeps the child's own type.
+                cls = NumericRecord if isinstance(self, NumericRecordArray) else type(val)
+                return cls({k: _elem(val[k]) for k in val.fields})
             return val[nd_index]
 
         return self._record_cls({name: _elem(self._store[name]) for name in self._store})

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -16,7 +16,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from ..custom_types import ArrayLike
+from ..custom_types import Array
 from ._numeric_record import _NUMERIC_DTYPE_KINDS, NumericRecord
 from .provenance import Provenance
 from .record import _PATH_SEP, Record, RecordTemplate, _spec_size
@@ -206,7 +206,7 @@ class RecordArray(Record):
         """
         nd_index = np.unravel_index(index, self._batch_shape)
 
-        def _elem(val: Any) -> Any:
+        def _elem(val: Record | Array) -> Record | Array:
             if isinstance(val, RecordArray):
                 return val._get_record(index)
             if isinstance(val, Record):

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -276,11 +276,17 @@ class ProductDistribution(
         from ..core._record_array import NumericRecordArray, RecordArray
         names = list(self._components.keys())
         keys = jax.random.split(key, len(names))
+        numeric = isinstance(self, NumericRecordDistribution)
         fields: dict[str, jnp.ndarray | Record] = {}
         for subkey, name in zip(keys, names):
             comp = self._components[name]
             if isinstance(comp, dict):
-                fields[name] = _sample_nested(comp, subkey, sample_shape)
+                # Pass the sub-template so a batched nested draw is a nested
+                # record-array (canonical, flattenable), not a plain Record.
+                sub_template = self.record_template[name] if sample_shape else None
+                fields[name] = _sample_nested(
+                    comp, subkey, sample_shape,
+                    template=sub_template, numeric=numeric)
             else:
                 fields[name] = comp._sample(subkey, sample_shape)
         if sample_shape:
@@ -504,17 +510,30 @@ class TFPProductDistribution(ProductDistribution):
 # -- Helpers for nested component pytrees ----------------------------------
 
 
-def _sample_nested(components: dict, key, sample_shape) -> Record:
-    """Recursively sample from nested component dicts, returning nested Record."""
+def _sample_nested(components: dict, key, sample_shape, template=None, numeric=False):
+    """Recursively sample from nested component dicts.
+
+    For an **unbatched** draw (``sample_shape == ()``) returns a plain nested
+    ``Record``. For a **batched** draw returns a nested record-array
+    (``NumericRecordArray`` when ``numeric`` else ``RecordArray``) carrying the
+    sub-``template`` and ``batch_shape``, so the result is canonical and
+    flattenable rather than a plain ``Record`` with batch-shaped leaves.
+    """
     names = list(components.keys())
     keys = jax.random.split(key, len(names))
     fields: dict = {}
     for subkey, name in zip(keys, names):
         comp = components[name]
         if isinstance(comp, dict):
-            fields[name] = _sample_nested(comp, subkey, sample_shape)
+            sub_template = template[name] if template is not None else None
+            fields[name] = _sample_nested(
+                comp, subkey, sample_shape, template=sub_template, numeric=numeric)
         else:
             fields[name] = comp._sample(subkey, sample_shape)
+    if sample_shape and template is not None:
+        from ..core._record_array import NumericRecordArray, RecordArray
+        cls = NumericRecordArray if numeric else RecordArray
+        return cls(fields, batch_shape=sample_shape, template=template)
     return Record(fields)
 
 

--- a/probpipe/inference/_bayesflow_common.py
+++ b/probpipe/inference/_bayesflow_common.py
@@ -154,14 +154,15 @@ def _simulate_offline(
     """Draw ``(theta, y)`` pairs offline: ``theta ~ prior``, ``y ~ simulator(theta)``.
 
     Returns ``(named_theta, y)`` where ``named_theta`` maps each prior
-    record-template field to a ``(num_simulations, d_field)`` float32 array and
-    ``y`` is the ``(num_simulations, d_y)`` float32 array of flattened simulated
-    observations.  With ``bijectors`` given (the NPE path), each theta field is
-    *unconstrained* (pushed through its inverse bijector at the field's native
-    event shape, then flattened); with ``bijectors=None`` (the NLE/NRE paths,
-    where theta is a network *input* rather than a modeled density), the raw
-    constrained draws are returned.  The simulator itself always sees the
-    constrained, structured draws.
+    record-template numeric leaf (slash paths like ``"outer/a"`` for a nested
+    prior; top-level fields for a flat one) to a ``(num_simulations, d_leaf)``
+    float32 array and ``y`` is the ``(num_simulations, d_y)`` float32 array of
+    flattened simulated observations.  With ``bijectors`` given (the NPE path),
+    each theta leaf is *unconstrained* (pushed through its inverse bijector at the
+    leaf's native event shape, then flattened); with ``bijectors=None`` (the
+    NLE/NRE paths, where theta is a network *input* rather than a modeled
+    density), the raw constrained draws are returned.  The simulator itself always
+    sees the constrained, structured draws.
     """
     template = prior.record_template
     # Iterate numeric leaves (slash paths like "outer/a" for nested priors; ==

--- a/probpipe/inference/_bayesflow_common.py
+++ b/probpipe/inference/_bayesflow_common.py
@@ -78,14 +78,16 @@ def _import_bayesflow() -> ModuleType:
     return bf
 
 
-def _adapter_field_keys(fields: tuple[str, ...]) -> tuple[str, ...]:
+def _adapter_field_keys(keys: tuple[str, ...]) -> tuple[str, ...]:
     """Positional internal keys (``theta_0``, ``theta_1``, ...) for the adapter.
 
     Both the training dict and the sample-side extraction derive these from the
-    prior's ``record_template.fields`` order, so the mapping is deterministic
-    across train and inference without storing it.
+    prior's ``record_template`` leaf order (``numeric_leaf_shapes`` keys; ==
+    ``fields`` for a flat prior), so the mapping is deterministic across train
+    and inference without storing it, and slash-delimited nested leaf paths
+    never reach BayesFlow's key namespace.
     """
-    return tuple(f"theta_{i}" for i in range(len(fields)))
+    return tuple(f"theta_{i}" for i in range(len(keys)))
 
 
 def _validate_learn_inputs(
@@ -118,17 +120,6 @@ def _validate_learn_inputs(
             f"{caller} requires a RecordDistribution prior with named parameter "
             "fields -- typically a ProductDistribution of named distributions -- "
             f"but got {type(prior).__name__}, which has no record_template."
-        )
-    if any("/" in k for k in record_template.numeric_leaf_shapes):
-        # Nothing here needs flatness in principle (the adapter could key on
-        # numeric leaves), but batched draws from a nested prior do not yet
-        # flatten -- NumericRecordArray.flatten chokes on the plain-Record
-        # sub-records ProductDistribution._sample embeds -- and flattening is
-        # this pipeline's first step. Reject early with a clear error instead.
-        raise TypeError(
-            f"{caller} does not support nested priors yet: batched draws from "
-            "a nested prior cannot currently be flattened for offline "
-            "simulation. Flatten the prior into top-level named fields."
         )
     return record_template
 
@@ -173,7 +164,10 @@ def _simulate_offline(
     constrained, structured draws.
     """
     template = prior.record_template
-    fields = template.fields
+    # Iterate numeric leaves (slash paths like "outer/a" for nested priors; ==
+    # top-level fields for flat priors). The adapter re-keys positionally, so
+    # leaf paths never reach BayesFlow's namespace.
+    leaf_keys = tuple(template.numeric_leaf_shapes)
     k_theta, k_sim = jax.random.split(key)
     theta = _sample_op(prior, key=k_theta, sample_shape=(num_simulations,))
     # Round-trip through the canonical flat layout: single-field priors' raw draws
@@ -183,13 +177,13 @@ def _simulate_offline(
         theta_flat, template=template, batch_shape=(num_simulations,)
     )
     # Invert before flattening: matrix-valued bijectors (positive-definite) require
-    # the field's native (..., n, n) event shape, not the flat adapter layout.
+    # the leaf's native (..., n, n) event shape, not the flat adapter layout.
     named = {}
-    for f in fields:
-        arr = jnp.asarray(record[f])
+    for leaf in leaf_keys:
+        arr = jnp.asarray(record[leaf])
         if bijectors is not None:
-            arr = bijectors[f].inverse(arr)
-        named[f] = np.asarray(jnp.reshape(arr, (num_simulations, -1)), dtype="float32")
+            arr = bijectors[leaf].inverse(arr)
+        named[leaf] = np.asarray(jnp.reshape(arr, (num_simulations, -1)), dtype="float32")
     sim_keys = jax.random.split(k_sim, num_simulations)
 
     def _one(flat_row: Array, k: PRNGKey) -> Array:

--- a/probpipe/inference/_bayesflow_likelihoods.py
+++ b/probpipe/inference/_bayesflow_likelihoods.py
@@ -332,7 +332,9 @@ def _train_offline(
         counts=(("num_simulations", num_simulations), ("batch_size", batch_size),
                 ("epochs", epochs)),
     )
-    fields = record_template.fields
+    # Numeric leaves (slash paths for a nested prior; == fields for a flat one).
+    # NLE/NRE feed raw theta to the network, so no bijectors -- just the keying.
+    leaf_keys = tuple(record_template.numeric_leaf_shapes)
 
     bf = _import_bayesflow()
     with _isolated_keras_seeding(random_seed):
@@ -360,8 +362,8 @@ def _train_offline(
                 )
             y = np.asarray(jnp.asarray(y) + jax.random.uniform(k_jitter, y.shape),
                            dtype="float32")
-        internal_keys = _adapter_field_keys(fields)
-        sims = {k: named[f] for k, f in zip(internal_keys, fields)}
+        internal_keys = _adapter_field_keys(leaf_keys)
+        sims = {k: named[lk] for k, lk in zip(internal_keys, leaf_keys)}
         sims[_OBSERVATION_KEY] = y
 
         obs_role = ("inference_variables" if theta_role == "inference_conditions"
@@ -407,11 +409,12 @@ def learn_amortized_likelihood(
     Parameters
     ----------
     prior : Distribution
-        Prior over the model parameters; a ``RecordDistribution`` with named,
-        non-nested fields. Sampled (only) to draw training thetas; constrained
-        and discrete-valued parameter fields are both fine here, since theta is
-        a network *input* (whether the downstream sampler can handle the prior
-        is the sampler's concern).
+        Prior over the model parameters; a ``RecordDistribution`` with named
+        fields, which may be nested (a ``ProductDistribution`` of named
+        distributions, possibly nested). Sampled (only) to draw training thetas;
+        constrained and discrete-valued parameter fields are both fine here,
+        since theta is a network *input* (whether the downstream sampler can
+        handle the prior is the sampler's concern).
     simulator : GenerativeLikelihood
         ``generate_data(params, num_observations, *, key)``; receives the
         prior's structured per-draw record (named-field access). Must be
@@ -527,9 +530,9 @@ def learn_amortized_ratio(
     Parameters
     ----------
     prior : Distribution
-        Prior over the model parameters; a flat ``RecordDistribution`` (as in
-        :func:`learn_amortized_likelihood` -- constrained and discrete-valued
-        parameter fields are fine, theta is a network input).
+        Prior over the model parameters; a ``RecordDistribution``, possibly
+        nested (as in :func:`learn_amortized_likelihood` -- constrained and
+        discrete-valued parameter fields are fine, theta is a network input).
     simulator : GenerativeLikelihood
         ``generate_data(params, num_observations, *, key)``; receives the
         prior's structured per-draw record.

--- a/probpipe/inference/_bayesflow_likelihoods.py
+++ b/probpipe/inference/_bayesflow_likelihoods.py
@@ -476,7 +476,7 @@ def learn_amortized_likelihood(
         simulated observations reach ``2**23``.
     TypeError
         If a count parameter is not an integer, ``simulator`` lacks
-        ``generate_data``, or ``prior`` is not a flat ``RecordDistribution``.
+        ``generate_data``, or ``prior`` is not a ``RecordDistribution``.
     ImportError
         If the ``[bayesflow]`` extra is not installed.
     """
@@ -565,7 +565,7 @@ def learn_amortized_ratio(
         (no minimum observation dimension, unlike NLE).
     TypeError
         If a count parameter is not an integer, ``simulator`` lacks
-        ``generate_data``, or ``prior`` is not a flat ``RecordDistribution``.
+        ``generate_data``, or ``prior`` is not a ``RecordDistribution``.
     ImportError
         If the ``[bayesflow]`` extra is not installed.
     """

--- a/probpipe/inference/_bayesflow_posteriors.py
+++ b/probpipe/inference/_bayesflow_posteriors.py
@@ -154,8 +154,8 @@ class BayesFlowModel(Distribution, SupportsConditioning):
     ``p(theta | observed)`` in one forward pass, and -- because the estimator is
     amortized -- the same instance conditions on any observation with no
     retraining.  The network samples in unconstrained space; posterior draws are
-    mapped back to each field's support via the per-field forward bijectors
-    recorded at training time (identity for real-valued fields).  The amortized
+    mapped back to each leaf's support via the per-leaf forward bijectors
+    recorded at training time (identity for real-valued leaves).  The amortized
     path honours ``num_results`` (a positive integer) and ``random_seed``;
     ``num_warmup`` / ``num_chains`` do not apply (a forward pass yields a single
     draw block).  Direct sampling is not implemented; simulate from the joint

--- a/probpipe/inference/_bayesflow_posteriors.py
+++ b/probpipe/inference/_bayesflow_posteriors.py
@@ -98,8 +98,12 @@ def _build_adapter(bf: ModuleType, internal_keys: tuple[str, ...]) -> Adapter:
     )
 
 
-def _field_bijectors(prior: Distribution, fields: tuple[str, ...]) -> dict[str, tfb.Bijector]:
-    """Per-field bijector mapping each parameter's unconstrained R^d to its support.
+def _field_bijectors(prior: Distribution, keys: tuple[str, ...]) -> dict[str, tfb.Bijector]:
+    """Per-leaf bijector mapping each parameter's unconstrained R^d to its support.
+
+    ``keys`` are the prior's numeric leaves (slash paths like ``"outer/a"`` for a
+    nested prior; top-level field names for a flat one), matching the keying of
+    ``prior.supports``.
 
     BayesFlow's ``ContinuousApproximator`` operates in unconstrained, real space, so a
     constrained prior (positive, an interval, ...) is trained on the *unconstrained*
@@ -113,24 +117,24 @@ def _field_bijectors(prior: Distribution, fields: tuple[str, ...]) -> dict[str, 
     try:
         supports = prior.supports
     except NotImplementedError:
-        if len(fields) > 1:
+        if len(keys) > 1:
             raise TypeError(
-                f"{type(prior).__name__} has {len(fields)} fields but does not "
+                f"{type(prior).__name__} has {len(keys)} parameters but does not "
                 "implement per-field `supports`; cannot infer per-field constraints "
                 "from the single `support`. Implement `supports` on the prior."
             ) from None
         # Single-field priors: the whole-distribution support is the field's support.
-        supports = {f: prior.support for f in fields}
+        supports = {k: prior.support for k in keys}
     bijectors: dict[str, tfb.Bijector] = {}
-    for f in fields:
-        constraint = supports[f]
+    for k in keys:
+        constraint = supports[k]
         try:
-            bijectors[f] = bijector_for(constraint)
+            bijectors[k] = bijector_for(constraint)
         except NotImplementedError as e:
             raise ValueError(
-                f"learn_amortized_posterior cannot handle prior field {f!r} with support "
-                f"{constraint!r}: {e}. Amortized SBI requires a continuous prior whose "
-                "support admits a smooth bijector to R^d (e.g. real, positive, an "
+                f"learn_amortized_posterior cannot handle prior parameter {k!r} with "
+                f"support {constraint!r}: {e}. Amortized SBI requires a continuous prior "
+                "whose support admits a smooth bijector to R^d (e.g. real, positive, an "
                 "interval); discrete priors are not supported."
             ) from e
     return bijectors
@@ -173,7 +177,9 @@ class BayesFlowModel(Distribution, SupportsConditioning):
         self._approximator = approximator
         self._prior = prior
         self._simulator = simulator
-        self._fields = tuple(prior.record_template.fields)
+        # Numeric leaves (slash paths for a nested prior; == fields for a flat
+        # one) -- the column order the network emits, matching training.
+        self._leaf_keys = tuple(prior.record_template.numeric_leaf_shapes)
         self._method = method
         self._data_dim = data_dim
         self._num_results = num_results
@@ -226,13 +232,14 @@ class BayesFlowModel(Distribution, SupportsConditioning):
             conditions={_OBSERVATION_KEY: obs_flat[None, :]},
             seed=random_seed,
         )
-        # ``out`` maps each internal theta key to ``(1, num_results, d_field)``.
+        # ``out`` maps each internal theta key to ``(1, num_results, d_leaf)``.
         # Stays in jnp end-to-end: this is the latency-critical amortized path,
-        # so no per-field host round-trips.
+        # so no per-leaf host round-trips. Columns are concatenated in leaf order,
+        # which is the canonical flatten order the record_template unflattens by.
         cols = []
-        for k, f in zip(_adapter_field_keys(self._fields), self._fields):
+        for k, leaf in zip(_adapter_field_keys(self._leaf_keys), self._leaf_keys):
             draws = jnp.asarray(out[k])[0]
-            bij = self._bijectors.get(f)
+            bij = self._bijectors.get(leaf)
             if bij is not None:
                 draws = bij.forward(draws)
             cols.append(jnp.reshape(draws, (num_results, -1)))
@@ -285,14 +292,14 @@ def learn_amortized_posterior(
     ----------
     prior : Distribution
         Prior over the model parameters.  Must be a ``RecordDistribution`` --
-        typically a ``ProductDistribution`` of named distributions, or a single
-        named distribution for a one-parameter model.  It is sampled via the
-        :func:`~probpipe.sample` op to draw training thetas; it is *not*
-        otherwise translated.  Constrained fields (positive, an interval, a simplex,
-        positive-definite matrices, ...) are trained in unconstrained space via the
-        per-field bijector from :func:`~probpipe.bijector_for` -- applied at the
-        field's native event shape -- and mapped back to the support at sample time;
-        real-valued fields use the identity.  Discrete priors are not supported.
+        typically a ``ProductDistribution`` of named distributions (which may be
+        nested), or a single named distribution for a one-parameter model.  It is
+        sampled via the :func:`~probpipe.sample` op to draw training thetas; it is
+        *not* otherwise translated.  Constrained leaves (positive, an interval, a
+        simplex, positive-definite matrices, ...) are trained in unconstrained space
+        via the per-leaf bijector from :func:`~probpipe.bijector_for` -- applied at
+        the leaf's native event shape -- and mapped back to the support at sample
+        time; real-valued leaves use the identity.  Discrete priors are not supported.
     simulator : GenerativeLikelihood
         Must implement ``generate_data(params, num_observations, *, key)``.  As with
         ``SimpleGenerativeModel`` / ``PriorPredictiveCheck``, ``params`` is the prior's
@@ -349,8 +356,8 @@ def learn_amortized_posterior(
     TypeError
         If a count parameter is not an integer, ``simulator`` lacks
         ``generate_data``, ``prior`` is not a ``RecordDistribution`` (has no
-        ``record_template``), the prior is nested, or a multi-field prior
-        implements no per-field ``supports`` accessor.
+        ``record_template``), or a multi-field prior implements no per-field
+        ``supports`` accessor.
     ImportError
         If the ``[bayesflow]`` extra is not installed.
     """
@@ -363,16 +370,18 @@ def learn_amortized_posterior(
         counts=(("num_simulations", num_simulations), ("batch_size", batch_size),
                 ("epochs", epochs), ("num_results", num_results)),
     )
-    fields = record_template.fields
+    # Per numeric leaf (slash paths for a nested prior; == fields for a flat
+    # one). supports / bijectors are leaf-keyed, so this serves both uniformly.
     leaf_shapes = record_template.numeric_leaf_shapes
+    leaf_keys = tuple(leaf_shapes)
     # Built up front: also rejects discrete / unsupported-support priors before
     # any simulation runs.
-    bijectors = _field_bijectors(prior, fields)
+    bijectors = _field_bijectors(prior, leaf_keys)
     # The network trains on *unconstrained* widths, which differ from the prior's
     # event sizes for dimension-shifting bijectors (a d-simplex contributes d-1).
     unconstrained_size = sum(
-        int(np.prod(tuple(bijectors[f].inverse_event_shape(leaf_shapes[f])), dtype=int))
-        for f in fields
+        int(np.prod(tuple(bijectors[k].inverse_event_shape(leaf_shapes[k])), dtype=int))
+        for k in leaf_keys
     )
 
     bf = _import_bayesflow()
@@ -382,11 +391,11 @@ def learn_amortized_posterior(
             prior, simulator, num_simulations, key,
             sim_backend=sim_backend, bijectors=bijectors,
         )
-        # Re-key theta fields to positional internal names so user field names
+        # Re-key theta leaves to positional internal names so user field names
         # never enter BayesFlow's key namespace (no collision with the
         # observation key or the adapter's inference_variables/conditions).
-        internal_keys = _adapter_field_keys(fields)
-        sims = {k: named[f] for k, f in zip(internal_keys, fields)}
+        internal_keys = _adapter_field_keys(leaf_keys)
+        sims = {k: named[lk] for k, lk in zip(internal_keys, leaf_keys)}
         sims[_OBSERVATION_KEY] = y
 
         adapter = _build_adapter(bf, internal_keys)

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -340,6 +340,11 @@ class TestNumericRecordArrayNested:
         np.testing.assert_allclose(flat[:, 0], inner["a"])
         np.testing.assert_allclose(flat[:, 1], inner["b"])
         np.testing.assert_allclose(flat[:, 2], nra["m"])
+        # Integer-indexing descends the plain-Record nested field (the Record
+        # branch of _get_record), returning a nested record element.
+        elem = nra[2]
+        np.testing.assert_allclose(elem["outer"]["a"], inner["a"][2])
+        np.testing.assert_allclose(elem["outer"]["b"], inner["b"][2])
 
     def test_flatten_nested_depth2_roundtrip(self):
         tpl = RecordTemplate(
@@ -349,13 +354,29 @@ class TestNumericRecordArrayNested:
         np.testing.assert_allclose(nra.flatten(), flat)
         np.testing.assert_allclose(nra["outer/deep/g"], flat[:, 0])
 
+    def test_flatten_nested_vector_leaf(self):
+        # A non-scalar (vector) leaf under nesting: flatten lays out its columns
+        # at the leaf's event size, in canonical leaf order, and round-trips.
+        tpl = RecordTemplate(outer=RecordTemplate(a=(2,), b=()), m=())
+        flat = jnp.arange(20.0).reshape(5, 4)  # outer/a (2), outer/b (1), m (1)
+        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(5,))
+        assert np.asarray(nra["outer/a"]).shape == (5, 2)
+        np.testing.assert_allclose(nra["outer/a"], flat[:, 0:2])
+        np.testing.assert_allclose(nra["outer/b"], flat[:, 2])
+        np.testing.assert_allclose(nra["m"], flat[:, 3])
+        np.testing.assert_allclose(nra.flatten(), flat)
+
     def test_getitem_slash_path(self):
         tpl = self._nested_tpl()
         nra = NumericRecordArray.unflatten(
             jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,))
         np.testing.assert_allclose(nra["outer/a"], nra["outer"]["a"])
         with pytest.raises(KeyError):
-            nra["outer/missing"]
+            nra["outer/missing"]    # leaf missing inside the sub-record
+        with pytest.raises(KeyError):
+            nra["nope/a"]           # head field not in the store
+        with pytest.raises(KeyError):
+            nra["m/x"]              # slash descends into a (scalar) leaf
 
     def test_getitem_int_nested_element(self):
         # Integer indexing of a nested record array descends into the nested

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -305,6 +305,60 @@ class TestNumericRecordArrayFlatten:
 
 
 # ---------------------------------------------------------------------------
+# Nested-record flatten / slash indexing (issue #262)
+# ---------------------------------------------------------------------------
+
+
+class TestNumericRecordArrayNested:
+    """flatten() recurses into nested record fields, in depth-first leaf order,
+    and round-trips through unflatten; slash paths index leaves."""
+
+    @staticmethod
+    def _nested_tpl():
+        return RecordTemplate(outer=RecordTemplate(a=(), b=()), m=())
+
+    def test_flatten_nested_record_array_field(self):
+        # The unflatten / canonical-_sample shape: the nested field is itself a
+        # NumericRecordArray (exercises the RecordArray branch).
+        tpl = self._nested_tpl()
+        flat = jnp.arange(15.0).reshape(5, 3)  # columns = outer/a, outer/b, m
+        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(5,))
+        assert isinstance(nra["outer"], NumericRecordArray)
+        np.testing.assert_allclose(nra.flatten(), flat)  # round-trips exactly
+
+    def test_flatten_nested_record_field(self):
+        # The pre-canonical shape: the nested field is a plain Record holding
+        # batch-shaped leaves (exercises the Record branch).
+        tpl = self._nested_tpl()
+        inner = Record(a=jnp.arange(5.0), b=jnp.arange(5.0) + 10)
+        nra = NumericRecordArray(
+            {"outer": inner, "m": jnp.arange(5.0) + 100},
+            batch_shape=(5,), template=tpl,
+        )
+        flat = nra.flatten()
+        assert flat.shape == (5, 3)
+        np.testing.assert_allclose(flat[:, 0], inner["a"])
+        np.testing.assert_allclose(flat[:, 1], inner["b"])
+        np.testing.assert_allclose(flat[:, 2], nra["m"])
+
+    def test_flatten_nested_depth2_roundtrip(self):
+        tpl = RecordTemplate(
+            outer=RecordTemplate(deep=RecordTemplate(g=(), h=()), a=()), m=())
+        flat = jnp.arange(20.0).reshape(5, 4)  # outer/deep/g, outer/deep/h, outer/a, m
+        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(5,))
+        np.testing.assert_allclose(nra.flatten(), flat)
+        np.testing.assert_allclose(nra["outer/deep/g"], flat[:, 0])
+
+    def test_getitem_slash_path(self):
+        tpl = self._nested_tpl()
+        nra = NumericRecordArray.unflatten(
+            jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,))
+        np.testing.assert_allclose(nra["outer/a"], nra["outer"]["a"])
+        with pytest.raises(KeyError):
+            nra["outer/missing"]
+
+
+# ---------------------------------------------------------------------------
 # NumericRecordArray mean / var
 # ---------------------------------------------------------------------------
 

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -357,6 +357,25 @@ class TestNumericRecordArrayNested:
         with pytest.raises(KeyError):
             nra["outer/missing"]
 
+    def test_getitem_int_nested_element(self):
+        # Integer indexing of a nested record array descends into the nested
+        # field, returning a (nested) record element — not an indexing error.
+        tpl = self._nested_tpl()
+        nra = NumericRecordArray.unflatten(
+            jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,))
+        elem = nra[2]
+        assert isinstance(elem, Record)
+        np.testing.assert_allclose(elem["outer"]["a"], nra["outer"]["a"][2])
+        np.testing.assert_allclose(elem.flatten(), nra.flatten()[2])
+
+    def test_getitem_int_nested_multidim_batch(self):
+        tpl = self._nested_tpl()
+        nra = NumericRecordArray.unflatten(
+            jnp.arange(24.0).reshape(2, 4, 3), template=tpl, batch_shape=(2, 4))
+        elem = nra[5]  # flat index into the (2, 4) batch
+        np.testing.assert_allclose(
+            elem["outer"]["a"], np.asarray(nra["outer"]["a"]).reshape(-1)[5])
+
 
 # ---------------------------------------------------------------------------
 # NumericRecordArray mean / var

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -304,10 +304,39 @@ class TestNestedSampleFlatten:
         leaves = list(nested.record_template.numeric_leaf_shapes)
         flat = s.flatten()
         assert flat.shape == (6, len(leaves))  # ('outer/a', 'outer/b', 'm')
+        # Primary check: flatten places each sampled leaf into its own column in
+        # canonical leaf order -- compared against the sample's own slash leaves.
+        # A permuted column order would fail here; the unflatten round-trip below
+        # cannot catch one, since flatten and unflatten share the leaf ordering.
+        for i, leaf in enumerate(leaves):
+            np.testing.assert_allclose(flat[:, i], s[leaf], atol=1e-6)
+        # Secondary: the columns round-trip back to the same leaves via unflatten.
         rec = NumericRecordArray.unflatten(
             flat, template=nested.record_template, batch_shape=(6,))
-        for i, leaf in enumerate(leaves):
-            np.testing.assert_allclose(rec[leaf], flat[:, i], atol=1e-6)
+        for leaf in leaves:
+            np.testing.assert_allclose(rec[leaf], s[leaf], atol=1e-6)
+
+    def test_batched_nested_non_numeric_field_is_plain_record_array(self):
+        # A non-numeric joint (an object-dtype JointEmpirical leaf) makes the
+        # batched nested field a plain RecordArray, not a NumericRecordArray
+        # (the else branch of _sample_nested); such a field is not flattenable.
+        from probpipe import JointEmpirical
+        from probpipe.core._record_array import NumericRecordArray, RecordArray
+        je = JointEmpirical(
+            labels=np.array(["a", "b", "c"], dtype=object),
+            ids=np.array([0, 1, 2]), name="je",
+        )
+        joint = ProductDistribution(
+            name="joint",
+            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
+                   "b": Normal(loc=2.0, scale=0.5, name="b")},
+            je=je,
+        )
+        assert not isinstance(joint, NumericRecordDistribution)
+        s = sample(joint, key=jax.random.PRNGKey(0), sample_shape=(4,))
+        assert isinstance(s, RecordArray) and not isinstance(s, NumericRecordArray)
+        assert isinstance(s["outer"], RecordArray)
+        assert not isinstance(s["outer"], NumericRecordArray)
 
 
 # ===========================================================================

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -270,6 +270,47 @@ class TestFlattenUnflatten:
 
 
 # ===========================================================================
+# 3b. TestNestedSampleFlatten (issue #262)
+# ===========================================================================
+
+class TestNestedSampleFlatten:
+    """A batched draw from a nested ProductDistribution is a canonical, nested
+    NumericRecordArray that flattens and round-trips; the unbatched draw stays
+    a plain Record."""
+
+    @pytest.fixture
+    def nested(self):
+        return ProductDistribution(
+            name="joint",
+            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
+                   "b": Normal(loc=2.0, scale=0.5, name="b")},
+            m=Normal(loc=-1.0, scale=1.0, name="m"),
+        )
+
+    def test_batched_nested_field_is_record_array(self, nested):
+        from probpipe.core._record_array import NumericRecordArray
+        s = sample(nested, key=jax.random.PRNGKey(0), sample_shape=(6,))
+        assert isinstance(s, NumericRecordArray)
+        assert isinstance(s["outer"], NumericRecordArray)  # not a plain Record
+
+    def test_unbatched_nested_field_stays_record(self, nested):
+        s = sample(nested, key=jax.random.PRNGKey(0))
+        assert isinstance(s, Record) and not isinstance(s, RecordArray)
+        assert isinstance(s["outer"], Record) and not isinstance(s["outer"], RecordArray)
+
+    def test_batched_nested_flatten_roundtrip(self, nested):
+        from probpipe.core._record_array import NumericRecordArray
+        s = sample(nested, key=jax.random.PRNGKey(1), sample_shape=(6,))
+        leaves = list(nested.record_template.numeric_leaf_shapes)
+        flat = s.flatten()
+        assert flat.shape == (6, len(leaves))  # ('outer/a', 'outer/b', 'm')
+        rec = NumericRecordArray.unflatten(
+            flat, template=nested.record_template, batch_shape=(6,))
+        for i, leaf in enumerate(leaves):
+            np.testing.assert_allclose(rec[leaf], flat[:, i], atol=1e-6)
+
+
+# ===========================================================================
 # 4. TestDistributionView (RecordDistributionView for ProductDistribution)
 # ===========================================================================
 

--- a/tests/inference/test_bayesflow_likelihoods.py
+++ b/tests/inference/test_bayesflow_likelihoods.py
@@ -62,6 +62,18 @@ def _prior():
     )
 
 
+def _nested_prior():
+    """Nested conjugate prior (issue #262): a sub-record ``outer={a, b}`` plus a
+    top-level ``m`` -- leaves ``outer/a``, ``outer/b``, ``m``, all ``N(0, 1)`` so
+    ``_analytic_posterior`` applies per leaf (``flatten`` order ``[a, b, m]``)."""
+    return ProductDistribution(
+        name="joint",
+        outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
+               "b": Normal(loc=0.0, scale=1.0, name="b")},
+        m=Normal(loc=0.0, scale=1.0, name="m"),
+    )
+
+
 def _analytic_posterior(y_rows: np.ndarray) -> tuple[np.ndarray, float]:
     n = y_rows.shape[0]
     s2 = _SIGMA**2
@@ -260,6 +272,46 @@ class TestConditioning:
         self._check_posterior(SimpleModel(prior=_prior(), likelihood=nre), y,
                               mean_tol=0.3, ratio_band=(0.8, 1.25))
 
+    def _check_nested_posterior(self, model, y, mean_tol, ratio_band):
+        """Like ``_check_posterior`` but over the three *nested* leaves
+        (``outer/a``, ``outer/b``, ``m``) -- in ``flatten`` order, so leaf j of
+        the analytic posterior lines up with observation column j."""
+        post = condition_on(model, jnp.asarray(y),
+                            num_results=1500, num_warmup=500, random_seed=0)
+        draws = np.stack([np.asarray(post.draws()[f]).reshape(-1)
+                          for f in ("outer/a", "outer/b", "m")], axis=-1)
+        an_mean, an_std = _analytic_posterior(np.asarray(y))
+        mean_err = np.abs(draws.mean(0) - an_mean).max() / an_std
+        ratio = draws.std(0) / an_std
+        assert mean_err < mean_tol, (mean_err, draws.mean(0), an_mean)
+        assert (ratio_band[0] < ratio).all() and (ratio < ratio_band[1]).all(), ratio
+
+    def test_nle_nested_prior_end_to_end(self):
+        """NLE lifts a nested prior (issue #262): SimpleModel(nested prior, learned
+        likelihood) + condition_on -> NUTS recovers the analytic conjugate
+        posterior, per nested leaf. NLE feeds raw theta to the network, so the
+        nesting is purely the leaf-keyed adapter routing (no bijectors)."""
+        prior = _nested_prior()
+        nle = learn_amortized_likelihood(
+            prior, _SIM, num_simulations=4000, epochs=25,
+            batch_size=256, random_seed=0, verbose=0,
+        )
+        y = np.array([[0.8, -0.4, 0.3]], dtype="float32")
+        self._check_nested_posterior(SimpleModel(prior=prior, likelihood=nle), y,
+                                     mean_tol=0.3, ratio_band=(0.85, 1.25))
+
+    def test_nre_nested_prior_end_to_end(self):
+        """NRE lifts a nested prior (issue #262): the same nested conjugate
+        recovery as NLE, via the leaf-keyed classifier routing."""
+        prior = _nested_prior()
+        nre = learn_amortized_ratio(
+            prior, _SIM, num_simulations=8000, epochs=40,
+            batch_size=256, random_seed=0, verbose=0,
+        )
+        y = np.array([[0.8, -0.4, 0.3]], dtype="float32")
+        self._check_nested_posterior(SimpleModel(prior=prior, likelihood=nre), y,
+                                     mean_tol=0.3, ratio_band=(0.8, 1.25))
+
     def test_nle_constrained_prior_matches_true_likelihood(self):
         """A constrained (Gamma) prior end to end, judged against NUTS run with
         the TRUE (analytic Gaussian) likelihood on the same model -- isolating
@@ -371,16 +423,6 @@ class TestValidation:
     def test_rejects_non_record_prior(self):
         with pytest.raises(TypeError, match="RecordDistribution"):
             learn_amortized_ratio(jnp.zeros(2), _SIM, num_simulations=8, epochs=1)
-
-    def test_rejects_nested_prior(self):
-        nested = ProductDistribution(
-            name="joint",
-            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
-                   "b": Normal(loc=0.0, scale=1.0, name="b")},
-            m=Normal(loc=0.0, scale=1.0, name="m"),
-        )
-        with pytest.raises(TypeError, match="nested"):
-            learn_amortized_likelihood(nested, _SIM, num_simulations=8, epochs=1)
 
     def test_dequantize_rejects_counts_at_float32_cell_limit(self):
         """dequantize=True enforces the documented 2**23 bound on the simulated

--- a/tests/inference/test_bayesflow_posteriors.py
+++ b/tests/inference/test_bayesflow_posteriors.py
@@ -26,6 +26,7 @@ from probpipe import (
     condition_on,
     learn_amortized_posterior,
 )
+from probpipe.core._record_array import NumericRecordArray
 from probpipe.modeling import GenerativeLikelihood, Likelihood
 
 
@@ -193,6 +194,44 @@ class _PositiveLikelihood(Likelihood, GenerativeLikelihood):
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([r + m, r - m])
         return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
+
+
+def _nested_prior():
+    """Nested ``ProductDistribution`` (issue #262): a sub-record ``outer`` (a
+    positive leaf ``r`` and a real leaf ``m``) plus a top-level real ``c`` --
+    leaves ``outer/r``, ``outer/m``, ``c``. The ``Gamma`` leaf exercises a
+    per-leaf bijector *under* nesting; ``flatten`` order is ``[r, m, c]``."""
+    return ProductDistribution(
+        name="joint",
+        outer={"r": pp.Gamma(3.0, 1.0, name="r"),
+               "m": Normal(loc=0.0, scale=1.0, name="m")},
+        c=Normal(loc=0.0, scale=1.0, name="c"),
+    )
+
+
+class _NestedLikelihood(Likelihood, GenerativeLikelihood):
+    """Nested params (``outer={r, m}``, ``c``) -> ``y = [r + c, m - c, r - m]`` +
+    small noise. Reads the per-draw record by *nested* name
+    (``params["outer"]["r"]``), locking the structured-record contract under
+    nesting -- a flattened-vector regression would raise here."""
+
+    def log_likelihood(self, params, data):
+        return jnp.array(0.0)
+
+    def generate_data(self, params, num_observations, *, key=None):
+        r, m, c = params["outer"]["r"], params["outer"]["m"], params["c"]
+        key = key if key is not None else jax.random.PRNGKey(0)
+        mean = jnp.stack([r + c, m - c, r - m])
+        return mean[None, :] + 0.1 * jax.random.normal(key, (num_observations, 3))
+
+
+def _nested_observe(r, m, c, seed):
+    """Observe ``_NestedLikelihood`` at a given (r, m, c) by building the nested
+    per-draw record via ``unflatten`` (flatten order ``[r, m, c]``) -- the same
+    structured object the offline simulator passes the simulator at train time."""
+    rec = NumericRecordArray.unflatten(
+        jnp.array([r, m, c]), template=_nested_prior().record_template, batch_shape=())
+    return _NestedLikelihood().generate_data(rec, 1, key=jax.random.PRNGKey(seed))[0]
 
 
 @pytest.fixture(scope="module")
@@ -473,6 +512,68 @@ class TestBayesFlowMethods:
         # Uncertainty: mean std ratio in [0.8, 1.25] (observed ~1.01-1.03 across seeds).
         assert 0.8 < np.mean(std_ratios) < 1.25
 
+    def test_nested_prior_end_to_end(self):
+        """A nested prior (issue #262) trains and conditions end to end. The
+        simulator receives the structured *nested* record (read by nested name),
+        posterior draws come back under the same nested leaf names, and the
+        constrained leaf ``outer/r`` is mapped back through its per-leaf bijector
+        so every draw lands in the positive support. NPE no longer rejects nested
+        priors -- it lifts them via per-leaf bijectors and adapter keying."""
+        model = learn_amortized_posterior(
+            _nested_prior(), _NestedLikelihood(), method="npe",
+            num_simulations=3000, epochs=8, batch_size=256,
+            num_results=400, random_seed=0, verbose=0,
+        )
+        draws = condition_on(model, _nested_observe(2.0, -0.5, 0.4, seed=7)).draws()
+        r = np.asarray(draws["outer/r"]).reshape(-1)
+        m = np.asarray(draws["outer/m"]).reshape(-1)
+        c = np.asarray(draws["c"]).reshape(-1)
+        assert r.shape == (400,) and m.shape == (400,) and c.shape == (400,)
+        assert np.isfinite(r).all() and np.isfinite(m).all() and np.isfinite(c).all()
+        assert (r > 0).all()        # per-leaf forward bijector (Exp) under nesting
+        # Amortized response: the posterior mean of `c` tracks the observation.
+        mean_c_hi = float(np.mean(np.asarray(
+            condition_on(model, _nested_observe(2.0, 0.0, 1.0, 2)).draws()["c"])))
+        mean_c_lo = float(np.mean(np.asarray(
+            condition_on(model, _nested_observe(2.0, 0.0, -1.0, 3)).draws()["c"])))
+        assert mean_c_hi > mean_c_lo
+
+    def test_nested_prior_calibration_against_conjugate(self):
+        """Decisive correctness check for the nested lift (issue #262): against a
+        conjugate Gaussian with an analytic posterior, each *nested* leaf's
+        posterior mean and spread match the analytic values. The leaves round-trip
+        in flatten order (``outer/a``, ``outer/b``, ``m``); a mis-ordered column or
+        a mis-keyed per-leaf bijector would land a leaf's mass on the wrong
+        coordinate and fail here."""
+        prior = ProductDistribution(
+            name="joint",
+            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
+                   "b": Normal(loc=0.0, scale=1.0, name="b")},
+            m=Normal(loc=0.0, scale=1.0, name="m"),
+        )
+        model = learn_amortized_posterior(
+            prior, _ConjugateGaussianLikelihood(), method="npe",
+            num_simulations=5000, epochs=40, batch_size=256,
+            num_results=4000, random_seed=0, verbose=0,
+        )
+        s2 = _CONJ_SIGMA**2
+        post_std = (s2 / (1 + s2)) ** 0.5
+        sim = _ConjugateGaussianLikelihood()
+        leaves = ("outer/a", "outer/b", "m")
+        mean_errs, std_ratios = [], []
+        for i in range(6):
+            theta = jax.random.normal(jax.random.PRNGKey(100 + i), (3,))
+            obs = sim.generate_data(theta, 1, key=jax.random.PRNGKey(900 + i))[0]
+            draws = condition_on(model, obs).draws()
+            for j, leaf in enumerate(leaves):
+                x = np.asarray(draws[leaf]).reshape(-1)
+                analytic_mean = float(obs[j]) / (1 + s2)
+                mean_errs.append(abs(float(x.mean()) - analytic_mean))
+                std_ratios.append(float(x.std()) / post_std)
+        # Same margins as the flat conjugate test (seed-reproducible; absorbs drift).
+        assert np.mean(mean_errs) < 0.3 * post_std
+        assert 0.8 < np.mean(std_ratios) < 1.25
+
     def test_simulator_receives_named_record(self):
         """generate_data receives the prior's structured per-draw sample (named
         fields), per the GenerativeLikelihood contract -- the simulator uses
@@ -665,18 +766,6 @@ class TestBayesFlowValidation:
         kwargs = {"num_simulations": 8, "epochs": 1, **override}
         with pytest.raises(TypeError, match="must be an integer"):
             learn_amortized_posterior(_prior(), _ToyLikelihood(), **kwargs)
-
-    def test_rejects_nested_prior(self):
-        """A nested prior (dict components) is rejected up front: the per-field
-        bijector and adapter machinery is flat."""
-        nested = ProductDistribution(
-            name="joint",
-            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
-                   "b": Normal(loc=0.0, scale=1.0, name="b")},
-            m=Normal(loc=0.0, scale=1.0, name="m"),
-        )
-        with pytest.raises(TypeError, match="nested"):
-            learn_amortized_posterior(nested, _ToyLikelihood(), num_simulations=8, epochs=1)
 
     def test_rejects_discrete_prior(self):
         """A discrete prior field has no smooth bijector to R^d and is rejected up

--- a/tests/inference/test_bayesflow_posteriors.py
+++ b/tests/inference/test_bayesflow_posteriors.py
@@ -574,6 +574,30 @@ class TestBayesFlowMethods:
         assert np.mean(mean_errs) < 0.3 * post_std
         assert 0.8 < np.mean(std_ratios) < 1.25
 
+    def test_nested_wishart_matrix_leaf(self):
+        """A matrix-valued constrained leaf (Wishart, positive-definite) nested
+        under ``outer``: the per-leaf inverse bijector runs at the leaf's native
+        (n, n) event shape under nesting (a flat layout would crash the
+        CholeskyOuterProduct chain), and the forward map at sample time returns
+        SPD draws under the nested leaf name ``outer/cov`` -- the nested analogue
+        of test_wishart_matrix_prior_round_trip."""
+        prior = ProductDistribution(
+            name="joint",
+            outer={"cov": pp.Wishart(df=4.0, scale=jnp.eye(2), name="cov"),
+                   "m": Normal(loc=0.0, scale=1.0, name="m")},
+            c=Normal(loc=0.0, scale=1.0, name="c"),
+        )
+        model = learn_amortized_posterior(
+            prior, _ConjugateGaussianLikelihood(), method="fmpe",
+            num_simulations=600, epochs=2, batch_size=256,
+            num_results=200, random_seed=0, verbose=0,
+        )
+        obs = jnp.array([1.5, 0.3, 0.3, 1.2, 0.5, 0.0])  # flat (cov 2x2, m, c)
+        cov = np.asarray(condition_on(model, obs).draws()["outer/cov"]).reshape(-1, 2, 2)
+        assert np.isfinite(cov).all()
+        np.testing.assert_allclose(cov, np.swapaxes(cov, -1, -2), atol=1e-5)  # symmetric
+        assert np.linalg.eigvalsh(cov).min() > 0  # positive definite
+
     def test_simulator_receives_named_record(self):
         """generate_data receives the prior's structured per-draw sample (named
         fields), per the GenerativeLikelihood contract -- the simulator uses


### PR DESCRIPTION
## Summary

Lifts the BayesFlow amortized SBI learners (**NPE / NLE / NRE**) to **nested
`ProductDistribution` priors** — the bridge half of #262. Closes #262.

> **Stacked on #274.** This PR's base is `dev/nested-record-flatten`. #274 is
> the core half (nested `RecordArray.flatten` / `ProductDistribution._sample`);
> this PR builds the SBI bridge on top of it. Review/merge #274 first — once it
> lands, GitHub will retarget this PR to `main`. The diff below is **only** the
> bridge changes.

## Background

A nested prior is a `ProductDistribution` whose components include a dict, e.g.

```python
prior = ProductDistribution(
    name="joint",
    outer={"a": Normal(0., 1., name="a"), "b": Normal(0., 1., name="b")},
    m=Normal(0., 1., name="m"),
)
```

Its `record_template` has top-level **fields** `("outer", "m")` but numeric
**leaves** `("outer/a", "outer/b", "m")`. The bridge used to iterate the
top-level fields and reject any nested prior up front with a `TypeError`,
because the offline-simulation pipeline flattens the draws first and that
flatten did not handle nested records (fixed in #274).

## What changed

The bridge now iterates the prior's **numeric leaves**
(`record_template.numeric_leaf_shapes`, slash paths like `"outer/a"`) instead of
its top-level fields. For a flat prior the leaves *are* the fields, in the same
order, so the flat path is **behavior-preserving**; for a nested prior they span
the full structure.

| File | Change |
|------|--------|
| `_bayesflow_common.py` | `_simulate_offline` keys the simulated-theta dict by leaf path; `_adapter_field_keys` documents leaf-order keying; the nested-prior guard in `_validate_learn_inputs` is removed. |
| `_bayesflow_posteriors.py` (NPE) | `_field_bijectors`, the unconstrained-size sum, and `BayesFlowModel`'s sample-time column assembly all key on leaves. Per-leaf bijectors run at each leaf's native event shape; columns are concatenated in canonical flatten order, so the nested `record_template` unflattens posterior draws back under their leaf names. |
| `_bayesflow_likelihoods.py` (NLE/NRE) | Keys the training `sims` dict by leaf. θ is a raw network input here, so there are no bijectors — purely the adapter routing. |

The internal `theta_i` adapter re-keying means slash-delimited leaf paths never
enter BayesFlow's key namespace, so nesting introduces no new collision surface.

## Tests

The two `test_rejects_nested_prior` tests (one per file) are replaced with
positive end-to-end coverage:

- **NPE — `test_nested_prior_end_to_end`**: a nested prior with a constrained
  (`Gamma`) leaf trains and conditions; the simulator receives the structured
  *nested* record (read by nested name); draws come back under their nested leaf
  names; the constrained leaf's draws all land in the positive support (per-leaf
  forward bijector under nesting); and the posterior responds to the data
  (amortization).
- **NPE — `test_nested_prior_calibration_against_conjugate`**: the decisive
  correctness check. Against a conjugate Gaussian with an analytic posterior,
  each nested leaf's posterior mean *and* spread match the analytic values. A
  mis-ordered column or a mis-keyed per-leaf bijector would land a leaf's mass on
  the wrong coordinate and fail here.
- **NLE / NRE — `test_{nle,nre}_nested_prior_end_to_end`**: nested conjugate
  recovery (`SimpleModel(nested prior, learned) + condition_on → NUTS`) against
  the analytic posterior, per leaf.

### Verification

Run in a `dev + bayesflow` env (`KERAS_BACKEND=jax`):

- 4 nested tests (NPE smoke, NPE calibration, NLE e2e, NRE e2e): **pass**.
- 29 flat-prior regression tests across the refactored paths
  (vector / matrix-Wishart / multi- / single-field, constrained, adapter
  collisions, both validation classes, NLE/NRE conditioning): **pass**.
- `ruff check` on all five changed files: clean.

## Notes

- No public API change: `learn_amortized_posterior` / `learn_amortized_likelihood`
  / `learn_amortized_ratio` signatures are unchanged; nested priors that used to
  raise now train.
- Docstrings updated to drop the "flat / non-nested" restriction (including the
  now-removed `Raises: TypeError ... the prior is nested` clause on
  `learn_amortized_posterior`).
