### PR TITLE
test(core): skip optional-dependency tests when graphviz/prefect absent

### DIFF
--- a/tests/core/test_provenance.py
+++ b/tests/core/test_provenance.py
@@ -370,6 +370,12 @@ def _count_dag_entries(dot) -> tuple[int, int]:
 
 class TestProvenanceDag:
 
+    @pytest.fixture(autouse=True)
+    def _require_graphviz(self):
+        # provenance_dag() builds a graphviz.Digraph; skip this class's
+        # tests when the optional graphviz package is not installed.
+        pytest.importorskip("graphviz")
+
     def test_basic_dag_has_correct_node_and_edge_count(self):
         base = Normal(loc=0.0, scale=1.0, name="base")
         td = TransformedDistribution(base, tfb.Exp(), name="positive")

--- a/tests/core/test_workflow_parallel.py
+++ b/tests/core/test_workflow_parallel.py
@@ -329,6 +329,9 @@ class TestWorkflowFunctionExecutionConfig:
         assert execution.max_workers is None
 
     def test_explicit_prefect_warns_and_ignores_local_thread_options(self, monkeypatch):
+        # The mode resolver only yields prefect_* when Prefect is installed
+        # (effective_workflow_kind also gates on node_mod.flow, not just task).
+        pytest.importorskip("prefect")
         monkeypatch.setattr(node_mod, "task", object())
         wf = WorkflowFunction(
             func=add_one,
@@ -347,6 +350,9 @@ class TestWorkflowFunctionExecutionConfig:
         self,
         monkeypatch,
     ):
+        # The mode resolver only yields prefect_* when Prefect is installed
+        # (effective_workflow_kind also gates on node_mod.flow, not just task).
+        pytest.importorskip("prefect")
         monkeypatch.setattr(node_mod, "task", object())
         prefect_config.workflow_kind = WorkflowKind.FLOW
         with pytest.warns(UserWarning, match="max_workers configures only"):
@@ -396,6 +402,9 @@ class TestWorkflowFunctionExecutionConfig:
         assert result.num_atoms == 8
 
     def test_public_call_resolves_task_and_flow_modes(self, monkeypatch):
+        # The mode resolver only yields prefect_* when Prefect is installed
+        # (effective_workflow_kind also gates on node_mod.flow, not just task).
+        pytest.importorskip("prefect")
         seen_modes = []
 
         def fake_execute_many(request):


### PR DESCRIPTION
## Summary

Six tests in `tests/core/` **errored instead of skipping** on a clean `main`
checkout when the optional `graphviz` or `prefect` packages were absent. This
is a test-robustness bug — the product code already degrades gracefully; the
tests simply did not guard for the missing dependency.

Per [STYLE_GUIDE §8.4](STYLE_GUIDE.md#84-optional-dependencies),
optional-dependency tests should use `pytest.importorskip`.

## Root cause

### graphviz — `test_provenance.py::TestProvenanceDag` (3 tests)

`test_basic_dag_has_correct_node_and_edge_count`, `test_multi_step_dag_structure`,
and `test_no_provenance_single_node` all call `provenance_dag(...)`, which builds
a Graphviz `Digraph` via `from graphviz import Digraph`
([`provenance.py:137`](probpipe/core/provenance.py)) and raises `ImportError`
when `graphviz` is not installed. The tests did not guard for it.

### prefect — `test_workflow_parallel.py::TestWorkflowFunctionExecutionConfig` (3 tests)

`test_explicit_prefect_warns_and_ignores_local_thread_options`,
`test_global_prefect_warns_and_ignores_max_workers_with_sequential_dispatch`, and
`test_public_call_resolves_task_and_flow_modes` assert that the `WorkflowFunction`
mode resolver yields `prefect_task` / `prefect_flow`.

They fake Prefect by monkeypatching only `node_mod.task`. But
`effective_workflow_kind` ([`node.py:325`](probpipe/core/node.py)) gates on
`task is None or flow is None` — so with Prefect genuinely absent, `node_mod.flow`
stays `None`, the resolver falls back to `OFF`, and the mode resolves to
`sequential`. The tests therefore failed (e.g.
`assert ['sequential', 'sequential'] == ['prefect_task', 'prefect_flow']`). They
passed only where Prefect was installed — the real `flow` import made the partial
monkeypatch sufficient.

## Fix

- **graphviz**: an autouse `pytest.importorskip("graphviz")` fixture on
  `TestProvenanceDag` (all three tests in the class need it).
- **prefect**: `pytest.importorskip("prefect")` at the top of the three affected
  tests. A module-level skip would be wrong here — the rest of the class, and the
  `TestPrefectMapping` tests (which fake Prefect at the `_workflow_execution`
  level), correctly run without Prefect and must keep running.

## Verification

Against `tests/core/test_provenance.py tests/core/test_workflow_parallel.py`:

| Environment | Before | After |
|---|---|---|
| graphviz + prefect **absent** | 6 failed, 61 passed | **6 skipped, 61 passed** |
| graphviz + prefect **present** | 67 passed | 67 passed (unchanged) |

The absent-dependency case was simulated with a `sys.meta_path` finder that blocks
`graphviz` / `prefect` before `probpipe` is imported (so `node.py` and
`_workflow_execution.py` see `task = flow = None`), reproducing a clean install
without the extras.

## Notes

- Test-only change; no product code touched, no CHANGELOG entry needed.
- Small standalone fix — no plan/tracking issue (N/A per CONTRIBUTING.md).
