### PR TITLE
feat(core): keyword form for log_prob-family ops via _pack_value (#228 PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single draw via the new `Distribution._pack_value` (single-field → the bare
   field value; multi-field → a `Record`). The positional form is unchanged and
   still broadcasts. Per-call ProbPipe controls use `with_options` —
-  `log_prob.with_options(seed=0)(dist, x)` — consistent with the dispatch ops,
-  so a field whose name matches a control (`seed` / `n_broadcast_samples` /
-  `include_inputs`) is addressed normally by the keyword form.
+  `log_prob.with_options(seed=0)(dist, value)`, delegating to the op's inner
+  WorkflowFunction — so a field whose name matches a control (`seed` /
+  `n_broadcast_samples` / `include_inputs`) is addressed normally by the bare
+  keyword form.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single draw via the new `Distribution._pack_value` (single-field → the bare
   field value; multi-field → a `Record`). The positional form is unchanged and
   still broadcasts. Per-call ProbPipe controls use `with_options` —
-  `log_prob.with_options(seed=0)(dist, x)` — consistent with the dispatch ops.
-  Constructing a distribution whose field name collides with a reserved
-  WorkflowFunction control (`seed` / `n_broadcast_samples` / `include_inputs`)
-  now warns.
+  `log_prob.with_options(seed=0)(dist, x)` — consistent with the dispatch ops,
+  so a field whose name matches a control (`seed` / `n_broadcast_samples` /
+  `include_inputs`) is addressed normally by the keyword form.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dataset). The cell is a no-op in local Jupyter, the docs build, and CI, so
   notebook execution elsewhere is unaffected.
 
