### PR TITLE
feat(skills): add /review-all — parallel multi-lens PR review with consolidation

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -78,6 +78,38 @@ suggestions.
 
 This skill must be explicitly invoked — it will not auto-trigger.
 
+---
+
+### `/review-all [number]`
+
+Runs three independent PR reviews in parallel and merges them into one
+deduplicated, severity-tiered report.
+
+**When to use:** Before merging a non-trivial PR, or when correctness matters
+enough to want an adversarial second and third opinion. For a quick look,
+`/review-pr` alone is enough — `/review-all` is the heavier, multi-lens pass.
+
+**What it does:**
+- Fans out three concurrent reviews, each invoking a different skill:
+  - `/review-pr` — ProbPipe conventions, docs, tests, duplicate code, AI-artifact comments
+  - `/review` — general correctness, conventions, performance, test coverage, security
+  - `/code-review` — focused, high-effort correctness bug-hunt of the diff
+- Consolidates the three into a single report: deduplicates overlapping
+  findings, re-tiers by consensus severity, attributes each finding to the
+  lens(es) that raised it, surfaces disagreements between lenses, and keeps a
+  "verified correct" section so the sound core is clear.
+
+**Usage:**
+```
+/review-all          # reviews the PR for the current branch
+/review-all 273      # reviews PR #273
+```
+
+**Behavior:** Read-only. Presents the consolidated report and waits for the user
+to decide what to act on. Three agents is real token cost, so this skill must be
+explicitly invoked — it will not auto-trigger (general "review this PR" requests
+route to `/review-pr`).
+
 ## Adding New Skills
 
 To add a new skill, create a directory under `.claude/skills/` with a

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -82,19 +82,20 @@ This skill must be explicitly invoked — it will not auto-trigger.
 
 ### `/review-all [number]`
 
-Runs three independent PR reviews in parallel and merges them into one
+Runs four independent PR reviews in parallel and merges them into one
 deduplicated, severity-tiered report.
 
 **When to use:** Before merging a non-trivial PR, or when correctness matters
-enough to want an adversarial second and third opinion. For a quick look,
+enough to want an adversarial second, third, and fourth opinion. For a quick look,
 `/review-pr` alone is enough — `/review-all` is the heavier, multi-lens pass.
 
 **What it does:**
-- Fans out three concurrent reviews, each invoking a different skill:
+- Fans out four concurrent reviews, each invoking a different skill:
   - `/review-pr` — ProbPipe conventions, docs, tests, duplicate code, AI-artifact comments
   - `/review` — general correctness, conventions, performance, test coverage, security
   - `/code-review` — focused, high-effort correctness bug-hunt of the diff
-- Consolidates the three into a single report: deduplicates overlapping
+  - `/audit-tests` — test-suite quality: gaps, weak assertions, stale/duplicate tests, assertion correctness
+- Consolidates the four into a single report: deduplicates overlapping
   findings, re-tiers by consensus severity, attributes each finding to the
   lens(es) that raised it, surfaces disagreements between lenses, and keeps a
   "verified correct" section so the sound core is clear.
