### PR TITLE
fix(core): condition_on raises on case-mismatched data kwargs (#228 PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`condition_on` no longer silently ignores a case-mismatched data kwarg
+  (#228).** Passing `condition_on(model, x=...)` when the field is `X` used to
+  route `x` to the inference parameters, where it was silently dropped (e.g. by
+  NUTS) — a wrong result with no error. A kwarg that matches a field only up to
+  case now raises a `TypeError` with the correct casing (`did you mean X=...?`);
+  unknown kwargs that are *not* a case-variant of any field remain inference
+  parameters.
+
 - **Codecov no longer misreports coverage on targeted PRs (#261).**
   On a PR that ran only the changed-files test path, the main test job
   skipped its Codecov upload while the BayesFlow job still uploaded, so

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -287,13 +287,35 @@ def _split_data_kwargs(
     any kwarg whose name matches a component name is data (conditioning
     target); everything else is an inference parameter.
 
+    Guards against case-mismatched field names: a kwarg that matches a field
+    only up to case (e.g. ``x=`` when the field is ``X``) is almost certainly a
+    mistyped data field. Routed to ``inference_kwargs`` it would be silently
+    ignored downstream (e.g. by NUTS) — a wrong result with no error — so it
+    raises a :class:`TypeError` with the correct casing instead. Unknown
+    kwargs that are *not* a case-variant of any field stay inference
+    parameters (the inference layer validates those).
+
     Returns ``(data_kwargs, inference_kwargs)``.
     """
-    comp_names = frozenset(
-        dist.fields if hasattr(dist, 'fields') else ()
-    )
-    data_kwargs = {k: v for k, v in kwargs.items() if k in comp_names}
-    inference_kwargs = {k: v for k, v in kwargs.items() if k not in comp_names}
+    comp_names = tuple(dist.fields) if hasattr(dist, 'fields') else ()
+    comp_set = frozenset(comp_names)
+    by_lower = {name.lower(): name for name in comp_names}
+
+    data_kwargs: dict[str, Any] = {}
+    inference_kwargs: dict[str, Any] = {}
+    for k, v in kwargs.items():
+        if k in comp_set:
+            data_kwargs[k] = v
+            continue
+        canonical = by_lower.get(k.lower())
+        if canonical is not None:
+            raise TypeError(
+                f"condition_on: keyword argument {k!r} does not match a field "
+                f"of {type(dist).__name__}, but {canonical!r} does (case "
+                f"differs) — did you mean {canonical}=...? "
+                f"Fields: {comp_names}."
+            )
+        inference_kwargs[k] = v
     return data_kwargs, inference_kwargs
 
 

--- a/tests/core/test_ops.py
+++ b/tests/core/test_ops.py
@@ -234,6 +234,12 @@ class TestConditionOn:
         conditioned = ops.condition_on(joint, x=jnp.array(2.0))
         assert conditioned.fields == ("y",)
 
+    def test_condition_case_mismatched_kwarg_raises(self, joint):
+        """A case-mismatched data kwarg (`X` when the field is `x`) raises
+        loudly via condition_on rather than being silently ignored (#228)."""
+        with pytest.raises(TypeError, match="did you mean x"):
+            ops.condition_on(joint, X=jnp.array(2.0))
+
     def test_condition_sequential(self):
         sjd = SequentialJointDistribution(
             x=Normal(0, 1, name="x"),
@@ -357,4 +363,28 @@ class TestSplitDataKwargs:
             dist, {"num_results": 100},
         )
         assert data == {}
+        assert set(inference.keys()) == {"num_results"}
+
+    def test_case_mismatched_field_raises(self):
+        """A kwarg matching a field only up to case is a mistyped data field —
+        raise with the correct casing rather than silently routing it to
+        inference params (issue #228)."""
+        from probpipe.core.ops import _split_data_kwargs
+        dist = ProductDistribution(
+            X=Normal(0.0, 1.0, name="X"), y=Normal(0.0, 1.0, name="y")
+        )
+        with pytest.raises(TypeError, match="did you mean X"):
+            _split_data_kwargs(dist, {"x": jnp.array(1.0)})
+
+    def test_non_case_variant_kwarg_stays_inference(self):
+        """An unknown kwarg that is *not* a case-variant of any field is a
+        genuine inference parameter — no false positive."""
+        from probpipe.core.ops import _split_data_kwargs
+        dist = ProductDistribution(
+            X=Normal(0.0, 1.0, name="X"), y=Normal(0.0, 1.0, name="y")
+        )
+        data, inference = _split_data_kwargs(
+            dist, {"X": jnp.array(1.0), "num_results": 100},
+        )
+        assert set(data.keys()) == {"X"}
         assert set(inference.keys()) == {"num_results"}


### PR DESCRIPTION
## Summary

Fixes the `condition_on` silent-misroute bug called out in #228: a **case-mismatched** data kwarg (e.g. `condition_on(model, x=...)` when the field is `X`) was routed to the inference parameters and silently ignored downstream (e.g. by NUTS) — **a wrong result with no error**.

This is **PR 2 of #228**, independent of the keyword-form work in #282 (different code path: `condition_on` vs the `log_prob`-family ops).

## Change

`_split_data_kwargs` (`probpipe/core/ops.py`) now raises a clear `TypeError` when a kwarg matches a field **only up to case**:

```
condition_on(model, x=...)   # field is `X`
# TypeError: condition_on: keyword argument 'x' does not match a field of
#   SimpleModel, but 'X' does (case differs) — did you mean X=...? Fields: ('X', 'y').
```

An unknown kwarg that is *not* a case-variant of any field still routes to the inference parameters (the inference layer validates those), so genuine inference kwargs (`num_results`, `random_seed`, …) are unaffected. Straight to error — no soft-warn period (per the issue).

## Tests

- `TestSplitDataKwargs`: a case-variant kwarg raises with the suggestion; a non-case-variant unknown stays an inference param (no false positive).
- `TestConditionOn`: end-to-end `condition_on(joint, X=...)` raises.
- Existing exact-match `condition_on(…, x=…)` call sites unchanged; full suite green.

## Remaining #228 follow-ups

PR 3 (StanModel Tier 2 — per-Stan-parameter fields), PR 4 (`RandomMeasure` keyword form), and #229 (`PyMCModel._log_prob`).