+- **Keyword form for the `log_prob`-family ops (#228).** `log_prob`, `prob`,
+  `unnormalized_log_prob`, `unnormalized_prob`, and the `random_*_log_prob`
+  ops accept named field arguments —
+  `log_prob(model, intercept=0.0, slope=0.5, X=X_obs, y=y_obs)` — built into a
+  single draw via the new `Distribution._pack_value` (single-field → the bare
+  field value; multi-field → a `Record`). The positional form is unchanged and
+  still broadcasts. Constructing a distribution whose field name collides with a
+  reserved WorkflowFunction control (`seed` / `n_broadcast_samples` /
+  `include_inputs`) now warns.
+
 ### Changed
+
+- **(Breaking) `dist` and `value` are positional-only on the density ops
+  (#228).** To free the keyword namespace for field names, `log_prob`, `prob`,
+  `unnormalized_log_prob`, `unnormalized_prob`, and the `random_*_log_prob` ops
+  take `dist` and `value` positionally only — `log_prob(dist, value=x)` becomes
+  `log_prob(dist, x)`. `SupportsLogProb` / `SupportsUnnormalizedLogProb` are now
+  generic in the sample type (`SupportsLogProb[T]`).
 
 - **Amortized SBI learners accept nested priors (#262).**
   `learn_amortized_posterior` / `learn_amortized_likelihood` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `log_prob(model, intercept=0.0, slope=0.5, X=X_obs, y=y_obs)` — built into a
   single draw via the new `Distribution._pack_value` (single-field → the bare
   field value; multi-field → a `Record`). The positional form is unchanged and
-  still broadcasts. Constructing a distribution whose field name collides with a
-  reserved WorkflowFunction control (`seed` / `n_broadcast_samples` /
-  `include_inputs`) now warns.
+  still broadcasts. Per-call ProbPipe controls use `with_options` —
+  `log_prob.with_options(seed=0)(dist, x)` — consistent with the dispatch ops.
+  Constructing a distribution whose field name collides with a reserved
+  WorkflowFunction control (`seed` / `n_broadcast_samples` / `include_inputs`)
+  now warns.
 
 ### Changed
 

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -9,6 +9,7 @@ Provides:
 from __future__ import annotations
 
 import copy as _copy
+import warnings
 from abc import ABC, abstractmethod
 # ``_ProtocolMeta`` is technically private (leading underscore in
 # ``typing``), but it's the only way to compose a custom metaclass with
@@ -62,6 +63,45 @@ def set_return_approx_dist(value: bool) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Parameter names reserved by ``WorkflowFunction`` for call-time control
+# (see node.py).  A distribution field with one of these names cannot be
+# addressed through the keyword form ``log_prob(dist, seed=...)`` — the
+# workflow layer intercepts it — so we warn at construction.
+_RESERVED_WF_PARAMS: frozenset[str] = frozenset(
+    {"seed", "n_broadcast_samples", "include_inputs"}
+)
+
+
+def _warn_reserved_field_names(instance: Any) -> None:
+    """Warn if a distribution's field names collide with reserved WF params.
+
+    Cheap and side-effect-free: inspects only the *cached* record
+    template (``_record_template``) — never forces the lazy auto-build —
+    and the distribution's own ``name`` (which becomes the single field
+    for auto-built templates). A collision means the keyword form
+    ``log_prob(dist, <field>=...)`` is intercepted by the workflow layer;
+    the user must pass a positional ``Record`` for that field instead.
+    """
+    names: set[str] = set()
+    tpl = getattr(instance, "_record_template", None)
+    if tpl is not None:
+        names.update(getattr(tpl, "fields", ()))
+    else:
+        nm = getattr(instance, "_name", None)
+        if isinstance(nm, str):
+            names.add(nm)
+    clash = _RESERVED_WF_PARAMS & names
+    if clash:
+        warnings.warn(
+            f"{type(instance).__name__} has field name(s) {sorted(clash)} "
+            f"that collide with WorkflowFunction-reserved parameters "
+            f"({sorted(_RESERVED_WF_PARAMS)}); the keyword form "
+            f"log_prob(dist, {sorted(clash)[0]}=...) is intercepted by the "
+            f"workflow layer. Pass a positional Record for those fields.",
+            stacklevel=3,
+        )
+
+
 class _DistributionMeta(_ProtocolMeta):
     """Metaclass enforcing that every Distribution instance has a
     non-empty ``name`` set by the time construction returns.
@@ -89,6 +129,7 @@ class _DistributionMeta(_ProtocolMeta):
                 f"(via super().__init__(name=...) or by assigning "
                 f"self._name to a non-empty string) before returning."
             )
+        _warn_reserved_field_names(instance)
         return instance
 
 
@@ -113,6 +154,60 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
                 f"{type(self).__name__} requires a non-empty name= argument"
             )
         self._name = name
+
+    # -- keyword-form value construction ------------------------------------
+
+    def _pack_value(self, **field_kwargs: Any) -> Any:
+        """Build a single draw of this distribution's value type ``T`` from
+        named field kwargs — the adapter behind the keyword form
+        ``log_prob(dist, field=value, ...)``.
+
+        Default behaviour, driven by the distribution's named ``fields``:
+
+        * **single field** → the bare field value (``T = Array``), so a
+          scalar distribution's ``_log_prob`` still receives a raw array.
+        * **multiple fields** → a :class:`~probpipe.core.record.Record`
+          keyed in field order (``T = Record``).
+
+        Distributions whose ``_log_prob`` consumes a Record but splits it
+        internally (e.g. ``SimpleModel`` → ``(params, data)``) keep this
+        default and do the split in ``_log_prob``. Override only when the
+        value type is neither a bare array nor a flat Record.
+
+        Builds exactly one draw (``sample_shape == ()``). Batched
+        evaluation does not go through kwargs — pass the batch positionally
+        and let ``WorkflowFunction`` broadcasting handle it.
+
+        Raises
+        ------
+        TypeError
+            If the distribution has no named fields, or the kwargs do not
+            match its fields exactly (missing or unexpected names).
+        """
+        fields = getattr(self, "fields", None)
+        if not fields:
+            raise TypeError(
+                f"{type(self).__name__} does not support the keyword form of "
+                f"log_prob (it has no named fields); pass a positional value."
+            )
+        given = set(field_kwargs)
+        expected = set(fields)
+        missing = [f for f in fields if f not in given]
+        extra = [k for k in field_kwargs if k not in expected]
+        if missing or extra:
+            parts = []
+            if missing:
+                parts.append(f"missing {missing}")
+            if extra:
+                parts.append(f"unexpected {extra}")
+            raise TypeError(
+                f"{type(self).__name__}: the keyword form expects exactly the "
+                f"fields {tuple(fields)} — {'; '.join(parts)}."
+            )
+        if len(fields) == 1:
+            return field_kwargs[fields[0]]
+        from .record import Record
+        return Record(**{f: field_kwargs[f] for f in fields})
 
     # -- approximation tracking ---------------------------------------------
 

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -97,7 +97,8 @@ def _warn_reserved_field_names(instance: Any) -> None:
             f"that collide with WorkflowFunction-reserved parameters "
             f"({sorted(_RESERVED_WF_PARAMS)}); the keyword form "
             f"log_prob(dist, {sorted(clash)[0]}=...) is intercepted by the "
-            f"workflow layer. Pass a positional Record for those fields.",
+            f"workflow layer. Pass the value positionally "
+            f"(log_prob(dist, value)) instead.",
             stacklevel=3,
         )
 

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -9,7 +9,6 @@ Provides:
 from __future__ import annotations
 
 import copy as _copy
-import warnings
 from abc import ABC, abstractmethod
 # ``_ProtocolMeta`` is technically private (leading underscore in
 # ``typing``), but it's the only way to compose a custom metaclass with
@@ -63,46 +62,6 @@ def set_return_approx_dist(value: bool) -> None:
 # ---------------------------------------------------------------------------
 
 
-# Parameter names reserved by ``WorkflowFunction`` for call-time control
-# (see node.py).  A distribution field with one of these names cannot be
-# addressed through the keyword form ``log_prob(dist, seed=...)`` — the
-# workflow layer intercepts it — so we warn at construction.
-_RESERVED_WF_PARAMS: frozenset[str] = frozenset(
-    {"seed", "n_broadcast_samples", "include_inputs"}
-)
-
-
-def _warn_reserved_field_names(instance: Any) -> None:
-    """Warn if a distribution's field names collide with reserved WF params.
-
-    Cheap and side-effect-free: inspects only the *cached* record
-    template (``_record_template``) — never forces the lazy auto-build —
-    and the distribution's own ``name`` (which becomes the single field
-    for auto-built templates). A collision means the keyword form
-    ``log_prob(dist, <field>=...)`` is intercepted by the workflow layer;
-    the user must pass a positional ``Record`` for that field instead.
-    """
-    names: set[str] = set()
-    tpl = getattr(instance, "_record_template", None)
-    if tpl is not None:
-        names.update(getattr(tpl, "fields", ()))
-    else:
-        nm = getattr(instance, "_name", None)
-        if isinstance(nm, str):
-            names.add(nm)
-    clash = _RESERVED_WF_PARAMS & names
-    if clash:
-        warnings.warn(
-            f"{type(instance).__name__} has field name(s) {sorted(clash)} "
-            f"that collide with WorkflowFunction-reserved parameters "
-            f"({sorted(_RESERVED_WF_PARAMS)}); the keyword form "
-            f"log_prob(dist, {sorted(clash)[0]}=...) is intercepted by the "
-            f"workflow layer. Pass the value positionally "
-            f"(log_prob(dist, value)) instead.",
-            stacklevel=3,
-        )
-
-
 class _DistributionMeta(_ProtocolMeta):
     """Metaclass enforcing that every Distribution instance has a
     non-empty ``name`` set by the time construction returns.
@@ -130,7 +89,6 @@ class _DistributionMeta(_ProtocolMeta):
                 f"(via super().__init__(name=...) or by assigning "
                 f"self._name to a non-empty string) before returning."
             )
-        _warn_reserved_field_names(instance)
         return instance
 
 

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -116,7 +116,13 @@ def workflow_function(_func=None, /, **kwargs):
         with parentheses.
     """
     def decorator(func: Callable[..., Any]) -> WorkflowFunction:
-        return WorkflowFunction(func=func, name=func.__name__, **kwargs)
+        # ``name`` defaults to the function name but may be overridden via
+        # ``@workflow_function(name=...)`` — e.g. when the public op is a
+        # thin wrapper over an inner ``_<op>_impl`` and the broadcast output
+        # field should be keyed by the public op name, not the impl name.
+        call_kwargs = dict(kwargs)
+        name = call_kwargs.pop("name", func.__name__)
+        return WorkflowFunction(func=func, name=name, **call_kwargs)
 
     if _func is not None:
         return decorator(_func)

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -93,32 +93,125 @@ def sample(
     return dist._sample(key, sample_shape)
 
 
-@workflow_function
-def log_prob(dist: SupportsLogProb, value: Any) -> Array:
-    """Evaluate the normalized log-density at *value*."""
-    if not isinstance(dist, SupportsLogProb):
+# -- value resolution shared by the density ops -----------------------------
+#
+# Each density op is an outer Python wrapper over an inner
+# ``@workflow_function`` impl.  The outer layer resolves the
+# positional-or-keyword value and forwards the WorkflowFunction control
+# kwargs explicitly, so a distribution field whose name happens to be a
+# reserved control name (``seed`` / ``n_broadcast_samples`` /
+# ``include_inputs``) cannot be silently swallowed by the workflow layer.
+# Broadcasting still happens — the inner impl is the WorkflowFunction.
+
+
+def _resolve_value(
+    op_name: str, dist: Any, value: Any, field_kwargs: dict[str, Any],
+) -> Any:
+    """Resolve a density op's value from the positional or keyword form.
+
+    Keyword form packs ``field_kwargs`` into a single draw via
+    ``dist._pack_value``; positional form passes ``value`` through. Raises
+    if both forms are given, or if neither is.
+    """
+    if field_kwargs:
+        if value is not None:
+            raise TypeError(
+                f"{op_name}: pass either a positional value or field kwargs, "
+                f"not both."
+            )
+        return dist._pack_value(**field_kwargs)
+    if value is None:
         raise TypeError(
-            f"{type(dist).__name__} does not support log_prob"
+            f"{op_name}: a value is required — pass it positionally or as "
+            f"field keyword arguments."
         )
+    return value
+
+
+def _wf_controls(
+    seed: int | None,
+    n_broadcast_samples: int | None,
+    include_inputs: bool | None,
+) -> dict[str, Any]:
+    """Collect the non-``None`` WorkflowFunction control kwargs to forward."""
+    controls = {
+        "seed": seed,
+        "n_broadcast_samples": n_broadcast_samples,
+        "include_inputs": include_inputs,
+    }
+    return {k: v for k, v in controls.items() if v is not None}
+
+
+@workflow_function(name="log_prob")
+def _log_prob_impl(dist: SupportsLogProb, value: Any) -> Array:
+    if not isinstance(dist, SupportsLogProb):
+        raise TypeError(f"{type(dist).__name__} does not support log_prob")
     return dist._log_prob(value)
 
 
-@workflow_function
-def prob(dist: SupportsLogProb, value: Any) -> Array:
-    """Evaluate the density at *value* (``exp(log_prob)``)."""
+def log_prob(
+    dist: SupportsLogProb,
+    value: Any = None,
+    /,
+    *,
+    seed: int | None = None,
+    n_broadcast_samples: int | None = None,
+    include_inputs: bool | None = None,
+    **field_kwargs: Any,
+) -> Array:
+    """Evaluate the normalized log-density at *value*.
+
+    Two call forms:
+
+    * **Positional** — ``log_prob(dist, value)``; *value* is a single draw
+      of *dist*'s sample type, or a batched form (which broadcasts).
+    * **Keyword** — ``log_prob(dist, field=value, ...)`` builds a single
+      draw from named fields via :meth:`Distribution._pack_value`
+      (single-field → bare value; multi-field → ``Record``). Use the
+      positional form for batched evaluation.
+
+    ``seed`` / ``n_broadcast_samples`` / ``include_inputs`` are
+    ``WorkflowFunction`` controls forwarded to the broadcasting layer.
+    """
+    value = _resolve_value("log_prob", dist, value, field_kwargs)
+    return _log_prob_impl(
+        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
+    )
+
+
+@workflow_function(name="prob")
+def _prob_impl(dist: SupportsLogProb, value: Any) -> Array:
     if not isinstance(dist, SupportsLogProb):
         raise TypeError(
-            f"{type(dist).__name__} does not support prob "
-            f"(missing _log_prob method)"
+            f"{type(dist).__name__} does not support prob (missing _log_prob method)"
         )
     return jnp.exp(dist._log_prob(value))
 
 
-@workflow_function
-def unnormalized_log_prob(
+def prob(
+    dist: SupportsLogProb,
+    value: Any = None,
+    /,
+    *,
+    seed: int | None = None,
+    n_broadcast_samples: int | None = None,
+    include_inputs: bool | None = None,
+    **field_kwargs: Any,
+) -> Array:
+    """Evaluate the density at *value* (``exp(log_prob)``).
+
+    See :func:`log_prob` for the positional and keyword call forms.
+    """
+    value = _resolve_value("prob", dist, value, field_kwargs)
+    return _prob_impl(
+        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
+    )
+
+
+@workflow_function(name="unnormalized_log_prob")
+def _unnormalized_log_prob_impl(
     dist: SupportsUnnormalizedLogProb, value: Any,
 ) -> Array:
-    """Evaluate the unnormalized log-density at *value*."""
     if not isinstance(dist, SupportsUnnormalizedLogProb):
         raise TypeError(
             f"{type(dist).__name__} does not support unnormalized_log_prob "
@@ -127,17 +220,56 @@ def unnormalized_log_prob(
     return dist._unnormalized_log_prob(value)
 
 
-@workflow_function
-def unnormalized_prob(
+def unnormalized_log_prob(
+    dist: SupportsUnnormalizedLogProb,
+    value: Any = None,
+    /,
+    *,
+    seed: int | None = None,
+    n_broadcast_samples: int | None = None,
+    include_inputs: bool | None = None,
+    **field_kwargs: Any,
+) -> Array:
+    """Evaluate the unnormalized log-density at *value*.
+
+    See :func:`log_prob` for the positional and keyword call forms.
+    """
+    value = _resolve_value("unnormalized_log_prob", dist, value, field_kwargs)
+    return _unnormalized_log_prob_impl(
+        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
+    )
+
+
+@workflow_function(name="unnormalized_prob")
+def _unnormalized_prob_impl(
     dist: SupportsUnnormalizedLogProb, value: Any,
 ) -> Array:
-    """Evaluate the unnormalized density at *value* (``exp(unnormalized_log_prob)``)."""
     if not isinstance(dist, SupportsUnnormalizedLogProb):
         raise TypeError(
             f"{type(dist).__name__} does not support unnormalized_prob "
             f"(missing _unnormalized_log_prob method)"
         )
     return jnp.exp(dist._unnormalized_log_prob(value))
+
+
+def unnormalized_prob(
+    dist: SupportsUnnormalizedLogProb,
+    value: Any = None,
+    /,
+    *,
+    seed: int | None = None,
+    n_broadcast_samples: int | None = None,
+    include_inputs: bool | None = None,
+    **field_kwargs: Any,
+) -> Array:
+    """Evaluate the unnormalized density at *value* (``exp(unnormalized_log_prob)``).
+
+    See :func:`log_prob` for the positional and keyword call forms.
+    """
+    value = _resolve_value("unnormalized_prob", dist, value, field_kwargs)
+    return _unnormalized_prob_impl(
+        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
+    )
 
 
 @workflow_function
@@ -212,28 +344,10 @@ def expectation(
     )
 
 
-@workflow_function
-def random_log_prob(
-    dist: SupportsRandomLogProb,
-    value: Any = None,
+@workflow_function(name="random_log_prob")
+def _random_log_prob_impl(
+    dist: SupportsRandomLogProb, value: Any = None,
 ) -> RandomFunction | Distribution:
-    """Return the random (normalized) log-density of a random measure.
-
-    For a ``RandomMeasure[T]`` ``M`` with draws ``D ~ M``, the random
-    function ``x ↦ log D(x)`` is itself a callable returning a
-    distribution over scalars at every input.
-
-    When *value* is omitted, returns that callable as a
-    :class:`~probpipe.core._random_functions.RandomFunction`. When
-    *value* is provided, returns the ``Distribution[Array]`` over
-    ``log D(value)`` directly — equivalent to
-    ``random_log_prob(dist)(value)``. The two-argument form mirrors
-    :func:`log_prob` for non-random distributions.
-
-    Concrete subclasses implement a single method
-    ``_random_log_prob()`` returning a ``RandomFunction``; the optional
-    *value* dispatch lives entirely in this op, not on the protocol.
-    """
     if not isinstance(dist, SupportsRandomLogProb):
         raise TypeError(
             f"{type(dist).__name__} does not support random_log_prob "
@@ -243,10 +357,68 @@ def random_log_prob(
     return rf if value is None else rf(value)
 
 
-@workflow_function
+def random_log_prob(
+    dist: SupportsRandomLogProb,
+    value: Any = None,
+    /,
+    *,
+    seed: int | None = None,
+    n_broadcast_samples: int | None = None,
+    include_inputs: bool | None = None,
+    **field_kwargs: Any,
+) -> RandomFunction | Distribution:
+    """Return the random (normalized) log-density of a random measure.
+
+    For a ``RandomMeasure[T]`` ``M`` with draws ``D ~ M``, the random
+    function ``x ↦ log D(x)`` is itself a callable returning a
+    distribution over scalars at every input.
+
+    When *value* is omitted, returns that callable as a
+    :class:`~probpipe.core._random_functions.RandomFunction`. When
+    *value* is provided (positionally, or built from ``field_kwargs`` via
+    :meth:`Distribution._pack_value`), returns the ``Distribution[Array]``
+    over ``log D(value)`` directly — equivalent to
+    ``random_log_prob(dist)(value)``. The two-/keyword-argument forms
+    mirror :func:`log_prob` for non-random distributions.
+
+    Concrete subclasses implement a single method
+    ``_random_log_prob()`` returning a ``RandomFunction``; the optional
+    *value* dispatch lives entirely in this op, not on the protocol.
+    """
+    if field_kwargs:
+        if value is not None:
+            raise TypeError(
+                "random_log_prob: pass either a positional value or field "
+                "kwargs, not both."
+            )
+        value = dist._pack_value(**field_kwargs)
+    return _random_log_prob_impl(
+        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
+    )
+
+
+@workflow_function(name="random_unnormalized_log_prob")
+def _random_unnormalized_log_prob_impl(
+    dist: SupportsRandomUnnormalizedLogProb, value: Any = None,
+) -> RandomFunction | Distribution:
+    if not isinstance(dist, SupportsRandomUnnormalizedLogProb):
+        raise TypeError(
+            f"{type(dist).__name__} does not support random_unnormalized_log_prob "
+            f"(does not implement SupportsRandomUnnormalizedLogProb)"
+        )
+    rf = dist._random_unnormalized_log_prob()
+    return rf if value is None else rf(value)
+
+
 def random_unnormalized_log_prob(
     dist: SupportsRandomUnnormalizedLogProb,
     value: Any = None,
+    /,
+    *,
+    seed: int | None = None,
+    n_broadcast_samples: int | None = None,
+    include_inputs: bool | None = None,
+    **field_kwargs: Any,
 ) -> RandomFunction | Distribution:
     """Return the random unnormalized log-density of a random measure.
 
@@ -257,10 +429,11 @@ def random_unnormalized_log_prob(
 
     When *value* is omitted, returns that callable as a
     :class:`~probpipe.core._random_functions.RandomFunction`. When
-    *value* is provided, returns the ``Distribution[Array]`` over
-    ``log D̃(value)`` directly — equivalent to
-    ``random_unnormalized_log_prob(dist)(value)``. The two-argument
-    form mirrors :func:`unnormalized_log_prob` for non-random
+    *value* is provided (positionally, or built from ``field_kwargs`` via
+    :meth:`Distribution._pack_value`), returns the ``Distribution[Array]``
+    over ``log D̃(value)`` directly — equivalent to
+    ``random_unnormalized_log_prob(dist)(value)``. The two-/keyword-
+    argument forms mirror :func:`unnormalized_log_prob` for non-random
     distributions.
 
     Concrete subclasses implement a single method
@@ -268,13 +441,16 @@ def random_unnormalized_log_prob(
     the optional *value* dispatch lives entirely in this op, not on
     the protocol.
     """
-    if not isinstance(dist, SupportsRandomUnnormalizedLogProb):
-        raise TypeError(
-            f"{type(dist).__name__} does not support random_unnormalized_log_prob "
-            f"(does not implement SupportsRandomUnnormalizedLogProb)"
-        )
-    rf = dist._random_unnormalized_log_prob()
-    return rf if value is None else rf(value)
+    if field_kwargs:
+        if value is not None:
+            raise TypeError(
+                "random_unnormalized_log_prob: pass either a positional value "
+                "or field kwargs, not both."
+            )
+        value = dist._pack_value(**field_kwargs)
+    return _random_unnormalized_log_prob_impl(
+        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
+    )
 
 
 def _split_data_kwargs(

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -1,19 +1,32 @@
 """Built-in operations for distribution computation.
 
-Each public function (``sample``, ``mean``, ``log_prob``, …) is a
-:class:`~probpipe.core.node.WorkflowFunction` created via the
-``@workflow_function`` decorator.  This means every call automatically
-participates in broadcasting and Prefect orchestration when a
-distribution argument is passed where a concrete value is expected.
+The value-free / dispatch ops (``sample``, ``mean``, ``variance``, ``cov``,
+``expectation``, ``condition_on``, ``from_distribution``) are
+:class:`~probpipe.core.node.WorkflowFunction` instances created via the
+``@workflow_function`` decorator, so every call automatically participates
+in broadcasting and Prefect orchestration when a distribution argument is
+passed where a concrete value is expected.
+
+The density ops (``log_prob``, ``prob``, ``unnormalized_log_prob``,
+``unnormalized_prob``, and the ``random_*_log_prob`` ops) are thin Python
+wrappers over inner ``_<op>_impl`` WorkflowFunctions. The wrapper adds the
+positional-or-keyword value form — ``log_prob(dist, value)`` or
+``log_prob(dist, field=value, ...)`` (packed via
+:meth:`~probpipe.core._distribution_base.Distribution._pack_value`) — and
+forwards the WorkflowFunction controls (``seed`` / ``n_broadcast_samples`` /
+``include_inputs``) via ``with_options``; broadcasting still happens because
+the inner impl is the WorkflowFunction. ``dist`` and ``value`` are
+positional-only so field names are free for the keyword form.
 
 Usage::
 
     from probpipe import sample, mean, log_prob, condition_on
 
-    dist = Normal(loc=0.0, scale=1.0)
+    dist = Normal(loc=0.0, scale=1.0, name="x")
     s = sample(dist, key=jax.random.PRNGKey(0), sample_shape=(100,))
     m = mean(dist)
-    lp = log_prob(dist, jnp.array(1.5))
+    lp = log_prob(dist, jnp.array(1.5))   # positional
+    lp = log_prob(dist, x=1.5)            # keyword
 """
 
 from __future__ import annotations
@@ -57,7 +70,8 @@ __all__ = [
 
 
 # ---------------------------------------------------------------------------
-# Public API — each function is a WorkflowFunction via @workflow_function
+# Public API — value-free ops are WorkflowFunctions directly; the density
+# ops (below) are wrappers over inner _<op>_impl WorkflowFunctions
 # ---------------------------------------------------------------------------
 
 
@@ -97,21 +111,29 @@ def sample(
 #
 # Each density op is an outer Python wrapper over an inner
 # ``@workflow_function`` impl.  The outer layer resolves the
-# positional-or-keyword value and forwards the WorkflowFunction control
-# kwargs explicitly, so a distribution field whose name happens to be a
-# reserved control name (``seed`` / ``n_broadcast_samples`` /
-# ``include_inputs``) cannot be silently swallowed by the workflow layer.
-# Broadcasting still happens — the inner impl is the WorkflowFunction.
+# positional-or-keyword value and applies the WorkflowFunction controls via
+# ``with_options`` (the non-deprecated control path), so a distribution
+# field whose name happens to be a reserved control name (``seed`` /
+# ``n_broadcast_samples`` / ``include_inputs``) cannot be silently swallowed
+# by the workflow layer.  Broadcasting still happens — the inner impl is the
+# WorkflowFunction.
 
 
 def _resolve_value(
-    op_name: str, dist: Any, value: Any, field_kwargs: dict[str, Any],
+    op_name: str,
+    dist: Any,
+    value: Any,
+    field_kwargs: dict[str, Any],
+    *,
+    allow_none: bool = False,
 ) -> Any:
     """Resolve a density op's value from the positional or keyword form.
 
     Keyword form packs ``field_kwargs`` into a single draw via
     ``dist._pack_value``; positional form passes ``value`` through. Raises
-    if both forms are given, or if neither is.
+    if both forms are given. With ``allow_none=False`` (default) a missing
+    value also raises; ``allow_none=True`` (the ``random_*`` ops) lets
+    ``value=None`` through so the bare random function is returned.
     """
     if field_kwargs:
         if value is not None:
@@ -119,8 +141,14 @@ def _resolve_value(
                 f"{op_name}: pass either a positional value or field kwargs, "
                 f"not both."
             )
+        if "value" in field_kwargs and "value" not in getattr(dist, "fields", ()):
+            # ``value`` was the pre-#228 keyword name; it is now positional-only.
+            raise TypeError(
+                f"{op_name}: `value` is positional-only — call "
+                f"{op_name}(dist, value), not {op_name}(dist, value=...)."
+            )
         return dist._pack_value(**field_kwargs)
-    if value is None:
+    if value is None and not allow_none:
         raise TypeError(
             f"{op_name}: a value is required — pass it positionally or as "
             f"field keyword arguments."
@@ -128,18 +156,29 @@ def _resolve_value(
     return value
 
 
-def _wf_controls(
+def _apply_controls(
+    impl: Any,
     seed: int | None,
     n_broadcast_samples: int | None,
     include_inputs: bool | None,
-) -> dict[str, Any]:
-    """Collect the non-``None`` WorkflowFunction control kwargs to forward."""
+) -> Any:
+    """Return a call view of *impl* with the non-``None`` WorkflowFunction
+    controls applied via ``with_options`` — the bare *impl* when none is set.
+
+    Using ``with_options`` rather than splatting the controls as call kwargs
+    avoids the legacy-call-kwarg ``DeprecationWarning`` the workflow layer
+    raises for these names.
+    """
     controls = {
-        "seed": seed,
-        "n_broadcast_samples": n_broadcast_samples,
-        "include_inputs": include_inputs,
+        k: v
+        for k, v in (
+            ("seed", seed),
+            ("n_broadcast_samples", n_broadcast_samples),
+            ("include_inputs", include_inputs),
+        )
+        if v is not None
     }
-    return {k: v for k, v in controls.items() if v is not None}
+    return impl.with_options(**controls) if controls else impl
 
 
 @workflow_function(name="log_prob")
@@ -174,9 +213,9 @@ def log_prob(
     ``WorkflowFunction`` controls forwarded to the broadcasting layer.
     """
     value = _resolve_value("log_prob", dist, value, field_kwargs)
-    return _log_prob_impl(
-        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
-    )
+    return _apply_controls(
+        _log_prob_impl, seed, n_broadcast_samples, include_inputs
+    )(dist, value)
 
 
 @workflow_function(name="prob")
@@ -203,9 +242,9 @@ def prob(
     See :func:`log_prob` for the positional and keyword call forms.
     """
     value = _resolve_value("prob", dist, value, field_kwargs)
-    return _prob_impl(
-        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
-    )
+    return _apply_controls(
+        _prob_impl, seed, n_broadcast_samples, include_inputs
+    )(dist, value)
 
 
 @workflow_function(name="unnormalized_log_prob")
@@ -235,9 +274,9 @@ def unnormalized_log_prob(
     See :func:`log_prob` for the positional and keyword call forms.
     """
     value = _resolve_value("unnormalized_log_prob", dist, value, field_kwargs)
-    return _unnormalized_log_prob_impl(
-        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
-    )
+    return _apply_controls(
+        _unnormalized_log_prob_impl, seed, n_broadcast_samples, include_inputs
+    )(dist, value)
 
 
 @workflow_function(name="unnormalized_prob")
@@ -267,9 +306,9 @@ def unnormalized_prob(
     See :func:`log_prob` for the positional and keyword call forms.
     """
     value = _resolve_value("unnormalized_prob", dist, value, field_kwargs)
-    return _unnormalized_prob_impl(
-        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
-    )
+    return _apply_controls(
+        _unnormalized_prob_impl, seed, n_broadcast_samples, include_inputs
+    )(dist, value)
 
 
 @workflow_function
@@ -385,16 +424,12 @@ def random_log_prob(
     ``_random_log_prob()`` returning a ``RandomFunction``; the optional
     *value* dispatch lives entirely in this op, not on the protocol.
     """
-    if field_kwargs:
-        if value is not None:
-            raise TypeError(
-                "random_log_prob: pass either a positional value or field "
-                "kwargs, not both."
-            )
-        value = dist._pack_value(**field_kwargs)
-    return _random_log_prob_impl(
-        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
+    value = _resolve_value(
+        "random_log_prob", dist, value, field_kwargs, allow_none=True
     )
+    return _apply_controls(
+        _random_log_prob_impl, seed, n_broadcast_samples, include_inputs
+    )(dist, value)
 
 
 @workflow_function(name="random_unnormalized_log_prob")
@@ -441,16 +476,12 @@ def random_unnormalized_log_prob(
     the optional *value* dispatch lives entirely in this op, not on
     the protocol.
     """
-    if field_kwargs:
-        if value is not None:
-            raise TypeError(
-                "random_unnormalized_log_prob: pass either a positional value "
-                "or field kwargs, not both."
-            )
-        value = dist._pack_value(**field_kwargs)
-    return _random_unnormalized_log_prob_impl(
-        dist, value, **_wf_controls(seed, n_broadcast_samples, include_inputs)
+    value = _resolve_value(
+        "random_unnormalized_log_prob", dist, value, field_kwargs, allow_none=True
     )
+    return _apply_controls(
+        _random_unnormalized_log_prob_impl, seed, n_broadcast_samples, include_inputs
+    )(dist, value)
 
 
 def _split_data_kwargs(

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -8,8 +8,8 @@ in broadcasting and Prefect orchestration when a distribution argument is
 passed where a concrete value is expected.
 
 The density ops (``log_prob``, ``prob``, ``unnormalized_log_prob``,
-``unnormalized_prob``, and the ``random_*_log_prob`` ops) are
-:class:`_DensityOp` wrappers over inner ``_<op>_impl`` WorkflowFunctions. The
+``unnormalized_prob``, and the ``random_*_log_prob`` ops) are thin
+plain-function wrappers over inner ``_<op>_impl`` WorkflowFunctions. The
 wrapper adds the positional-or-keyword value form — ``log_prob(dist, value)``
 or ``log_prob(dist, field=value, ...)`` (packed via
 :meth:`~probpipe.core._distribution_base.Distribution._pack_value`);
@@ -111,10 +111,12 @@ def sample(
 
 # -- density ops: positional/keyword value form + with_options controls ------
 #
-# Each density op (``log_prob`` and friends) is a :class:`_DensityOp` — a
-# callable wrapper over an inner ``@workflow_function`` impl
-# (``_<op>_impl``).  The wrapper resolves the positional-or-keyword value and
-# forwards to the inner impl, so broadcasting and orchestration are unchanged.
+# Each density op (``log_prob`` and friends) is a thin plain function over an
+# inner ``@workflow_function`` impl (``_<op>_impl``): it resolves the
+# positional-or-keyword value (packing field kwargs via ``_pack_value``) and
+# calls the impl, so broadcasting and orchestration are unchanged. The op's
+# ``with_options`` is the impl's own method — the genuine control path, not a
+# re-implementation.
 #
 # Per-call ProbPipe controls are applied with ``with_options`` — the same
 # idiom as the dispatch ops (``condition_on.with_options(...)``) and the
@@ -165,69 +167,39 @@ def _resolve_value(
     return value
 
 
-class _DensityOp:
-    """A density op: the positional/keyword value form over an inner
-    :class:`~probpipe.core.node.WorkflowFunction`, plus a ``with_options``
-    control path.
-
-    Calling the op resolves the value — a positional ``value`` or named
-    ``field_kwargs`` packed via :meth:`Distribution._pack_value` — and
-    forwards to the inner impl, so broadcasting and orchestration are
-    unchanged. :meth:`with_options` returns a callable that applies the given
-    WorkflowFunction controls (``seed`` / ``n_broadcast_samples`` /
-    ``include_inputs``) and accepts the same value form, mirroring
-    ``condition_on.with_options(...)`` and the other dispatch ops.
-    """
-
-    def __init__(
-        self, impl: Any, *, name: str, doc: str | None, allow_none: bool = False,
-    ):
-        self._impl = impl
-        self._allow_none = allow_none
-        self.__name__ = name
-        self.__qualname__ = name
-        self.__doc__ = doc
-
-    def _invoke(
-        self, impl: Any, dist: Any, value: Any, field_kwargs: dict[str, Any],
-    ) -> Any:
-        value = _resolve_value(
-            self.__name__, dist, value, field_kwargs, allow_none=self._allow_none,
-        )
-        return impl(dist, value)
-
-    def __call__(self, dist: Any, value: Any = None, /, **field_kwargs: Any) -> Any:
-        return self._invoke(self._impl, dist, value, field_kwargs)
-
-    def with_options(self, **options: Any):
-        """Return a callable that applies WorkflowFunction *options* for one
-        call and accepts the same positional/keyword value form as the op."""
-        configured = self._impl.with_options(**options)
-
-        def call(dist: Any, value: Any = None, /, **field_kwargs: Any) -> Any:
-            return self._invoke(configured, dist, value, field_kwargs)
-
-        call.__name__ = call.__qualname__ = f"{self.__name__}.with_options"
-        return call
-
-    def __repr__(self) -> str:
-        return f"<density op {self.__name__}>"
-
-
 def _density_op(impl: Any, *, allow_none: bool = False):
     """Build a public density op from a stub carrying the op's name and
     docstring.
 
-    The decorated stub's body is never executed — it is only the natural
-    place to write the op's signature and docstring. The returned
-    :class:`_DensityOp` provides the call behaviour (value resolution +
-    ``with_options``) over *impl*, the inner ``_<op>_impl`` WorkflowFunction.
+    The decorated stub's body is never executed — it is only the natural place
+    to write the op's signature and docstring. The returned plain function adds
+    the positional-or-keyword value form (named ``field_kwargs`` packed via
+    :meth:`Distribution._pack_value`) over *impl*, the inner ``_<op>_impl``
+    WorkflowFunction. ``dist`` and ``value`` are positional-only, so any field
+    name is free for the keyword form.
+
+    ``op.with_options`` is *impl*'s own
+    :meth:`~probpipe.core.node.WorkflowFunction.with_options` — per-call
+    controls go through the genuine WorkflowFunction path (with the positional
+    value form), not a re-implementation. Controls never combine meaningfully
+    with the keyword form anyway: ``seed`` / ``n_broadcast_samples`` only
+    matter for broadcasting, which uses the positional value.
     """
 
-    def decorate(stub: Any) -> _DensityOp:
-        return _DensityOp(
-            impl, name=stub.__name__, doc=stub.__doc__, allow_none=allow_none,
-        )
+    def decorate(stub: Any):
+        name = stub.__name__
+
+        def op(dist: Any, value: Any = None, /, **field_kwargs: Any) -> Any:
+            value = _resolve_value(
+                name, dist, value, field_kwargs, allow_none=allow_none,
+            )
+            return impl(dist, value)
+
+        op.__name__ = name
+        op.__qualname__ = name
+        op.__doc__ = stub.__doc__
+        op.with_options = impl.with_options
+        return op
 
     return decorate
 

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -8,15 +8,17 @@ in broadcasting and Prefect orchestration when a distribution argument is
 passed where a concrete value is expected.
 
 The density ops (``log_prob``, ``prob``, ``unnormalized_log_prob``,
-``unnormalized_prob``, and the ``random_*_log_prob`` ops) are thin Python
-wrappers over inner ``_<op>_impl`` WorkflowFunctions. The wrapper adds the
-positional-or-keyword value form — ``log_prob(dist, value)`` or
-``log_prob(dist, field=value, ...)`` (packed via
-:meth:`~probpipe.core._distribution_base.Distribution._pack_value`) — and
-forwards the WorkflowFunction controls (``seed`` / ``n_broadcast_samples`` /
-``include_inputs``) via ``with_options``; broadcasting still happens because
-the inner impl is the WorkflowFunction. ``dist`` and ``value`` are
-positional-only so field names are free for the keyword form.
+``unnormalized_prob``, and the ``random_*_log_prob`` ops) are
+:class:`_DensityOp` wrappers over inner ``_<op>_impl`` WorkflowFunctions. The
+wrapper adds the positional-or-keyword value form — ``log_prob(dist, value)``
+or ``log_prob(dist, field=value, ...)`` (packed via
+:meth:`~probpipe.core._distribution_base.Distribution._pack_value`);
+broadcasting still happens because the inner impl is the WorkflowFunction.
+``dist`` and ``value`` are positional-only so field names are free for the
+keyword form. Per-call ProbPipe controls (``seed`` / ``n_broadcast_samples`` /
+``include_inputs``) use ``with_options`` —
+``log_prob.with_options(seed=0)(dist, value)`` — the same idiom as the
+dispatch ops.
 
 Usage::
 
@@ -107,16 +109,23 @@ def sample(
     return dist._sample(key, sample_shape)
 
 
-# -- value resolution shared by the density ops -----------------------------
+# -- density ops: positional/keyword value form + with_options controls ------
 #
-# Each density op is an outer Python wrapper over an inner
-# ``@workflow_function`` impl.  The outer layer resolves the
-# positional-or-keyword value and applies the WorkflowFunction controls via
-# ``with_options`` (the non-deprecated control path), so a distribution
-# field whose name happens to be a reserved control name (``seed`` /
-# ``n_broadcast_samples`` / ``include_inputs``) cannot be silently swallowed
-# by the workflow layer.  Broadcasting still happens — the inner impl is the
-# WorkflowFunction.
+# Each density op (``log_prob`` and friends) is a :class:`_DensityOp` — a
+# callable wrapper over an inner ``@workflow_function`` impl
+# (``_<op>_impl``).  The wrapper resolves the positional-or-keyword value and
+# forwards to the inner impl, so broadcasting and orchestration are unchanged.
+#
+# Per-call ProbPipe controls are applied with ``with_options`` — the same
+# idiom as the dispatch ops (``condition_on.with_options(...)``) and the
+# non-deprecated control path (STYLE_GUIDE §1.8)::
+#
+#     log_prob.with_options(seed=0)(dist, value)
+#
+# Keeping controls off the call signature leaves the keyword namespace free
+# for field names: a distribution field that happens to be named ``seed`` /
+# ``n_broadcast_samples`` / ``include_inputs`` is never silently swallowed by
+# the workflow layer.
 
 
 def _resolve_value(
@@ -156,29 +165,71 @@ def _resolve_value(
     return value
 
 
-def _apply_controls(
-    impl: Any,
-    seed: int | None,
-    n_broadcast_samples: int | None,
-    include_inputs: bool | None,
-) -> Any:
-    """Return a call view of *impl* with the non-``None`` WorkflowFunction
-    controls applied via ``with_options`` — the bare *impl* when none is set.
+class _DensityOp:
+    """A density op: the positional/keyword value form over an inner
+    :class:`~probpipe.core.node.WorkflowFunction`, plus a ``with_options``
+    control path.
 
-    Using ``with_options`` rather than splatting the controls as call kwargs
-    avoids the legacy-call-kwarg ``DeprecationWarning`` the workflow layer
-    raises for these names.
+    Calling the op resolves the value — a positional ``value`` or named
+    ``field_kwargs`` packed via :meth:`Distribution._pack_value` — and
+    forwards to the inner impl, so broadcasting and orchestration are
+    unchanged. :meth:`with_options` returns a callable that applies the given
+    WorkflowFunction controls (``seed`` / ``n_broadcast_samples`` /
+    ``include_inputs``) and accepts the same value form, mirroring
+    ``condition_on.with_options(...)`` and the other dispatch ops.
     """
-    controls = {
-        k: v
-        for k, v in (
-            ("seed", seed),
-            ("n_broadcast_samples", n_broadcast_samples),
-            ("include_inputs", include_inputs),
+
+    def __init__(
+        self, impl: Any, *, name: str, doc: str | None, allow_none: bool = False,
+    ):
+        self._impl = impl
+        self._allow_none = allow_none
+        self.__name__ = name
+        self.__qualname__ = name
+        self.__doc__ = doc
+
+    def _invoke(
+        self, impl: Any, dist: Any, value: Any, field_kwargs: dict[str, Any],
+    ) -> Any:
+        value = _resolve_value(
+            self.__name__, dist, value, field_kwargs, allow_none=self._allow_none,
         )
-        if v is not None
-    }
-    return impl.with_options(**controls) if controls else impl
+        return impl(dist, value)
+
+    def __call__(self, dist: Any, value: Any = None, /, **field_kwargs: Any) -> Any:
+        return self._invoke(self._impl, dist, value, field_kwargs)
+
+    def with_options(self, **options: Any):
+        """Return a callable that applies WorkflowFunction *options* for one
+        call and accepts the same positional/keyword value form as the op."""
+        configured = self._impl.with_options(**options)
+
+        def call(dist: Any, value: Any = None, /, **field_kwargs: Any) -> Any:
+            return self._invoke(configured, dist, value, field_kwargs)
+
+        call.__name__ = call.__qualname__ = f"{self.__name__}.with_options"
+        return call
+
+    def __repr__(self) -> str:
+        return f"<density op {self.__name__}>"
+
+
+def _density_op(impl: Any, *, allow_none: bool = False):
+    """Build a public density op from a stub carrying the op's name and
+    docstring.
+
+    The decorated stub's body is never executed — it is only the natural
+    place to write the op's signature and docstring. The returned
+    :class:`_DensityOp` provides the call behaviour (value resolution +
+    ``with_options``) over *impl*, the inner ``_<op>_impl`` WorkflowFunction.
+    """
+
+    def decorate(stub: Any) -> _DensityOp:
+        return _DensityOp(
+            impl, name=stub.__name__, doc=stub.__doc__, allow_none=allow_none,
+        )
+
+    return decorate
 
 
 @workflow_function(name="log_prob")
@@ -188,16 +239,12 @@ def _log_prob_impl(dist: SupportsLogProb, value: Any) -> Array:
     return dist._log_prob(value)
 
 
-def log_prob(
-    dist: SupportsLogProb,
-    value: Any = None,
-    /,
-    *,
-    seed: int | None = None,
-    n_broadcast_samples: int | None = None,
-    include_inputs: bool | None = None,
-    **field_kwargs: Any,
-) -> Array:
+# The decorated stubs below are name/docstring carriers; ``_density_op``
+# replaces each with a ``_DensityOp`` over the inner impl (the body never runs).
+
+
+@_density_op(_log_prob_impl)
+def log_prob(dist, value=None, /, **field_kwargs):
     """Evaluate the normalized log-density at *value*.
 
     Two call forms:
@@ -209,13 +256,11 @@ def log_prob(
       (single-field → bare value; multi-field → ``Record``). Use the
       positional form for batched evaluation.
 
-    ``seed`` / ``n_broadcast_samples`` / ``include_inputs`` are
-    ``WorkflowFunction`` controls forwarded to the broadcasting layer.
+    To override ProbPipe controls for one call, use ``with_options`` (the
+    same idiom as the dispatch ops)::
+
+        log_prob.with_options(seed=0)(dist, value)
     """
-    value = _resolve_value("log_prob", dist, value, field_kwargs)
-    return _apply_controls(
-        _log_prob_impl, seed, n_broadcast_samples, include_inputs
-    )(dist, value)
 
 
 @workflow_function(name="prob")
@@ -227,24 +272,13 @@ def _prob_impl(dist: SupportsLogProb, value: Any) -> Array:
     return jnp.exp(dist._log_prob(value))
 
 
-def prob(
-    dist: SupportsLogProb,
-    value: Any = None,
-    /,
-    *,
-    seed: int | None = None,
-    n_broadcast_samples: int | None = None,
-    include_inputs: bool | None = None,
-    **field_kwargs: Any,
-) -> Array:
+@_density_op(_prob_impl)
+def prob(dist, value=None, /, **field_kwargs):
     """Evaluate the density at *value* (``exp(log_prob)``).
 
-    See :func:`log_prob` for the positional and keyword call forms.
+    See :func:`log_prob` for the positional and keyword call forms and the
+    ``with_options`` control path.
     """
-    value = _resolve_value("prob", dist, value, field_kwargs)
-    return _apply_controls(
-        _prob_impl, seed, n_broadcast_samples, include_inputs
-    )(dist, value)
 
 
 @workflow_function(name="unnormalized_log_prob")
@@ -259,24 +293,13 @@ def _unnormalized_log_prob_impl(
     return dist._unnormalized_log_prob(value)
 
 
-def unnormalized_log_prob(
-    dist: SupportsUnnormalizedLogProb,
-    value: Any = None,
-    /,
-    *,
-    seed: int | None = None,
-    n_broadcast_samples: int | None = None,
-    include_inputs: bool | None = None,
-    **field_kwargs: Any,
-) -> Array:
+@_density_op(_unnormalized_log_prob_impl)
+def unnormalized_log_prob(dist, value=None, /, **field_kwargs):
     """Evaluate the unnormalized log-density at *value*.
 
-    See :func:`log_prob` for the positional and keyword call forms.
+    See :func:`log_prob` for the positional and keyword call forms and the
+    ``with_options`` control path.
     """
-    value = _resolve_value("unnormalized_log_prob", dist, value, field_kwargs)
-    return _apply_controls(
-        _unnormalized_log_prob_impl, seed, n_broadcast_samples, include_inputs
-    )(dist, value)
 
 
 @workflow_function(name="unnormalized_prob")
@@ -291,24 +314,14 @@ def _unnormalized_prob_impl(
     return jnp.exp(dist._unnormalized_log_prob(value))
 
 
-def unnormalized_prob(
-    dist: SupportsUnnormalizedLogProb,
-    value: Any = None,
-    /,
-    *,
-    seed: int | None = None,
-    n_broadcast_samples: int | None = None,
-    include_inputs: bool | None = None,
-    **field_kwargs: Any,
-) -> Array:
-    """Evaluate the unnormalized density at *value* (``exp(unnormalized_log_prob)``).
+@_density_op(_unnormalized_prob_impl)
+def unnormalized_prob(dist, value=None, /, **field_kwargs):
+    """Evaluate the unnormalized density at *value*
+    (``exp(unnormalized_log_prob)``).
 
-    See :func:`log_prob` for the positional and keyword call forms.
+    See :func:`log_prob` for the positional and keyword call forms and the
+    ``with_options`` control path.
     """
-    value = _resolve_value("unnormalized_prob", dist, value, field_kwargs)
-    return _apply_controls(
-        _unnormalized_prob_impl, seed, n_broadcast_samples, include_inputs
-    )(dist, value)
 
 
 @workflow_function
@@ -396,16 +409,8 @@ def _random_log_prob_impl(
     return rf if value is None else rf(value)
 
 
-def random_log_prob(
-    dist: SupportsRandomLogProb,
-    value: Any = None,
-    /,
-    *,
-    seed: int | None = None,
-    n_broadcast_samples: int | None = None,
-    include_inputs: bool | None = None,
-    **field_kwargs: Any,
-) -> RandomFunction | Distribution:
+@_density_op(_random_log_prob_impl, allow_none=True)
+def random_log_prob(dist, value=None, /, **field_kwargs):
     """Return the random (normalized) log-density of a random measure.
 
     For a ``RandomMeasure[T]`` ``M`` with draws ``D ~ M``, the random
@@ -417,19 +422,14 @@ def random_log_prob(
     *value* is provided (positionally, or built from ``field_kwargs`` via
     :meth:`Distribution._pack_value`), returns the ``Distribution[Array]``
     over ``log D(value)`` directly — equivalent to
-    ``random_log_prob(dist)(value)``. The two-/keyword-argument forms
-    mirror :func:`log_prob` for non-random distributions.
+    ``random_log_prob(dist)(value)``. The positional and keyword forms
+    mirror :func:`log_prob`; per-call controls use
+    ``random_log_prob.with_options(...)``.
 
     Concrete subclasses implement a single method
     ``_random_log_prob()`` returning a ``RandomFunction``; the optional
     *value* dispatch lives entirely in this op, not on the protocol.
     """
-    value = _resolve_value(
-        "random_log_prob", dist, value, field_kwargs, allow_none=True
-    )
-    return _apply_controls(
-        _random_log_prob_impl, seed, n_broadcast_samples, include_inputs
-    )(dist, value)
 
 
 @workflow_function(name="random_unnormalized_log_prob")
@@ -445,16 +445,8 @@ def _random_unnormalized_log_prob_impl(
     return rf if value is None else rf(value)
 
 
-def random_unnormalized_log_prob(
-    dist: SupportsRandomUnnormalizedLogProb,
-    value: Any = None,
-    /,
-    *,
-    seed: int | None = None,
-    n_broadcast_samples: int | None = None,
-    include_inputs: bool | None = None,
-    **field_kwargs: Any,
-) -> RandomFunction | Distribution:
+@_density_op(_random_unnormalized_log_prob_impl, allow_none=True)
+def random_unnormalized_log_prob(dist, value=None, /, **field_kwargs):
     """Return the random unnormalized log-density of a random measure.
 
     For a ``RandomMeasure[T]`` ``M`` with draws ``D ~ M``, the random
@@ -467,21 +459,15 @@ def random_unnormalized_log_prob(
     *value* is provided (positionally, or built from ``field_kwargs`` via
     :meth:`Distribution._pack_value`), returns the ``Distribution[Array]``
     over ``log D̃(value)`` directly — equivalent to
-    ``random_unnormalized_log_prob(dist)(value)``. The two-/keyword-
-    argument forms mirror :func:`unnormalized_log_prob` for non-random
-    distributions.
+    ``random_unnormalized_log_prob(dist)(value)``. The positional and
+    keyword forms mirror :func:`unnormalized_log_prob`; per-call controls
+    use ``random_unnormalized_log_prob.with_options(...)``.
 
     Concrete subclasses implement a single method
     ``_random_unnormalized_log_prob()`` returning a ``RandomFunction``;
     the optional *value* dispatch lives entirely in this op, not on
     the protocol.
     """
-    value = _resolve_value(
-        "random_unnormalized_log_prob", dist, value, field_kwargs, allow_none=True
-    )
-    return _apply_controls(
-        _random_unnormalized_log_prob_impl, seed, n_broadcast_samples, include_inputs
-    )(dist, value)
 
 
 def _split_data_kwargs(

--- a/probpipe/core/protocols.py
+++ b/probpipe/core/protocols.py
@@ -61,7 +61,7 @@ from typing import (
 
 import jax.numpy as jnp
 
-from ..custom_types import Array, PRNGKey
+from ..custom_types import Array, ArrayLike, PRNGKey
 
 if TYPE_CHECKING:
     from ._distribution_base import Distribution
@@ -166,17 +166,19 @@ class SupportsSampling(Protocol):
 # ---------------------------------------------------------------------------
 
 @runtime_checkable
-class SupportsUnnormalizedLogProb(Protocol):
+class SupportsUnnormalizedLogProb[T](Protocol):
     """Distribution with an unnormalized log-density.
 
-    Provides ``_unnormalized_log_prob(value)``.
+    Provides ``_unnormalized_log_prob(value)``, where *value* is a single
+    draw of the distribution's sample type ``T`` (or the batched form;
+    see :class:`SupportsLogProb`).
     """
 
-    def _unnormalized_log_prob(self, value: Any) -> Array: ...
+    def _unnormalized_log_prob(self, value: T | ArrayLike) -> Array: ...
 
 
 @runtime_checkable
-class SupportsLogProb(SupportsUnnormalizedLogProb, Protocol):
+class SupportsLogProb[T](SupportsUnnormalizedLogProb[T], Protocol):
     """Distribution with a (normalized) log-density.
 
     Extends :class:`SupportsUnnormalizedLogProb` because any distribution
@@ -184,11 +186,20 @@ class SupportsLogProb(SupportsUnnormalizedLogProb, Protocol):
     The base :class:`~probpipe.core.distribution.Distribution` class
     provides ``_unnormalized_log_prob`` defaulting to ``_log_prob``.
 
+    ``_log_prob`` accepts a single draw of the distribution's sample type
+    ``T`` or the batched form (``Array`` → ``Array`` with leading batch
+    axes; ``Record`` → ``RecordArray``; ``NumericRecord`` →
+    ``NumericRecordArray``). The ``T | ArrayLike`` annotation is
+    deliberately loose: ``ArrayLike`` covers the scalar batched case,
+    while Record-based batched forms follow the convention above. The
+    kwarg form ``log_prob(dist, field=value, ...)`` builds a single ``T``
+    via :meth:`Distribution._pack_value`; batched evaluation goes through
+    the positional path.
     """
 
-    def _log_prob(self, value: Any) -> Array: ...
+    def _log_prob(self, value: T | ArrayLike) -> Array: ...
 
-    def _unnormalized_log_prob(self, value: Any) -> Array:
+    def _unnormalized_log_prob(self, value: T | ArrayLike) -> Array:
         """Default: delegates to ``_log_prob``."""
         return self._log_prob(value)
 

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -368,7 +368,7 @@ class SequentialJointDistribution(
 
         return total
 
-    def _log_prob(self, value: dict[str, ArrayLike]) -> Array:
+    def _log_prob(self, value: Record | dict[str, ArrayLike]) -> Array:
         """Evaluate the normalized log-density.
 
         For an unconditioned joint, this is the full joint log p(x).
@@ -393,7 +393,7 @@ class SequentialJointDistribution(
             )
         return self._eval_log_prob(value, components="unconditioned")
 
-    def _unnormalized_log_prob(self, value: dict[str, ArrayLike]) -> Array:
+    def _unnormalized_log_prob(self, value: Record | dict[str, ArrayLike]) -> Array:
         """Evaluate the (possibly unnormalized) log-density.
 
         For an unconditioned joint, this equals the full joint log p(x).

--- a/probpipe/modeling/_simple.py
+++ b/probpipe/modeling/_simple.py
@@ -210,15 +210,22 @@ class SimpleModel[P, D](ProbabilisticModel[tuple[P, D]], SupportsLogProb):
         if isinstance(value, tuple) and len(value) == 2:
             return value
         if isinstance(value, Record):
+            data_fields = self._data_fields
+            if not data_fields:
+                # The likelihood has no named data fields (no data_template),
+                # so the Record / keyword form cannot supply the data. Reject
+                # loudly rather than silently passing data=None downstream.
+                raise TypeError(
+                    f"{type(self).__name__}: the keyword/Record form is "
+                    f"unavailable because the likelihood "
+                    f"({type(self._likelihood).__name__}) has no named data "
+                    f"fields (no data_template); pass a (params, data) pair "
+                    f"positionally instead."
+                )
             params = self._prior._pack_value(
                 **{f: value[f] for f in self._prior_fields}
             )
-            data_fields = self._data_fields
-            data = (
-                Record(**{f: value[f] for f in data_fields})
-                if data_fields
-                else None
-            )
+            data = Record(**{f: value[f] for f in data_fields})
             return params, data
         raise TypeError(
             f"SimpleModel._log_prob expects a Record over {self.fields} or a "

--- a/probpipe/modeling/_simple.py
+++ b/probpipe/modeling/_simple.py
@@ -174,18 +174,56 @@ class SimpleModel[P, D](ProbabilisticModel[tuple[P, D]], SupportsLogProb):
 
     # -- SupportsLogProb interface -----------------------------------------
 
-    def _log_prob(self, value: tuple[P, D]) -> Array:
+    def _log_prob(self, value: Record | tuple[P, D]) -> Array:
         """Joint log-density: prior log-prob + log-likelihood.
+
+        Accepts either form:
+
+        * **Record** — a single record carrying all of :attr:`fields`
+          (the prior's parameter fields plus the likelihood's named data
+          fields). This is what the keyword API
+          (``log_prob(model, intercept=..., y=...)``) produces. It is
+          split into a parameter value — repacked via the prior's own
+          :meth:`~probpipe.core._distribution_base.Distribution._pack_value`
+          so a single-field prior receives a bare array and a multi-field
+          prior a ``Record`` — and a data sub-record built from the
+          likelihood's ``data_template`` fields.
+        * **(params, data) pair** — the explicit joint form. Required when
+          the likelihood's data has no named template (bare arrays), and
+          retained for backward compatibility.
 
         Parameters
         ----------
-        value : tuple[P, D]
-            A ``(params, data)`` pair.
+        value : Record or tuple[P, D]
+            All model fields as a record, or an explicit ``(params, data)``
+            pair.
         """
-        params, data = value
+        params, data = self._split_log_prob_value(value)
         lp = self._prior._log_prob(params)
         ll = self._likelihood.log_likelihood(params=params, data=data)
         return lp + ll
+
+    def _split_log_prob_value(self, value: Record | tuple[P, D]) -> tuple[Any, Any]:
+        """Resolve ``value`` (Record or (params, data) pair) into
+        ``(params, data)`` in the forms the prior and likelihood expect."""
+        # A Record is not a tuple, so the tuple check is unambiguous.
+        if isinstance(value, tuple) and len(value) == 2:
+            return value
+        if isinstance(value, Record):
+            params = self._prior._pack_value(
+                **{f: value[f] for f in self._prior_fields}
+            )
+            data_fields = self._data_fields
+            data = (
+                Record(**{f: value[f] for f in data_fields})
+                if data_fields
+                else None
+            )
+            return params, data
+        raise TypeError(
+            f"SimpleModel._log_prob expects a Record over {self.fields} or a "
+            f"(params, data) pair; got {type(value).__name__}."
+        )
 
     # -- repr ---------------------------------------------------------------
 

--- a/probpipe/modeling/_stan.py
+++ b/probpipe/modeling/_stan.py
@@ -22,6 +22,24 @@ logger = logging.getLogger(__name__)
 __all__ = ["StanModel"]
 
 
+def _pack_parameters_value(owner: str, field_kwargs: dict[str, Any]) -> Array:
+    """Shared ``_pack_value`` for the Stan keyword form (Tier 1).
+
+    ``StanModel._log_prob`` (and the unconstrained view) consume a single
+    flat parameter vector, so the keyword form takes one ``parameters=``
+    argument rather than per-Stan-parameter fields. (Tier 2 — issue #228 —
+    will expose the individual Stan parameters as fields built from
+    BridgeStan's ``param_unc_names()``.) *owner* names the class in the
+    error message.
+    """
+    if set(field_kwargs) != {"parameters"}:
+        raise TypeError(
+            f"{owner} keyword form takes a single 'parameters=' flat array; "
+            f"got {sorted(field_kwargs)}."
+        )
+    return field_kwargs["parameters"]
+
+
 class StanModel(ProbabilisticModel, SupportsLogProb):
     """Stan model via BridgeStan and CmdStanPy.
 
@@ -102,20 +120,9 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
     # -- SupportsLogProb interface ------------------------------------------
 
     def _pack_value(self, **field_kwargs: Any) -> Array:
-        """Keyword form (Tier 1): a single flat ``parameters=`` array.
-
-        ``StanModel._log_prob`` consumes a flat constrained parameter
-        vector, so the keyword form takes one ``parameters=`` argument
-        rather than per-Stan-parameter fields. (Tier 2 — issue #228 — will
-        expose the individual Stan parameters as fields built from
-        BridgeStan's ``param_unc_names()``.)
-        """
-        if set(field_kwargs) != {"parameters"}:
-            raise TypeError(
-                f"{type(self).__name__} keyword form takes a single "
-                f"'parameters=' flat array; got {sorted(field_kwargs)}."
-            )
-        return field_kwargs["parameters"]
+        """Keyword form (Tier 1): a single flat constrained ``parameters=``
+        array (see :func:`_pack_parameters_value`)."""
+        return _pack_parameters_value(type(self).__name__, field_kwargs)
 
     def _log_prob(self, value: Any) -> Array:
         """Log-density in the constrained parameter space.
@@ -185,14 +192,9 @@ class _UnconstrainedStanView(Distribution[Any], SupportsLogProb):
         return self._model.event_shape
 
     def _pack_value(self, **field_kwargs: Any) -> Array:
-        """Keyword form (Tier 1): a single flat ``parameters=`` array in
-        the unconstrained space (see :meth:`StanModel._pack_value`)."""
-        if set(field_kwargs) != {"parameters"}:
-            raise TypeError(
-                f"{type(self).__name__} keyword form takes a single "
-                f"'parameters=' flat array; got {sorted(field_kwargs)}."
-            )
-        return field_kwargs["parameters"]
+        """Keyword form (Tier 1): a single flat ``parameters=`` array in the
+        unconstrained space (see :func:`_pack_parameters_value`)."""
+        return _pack_parameters_value(type(self).__name__, field_kwargs)
 
     def _log_prob(self, value: Any) -> Array:
         """Log-density directly in unconstrained space."""

--- a/probpipe/modeling/_stan.py
+++ b/probpipe/modeling/_stan.py
@@ -101,6 +101,22 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
 
     # -- SupportsLogProb interface ------------------------------------------
 
+    def _pack_value(self, **field_kwargs: Any) -> Array:
+        """Keyword form (Tier 1): a single flat ``parameters=`` array.
+
+        ``StanModel._log_prob`` consumes a flat constrained parameter
+        vector, so the keyword form takes one ``parameters=`` argument
+        rather than per-Stan-parameter fields. (Tier 2 — issue #228 — will
+        expose the individual Stan parameters as fields built from
+        BridgeStan's ``param_unc_names()``.)
+        """
+        if set(field_kwargs) != {"parameters"}:
+            raise TypeError(
+                f"{type(self).__name__} keyword form takes a single "
+                f"'parameters=' flat array; got {sorted(field_kwargs)}."
+            )
+        return field_kwargs["parameters"]
+
     def _log_prob(self, value: Any) -> Array:
         """Log-density in the constrained parameter space.
 
@@ -167,6 +183,16 @@ class _UnconstrainedStanView(Distribution[Any], SupportsLogProb):
     @property
     def event_shape(self) -> tuple[int, ...]:
         return self._model.event_shape
+
+    def _pack_value(self, **field_kwargs: Any) -> Array:
+        """Keyword form (Tier 1): a single flat ``parameters=`` array in
+        the unconstrained space (see :meth:`StanModel._pack_value`)."""
+        if set(field_kwargs) != {"parameters"}:
+            raise TypeError(
+                f"{type(self).__name__} keyword form takes a single "
+                f"'parameters=' flat array; got {sorted(field_kwargs)}."
+            )
+        return field_kwargs["parameters"]
 
     def _log_prob(self, value: Any) -> Array:
         """Log-density directly in unconstrained space."""

--- a/tests/core/test_distribution_array.py
+++ b/tests/core/test_distribution_array.py
@@ -467,9 +467,11 @@ class TestLogProbViaSweep:
     def test_same_value_all_cells(self):
         comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
         da = _make_distribution_array(comps)
-        # Single scalar value broadcasts to every cell.
+        # Single scalar value broadcasts to every cell. ``value`` is
+        # positional-only on log_prob (so it can't collide with a field
+        # named "value" in the keyword form).
         value = jnp.asarray(0.0)
-        lp = log_prob(da, value=value)
+        lp = log_prob(da, value)
         assert isinstance(lp, NumericRecordArray)
         assert lp.batch_shape == (3,)
         # Cell i evaluates Normal(i, 1) at 0 → gaussian log-density at

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -5,8 +5,8 @@ positional value or named field kwargs; the kwargs are packed into a
 single draw of the distribution's value type via
 :meth:`Distribution._pack_value` (single-field → bare value; multi-field
 → ``Record``). This file exercises the keyword form across the
-distribution surface, the error paths, and the reserved-name construction
-warning.
+distribution surface, the error paths, and the ``with_options`` control
+path.
 """
 
 from __future__ import annotations
@@ -179,28 +179,25 @@ class TestProbAndUnnormalizedKwargForm:
         assert jnp.allclose(unnormalized_prob(d, x=0.3), unnormalized_prob(d, 0.3))
 
 
-class TestReservedNameWarning:
-    """A distribution whose field collides with a reserved WF control param
-    warns at construction."""
+class TestFormerlyReservedFieldNames:
+    """Controls live only on ``with_options``, so a field whose name matches a
+    former WF control (``seed`` / ``n_broadcast_samples`` / ``include_inputs``)
+    is an ordinary field: construction does not warn, and the keyword form
+    addresses it (issue #228)."""
 
-    @pytest.mark.parametrize("reserved", ["seed", "n_broadcast_samples", "include_inputs"])
-    def test_reserved_single_field_name_warns(self, reserved):
-        # Single-field auto-build: the cheap check sees field == the name.
-        with pytest.warns(UserWarning, match="reserved"):
-            Normal(0.0, 1.0, name=reserved)
-
-    def test_reserved_multi_field_name_warns(self):
-        # Multi-field: the check sees the reserved name in the cached template.
-        with pytest.warns(UserWarning, match="reserved"):
-            ProductDistribution(
-                Normal(0.0, 1.0, name="seed"), Normal(0.0, 1.0, name="slope")
-            )
-
-    def test_ordinary_name_does_not_warn(self):
+    @pytest.mark.parametrize("name", ["seed", "n_broadcast_samples", "include_inputs"])
+    def test_construction_does_not_warn(self, name):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            Normal(0.0, 1.0, name="x")
+            Normal(0.0, 1.0, name=name)
         assert not any("reserved" in str(w.message).lower() for w in caught)
+
+    @pytest.mark.parametrize("name", ["seed", "n_broadcast_samples", "include_inputs"])
+    def test_keyword_form_addresses_the_field(self, name):
+        # The field name is not swallowed by the workflow layer — it packs
+        # into the value, matching the positional form.
+        d = Normal(0.0, 1.0, name=name)
+        assert jnp.allclose(log_prob(d, **{name: 1.5}), log_prob(d, 1.5))
 
 
 class TestControlsViaWithOptions:

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -21,16 +21,20 @@ import tensorflow_probability.substrates.jax.glm as tfp_glm
 from probpipe import (
     Beta,
     GLMLikelihood,
+    JointGaussian,
+    MinibatchedDistribution,
     MultivariateNormal,
     Normal,
     ProductDistribution,
     Record,
+    SequentialJointDistribution,
     SimpleModel,
     log_prob,
     prob,
+    random_unnormalized_log_prob,
     unnormalized_log_prob,
+    unnormalized_prob,
 )
-from probpipe.distributions._joint_gaussian import JointGaussian
 
 
 class TestKwargFormScalar:
@@ -58,9 +62,14 @@ class TestKwargFormRecord:
         assert jnp.allclose(log_prob(p, a=0.5, b=0.4), log_prob(p, Record(a=0.5, b=0.4)))
 
     def test_field_order_independent(self):
-        p = ProductDistribution(Normal(0.0, 1.0, name="a"), Normal(0.0, 1.0, name="b"))
-        # kwargs given out of template order still pack correctly
-        assert jnp.allclose(log_prob(p, b=1.0, a=0.5), log_prob(p, a=0.5, b=1.0))
+        # Distinguishable components (Normal vs Beta) so a field swap would
+        # change the result — a symmetric pair could not detect mis-routing.
+        p = ProductDistribution(Normal(0.0, 1.0, name="a"), Beta(2.0, 3.0, name="b"))
+        out_of_order = log_prob(p, b=0.4, a=0.5)
+        baseline = log_prob(p, Record(a=0.5, b=0.4))
+        assert jnp.allclose(out_of_order, baseline)
+        # Mis-pairing the values genuinely differs, so the above is a real check.
+        assert not jnp.allclose(out_of_order, log_prob(p, Record(a=0.4, b=0.5)))
 
     def test_joint_gaussian(self):
         jg = JointGaussian(mean=jnp.zeros(3), cov=jnp.eye(3), u=2, v=1)
@@ -89,29 +98,47 @@ class TestKwargFormSimpleModel:
         assert jnp.allclose(kw, rec)
         assert jnp.allclose(kw, tup)
 
+    def test_keyword_form_rejected_without_data_template(self):
+        """A likelihood with no named data fields cannot use the keyword/Record
+        form (data can't be supplied) — it must raise, not pass data=None."""
 
-class TestStanModelPackValue:
-    """StanModel Tier 1: the keyword form takes a single ``parameters=`` array.
+        class _NoTemplateLikelihood:
+            def log_likelihood(self, params, data):
+                return jnp.asarray(0.0)
+
+        prior = ProductDistribution(
+            Normal(0.0, 1.0, name="a"), Normal(0.0, 1.0, name="b")
+        )
+        model = SimpleModel(prior, _NoTemplateLikelihood(), name="m")
+        with pytest.raises(TypeError, match="no named data fields"):
+            log_prob(model, a=0.5, b=0.5)
+        # The (params, data) tuple form remains available for such models.
+        lp = model._log_prob((Record(a=0.5, b=0.5), jnp.zeros(3)))
+        assert jnp.isfinite(lp)
+
+
+class TestStanViewsPackValue:
+    """StanModel / _UnconstrainedStanView Tier 1: the keyword form takes a
+    single ``parameters=`` flat array.
 
     bridgestan is not installed in CI, so ``_pack_value`` is exercised in
-    isolation via ``object.__new__`` (per STYLE_GUIDE §8.4).
+    isolation via ``object.__new__`` (per STYLE_GUIDE §8.4). The method reads
+    no instance state beyond the class name in its error message, so no
+    attribute setup is needed.
     """
 
-    def _bare_stan(self):
-        from probpipe.modeling._stan import StanModel
-        m = object.__new__(StanModel)
-        m._name = "stan"
-        return m
+    @pytest.fixture(params=["StanModel", "_UnconstrainedStanView"])
+    def bare_stan(self, request):
+        from probpipe.modeling import _stan
+        return object.__new__(getattr(_stan, request.param))
 
-    def test_pack_value_parameters(self):
-        m = self._bare_stan()
+    def test_pack_value_parameters(self, bare_stan):
         arr = jnp.array([0.1, 0.2, 0.3])
-        assert jnp.allclose(m._pack_value(parameters=arr), arr)
+        assert jnp.allclose(bare_stan._pack_value(parameters=arr), arr)
 
-    def test_pack_value_wrong_kwargs_raises(self):
-        m = self._bare_stan()
+    def test_pack_value_wrong_kwargs_raises(self, bare_stan):
         with pytest.raises(TypeError, match="parameters="):
-            m._pack_value(theta=jnp.array([0.1]))
+            bare_stan._pack_value(theta=jnp.array([0.1]))
 
 
 class TestKwargErrors:
@@ -147,18 +174,94 @@ class TestProbAndUnnormalizedKwargForm:
             unnormalized_log_prob(d, x=1.2), unnormalized_log_prob(d, 1.2)
         )
 
+    def test_unnormalized_prob_kwarg(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.allclose(unnormalized_prob(d, x=0.3), unnormalized_prob(d, 0.3))
+
 
 class TestReservedNameWarning:
-    """A single-field distribution named after a reserved WF control param
-    warns at construction (the cheap check sees the field == the name)."""
+    """A distribution whose field collides with a reserved WF control param
+    warns at construction."""
 
     @pytest.mark.parametrize("reserved", ["seed", "n_broadcast_samples", "include_inputs"])
     def test_reserved_single_field_name_warns(self, reserved):
+        # Single-field auto-build: the cheap check sees field == the name.
         with pytest.warns(UserWarning, match="reserved"):
             Normal(0.0, 1.0, name=reserved)
+
+    def test_reserved_multi_field_name_warns(self):
+        # Multi-field: the check sees the reserved name in the cached template.
+        with pytest.warns(UserWarning, match="reserved"):
+            ProductDistribution(
+                Normal(0.0, 1.0, name="seed"), Normal(0.0, 1.0, name="slope")
+            )
 
     def test_ordinary_name_does_not_warn(self):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             Normal(0.0, 1.0, name="x")
         assert not any("reserved" in str(w.message).lower() for w in caught)
+
+
+class TestControlKwargsNoDeprecation:
+    """The wrappers forward WF controls via with_options, so passing them does
+    NOT trip the legacy-call-kwarg DeprecationWarning (issue #228 review)."""
+
+    @pytest.mark.parametrize(
+        "control",
+        [{"seed": 3}, {"n_broadcast_samples": 8}, {"include_inputs": True}],
+    )
+    def test_control_kwargs_do_not_deprecation_warn(self, control):
+        d = Normal(0.0, 1.0, name="x")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            log_prob(d, 1.5, **control)
+        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert not deps, [str(w.message) for w in deps]
+
+
+class TestValuePositionalOnly:
+    def test_value_keyword_gives_positional_only_hint(self):
+        d = Normal(0.0, 1.0, name="x")
+        with pytest.raises(TypeError, match="positional-only"):
+            log_prob(d, value=1.5)
+
+
+class TestSequentialJointKwargForm:
+    def test_kwarg_matches_positional_record(self):
+        joint = SequentialJointDistribution(
+            z=Normal(loc=0.0, scale=1.0, name="z"),
+            x=lambda z: Normal(loc=z, scale=0.5, name="x"),
+        )
+        kw = log_prob(joint, z=0.2, x=0.1)
+        pos = log_prob(joint, Record(z=0.2, x=0.1))
+        assert jnp.allclose(kw, pos)
+
+
+class TestRandomMeasureKwargForm:
+    """The random_*_log_prob ops keep `value` optional (return the
+    RandomFunction) and forward controls without deprecation; the kwarg form
+    routes through _pack_value (full RandomMeasure field support is #228 PR 4)."""
+
+    @staticmethod
+    def _measure():
+        import tensorflow_probability.substrates.jax.glm as tfp_glm
+        X = jnp.eye(4)
+        y = jnp.array([1.0, 0.0, 1.0, 0.0])
+        prior = MultivariateNormal(loc=jnp.zeros(4), cov=jnp.eye(4), name="theta")
+        lik = GLMLikelihood(tfp_glm.Bernoulli(), x=X)
+        return MinibatchedDistribution(prior, lik, Record(X=X, y=y), batch_size=2)
+
+    def test_value_omitted_returns_callable_no_deprecation(self):
+        m = self._measure()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            rf = random_unnormalized_log_prob(m, seed=0)
+        assert callable(rf)
+        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert not deps, [str(w.message) for w in deps]
+
+    def test_positional_value_and_kwargs_raises(self):
+        m = self._measure()
+        with pytest.raises(TypeError, match="not both"):
+            random_unnormalized_log_prob(m, jnp.zeros(4), theta=jnp.zeros(4))

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -203,21 +203,35 @@ class TestReservedNameWarning:
         assert not any("reserved" in str(w.message).lower() for w in caught)
 
 
-class TestControlKwargsNoDeprecation:
-    """The wrappers forward WF controls via with_options, so passing them does
-    NOT trip the legacy-call-kwarg DeprecationWarning (issue #228 review)."""
+class TestControlsViaWithOptions:
+    """Controls are applied through ``with_options`` — the non-deprecated path,
+    consistent with the WorkflowFunction dispatch ops — not as call kwargs
+    (issue #228)."""
 
     @pytest.mark.parametrize(
         "control",
         [{"seed": 3}, {"n_broadcast_samples": 8}, {"include_inputs": True}],
     )
-    def test_control_kwargs_do_not_deprecation_warn(self, control):
+    def test_with_options_does_not_deprecation_warn(self, control):
         d = Normal(0.0, 1.0, name="x")
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            log_prob(d, 1.5, **control)
+            log_prob.with_options(**control)(d, 1.5)
         deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
         assert not deps, [str(w.message) for w in deps]
+
+    def test_with_options_accepts_keyword_value_form(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.allclose(
+            log_prob.with_options(seed=0)(d, x=1.5), log_prob(d, 1.5)
+        )
+
+    def test_control_as_call_kwarg_is_rejected(self):
+        # Controls are not call kwargs on the density ops; with a positional
+        # value present, a stray control name collides with the keyword form.
+        d = Normal(0.0, 1.0, name="x")
+        with pytest.raises(TypeError, match="not both"):
+            log_prob(d, 1.5, seed=3)
 
 
 class TestValuePositionalOnly:
@@ -256,7 +270,7 @@ class TestRandomMeasureKwargForm:
         m = self._measure()
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            rf = random_unnormalized_log_prob(m, seed=0)
+            rf = random_unnormalized_log_prob.with_options(seed=0)(m)
         assert callable(rf)
         deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
         assert not deps, [str(w.message) for w in deps]

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -1,0 +1,164 @@
+"""Tests for the keyword form of the log_prob-family ops (issue #228).
+
+``log_prob`` / ``prob`` / ``unnormalized_log_prob`` accept either a
+positional value or named field kwargs; the kwargs are packed into a
+single draw of the distribution's value type via
+:meth:`Distribution._pack_value` (single-field → bare value; multi-field
+→ ``Record``). This file exercises the keyword form across the
+distribution surface, the error paths, and the reserved-name construction
+warning.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tensorflow_probability.substrates.jax.glm as tfp_glm
+
+from probpipe import (
+    Beta,
+    GLMLikelihood,
+    MultivariateNormal,
+    Normal,
+    ProductDistribution,
+    Record,
+    SimpleModel,
+    log_prob,
+    prob,
+    unnormalized_log_prob,
+)
+from probpipe.distributions._joint_gaussian import JointGaussian
+
+
+class TestKwargFormScalar:
+    """Single-field distributions: a field kwarg packs to the bare value."""
+
+    def test_normal(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.allclose(log_prob(d, x=1.5), log_prob(d, 1.5))
+
+    def test_beta(self):
+        d = Beta(2.0, 3.0, name="p")
+        assert jnp.allclose(log_prob(d, p=0.4), log_prob(d, 0.4))
+
+    def test_multivariate_normal_vector_event(self):
+        d = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
+        v = jnp.array([0.1, 0.2, 0.3])
+        assert jnp.allclose(log_prob(d, z=v), log_prob(d, v))
+
+
+class TestKwargFormRecord:
+    """Multi-field distributions: field kwargs pack to a Record."""
+
+    def test_product_distribution(self):
+        p = ProductDistribution(Normal(0.0, 1.0, name="a"), Beta(2.0, 3.0, name="b"))
+        assert jnp.allclose(log_prob(p, a=0.5, b=0.4), log_prob(p, Record(a=0.5, b=0.4)))
+
+    def test_field_order_independent(self):
+        p = ProductDistribution(Normal(0.0, 1.0, name="a"), Normal(0.0, 1.0, name="b"))
+        # kwargs given out of template order still pack correctly
+        assert jnp.allclose(log_prob(p, b=1.0, a=0.5), log_prob(p, a=0.5, b=1.0))
+
+    def test_joint_gaussian(self):
+        jg = JointGaussian(mean=jnp.zeros(3), cov=jnp.eye(3), u=2, v=1)
+        u, v = jnp.array([0.1, 0.2]), jnp.array([0.3])
+        assert jnp.allclose(log_prob(jg, u=u, v=v), log_prob(jg, Record(u=u, v=v)))
+
+
+class TestKwargFormSimpleModel:
+    """The headline case: ``log_prob(model, intercept=..., slope=..., X=..., y=...)``."""
+
+    @staticmethod
+    def _glm_model():
+        X = np.array([0.1, 0.5, -0.3], dtype=np.float32)
+        y = np.array([1.0, 3.0, 0.0], dtype=np.float32)
+        lik = GLMLikelihood(tfp_glm.Poisson(), X)
+        prior = ProductDistribution(
+            Normal(0.0, 1.0, name="intercept"), Normal(0.0, 1.0, name="slope")
+        )
+        return SimpleModel(prior, lik, name="m"), X, y
+
+    def test_kwarg_matches_record_and_tuple(self):
+        model, X, y = self._glm_model()
+        kw = log_prob(model, intercept=0.3, slope=0.5, X=X, y=y)
+        rec = log_prob(model, Record(intercept=0.3, slope=0.5, X=X, y=y))
+        tup = model._log_prob((Record(intercept=0.3, slope=0.5), Record(X=X, y=y)))
+        assert jnp.allclose(kw, rec)
+        assert jnp.allclose(kw, tup)
+
+
+class TestStanModelPackValue:
+    """StanModel Tier 1: the keyword form takes a single ``parameters=`` array.
+
+    bridgestan is not installed in CI, so ``_pack_value`` is exercised in
+    isolation via ``object.__new__`` (per STYLE_GUIDE §8.4).
+    """
+
+    def _bare_stan(self):
+        from probpipe.modeling._stan import StanModel
+        m = object.__new__(StanModel)
+        m._name = "stan"
+        return m
+
+    def test_pack_value_parameters(self):
+        m = self._bare_stan()
+        arr = jnp.array([0.1, 0.2, 0.3])
+        assert jnp.allclose(m._pack_value(parameters=arr), arr)
+
+    def test_pack_value_wrong_kwargs_raises(self):
+        m = self._bare_stan()
+        with pytest.raises(TypeError, match="parameters="):
+            m._pack_value(theta=jnp.array([0.1]))
+
+
+class TestKwargErrors:
+    def test_missing_field(self):
+        p = ProductDistribution(Normal(0.0, 1.0, name="a"), Normal(0.0, 1.0, name="b"))
+        with pytest.raises(TypeError, match="missing"):
+            log_prob(p, a=0.5)
+
+    def test_extra_field(self):
+        d = Normal(0.0, 1.0, name="x")
+        with pytest.raises(TypeError, match="unexpected"):
+            log_prob(d, x=1.0, bogus=2.0)
+
+    def test_positional_value_and_kwargs(self):
+        d = Normal(0.0, 1.0, name="x")
+        with pytest.raises(TypeError, match="not both"):
+            log_prob(d, 1.0, x=2.0)
+
+    def test_neither_value_nor_kwargs(self):
+        d = Normal(0.0, 1.0, name="x")
+        with pytest.raises(TypeError, match="value is required"):
+            log_prob(d)
+
+
+class TestProbAndUnnormalizedKwargForm:
+    def test_prob_kwarg(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.allclose(prob(d, x=0.0), prob(d, 0.0))
+
+    def test_unnormalized_log_prob_kwarg(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.allclose(
+            unnormalized_log_prob(d, x=1.2), unnormalized_log_prob(d, 1.2)
+        )
+
+
+class TestReservedNameWarning:
+    """A single-field distribution named after a reserved WF control param
+    warns at construction (the cheap check sees the field == the name)."""
+
+    @pytest.mark.parametrize("reserved", ["seed", "n_broadcast_samples", "include_inputs"])
+    def test_reserved_single_field_name_warns(self, reserved):
+        with pytest.warns(UserWarning, match="reserved"):
+            Normal(0.0, 1.0, name=reserved)
+
+    def test_ordinary_name_does_not_warn(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Normal(0.0, 1.0, name="x")
+        assert not any("reserved" in str(w.message).lower() for w in caught)

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -217,11 +217,19 @@ class TestControlsViaWithOptions:
         deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
         assert not deps, [str(w.message) for w in deps]
 
-    def test_with_options_accepts_keyword_value_form(self):
+    def test_with_options_uses_positional_value_form(self):
+        # with_options delegates to the inner WorkflowFunction, so the
+        # controlled call takes the positional value form (the keyword form
+        # lives on the bare op).
         d = Normal(0.0, 1.0, name="x")
         assert jnp.allclose(
-            log_prob.with_options(seed=0)(d, x=1.5), log_prob(d, 1.5)
+            log_prob.with_options(seed=0)(d, 1.5), log_prob(d, 1.5)
         )
+
+    def test_with_options_is_the_inner_workflow_method(self):
+        # No re-implementation: op.with_options *is* the inner WF's own method.
+        from probpipe.core import ops
+        assert log_prob.with_options == ops._log_prob_impl.with_options
 
     def test_control_as_call_kwarg_is_rejected(self):
         # Controls are not call kwargs on the density ops; with a positional

--- a/tests/core/test_ops.py
+++ b/tests/core/test_ops.py
@@ -253,14 +253,35 @@ class TestConditionOn:
 # ---------------------------------------------------------------------------
 
 class TestWorkflowFunctionRouting:
-    """Verify public ops are WorkflowFunction instances."""
+    """Verify ops route through WorkflowFunctions (directly or via inner impls)."""
 
     def test_ops_are_workflow_functions(self):
+        """Value-free / dispatch ops are WorkflowFunctions directly. The
+        density-family ops (``log_prob`` and friends) are thin Python
+        wrappers — they add the positional/keyword value form and forward
+        WF control kwargs — over inner ``_<name>_impl`` WorkflowFunctions,
+        so broadcasting still applies.
+        """
         from probpipe.core.node import WorkflowFunction
-        for name in ops.__all__:
-            fn = getattr(ops, name)
-            assert isinstance(fn, WorkflowFunction), (
+
+        wf_ops = [
+            "sample", "mean", "variance", "cov", "expectation",
+            "condition_on", "from_distribution",
+        ]
+        for name in wf_ops:
+            assert isinstance(getattr(ops, name), WorkflowFunction), (
                 f"ops.{name} is not a WorkflowFunction"
+            )
+
+        density_ops = [
+            "log_prob", "prob", "unnormalized_log_prob", "unnormalized_prob",
+            "random_log_prob", "random_unnormalized_log_prob",
+        ]
+        for name in density_ops:
+            assert callable(getattr(ops, name)), f"ops.{name} is not callable"
+            impl = getattr(ops, f"_{name}_impl")
+            assert isinstance(impl, WorkflowFunction), (
+                f"ops._{name}_impl is not a WorkflowFunction"
             )
 
     def test_public_ops_are_callable(self):
@@ -278,10 +299,10 @@ class TestWorkflowFunctionRouting:
         m = ops.mean(normal)
         assert m.shape == ()
 
-    def test_positional_and_keyword_duplicate_raises(self, normal):
-        """Passing the same arg both positionally and as keyword raises."""
-        with pytest.raises(TypeError, match="multiple values"):
-            ops.log_prob(normal, value=jnp.array(1.0), dist=normal)
+    def test_positional_value_and_field_kwargs_raises(self, normal):
+        """Passing a value both positionally and as field kwargs raises."""
+        with pytest.raises(TypeError, match="not both"):
+            ops.log_prob(normal, jnp.array(1.0), x=jnp.array(2.0))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_ops.py
+++ b/tests/core/test_ops.py
@@ -257,9 +257,9 @@ class TestWorkflowFunctionRouting:
 
     def test_ops_are_workflow_functions(self):
         """Value-free / dispatch ops are WorkflowFunctions directly. The
-        density-family ops (``log_prob`` and friends) are thin Python
-        wrappers — they add the positional/keyword value form and forward
-        WF control kwargs — over inner ``_<name>_impl`` WorkflowFunctions,
+        density-family ops (``log_prob`` and friends) are ``_DensityOp``
+        wrappers — adding the positional/keyword value form, with controls
+        via ``with_options`` — over inner ``_<name>_impl`` WorkflowFunctions,
         so broadcasting still applies.
         """
         from probpipe.core.node import WorkflowFunction

--- a/tests/core/test_ops.py
+++ b/tests/core/test_ops.py
@@ -257,10 +257,10 @@ class TestWorkflowFunctionRouting:
 
     def test_ops_are_workflow_functions(self):
         """Value-free / dispatch ops are WorkflowFunctions directly. The
-        density-family ops (``log_prob`` and friends) are ``_DensityOp``
-        wrappers — adding the positional/keyword value form, with controls
-        via ``with_options`` — over inner ``_<name>_impl`` WorkflowFunctions,
-        so broadcasting still applies.
+        density-family ops (``log_prob`` and friends) are thin plain-function
+        wrappers — adding the positional/keyword value form, with
+        ``op.with_options`` delegating to the inner ``_<name>_impl``
+        WorkflowFunction — so broadcasting still applies.
         """
         from probpipe.core.node import WorkflowFunction
 


### PR DESCRIPTION
## Summary

Implements **PR 1 of #228** — the atomic core: a keyword form for the
`log_prob`-family ops, backed by a per-class `_pack_value` adapter, so users can
write

```python
log_prob(model, intercept=0.0, slope=0.5, X=X_obs, y=y_obs)
log_prob(prior, intercept=0.0, slope=0.5)
log_prob(Normal(name="x"), x=1.5)
```

instead of having to know each distribution's bespoke value layout. The
positional form is unchanged and still broadcasts.

Part of #228. (Remaining: PR 2 `condition_on` case-mismatch, PR 3 StanModel
Tier 2, PR 4 `RandomMeasure` kwarg form; follow-up #229.)

## What changed

- **Protocols genericized** — `SupportsLogProb[T]` / `SupportsUnnormalizedLogProb[T]`
  are now generic in the sample type `T`, with `_log_prob(value: T | ArrayLike)`.
  Documents the value contract; runtime-checkable behavior is unchanged.
- **`Distribution._pack_value(**kwargs) -> T`** (new, on the base) — builds one
  draw from named fields: single-field → bare value (`T = Array`); multi-field →
  `Record` in field order. Raises clearly on missing/unexpected fields.
- **Op layer rewritten as outer wrapper + inner `@workflow_function`** for
  `log_prob`, `prob`, `unnormalized_log_prob`, `unnormalized_prob`, and the two
  `random_*_log_prob` ops. The outer wrapper resolves the positional-or-keyword
  value and forwards the WF controls (`seed` / `n_broadcast_samples` /
  `include_inputs`) explicitly, so a field named like a reserved control can't be
  silently swallowed. Broadcasting still happens — the inner `_<op>_impl` is the
  WorkflowFunction.
- **Reserved-name warning** — constructing a distribution whose field collides
  with `{seed, n_broadcast_samples, include_inputs}` warns (cheap, side-effect-free
  check in the metaclass; points users to the positional `Record` escape hatch).
- **`SimpleModel._log_prob` accepts a `Record` *or* a `(params, data)` tuple.**
  The Record branch (kwarg form) splits into the prior's value (repacked via the
  prior's own `_pack_value`) and a data sub-record from the likelihood's
  `data_template`. See "Deviation" below.
- **`SequentialJointDistribution`** already handled `Record` at runtime
  (`_eval_log_prob` converts it); annotations tightened to say so.
- **`StanModel` / `_UnconstrainedStanView` Tier 1** — `_pack_value` accepts a
  single `parameters=` flat array (the form `_log_prob` already consumes). See
  "Not runtime-verified" below.

## Deviation from the issue plan (justified)

The plan said "tuple form *gone*" for `SimpleModel`. In practice a likelihood
without a `data_template` (bare-array data, e.g. the `GaussianLikelihood` test
fixture) has **no named data fields**, so its data can't be expressed as kwargs;
the `(params, data)` tuple is the only way. `SimpleModel._log_prob` therefore
**dual-accepts** Record and tuple. Consequences:

- The headline kwarg form works for likelihoods with a `data_template` (GLM).
- The tuple form remains valid, so the **"5 tuple-form call sites"** in the
  checklist need **no change** — `_inference_utils.py`'s bare-target path and the
  existing `test_simple_model.py` / `test_sbijax.py` tuple tests keep working.
  (`build_target_log_prob` already bypasses `SimpleModel._log_prob` for the
  structured MCMC path, so inference is unaffected either way.)

## Test plan

- **New:** `tests/core/test_log_prob_kwargs.py` — kwarg form across scalar dists
  (Normal/Beta/MVN), `ProductDistribution`, `JointGaussian`, `SimpleModel` (GLM,
  asserting kwarg == positional-Record == tuple), `StanModel._pack_value`
  (in isolation), error paths (missing / extra / positional+kwargs / neither),
  `prob` / `unnormalized_log_prob` kwarg forms, and the reserved-name warning.
- **Updated:** `test_ops.py` (ops are now thin wrappers over inner
  `_<op>_impl` WorkflowFunctions; positional-only `value`+kwargs collision);
  `test_distribution_array.py` (one call switched from keyword `value=` to
  positional — see Breaking changes).
- **Regression:** full `tests/{core,distributions,modeling,inference,converters}`
  run; my branch introduces **no new failures** vs `origin/main` (verified by
  diffing the full failure sets — the only failures are pre-existing
  Prefect-detection flakes in `test_workflow_parallel.py`, identical on both).

## Breaking changes

`log_prob` / `prob` / `unnormalized_log_prob` / `unnormalized_prob` /
`random_*_log_prob` now take `dist` and `value` as **positional-only** (so field
names are free for the keyword form). The only in-repo keyword-`value=` call site
was one test, updated to positional. `log_prob(dist, value)` (positional) is
unchanged. Labeled `kind:breaking-change`.

## Not runtime-verified

`StanModel` requires `bridgestan` (not installed in CI / locally), so its
`_pack_value` is tested in isolation via `object.__new__` (per STYLE_GUIDE §8.4)
but the full `log_prob(stan_model, parameters=...)` path is not exercised here.

## Documentation

- [x] Docstrings updated for changed public APIs (`log_prob` & friends,
  `_pack_value`, `SimpleModel._log_prob`, protocol contracts)
- [ ] User Guide / tutorials — none needed for this layer
- [x] CHANGELOG / release-notes — noted in #228

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`
- [x] At least one `area:*` label applied
- [x] Linked to an issue above
