### PR TITLE
docs: unflatten Returns + nested-array note + fix Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/TARPS-group/prob-pipe/actions/workflows/ci.yml/badge.svg)](https://github.com/TARPS-group/prob-pipe/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/TARPS-group/prob-pipe/branch/main/graph/badge.svg)](https://codecov.io/gh/TARPS-group/prob-pipe)
 [![docs](https://img.shields.io/badge/docs-tarps--group.github.io%2Fprob--pipe-blue)](https://tarps-group.github.io/prob-pipe/)
-[![DOI](https://zenodo.org/badge/1041525504.svg)](https://doi.org/10.5281/zenodo.20683559)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20683559.svg)](https://doi.org/10.5281/zenodo.20683559)
 
 **[Installation Guide](#installation)** | **[Getting Started](https://tarps-group.github.io/prob-pipe/tutorials/getting_started/)** | **[Full Documentation](https://tarps-group.github.io/prob-pipe/)** | **[Help](https://tarps-group.github.io/prob-pipe/help/)**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/TARPS-group/prob-pipe/actions/workflows/ci.yml/badge.svg)](https://github.com/TARPS-group/prob-pipe/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/TARPS-group/prob-pipe/branch/main/graph/badge.svg)](https://codecov.io/gh/TARPS-group/prob-pipe)
 [![docs](https://img.shields.io/badge/docs-tarps--group.github.io%2Fprob--pipe-blue)](https://tarps-group.github.io/prob-pipe/)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20683559.svg)](https://doi.org/10.5281/zenodo.20683559)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20683559-blue)](https://doi.org/10.5281/zenodo.20683559)
 
 **[Installation Guide](#installation)** | **[Getting Started](https://tarps-group.github.io/prob-pipe/tutorials/getting_started/)** | **[Full Documentation](https://tarps-group.github.io/prob-pipe/)** | **[Help](https://tarps-group.github.io/prob-pipe/help/)**
 

--- a/docs/examples/02_records.ipynb
+++ b/docs/examples/02_records.ipynb
@@ -1162,6 +1162,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "585c9699",
+   "metadata": {},
+   "source": [
+    "**Nested fields carry through to arrays.** The nesting from §2 (and the\n",
+    "nested templates above) also works for batches: a `NumericRecordArray` whose\n",
+    "template has nested fields supports the same slash-path access as a `Record`\n",
+    "— `arr[\"outer/a\"]` indexes a nested leaf across the whole batch — and\n",
+    "`flatten` / `unflatten` recurse into nested fields depth-first in leaf order,\n",
+    "so a nested batch round-trips through a single flat array just like the flat\n",
+    "case above. Build one by sampling a nested `ProductDistribution`, or with\n",
+    "`NumericRecordArray.unflatten` and a nested `RecordTemplate`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c1c39ef0",
    "metadata": {},
    "source": [

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -482,6 +482,11 @@ class NumericRecordArray(RecordArray):
     ) -> NumericRecordArray:
         """Reconstruct from a flat array.
 
+        The inverse of :meth:`flatten`: nested ``RecordTemplate`` specs are
+        rebuilt recursively, so a template with nested fields yields nested
+        ``NumericRecordArray`` fields, matching the depth-first leaf order
+        ``flatten`` uses.
+
         Parameters
         ----------
         flat : array
@@ -490,6 +495,12 @@ class NumericRecordArray(RecordArray):
             Structural description providing field names and event shapes.
         batch_shape : tuple of int, optional
             If not provided, inferred as ``flat.shape[:-1]``.
+
+        Returns
+        -------
+        NumericRecordArray
+            Array of the template's structure with the given ``batch_shape``;
+            nested template fields become nested ``NumericRecordArray`` fields.
         """
         if batch_shape is None:
             batch_shape = flat.shape[:-1]


### PR DESCRIPTION
## Summary

Documentation follow-ups. The first two items are from the comments/docs review of
#274 (nested-record support in the core record layer) — #274 merged before they
landed, so they're split out here — plus a README badge fix.

- **`NumericRecordArray.unflatten`** gains a `Returns` section and a note that it is
  the inverse of `flatten` — nested `RecordTemplate` specs rebuild as nested
  `NumericRecordArray` fields in depth-first leaf order. `flatten`'s docstring
  already referenced `unflatten`; this completes the pair.
- **`docs/examples/02_records.ipynb`** gains a note in the array section (§5) that
  nesting carries through to `NumericRecordArray` — slash-path leaf access
  (`arr["outer/a"]`) and depth-first `flatten` / `unflatten` — tying it to the
  nested Records and nested templates shown earlier in the notebook.
- **`README.md` — fix the broken Zenodo DOI badge.** The Zenodo-hosted badge SVG
  resolves fine when opened directly but does not render through GitHub's camo
  image proxy (a known Zenodo + camo issue), so it showed as a broken image.
  Replaced it with a shields.io static badge for the **concept** DOI
  (`…20683559`) — the same service as the existing `docs` badge, which camo
  renders reliably. This also fixes a prior inconsistency: the old
  `badge/<repo_id>.svg` form rendered the *version* DOI (`…20683560`) rather than
  the concept DOI used by the badge link, the BibTeX entry, `CITATION.cff`, and the
  Cite page. The link target (the DOI) is unchanged.

## Notes

- Docs-only; no code behavior change.
- Markdown-only notebook edit (no new executed cells); the notebook still executes
  cleanly under the same `nbconvert --execute` that CI runs (verified locally).