@@ -106,7 +107,7 @@ enough to want an adversarial second and third opinion. For a quick look,
 ```
 
 **Behavior:** Read-only. Presents the consolidated report and waits for the user
-to decide what to act on. Three agents is real token cost, so this skill must be
+to decide what to act on. Four agents is real token cost, so this skill must be
 explicitly invoked — it will not auto-trigger (general "review this PR" requests
 route to `/review-pr`).
 

--- a/.claude/skills/review-all/SKILL.md
+++ b/.claude/skills/review-all/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: review-all
+description: Run three independent PR reviews (/review-pr, /review, /code-review) in parallel and merge them into one deduplicated, severity-tiered report. Use for a thorough multi-lens review before merging a non-trivial PR.
+disable-model-invocation: true
+allowed-tools: Read Grep Glob Bash(gh *) Bash(git *) Agent
+argument-hint: [pr-number]
+---
+
+# ProbPipe Consolidated PR Review
+
+Review pull request **$ARGUMENTS** (if no number is given, detect the PR for the
+current branch with `gh pr view`) by running three independent reviews in
+parallel and merging them into one report.
+
+This is READ-ONLY. **Do not edit any files.** Present the consolidated report
+and wait for the user to decide what to act on.
+
+The three lenses are complementary, and running them as separate agents keeps
+their judgments independent. A finding raised by two lenses is high-confidence;
+a disagreement between lenses is itself signal.
+
+## Step 1: Gather context
+
+```
+gh pr view <number> --repo TARPS-group/prob-pipe --json title,baseRefName,headRefName,files,state
+gh pr diff <number> --repo TARPS-group/prob-pipe
+```
+
+Note the head/base branches, the changed files, and a one-line statement of what
+the PR is meant to do. Pass this to all three agents so none re-derives it.
+
+## Step 2: Spawn the three reviews as parallel agents
+
+Spawn **all three in a single message** (three `Agent` tool calls, `general-purpose`
+type) so they run concurrently. Each agent **invokes the corresponding skill**
+on the PR and returns its report. In every prompt, include the Step 1 context
+and require: READ-ONLY; **do not spawn further sub-agents**; return a
+**self-contained structured report with no preamble or sign-off** (it goes to a
+coordinator for consolidation).
+
+- **Agent 1** — invoke the `review-pr` skill (ProbPipe conventions, docs, tests,
+  duplicate code, AI-artifact comments).
+- **Agent 2** — invoke the `review` skill (general correctness, conventions,
+  performance, test coverage, security).
+- **Agent 3** — invoke the `code-review` skill (focused, high-effort correctness
+  bug-hunt of the diff; it may run code read-only to confirm/refute findings).
+
+If a skill is unavailable in the agent's context, tell it to fall back to
+performing that review directly per the lens description above.
+
+## Step 3: Consolidate
+
+Merge the three reports into ONE — do not concatenate.
+
+1. **Deduplicate** findings that describe the same underlying issue, even when
+   worded or located differently. Note where lenses agree independently.
+2. **Re-tier by consensus severity** (your judgment, informed by how many lenses
+   flagged it and how load-bearing it is): **Must fix** / **Should fix** /
+   **Minor / polish**.
+3. **Attribute** each finding to the lens(es) that raised it; keep `file:line`.
+4. **Surface disagreements** explicitly, with a reconciliation grounded in
+   `STYLE_GUIDE.md` / `CONTRIBUTING.md`.
+5. **Keep a "Verified correct" section** carrying forward what the bug-hunt lens
+   checked and found sound.
+6. **End with a recommendation** — what you would do, in order — and offer to
+   implement it.
+
+### Output format
+
+```
+# Consolidated Review: PR #<n> — <title>
+
+## Verdict
+## Must fix
+## Should fix
+## Minor / polish
+## Contested (lenses disagreed)
+## Verified correct
+## Recommendation
+```
+
+## Notes
+
+- Three agents is real token cost. For a quick look, `/review-pr` alone is
+  enough; reach for `/review-all` before merging a non-trivial PR.
+- Explicit-invocation only — general "review this PR" requests route to
+  `/review-pr`.

--- a/.claude/skills/review-all/SKILL.md
+++ b/.claude/skills/review-all/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-all
-description: Run three independent PR reviews (/review-pr, /review, /code-review) in parallel and merge them into one deduplicated, severity-tiered report. Use for a thorough multi-lens review before merging a non-trivial PR.
+description: Run four independent PR reviews (/review-pr, /review, /code-review, /audit-tests) in parallel and merge them into one deduplicated, severity-tiered report. Use for a thorough multi-lens review before merging a non-trivial PR.
 disable-model-invocation: true
 allowed-tools: Read Grep Glob Bash(gh *) Bash(git *) Agent
 argument-hint: [pr-number]
@@ -9,13 +9,13 @@ argument-hint: [pr-number]
 # ProbPipe Consolidated PR Review
 
 Review pull request **$ARGUMENTS** (if no number is given, detect the PR for the
-current branch with `gh pr view`) by running three independent reviews in
+current branch with `gh pr view`) by running four independent reviews in
 parallel and merging them into one report.
 
 This is READ-ONLY. **Do not edit any files.** Present the consolidated report
 and wait for the user to decide what to act on.
 
-The three lenses are complementary, and running them as separate agents keeps
+The four lenses are complementary, and running them as separate agents keeps
 their judgments independent. A finding raised by two lenses is high-confidence;
 a disagreement between lenses is itself signal.
 
@@ -27,11 +27,11 @@ gh pr diff <number> --repo TARPS-group/prob-pipe
 ```
 
 Note the head/base branches, the changed files, and a one-line statement of what
