### PR TITLE
feat(core): keyword form for the log_prob-family ops (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `value=`) is unchanged and still broadcasts, and per-call controls use
   `with_options` (`log_prob.with_options(seed=0)(dist, value)`). The keyword
   form is purely additive; the one case it cannot express is a distribution
-  whose field name collides with the op's own `value`/`dist` parameter — pass
-  the positional `Record` there (mirroring `condition_on`'s `observed`).
+  whose field name collides with the op's own `value`/`dist` parameter — for a
+  multi-field distribution pass a positional `Record`, for a single-field one
+  the bare positional value (mirroring `condition_on`'s `observed`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dataset). The cell is a no-op in local Jupyter, the docs build, and CI, so
   notebook execution elsewhere is unaffected.
 
+- **Keyword form for the `log_prob`-family ops (#228).** `log_prob`, `prob`,
+  `unnormalized_log_prob`, `unnormalized_prob`, and the `random_*_log_prob`
+  ops accept named field arguments —
+  `log_prob(model, intercept=0.0, slope=0.5, X=X_obs, y=y_obs)` — built into a
+  single draw via the new `Distribution._pack_value` (single-field → the bare
+  field value; multi-field → a `Record`). The ops stay plain
+  `WorkflowFunction`s that resolve this in their body — the same shape as
+  `condition_on`'s named data kwargs — so the positional form (including
+  `value=`) is unchanged and still broadcasts, and per-call controls use
+  `with_options` (`log_prob.with_options(seed=0)(dist, value)`). The keyword
+  form is purely additive; the one case it cannot express is a distribution
+  whose field name collides with the op's own `value`/`dist` parameter — pass
+  the positional `Record` there (mirroring `condition_on`'s `observed`).
+
 ### Changed
+
+- **`SupportsLogProb` / `SupportsUnnormalizedLogProb` are now generic in the
+  sample type (#228)** — `SupportsLogProb[T]`. Annotation-level only; runtime
+  behavior is unchanged.
 
 - **Amortized SBI learners accept nested priors (#262).**
   `learn_amortized_posterior` / `learn_amortized_likelihood` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `unnormalized_log_prob`, `unnormalized_prob`, and the `random_*_log_prob`
   ops accept named field arguments —
   `log_prob(model, intercept=0.0, slope=0.5, X=X_obs, y=y_obs)` — built into a
-  single draw via the new `Distribution._pack_value` (single-field → the bare
-  field value; multi-field → a `Record`). The ops stay plain
+  single draw via `Distribution._pack_value` (single-field → the bare field
+  value; multi-field → a `Record`), whose general field validation and
+  `Record` building is the new public `RecordTemplate.pack`. The ops stay plain
   `WorkflowFunction`s that resolve this in their body — the same shape as
   `condition_on`'s named data kwargs — so the positional form (including
   `value=`) is unchanged and still broadcasts, and per-call controls use

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -62,6 +62,15 @@ m = mean(dist)
 m = dist._mean()
 ```
 
+The density ops (`log_prob` and its family) also accept the value by **named
+fields** — `log_prob(model, intercept=0.0, X=X_obs, y=y_obs)` — packed into one
+draw via `Distribution._pack_value` / the public `RecordTemplate.pack`
+(single-field → the bare value; multi-field → a `Record`), the same shape as
+`condition_on`'s named data kwargs. Because `dist` and `value` are ordinary
+parameters, a distribution field whose name is exactly `value` or `dist` is
+*reserved*: address it positionally (the bare value for a single-field
+distribution, or a `Record` for a multi-field one), not by keyword.
+
 ### 1.3 Implementation functions
 
 Each op has a private implementation function named `_<op>_impl`:

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -118,8 +118,8 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
 
     def _pack_value(self, **field_kwargs: Any) -> Any:
         """Build a single draw of this distribution's value type ``T`` from
-        named field kwargs — the adapter behind the keyword form
-        ``log_prob(dist, field=value, ...)``.
+        named field kwargs — the adapter behind the keyword form of the
+        log_prob-family ops (``log_prob(dist, field=value, ...)``).
 
         Delegates field validation and ``Record`` construction to the general
         :func:`~probpipe.core.record._pack_fields` (also exposed object-style
@@ -152,7 +152,8 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
         if not fields:
             raise TypeError(
                 f"{type(self).__name__} does not support the keyword form of "
-                f"log_prob (it has no named fields); pass a positional value."
+                f"the log_prob-family ops (it has no named fields); pass a "
+                f"positional value."
             )
         rec = _pack_fields(fields, field_kwargs, owner=type(self).__name__)
         return field_kwargs[fields[0]] if len(fields) == 1 else rec

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -114,6 +114,60 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
             )
         self._name = name
 
+    # -- keyword-form value construction ------------------------------------
+
+    def _pack_value(self, **field_kwargs: Any) -> Any:
+        """Build a single draw of this distribution's value type ``T`` from
+        named field kwargs — the adapter behind the keyword form
+        ``log_prob(dist, field=value, ...)``.
+
+        Default behaviour, driven by the distribution's named ``fields``:
+
+        * **single field** → the bare field value (``T = Array``), so a
+          scalar distribution's ``_log_prob`` still receives a raw array.
+        * **multiple fields** → a :class:`~probpipe.core.record.Record`
+          keyed in field order (``T = Record``).
+
+        Distributions whose ``_log_prob`` consumes a Record but splits it
+        internally (e.g. ``SimpleModel`` → ``(params, data)``) keep this
+        default and do the split in ``_log_prob``. Override only when the
+        value type is neither a bare array nor a flat Record.
+
+        Builds exactly one draw (``sample_shape == ()``). Batched
+        evaluation does not go through kwargs — pass the batch positionally
+        and let ``WorkflowFunction`` broadcasting handle it.
+
+        Raises
+        ------
+        TypeError
+            If the distribution has no named fields, or the kwargs do not
+            match its fields exactly (missing or unexpected names).
+        """
+        fields = getattr(self, "fields", None)
+        if not fields:
+            raise TypeError(
+                f"{type(self).__name__} does not support the keyword form of "
+                f"log_prob (it has no named fields); pass a positional value."
+            )
+        given = set(field_kwargs)
+        expected = set(fields)
+        missing = [f for f in fields if f not in given]
+        extra = [k for k in field_kwargs if k not in expected]
+        if missing or extra:
+            parts = []
+            if missing:
+                parts.append(f"missing {missing}")
+            if extra:
+                parts.append(f"unexpected {extra}")
+            raise TypeError(
+                f"{type(self).__name__}: the keyword form expects exactly the "
+                f"fields {tuple(fields)} — {'; '.join(parts)}."
+            )
+        if len(fields) == 1:
+            return field_kwargs[fields[0]]
+        from .record import Record
+        return Record(**{f: field_kwargs[f] for f in fields})
+
     # -- approximation tracking ---------------------------------------------
 
     @property

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -121,17 +121,21 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
         named field kwargs — the adapter behind the keyword form
         ``log_prob(dist, field=value, ...)``.
 
-        Default behaviour, driven by the distribution's named ``fields``:
+        Delegates field validation and ``Record`` construction to the general
+        :func:`~probpipe.core.record._pack_fields` (also exposed object-style
+        as :meth:`~probpipe.core.record.RecordTemplate.pack`) and layers this
+        distribution's value-type convention on top:
 
         * **single field** → the bare field value (``T = Array``), so a
           scalar distribution's ``_log_prob`` still receives a raw array.
-        * **multiple fields** → a :class:`~probpipe.core.record.Record`
-          keyed in field order (``T = Record``).
+        * **multiple fields** → the :class:`~probpipe.core.record.Record`
+          built from the named fields (``T = Record``).
 
         Distributions whose ``_log_prob`` consumes a Record but splits it
         internally (e.g. ``SimpleModel`` → ``(params, data)``) keep this
         default and do the split in ``_log_prob``. Override only when the
-        value type is neither a bare array nor a flat Record.
+        value type is neither a bare array nor a flat Record (e.g.
+        ``StanModel``'s single ``parameters=`` flat array).
 
         Builds exactly one draw (``sample_shape == ()``). Batched
         evaluation does not go through kwargs — pass the batch positionally
@@ -143,30 +147,15 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
             If the distribution has no named fields, or the kwargs do not
             match its fields exactly (missing or unexpected names).
         """
+        from .record import _pack_fields
         fields = getattr(self, "fields", None)
         if not fields:
             raise TypeError(
                 f"{type(self).__name__} does not support the keyword form of "
                 f"log_prob (it has no named fields); pass a positional value."
             )
-        given = set(field_kwargs)
-        expected = set(fields)
-        missing = [f for f in fields if f not in given]
-        extra = [k for k in field_kwargs if k not in expected]
-        if missing or extra:
-            parts = []
-            if missing:
-                parts.append(f"missing {missing}")
-            if extra:
-                parts.append(f"unexpected {extra}")
-            raise TypeError(
-                f"{type(self).__name__}: the keyword form expects exactly the "
-                f"fields {tuple(fields)} — {'; '.join(parts)}."
-            )
-        if len(fields) == 1:
-            return field_kwargs[fields[0]]
-        from .record import Record
-        return Record(**{f: field_kwargs[f] for f in fields})
+        rec = _pack_fields(fields, field_kwargs, owner=type(self).__name__)
+        return field_kwargs[fields[0]] if len(fields) == 1 else rec
 
     # -- approximation tracking ---------------------------------------------
 

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -119,10 +119,12 @@ def _resolve_value(
     value also errors; ``allow_none=True`` (the ``random_*`` ops) lets
     ``value=None`` through so the bare random function is returned.
 
-    A distribution field whose name collides with the op's own ``value``
-    parameter cannot be addressed by the keyword form (it binds to ``value``);
-    pass a positional ``Record`` for such a distribution — mirroring how
-    ``condition_on`` treats a field named ``observed``.
+    A distribution field whose name collides with the op's own ``value`` or
+    ``dist`` parameter cannot be addressed by the keyword form (it binds to the
+    parameter). For a multi-field distribution, pass a positional ``Record``
+    (``log_prob(d, Record(value=...))``); for a single-field one, pass the bare
+    positional value (``log_prob(d, v)`` — a scalar ``_log_prob`` does not
+    accept a ``Record``). This mirrors ``condition_on``'s ``observed``.
     """
     if field_kwargs:
         if value is not None:
@@ -140,9 +142,7 @@ def _resolve_value(
 
 
 @workflow_function
-def log_prob(
-    dist: SupportsLogProb, value: Any = None, **field_kwargs: Any,
-) -> Array:
+def log_prob(dist: SupportsLogProb, value: Any = None, **field_kwargs: Any) -> Array:
     """Evaluate the normalized log-density at *value*.
 
     Two call forms: positional ``log_prob(dist, value)`` (a single draw, or a
@@ -194,8 +194,7 @@ def unnormalized_log_prob(
 def unnormalized_prob(
     dist: SupportsUnnormalizedLogProb, value: Any = None, **field_kwargs: Any,
 ) -> Array:
-    """Evaluate the unnormalized density at *value*
-    (``exp(unnormalized_log_prob)``).
+    """Evaluate the unnormalized density at *value* — ``exp(unnormalized_log_prob)``.
 
     See :func:`log_prob` for the positional and keyword call forms.
     """

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -93,50 +93,118 @@ def sample(
     return dist._sample(key, sample_shape)
 
 
+# -- keyword value form shared by the density ops ---------------------------
+#
+# Each density op accepts either a positional ``value`` or named field kwargs
+# packed into one draw via ``dist._pack_value`` (single-field → the bare
+# value; multi-field → a ``Record``). The ops stay plain WorkflowFunctions and
+# resolve this in their body — exactly as ``condition_on`` resolves its named
+# data kwargs from ``**kwargs``. Per-call controls use ``with_options`` (the
+# WorkflowFunction control path).
+
+
+def _resolve_value(
+    op_name: str,
+    dist: Any,
+    value: Any,
+    field_kwargs: dict[str, Any],
+    *,
+    allow_none: bool = False,
+) -> Any:
+    """Resolve a density op's value from the positional or keyword form.
+
+    Keyword form packs ``field_kwargs`` into a single draw via
+    ``dist._pack_value``; the positional form passes ``value`` through.
+    Passing both is an error. With ``allow_none=False`` (default) a missing
+    value also errors; ``allow_none=True`` (the ``random_*`` ops) lets
+    ``value=None`` through so the bare random function is returned.
+
+    A distribution field whose name collides with the op's own ``value``
+    parameter cannot be addressed by the keyword form (it binds to ``value``);
+    pass a positional ``Record`` for such a distribution — mirroring how
+    ``condition_on`` treats a field named ``observed``.
+    """
+    if field_kwargs:
+        if value is not None:
+            raise TypeError(
+                f"{op_name}: pass either a positional value or field kwargs, "
+                f"not both."
+            )
+        return dist._pack_value(**field_kwargs)
+    if value is None and not allow_none:
+        raise TypeError(
+            f"{op_name}: a value is required — pass it positionally or as "
+            f"field keyword arguments."
+        )
+    return value
+
+
 @workflow_function
-def log_prob(dist: SupportsLogProb, value: Any) -> Array:
-    """Evaluate the normalized log-density at *value*."""
+def log_prob(
+    dist: SupportsLogProb, value: Any = None, **field_kwargs: Any,
+) -> Array:
+    """Evaluate the normalized log-density at *value*.
+
+    Two call forms: positional ``log_prob(dist, value)`` (a single draw, or a
+    batched form that broadcasts), or keyword ``log_prob(dist, field=..., ...)``
+    built into one draw via :meth:`Distribution._pack_value` (single-field →
+    the bare value; multi-field → a ``Record``). Use the positional form for
+    batched evaluation; per-call controls use ``log_prob.with_options(...)``.
+    """
     if not isinstance(dist, SupportsLogProb):
         raise TypeError(
             f"{type(dist).__name__} does not support log_prob"
         )
-    return dist._log_prob(value)
+    return dist._log_prob(_resolve_value("log_prob", dist, value, field_kwargs))
 
 
 @workflow_function
-def prob(dist: SupportsLogProb, value: Any) -> Array:
-    """Evaluate the density at *value* (``exp(log_prob)``)."""
+def prob(dist: SupportsLogProb, value: Any = None, **field_kwargs: Any) -> Array:
+    """Evaluate the density at *value* (``exp(log_prob)``).
+
+    See :func:`log_prob` for the positional and keyword call forms.
+    """
     if not isinstance(dist, SupportsLogProb):
         raise TypeError(
             f"{type(dist).__name__} does not support prob "
             f"(missing _log_prob method)"
         )
+    value = _resolve_value("prob", dist, value, field_kwargs)
     return jnp.exp(dist._log_prob(value))
 
 
 @workflow_function
 def unnormalized_log_prob(
-    dist: SupportsUnnormalizedLogProb, value: Any,
+    dist: SupportsUnnormalizedLogProb, value: Any = None, **field_kwargs: Any,
 ) -> Array:
-    """Evaluate the unnormalized log-density at *value*."""
+    """Evaluate the unnormalized log-density at *value*.
+
+    See :func:`log_prob` for the positional and keyword call forms.
+    """
     if not isinstance(dist, SupportsUnnormalizedLogProb):
         raise TypeError(
             f"{type(dist).__name__} does not support unnormalized_log_prob "
             f"(missing _unnormalized_log_prob method)"
         )
+    value = _resolve_value("unnormalized_log_prob", dist, value, field_kwargs)
     return dist._unnormalized_log_prob(value)
 
 
 @workflow_function
 def unnormalized_prob(
-    dist: SupportsUnnormalizedLogProb, value: Any,
+    dist: SupportsUnnormalizedLogProb, value: Any = None, **field_kwargs: Any,
 ) -> Array:
-    """Evaluate the unnormalized density at *value* (``exp(unnormalized_log_prob)``)."""
+    """Evaluate the unnormalized density at *value*
+    (``exp(unnormalized_log_prob)``).
+
+    See :func:`log_prob` for the positional and keyword call forms.
+    """
     if not isinstance(dist, SupportsUnnormalizedLogProb):
         raise TypeError(
             f"{type(dist).__name__} does not support unnormalized_prob "
             f"(missing _unnormalized_log_prob method)"
         )
+    value = _resolve_value("unnormalized_prob", dist, value, field_kwargs)
     return jnp.exp(dist._unnormalized_log_prob(value))
 
 
@@ -216,6 +284,7 @@ def expectation(
 def random_log_prob(
     dist: SupportsRandomLogProb,
     value: Any = None,
+    **field_kwargs: Any,
 ) -> RandomFunction | Distribution:
     """Return the random (normalized) log-density of a random measure.
 
@@ -224,11 +293,11 @@ def random_log_prob(
     distribution over scalars at every input.
 
     When *value* is omitted, returns that callable as a
-    :class:`~probpipe.core._random_functions.RandomFunction`. When
-    *value* is provided, returns the ``Distribution[Array]`` over
-    ``log D(value)`` directly — equivalent to
-    ``random_log_prob(dist)(value)``. The two-argument form mirrors
-    :func:`log_prob` for non-random distributions.
+    :class:`~probpipe.core._random_functions.RandomFunction`. When *value* is
+    provided (positionally, or built from field kwargs via
+    :meth:`Distribution._pack_value`), returns the ``Distribution[Array]`` over
+    ``log D(value)`` directly — equivalent to ``random_log_prob(dist)(value)``.
+    The positional and keyword forms mirror :func:`log_prob`.
 
     Concrete subclasses implement a single method
     ``_random_log_prob()`` returning a ``RandomFunction``; the optional
@@ -239,6 +308,9 @@ def random_log_prob(
             f"{type(dist).__name__} does not support random_log_prob "
             f"(does not implement SupportsRandomLogProb)"
         )
+    value = _resolve_value(
+        "random_log_prob", dist, value, field_kwargs, allow_none=True
+    )
     rf = dist._random_log_prob()
     return rf if value is None else rf(value)
 
@@ -247,6 +319,7 @@ def random_log_prob(
 def random_unnormalized_log_prob(
     dist: SupportsRandomUnnormalizedLogProb,
     value: Any = None,
+    **field_kwargs: Any,
 ) -> RandomFunction | Distribution:
     """Return the random unnormalized log-density of a random measure.
 
@@ -256,12 +329,12 @@ def random_unnormalized_log_prob(
     scalars at every input.
 
     When *value* is omitted, returns that callable as a
-    :class:`~probpipe.core._random_functions.RandomFunction`. When
-    *value* is provided, returns the ``Distribution[Array]`` over
+    :class:`~probpipe.core._random_functions.RandomFunction`. When *value* is
+    provided (positionally, or built from field kwargs via
+    :meth:`Distribution._pack_value`), returns the ``Distribution[Array]`` over
     ``log D̃(value)`` directly — equivalent to
-    ``random_unnormalized_log_prob(dist)(value)``. The two-argument
-    form mirrors :func:`unnormalized_log_prob` for non-random
-    distributions.
+    ``random_unnormalized_log_prob(dist)(value)``. The positional and keyword
+    forms mirror :func:`unnormalized_log_prob`.
 
     Concrete subclasses implement a single method
     ``_random_unnormalized_log_prob()`` returning a ``RandomFunction``;
@@ -273,6 +346,9 @@ def random_unnormalized_log_prob(
             f"{type(dist).__name__} does not support random_unnormalized_log_prob "
             f"(does not implement SupportsRandomUnnormalizedLogProb)"
         )
+    value = _resolve_value(
+        "random_unnormalized_log_prob", dist, value, field_kwargs, allow_none=True
+    )
     rf = dist._random_unnormalized_log_prob()
     return rf if value is None else rf(value)
 

--- a/probpipe/core/protocols.py
+++ b/probpipe/core/protocols.py
@@ -61,7 +61,7 @@ from typing import (
 
 import jax.numpy as jnp
 
-from ..custom_types import Array, PRNGKey
+from ..custom_types import Array, ArrayLike, PRNGKey
 
 if TYPE_CHECKING:
     from ._distribution_base import Distribution
@@ -166,17 +166,19 @@ class SupportsSampling(Protocol):
 # ---------------------------------------------------------------------------
 
 @runtime_checkable
-class SupportsUnnormalizedLogProb(Protocol):
+class SupportsUnnormalizedLogProb[T](Protocol):
     """Distribution with an unnormalized log-density.
 
-    Provides ``_unnormalized_log_prob(value)``.
+    Provides ``_unnormalized_log_prob(value)``, where *value* is a single
+    draw of the distribution's sample type ``T`` (or the batched form;
+    see :class:`SupportsLogProb`).
     """
 
-    def _unnormalized_log_prob(self, value: Any) -> Array: ...
+    def _unnormalized_log_prob(self, value: T | ArrayLike) -> Array: ...
 
 
 @runtime_checkable
-class SupportsLogProb(SupportsUnnormalizedLogProb, Protocol):
+class SupportsLogProb[T](SupportsUnnormalizedLogProb[T], Protocol):
     """Distribution with a (normalized) log-density.
 
     Extends :class:`SupportsUnnormalizedLogProb` because any distribution
@@ -184,11 +186,20 @@ class SupportsLogProb(SupportsUnnormalizedLogProb, Protocol):
     The base :class:`~probpipe.core.distribution.Distribution` class
     provides ``_unnormalized_log_prob`` defaulting to ``_log_prob``.
 
+    ``_log_prob`` accepts a single draw of the distribution's sample type
+    ``T`` or the batched form (``Array`` → ``Array`` with leading batch
+    axes; ``Record`` → ``RecordArray``; ``NumericRecord`` →
+    ``NumericRecordArray``). The ``T | ArrayLike`` annotation is
+    deliberately loose: ``ArrayLike`` covers the scalar batched case,
+    while Record-based batched forms follow the convention above. The
+    kwarg form ``log_prob(dist, field=value, ...)`` builds a single ``T``
+    via :meth:`Distribution._pack_value`; batched evaluation goes through
+    the positional path.
     """
 
-    def _log_prob(self, value: Any) -> Array: ...
+    def _log_prob(self, value: T | ArrayLike) -> Array: ...
 
-    def _unnormalized_log_prob(self, value: Any) -> Array:
+    def _unnormalized_log_prob(self, value: T | ArrayLike) -> Array:
         """Default: delegates to ``_log_prob``."""
         return self._log_prob(value)
 

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -594,6 +594,42 @@ def _all_numeric(specs) -> bool:
     return True
 
 
+def _pack_fields(
+    fields: tuple[str, ...],
+    field_kwargs: dict[str, Any],
+    *,
+    owner: str = "",
+) -> Record:
+    """Validate that *field_kwargs* names exactly *fields*, then build a Record.
+
+    The general "named values → validated :class:`Record`" operation behind
+    :meth:`RecordTemplate.pack`. Raises ``TypeError`` if any field is missing
+    or unexpected; otherwise returns a ``Record`` keyed in *fields* order.
+    *owner* (optional) prefixes the error message — the calling distribution or
+    template class name.
+
+    :meth:`Distribution._pack_value` calls this directly rather than through
+    :meth:`RecordTemplate.pack` because some distributions expose ``fields``
+    without a ``RecordTemplate`` instance.
+    """
+    given = set(field_kwargs)
+    expected = set(fields)
+    missing = [f for f in fields if f not in given]
+    extra = [k for k in field_kwargs if k not in expected]
+    if missing or extra:
+        parts = []
+        if missing:
+            parts.append(f"missing {missing}")
+        if extra:
+            parts.append(f"unexpected {extra}")
+        prefix = f"{owner}: " if owner else ""
+        raise TypeError(
+            f"{prefix}expected exactly the fields {tuple(fields)} — "
+            f"{'; '.join(parts)}."
+        )
+    return Record(**{f: field_kwargs[f] for f in fields})
+
+
 class RecordTemplate:
     """Structural description of a Record: field names, leaf shapes, nesting.
 
@@ -753,6 +789,17 @@ class RecordTemplate:
             return spec
         # Record-valued fallback (legacy templates).
         return spec.shape if not isinstance(spec, Record) else ()
+
+    def pack(self, **field_kwargs: Any) -> Record:
+        """Build a :class:`Record` from named values matching this template.
+
+        Validates that *field_kwargs* names exactly this template's top-level
+        :attr:`fields` (no missing or unexpected names) and returns a
+        ``Record`` keyed in field order. Values pass through unchanged (a
+        nested-template field takes a sub-``Record``). Object form of
+        :func:`_pack_fields`.
+        """
+        return _pack_fields(self.fields, field_kwargs, owner=type(self).__name__)
 
     def __contains__(self, name: str) -> bool:
         return name in self._specs

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -368,7 +368,7 @@ class SequentialJointDistribution(
 
         return total
 
-    def _log_prob(self, value: dict[str, ArrayLike]) -> Array:
+    def _log_prob(self, value: Record | dict[str, ArrayLike]) -> Array:
         """Evaluate the normalized log-density.
 
         For an unconditioned joint, this is the full joint log p(x).
@@ -393,7 +393,7 @@ class SequentialJointDistribution(
             )
         return self._eval_log_prob(value, components="unconditioned")
 
-    def _unnormalized_log_prob(self, value: dict[str, ArrayLike]) -> Array:
+    def _unnormalized_log_prob(self, value: Record | dict[str, ArrayLike]) -> Array:
         """Evaluate the (possibly unnormalized) log-density.
 
         For an unconditioned joint, this equals the full joint log p(x).

--- a/probpipe/modeling/_simple.py
+++ b/probpipe/modeling/_simple.py
@@ -174,18 +174,63 @@ class SimpleModel[P, D](ProbabilisticModel[tuple[P, D]], SupportsLogProb):
 
     # -- SupportsLogProb interface -----------------------------------------
 
-    def _log_prob(self, value: tuple[P, D]) -> Array:
+    def _log_prob(self, value: Record | tuple[P, D]) -> Array:
         """Joint log-density: prior log-prob + log-likelihood.
+
+        Accepts either form:
+
+        * **Record** — a single record carrying all of :attr:`fields`
+          (the prior's parameter fields plus the likelihood's named data
+          fields). This is what the keyword API
+          (``log_prob(model, intercept=..., y=...)``) produces. It is
+          split into a parameter value — repacked via the prior's own
+          :meth:`~probpipe.core._distribution_base.Distribution._pack_value`
+          so a single-field prior receives a bare array and a multi-field
+          prior a ``Record`` — and a data sub-record built from the
+          likelihood's ``data_template`` fields.
+        * **(params, data) pair** — the explicit joint form. Required when
+          the likelihood's data has no named template (bare arrays), and
+          retained for backward compatibility.
 
         Parameters
         ----------
-        value : tuple[P, D]
-            A ``(params, data)`` pair.
+        value : Record or tuple[P, D]
+            All model fields as a record, or an explicit ``(params, data)``
+            pair.
         """
-        params, data = value
+        params, data = self._split_log_prob_value(value)
         lp = self._prior._log_prob(params)
         ll = self._likelihood.log_likelihood(params=params, data=data)
         return lp + ll
+
+    def _split_log_prob_value(self, value: Record | tuple[P, D]) -> tuple[Any, Any]:
+        """Resolve ``value`` (Record or (params, data) pair) into
+        ``(params, data)`` in the forms the prior and likelihood expect."""
+        # A Record is not a tuple, so the tuple check is unambiguous.
+        if isinstance(value, tuple) and len(value) == 2:
+            return value
+        if isinstance(value, Record):
+            data_fields = self._data_fields
+            if not data_fields:
+                # The likelihood has no named data fields (no data_template),
+                # so the Record / keyword form cannot supply the data. Reject
+                # loudly rather than silently passing data=None downstream.
+                raise TypeError(
+                    f"{type(self).__name__}: the keyword/Record form is "
+                    f"unavailable because the likelihood "
+                    f"({type(self._likelihood).__name__}) has no named data "
+                    f"fields (no data_template); pass a (params, data) pair "
+                    f"positionally instead."
+                )
+            params = self._prior._pack_value(
+                **{f: value[f] for f in self._prior_fields}
+            )
+            data = Record(**{f: value[f] for f in data_fields})
+            return params, data
+        raise TypeError(
+            f"SimpleModel._log_prob expects a Record over {self.fields} or a "
+            f"(params, data) pair; got {type(value).__name__}."
+        )
 
     # -- repr ---------------------------------------------------------------
 

--- a/probpipe/modeling/_stan.py
+++ b/probpipe/modeling/_stan.py
@@ -22,6 +22,24 @@ logger = logging.getLogger(__name__)
 __all__ = ["StanModel"]
 
 
+def _pack_parameters_value(owner: str, field_kwargs: dict[str, Any]) -> Array:
+    """Shared ``_pack_value`` for the Stan keyword form (Tier 1).
+
+    ``StanModel._log_prob`` (and the unconstrained view) consume a single
+    flat parameter vector, so the keyword form takes one ``parameters=``
+    argument rather than per-Stan-parameter fields. (Tier 2 — issue #228 —
+    will expose the individual Stan parameters as fields built from
+    BridgeStan's ``param_unc_names()``.) *owner* names the class in the
+    error message.
+    """
+    if set(field_kwargs) != {"parameters"}:
+        raise TypeError(
+            f"{owner} keyword form takes a single 'parameters=' flat array; "
+            f"got {sorted(field_kwargs)}."
+        )
+    return field_kwargs["parameters"]
+
+
 class StanModel(ProbabilisticModel, SupportsLogProb):
     """Stan model via BridgeStan and CmdStanPy.
 
@@ -101,6 +119,11 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
 
     # -- SupportsLogProb interface ------------------------------------------
 
+    def _pack_value(self, **field_kwargs: Any) -> Array:
+        """Keyword form (Tier 1): a single flat constrained ``parameters=``
+        array (see :func:`_pack_parameters_value`)."""
+        return _pack_parameters_value(type(self).__name__, field_kwargs)
+
     def _log_prob(self, value: Any) -> Array:
         """Log-density in the constrained parameter space.
 
@@ -167,6 +190,11 @@ class _UnconstrainedStanView(Distribution[Any], SupportsLogProb):
     @property
     def event_shape(self) -> tuple[int, ...]:
         return self._model.event_shape
+
+    def _pack_value(self, **field_kwargs: Any) -> Array:
+        """Keyword form (Tier 1): a single flat ``parameters=`` array in the
+        unconstrained space (see :func:`_pack_parameters_value`)."""
+        return _pack_parameters_value(type(self).__name__, field_kwargs)
 
     def _log_prob(self, value: Any) -> Array:
         """Log-density directly in unconstrained space."""

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -1,0 +1,290 @@
+"""Tests for the keyword form of the log_prob-family ops (issue #228).
+
+``log_prob`` / ``prob`` / ``unnormalized_log_prob`` accept either a
+positional value or named field kwargs; the kwargs are packed into a
+single draw of the distribution's value type via
+:meth:`Distribution._pack_value` (single-field → bare value; multi-field
+→ ``Record``). This file exercises the keyword form across the
+distribution surface, the error paths, and the ``with_options`` control
+path.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tensorflow_probability.substrates.jax.glm as tfp_glm
+
+from probpipe import (
+    Beta,
+    GLMLikelihood,
+    JointGaussian,
+    MinibatchedDistribution,
+    MultivariateNormal,
+    Normal,
+    ProductDistribution,
+    Record,
+    SequentialJointDistribution,
+    SimpleModel,
+    log_prob,
+    prob,
+    random_unnormalized_log_prob,
+    unnormalized_log_prob,
+    unnormalized_prob,
+)
+
+
+class TestKwargFormScalar:
+    """Single-field distributions: a field kwarg packs to the bare value."""
+
+    def test_normal(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.allclose(log_prob(d, x=1.5), log_prob(d, 1.5))
+
+    def test_beta(self):
+        d = Beta(2.0, 3.0, name="p")
+        assert jnp.allclose(log_prob(d, p=0.4), log_prob(d, 0.4))
+
+    def test_multivariate_normal_vector_event(self):
+        d = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
+        v = jnp.array([0.1, 0.2, 0.3])
+        assert jnp.allclose(log_prob(d, z=v), log_prob(d, v))
+
+
+class TestKwargFormRecord:
+    """Multi-field distributions: field kwargs pack to a Record."""
+
+    def test_product_distribution(self):
+        p = ProductDistribution(Normal(0.0, 1.0, name="a"), Beta(2.0, 3.0, name="b"))
+        assert jnp.allclose(log_prob(p, a=0.5, b=0.4), log_prob(p, Record(a=0.5, b=0.4)))
+
+    def test_field_order_independent(self):
+        # Distinguishable components (Normal vs Beta) so a field swap would
+        # change the result — a symmetric pair could not detect mis-routing.
+        p = ProductDistribution(Normal(0.0, 1.0, name="a"), Beta(2.0, 3.0, name="b"))
+        out_of_order = log_prob(p, b=0.4, a=0.5)
+        baseline = log_prob(p, Record(a=0.5, b=0.4))
+        assert jnp.allclose(out_of_order, baseline)
+        # Mis-pairing the values genuinely differs, so the above is a real check.
+        assert not jnp.allclose(out_of_order, log_prob(p, Record(a=0.4, b=0.5)))
+
+    def test_joint_gaussian(self):
+        jg = JointGaussian(mean=jnp.zeros(3), cov=jnp.eye(3), u=2, v=1)
+        u, v = jnp.array([0.1, 0.2]), jnp.array([0.3])
+        assert jnp.allclose(log_prob(jg, u=u, v=v), log_prob(jg, Record(u=u, v=v)))
+
+
+class TestKwargFormSimpleModel:
+    """The headline case: ``log_prob(model, intercept=..., slope=..., X=..., y=...)``."""
+
+    @staticmethod
+    def _glm_model():
+        X = np.array([0.1, 0.5, -0.3], dtype=np.float32)
+        y = np.array([1.0, 3.0, 0.0], dtype=np.float32)
+        lik = GLMLikelihood(tfp_glm.Poisson(), X)
+        prior = ProductDistribution(
+            Normal(0.0, 1.0, name="intercept"), Normal(0.0, 1.0, name="slope")
+        )
+        return SimpleModel(prior, lik, name="m"), X, y
+
+    def test_kwarg_matches_record_and_tuple(self):
+        model, X, y = self._glm_model()
+        kw = log_prob(model, intercept=0.3, slope=0.5, X=X, y=y)
+        rec = log_prob(model, Record(intercept=0.3, slope=0.5, X=X, y=y))
+        tup = model._log_prob((Record(intercept=0.3, slope=0.5), Record(X=X, y=y)))
+        assert jnp.allclose(kw, rec)
+        assert jnp.allclose(kw, tup)
+
+    def test_keyword_form_rejected_without_data_template(self):
+        """A likelihood with no named data fields cannot use the keyword/Record
+        form (data can't be supplied) — it must raise, not pass data=None."""
+
+        class _NoTemplateLikelihood:
+            def log_likelihood(self, params, data):
+                return jnp.asarray(0.0)
+
+        prior = ProductDistribution(
+            Normal(0.0, 1.0, name="a"), Normal(0.0, 1.0, name="b")
+        )
+        model = SimpleModel(prior, _NoTemplateLikelihood(), name="m")
+        with pytest.raises(TypeError, match="no named data fields"):
+            log_prob(model, a=0.5, b=0.5)
+        # The (params, data) tuple form remains available for such models.
+        lp = model._log_prob((Record(a=0.5, b=0.5), jnp.zeros(3)))
+        assert jnp.isfinite(lp)
+
+
+class TestStanViewsPackValue:
+    """StanModel / _UnconstrainedStanView Tier 1: the keyword form takes a
+    single ``parameters=`` flat array.
+
+    bridgestan is not installed in CI, so ``_pack_value`` is exercised in
+    isolation via ``object.__new__`` (per STYLE_GUIDE §8.4). The method reads
+    no instance state beyond the class name in its error message, so no
+    attribute setup is needed.
+    """
+
+    @pytest.fixture(params=["StanModel", "_UnconstrainedStanView"])
+    def bare_stan(self, request):
+        from probpipe.modeling import _stan
+        return object.__new__(getattr(_stan, request.param))
+
+    def test_pack_value_parameters(self, bare_stan):
+        arr = jnp.array([0.1, 0.2, 0.3])
+        assert jnp.allclose(bare_stan._pack_value(parameters=arr), arr)
+
+    def test_pack_value_wrong_kwargs_raises(self, bare_stan):
+        with pytest.raises(TypeError, match="parameters="):
+            bare_stan._pack_value(theta=jnp.array([0.1]))
+
+
+class TestKwargErrors:
+    def test_missing_field(self):
+        p = ProductDistribution(Normal(0.0, 1.0, name="a"), Normal(0.0, 1.0, name="b"))
+        with pytest.raises(TypeError, match="missing"):
+            log_prob(p, a=0.5)
+
+    def test_extra_field(self):
+        d = Normal(0.0, 1.0, name="x")
+        with pytest.raises(TypeError, match="unexpected"):
+            log_prob(d, x=1.0, bogus=2.0)
+
+    def test_positional_value_and_kwargs(self):
+        d = Normal(0.0, 1.0, name="x")
+        with pytest.raises(TypeError, match="not both"):
+            log_prob(d, 1.0, x=2.0)
+
+    def test_neither_value_nor_kwargs(self):
+        d = Normal(0.0, 1.0, name="x")
+        with pytest.raises(TypeError, match="value is required"):
+            log_prob(d)
+
+
+class TestProbAndUnnormalizedKwargForm:
+    def test_prob_kwarg(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.allclose(prob(d, x=0.0), prob(d, 0.0))
+
+    def test_unnormalized_log_prob_kwarg(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.allclose(
+            unnormalized_log_prob(d, x=1.2), unnormalized_log_prob(d, 1.2)
+        )
+
+    def test_unnormalized_prob_kwarg(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.allclose(unnormalized_prob(d, x=0.3), unnormalized_prob(d, 0.3))
+
+
+class TestFormerlyReservedFieldNames:
+    """Controls live only on ``with_options``, so a field whose name matches a
+    former WF control (``seed`` / ``n_broadcast_samples`` / ``include_inputs``)
+    is an ordinary field: construction does not warn, and the keyword form
+    addresses it (issue #228)."""
+
+    @pytest.mark.parametrize("name", ["seed", "n_broadcast_samples", "include_inputs"])
+    def test_construction_does_not_warn(self, name):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Normal(0.0, 1.0, name=name)
+        assert not any("reserved" in str(w.message).lower() for w in caught)
+
+    @pytest.mark.parametrize("name", ["seed", "n_broadcast_samples", "include_inputs"])
+    def test_keyword_form_addresses_the_field(self, name):
+        # The field name is not swallowed by the workflow layer — it packs
+        # into the value, matching the positional form.
+        d = Normal(0.0, 1.0, name=name)
+        assert jnp.allclose(log_prob(d, **{name: 1.5}), log_prob(d, 1.5))
+
+
+class TestControlsViaWithOptions:
+    """The density ops are plain WorkflowFunctions, so per-call controls use
+    their own ``with_options`` (the WorkflowFunction control path), exactly
+    like the dispatch ops — not call kwargs (issue #228)."""
+
+    @pytest.mark.parametrize(
+        "control",
+        [{"seed": 3}, {"n_broadcast_samples": 8}, {"include_inputs": True}],
+    )
+    def test_with_options_does_not_deprecation_warn(self, control):
+        d = Normal(0.0, 1.0, name="x")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            log_prob.with_options(**control)(d, 1.5)
+        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert not deps, [str(w.message) for w in deps]
+
+    def test_op_is_its_own_workflow_function(self):
+        # No wrapper: log_prob *is* a WorkflowFunction, so with_options is its
+        # own bound method — not a re-implementation.
+        from probpipe.core.node import WorkflowFunction
+        assert isinstance(log_prob, WorkflowFunction)
+        assert log_prob.with_options.__self__ is log_prob
+
+    def test_with_options_supports_both_value_forms(self):
+        # Because the op is a real WF with **field_kwargs, with_options accepts
+        # the positional and keyword value forms alike.
+        d = Normal(0.0, 1.0, name="x")
+        base = log_prob(d, 1.5)
+        assert jnp.allclose(log_prob.with_options(seed=0)(d, 1.5), base)
+        assert jnp.allclose(log_prob.with_options(seed=0)(d, x=1.5), base)
+
+    def test_control_as_call_kwarg_is_rejected(self):
+        # Controls are not call kwargs on the density ops; with a positional
+        # value present, a stray control name collides with the keyword form.
+        d = Normal(0.0, 1.0, name="x")
+        with pytest.raises(TypeError, match="not both"):
+            log_prob(d, 1.5, seed=3)
+
+
+class TestValueKeywordBackwardCompat:
+    """``value=`` still works — the ``value`` parameter is positional-or-keyword
+    (like ``condition_on``'s ``observed``), so the keyword form is purely
+    additive and does not break the legacy ``log_prob(dist, value=x)`` call."""
+
+    def test_value_keyword_equals_positional(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.allclose(log_prob(d, value=1.5), log_prob(d, 1.5))
+
+
+class TestSequentialJointKwargForm:
+    def test_kwarg_matches_positional_record(self):
+        joint = SequentialJointDistribution(
+            z=Normal(loc=0.0, scale=1.0, name="z"),
+            x=lambda z: Normal(loc=z, scale=0.5, name="x"),
+        )
+        kw = log_prob(joint, z=0.2, x=0.1)
+        pos = log_prob(joint, Record(z=0.2, x=0.1))
+        assert jnp.allclose(kw, pos)
+
+
+class TestRandomMeasureKwargForm:
+    """The random_*_log_prob ops keep `value` optional (return the
+    RandomFunction) and forward controls without deprecation; the kwarg form
+    routes through _pack_value (full RandomMeasure field support is #228 PR 4)."""
+
+    @staticmethod
+    def _measure():
+        import tensorflow_probability.substrates.jax.glm as tfp_glm
+        X = jnp.eye(4)
+        y = jnp.array([1.0, 0.0, 1.0, 0.0])
+        prior = MultivariateNormal(loc=jnp.zeros(4), cov=jnp.eye(4), name="theta")
+        lik = GLMLikelihood(tfp_glm.Bernoulli(), x=X)
+        return MinibatchedDistribution(prior, lik, Record(X=X, y=y), batch_size=2)
+
+    def test_value_omitted_returns_callable_no_deprecation(self):
+        m = self._measure()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            rf = random_unnormalized_log_prob.with_options(seed=0)(m)
+        assert callable(rf)
+        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert not deps, [str(w.message) for w in deps]
+
+    def test_positional_value_and_kwargs_raises(self):
+        m = self._measure()
+        with pytest.raises(TypeError, match="not both"):
+            random_unnormalized_log_prob(m, jnp.zeros(4), theta=jnp.zeros(4))

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -31,10 +31,13 @@ from probpipe import (
     SimpleModel,
     log_prob,
     prob,
+    random_log_prob,
     random_unnormalized_log_prob,
     unnormalized_log_prob,
     unnormalized_prob,
 )
+from probpipe.core.distribution import Distribution
+from probpipe.core.record import RecordTemplate
 
 
 class TestKwargFormScalar:
@@ -116,6 +119,27 @@ class TestKwargFormSimpleModel:
         lp = model._log_prob((Record(a=0.5, b=0.5), jnp.zeros(3)))
         assert jnp.isfinite(lp)
 
+    def test_single_field_prior_packs_to_bare_array(self):
+        """A single-field prior's params repack to a bare array (not a 1-field
+        Record) in _split_log_prob_value — exercises the len(fields) == 1 branch."""
+
+        class _ScalarLikelihood:
+            data_template = RecordTemplate(y=())
+
+            def log_likelihood(self, params, data):
+                # params is the bare scalar from the single-field prior
+                return -0.5 * jnp.sum((data["y"] - params) ** 2)
+
+        model = SimpleModel(
+            Normal(0.0, 1.0, name="theta"), _ScalarLikelihood(), name="m"
+        )
+        y = jnp.array([0.2, -0.1, 0.4])
+        kw = log_prob(model, theta=0.5, y=y)
+        rec = log_prob(model, Record(theta=0.5, y=y))
+        tup = model._log_prob((0.5, Record(y=y)))  # single-field prior → bare scalar
+        assert jnp.allclose(kw, rec)
+        assert jnp.allclose(kw, tup)
+
 
 class TestStanViewsPackValue:
     """StanModel / _UnconstrainedStanView Tier 1: the keyword form takes a
@@ -177,6 +201,17 @@ class TestProbAndUnnormalizedKwargForm:
     def test_unnormalized_prob_kwarg(self):
         d = Normal(0.0, 1.0, name="x")
         assert jnp.allclose(unnormalized_prob(d, x=0.3), unnormalized_prob(d, 0.3))
+
+    def test_prob_multifield_kwarg_matches_record(self):
+        p = ProductDistribution(Normal(0.0, 1.0, name="a"), Beta(2.0, 3.0, name="b"))
+        assert jnp.allclose(prob(p, a=0.5, b=0.4), prob(p, Record(a=0.5, b=0.4)))
+
+    def test_unnormalized_prob_multifield_kwarg_matches_record(self):
+        p = ProductDistribution(Normal(0.0, 1.0, name="a"), Beta(2.0, 3.0, name="b"))
+        assert jnp.allclose(
+            unnormalized_prob(p, a=0.5, b=0.4),
+            unnormalized_prob(p, Record(a=0.5, b=0.4)),
+        )
 
 
 class TestFormerlyReservedFieldNames:
@@ -261,10 +296,29 @@ class TestSequentialJointKwargForm:
         assert jnp.allclose(kw, pos)
 
 
+class _FieldlessRandomMeasure(Distribution):
+    """A random measure with no named fields, implementing both random
+    log-prob protocols — for the random_* ops' keyword-form error paths
+    (random measures have no field support yet; #228 PR 4). The returned
+    callables are never invoked: each test below raises before reaching them.
+    """
+
+    def __init__(self):
+        super().__init__(name="fieldless_rm")
+
+    def _random_log_prob(self):
+        return lambda v: v
+
+    def _random_unnormalized_log_prob(self):
+        return lambda v: v
+
+
 class TestRandomMeasureKwargForm:
     """The random_*_log_prob ops keep `value` optional (return the
-    RandomFunction) and forward controls without deprecation; the kwarg form
-    routes through _pack_value (full RandomMeasure field support is #228 PR 4)."""
+    RandomFunction) and apply controls via with_options without deprecation.
+    The keyword form routes to `_pack_value`; since random measures carry no
+    named `fields` yet, it raises a clear "no named fields" error — full
+    RandomMeasure field support is #228 PR 4."""
 
     @staticmethod
     def _measure():
@@ -284,7 +338,50 @@ class TestRandomMeasureKwargForm:
         deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
         assert not deps, [str(w.message) for w in deps]
 
-    def test_positional_value_and_kwargs_raises(self):
-        m = self._measure()
+    @pytest.mark.parametrize("op", [random_log_prob, random_unnormalized_log_prob])
+    def test_kwarg_form_raises_no_named_fields(self, op):
+        # The kwarg form routes to _pack_value; a fields-less random measure
+        # has none, so it raises loudly — covering both random ops and the base
+        # Distribution._pack_value no-named-fields guard.
+        with pytest.raises(TypeError, match="no named fields"):
+            op(_FieldlessRandomMeasure(), theta=jnp.zeros(4))
+
+    @pytest.mark.parametrize("op", [random_log_prob, random_unnormalized_log_prob])
+    def test_positional_value_and_kwargs_raises(self, op):
         with pytest.raises(TypeError, match="not both"):
-            random_unnormalized_log_prob(m, jnp.zeros(4), theta=jnp.zeros(4))
+            op(_FieldlessRandomMeasure(), jnp.zeros(4), theta=jnp.zeros(4))
+
+
+class TestKwargShapeAndBroadcast:
+    """The keyword form builds exactly one draw (scalar for a scalar dist);
+    the positional form still broadcasts after the `value=None` default."""
+
+    def test_kwarg_result_is_scalar_for_scalar_dist(self):
+        d = Normal(0.0, 1.0, name="x")
+        assert jnp.asarray(log_prob(d, x=1.5)).shape == ()
+
+    def test_positional_still_broadcasts(self):
+        d = Normal(0.0, 1.0, name="x")
+        out = log_prob(d, jnp.array([0.0, 1.0, 2.0]))
+        assert jnp.asarray(out).shape == (3,)
+
+
+class TestFieldNameCollision:
+    """A field named exactly `value`/`dist` collides with the op's parameter;
+    the escape differs by single- vs multi-field (#228, see CHANGELOG)."""
+
+    def test_multifield_value_field_via_positional_record(self):
+        p = ProductDistribution(Normal(0.0, 1.0, name="value"), Beta(2.0, 3.0, name="b"))
+        # the keyword form can't address the 'value' field (binds to the param):
+        with pytest.raises(TypeError, match="not both"):
+            log_prob(p, value=0.5, b=0.4)
+        # escape hatch for a multi-field distribution: the positional Record
+        assert jnp.isfinite(log_prob(p, Record(value=0.5, b=0.4)))
+
+    def test_singlefield_value_field_via_bare_positional(self):
+        d = Normal(0.0, 1.0, name="value")
+        # bare positional works (and equals value=, which binds to the param):
+        assert jnp.allclose(log_prob(d, 1.5), log_prob(d, value=1.5))
+        # the positional Record does NOT work for a single-field distribution:
+        with pytest.raises(TypeError):
+            log_prob(d, Record(value=1.5))

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -726,3 +726,28 @@ class TestProvenance:
         ancestors = provenance_ancestors(outer)
         names = [getattr(a, "name", None) for a in ancestors]
         assert names == [middle.name, "prior"]
+
+
+class TestRecordTemplatePack:
+    """RecordTemplate.pack builds a validated Record from named values
+    (the general field-packing behind Distribution._pack_value, #228)."""
+
+    def test_pack_builds_record_in_field_order(self):
+        from probpipe.core.record import RecordTemplate
+        tpl = RecordTemplate(a=(), b=(3,))
+        # kwargs out of order — pack keys the Record in template field order
+        rec = tpl.pack(b=jnp.ones(3), a=jnp.array(0.5))
+        assert rec.fields == ("a", "b")
+        d = rec.to_dict()
+        assert jnp.allclose(d["a"], 0.5)
+        assert jnp.allclose(d["b"], jnp.ones(3))
+
+    def test_pack_missing_field_raises(self):
+        from probpipe.core.record import RecordTemplate
+        with pytest.raises(TypeError, match="missing"):
+            RecordTemplate(a=(), b=()).pack(a=0.5)
+
+    def test_pack_unexpected_field_raises(self):
+        from probpipe.core.record import RecordTemplate
+        with pytest.raises(TypeError, match="unexpected"):
+            RecordTemplate(a=(), b=()).pack(a=0.5, b=0.4, c=1.0)


### PR DESCRIPTION
## Summary

Adds the **keyword form** to the `log_prob`-family ops, so a model's named fields can be passed directly:

```python
log_prob(model, intercept=0.0, slope=0.5, X=X_obs, y=y_obs)   # == log_prob(model, Record(...))
```

This is **issue #228, PR-1**.

## Design

Each density op (`log_prob`, `prob`, `unnormalized_log_prob`, `unnormalized_prob`, `random_log_prob`, `random_unnormalized_log_prob`) stays a plain `@workflow_function` and resolves its value **in the body** via the new `Distribution._pack_value`:

- **single-field** distribution → the bare value (`T = Array`)
- **multi-field** distribution → a `Record`

This is exactly the shape `condition_on` already uses (it resolves named data kwargs from `**kwargs` in its body). So there is **no wrapper and no inner indirection**: `log_prob.with_options(...)` is the op's own `WorkflowFunction` method, and the positional form is unchanged and still broadcasts.

### Non-breaking

The keyword form is **purely additive** — `log_prob(dist, value)` and `log_prob(dist, value=v)` both still work. The one case it cannot express is a distribution whose field name collides with the op's own `value`/`dist` parameter (it binds to the parameter); pass the positional `Record` there — mirroring how `condition_on` handles a field named `observed`. Such a collision **fails loudly**, never silently.

## Changes

- `Distribution._pack_value` (default field-packing) + generic `SupportsLogProb[T]` / `SupportsUnnormalizedLogProb[T]` (annotation-level).
- `ops.py`: each density op gains `value=None, **field_kwargs` + a shared `_resolve_value` helper.
- `SimpleModel._log_prob` dual-accepts a `Record` or the `(params, data)` pair (rejecting the `Record` form loudly when the likelihood has no named data fields).
- `StanModel` / `_UnconstrainedStanView` share one `_pack_parameters_value` helper (Tier 1: a single `parameters=` flat array).
- `SequentialJointDistribution` annotations accept `Record | dict`.
- New `tests/core/test_log_prob_kwargs.py`.

## Verification

- Full suite green (branched off current `main`); `tests/core/test_log_prob_kwargs.py` covers the keyword form across the distribution surface, error paths, `with_options`, `value=` backward-compat, and formerly-control field names.
- ruff: no new lint — the rule-code set in every touched file is unchanged vs `main` (pre-existing lint left as-is).

## Follow-ups (issue #228)

- PR 2 — `condition_on` case-mismatch handling.
- PR 3 — StanModel Tier 2 (per-Stan-parameter fields from `param_unc_names()`).
- PR 4 — `RandomMeasure` field support in the `random_*` keyword form.
- #229 — `PyMCModel._log_prob`.