-the PR is meant to do. Pass this to all three agents so none re-derives it.
+the PR is meant to do. Pass this to all four agents so none re-derives it.
 
-## Step 2: Spawn the three reviews as parallel agents
+## Step 2: Spawn the four reviews as parallel agents
 
-Spawn **all three in a single message** (three `Agent` tool calls, `general-purpose`
+Spawn **all four in a single message** (four `Agent` tool calls, `general-purpose`
 type) so they run concurrently. Each agent **invokes the corresponding skill**
 on the PR and returns its report. In every prompt, include the Step 1 context
 and require: READ-ONLY; **do not spawn further sub-agents**; return a
@@ -44,13 +44,17 @@ coordinator for consolidation).
   performance, test coverage, security).
 - **Agent 3** — invoke the `code-review` skill (focused, high-effort correctness
   bug-hunt of the diff; it may run code read-only to confirm/refute findings).
+- **Agent 4** — invoke the `audit-tests` skill, scoped to the test files the PR
+  touches (test gaps, weak or tautological assertions, stale/duplicate tests, and
+  the mathematical correctness of the assertions). If the PR changes no tests, it
+  judges whether the changed behavior should have had coverage.
 
 If a skill is unavailable in the agent's context, tell it to fall back to
 performing that review directly per the lens description above.
 
 ## Step 3: Consolidate
 
-Merge the three reports into ONE — do not concatenate.
+Merge the four reports into ONE — do not concatenate.
 
 1. **Deduplicate** findings that describe the same underlying issue, even when
    worded or located differently. Note where lenses agree independently.
@@ -60,8 +64,8 @@ Merge the three reports into ONE — do not concatenate.
 3. **Attribute** each finding to the lens(es) that raised it; keep `file:line`.
 4. **Surface disagreements** explicitly, with a reconciliation grounded in
    `STYLE_GUIDE.md` / `CONTRIBUTING.md`.
-5. **Keep a "Verified correct" section** carrying forward what the bug-hunt lens
-   checked and found sound.
+5. **Keep a "Verified correct" section** carrying forward what the bug-hunt and
+   test-audit lenses checked and found sound.
 6. **End with a recommendation** — what you would do, in order — and offer to
    implement it.
 
@@ -81,7 +85,7 @@ Merge the three reports into ONE — do not concatenate.
 
 ## Notes
 
-- Three agents is real token cost. For a quick look, `/review-pr` alone is
+- Four agents is real token cost. For a quick look, `/review-pr` alone is
   enough; reach for `/review-all` before merging a non-trivial PR.
 - Explicit-invocation only — general "review this PR" requests route to
   `/review-pr`.


### PR DESCRIPTION
## Summary

Adds a `/review-all` Claude Code skill that runs **four independent PR reviews in
parallel** and consolidates them into one deduplicated, severity-tiered report.
Formalizes a previously ad-hoc workflow; keeping the lenses independent makes a
finding raised by two lenses high-confidence and a disagreement between lenses a
signal worth surfacing.

**The four lenses (one parallel agent each, invoking the matching skill):**
- `/review-pr` — ProbPipe conventions, docs, tests, duplicate code, AI-artifact comments
- `/review` — general correctness, conventions, performance, test coverage, security
- `/code-review` — focused, high-effort correctness bug-hunt of the diff
- `/audit-tests` — test-suite quality (gaps, weak/tautological assertions, stale or duplicate tests, assertion correctness), scoped to the PR's touched test files

**Consolidation:** dedupes overlapping findings across lenses, re-tiers by
consensus severity (Must fix / Should fix / Minor), attributes each finding to
its lens(es) with `file:line`, surfaces contested findings reconciled against
`STYLE_GUIDE.md` / `CONTRIBUTING.md`, and keeps a "verified correct" section.

## Behavior

Read-only — presents the report and waits for the user to act; never edits.
Explicit-invocation only (`disable-model-invocation: true`), since four agents is
real token cost — general "review this PR" requests still route to `/review-pr`.

## Files

- `.claude/skills/review-all/SKILL.md` — the skill.
- `.claude/skills/README.md` — adds the `/review-all` entry.

## Test plan

Tooling/docs only; no library code touched. The skill is read-only (reviews,
never edits).
