### PR TITLE
feat(modeling): per-Stan-parameter keyword form for StanModel (#228 PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-field distribution pass a positional `Record`, for a single-field one
   the bare positional value (mirroring `condition_on`'s `observed`).
 
+- **`StanModel` participates in the `log_prob` keyword form with one field per
+  Stan parameter (#228).** `StanModel` and its unconstrained view gain a
+  `record_template` exposing one field per Stan parameter *block* — e.g.
+  `theta` for `vector[3] theta`, `L` for `matrix[2, 2] L` — with each block's
+  full multidimensional shape reconstructed from BridgeStan's flattened
+  parameter names. The keyword form assembles the flat parameter vector
+  BridgeStan consumes — `log_prob(model, mu=0.0, theta=theta_vec, L=chol)` —
+  placing each scalar by its parsed index so matrices pack in BridgeStan's
+  column-major order; a flat array may still be passed positionally.
+
 ### Changed
 
 - **`SupportsLogProb` / `SupportsUnnormalizedLogProb` are now generic in the
   sample type (#228)** — `SupportsLogProb[T]`. Annotation-level only; runtime
   behavior is unchanged.
+
+- **`StanModel.fields` now returns one name per Stan parameter block (#228)**
+  rather than one per scalar (`vector[3] theta` is the single field `theta`,
+  not `theta.1` / `theta.2` / `theta.3`). BridgeStan's flat, per-scalar names
+  remain available unchanged via `parameter_names`.
 
 - **Amortized SBI learners accept nested priors (#262).**
   `learn_amortized_posterior` / `learn_amortized_likelihood` /

--- a/docs/examples/04_joint_distributions.ipynb
+++ b/docs/examples/04_joint_distributions.ipynb
@@ -92,10 +92,10 @@
     "    sigma=Gamma(concentration=2.0, rate=1.0, name=\"sigma\"),\n",
     ")\n",
     "\n",
-    "# log_prob accepts either a Record or a plain dict with matching keys.\n",
-    "x = {\"theta\": jnp.array(0.5), \"sigma\": jnp.array(1.5)}\n",
-    "lp_joint = float(log_prob(joint, x))\n",
-    "lp_sum = float(log_prob(joint[\"theta\"], x[\"theta\"])) + float(log_prob(joint[\"sigma\"], x[\"sigma\"]))\n",
+    "# log_prob accepts a Record, a plain dict with matching keys, or one keyword\n",
+    "# argument per field — all equivalent. Here we use the keyword form:\n",
+    "lp_joint = float(log_prob(joint, theta=jnp.array(0.5), sigma=jnp.array(1.5)))\n",
+    "lp_sum = float(log_prob(joint[\"theta\"], jnp.array(0.5))) + float(log_prob(joint[\"sigma\"], jnp.array(1.5)))\n",
     "print(f\"joint log_prob:   {lp_joint:.4f}\")\n",
     "print(f\"sum of marginals: {lp_sum:.4f}  (match: {bool(jnp.isclose(lp_joint, lp_sum))})\")"
    ]

--- a/probpipe/modeling/_stan.py
+++ b/probpipe/modeling/_stan.py
@@ -90,8 +90,8 @@ def _pack_block_params(
 
     Each value must match its block's declared shape; values are scattered into
     BridgeStan's flat order via each block's ``gather`` and concatenated. The
-    flat result is exactly what ``_log_prob`` consumes (Tier 2, issue #228); the
-    flat array can also be passed positionally instead.
+    flat result is exactly what ``_log_prob`` consumes; the flat array can also
+    be passed positionally instead.
     """
     expected = [b.name for b in blocks]
     expected_set = set(expected)
@@ -183,7 +183,7 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
 
     @cached_property
     def _blocks(self) -> tuple[_StanBlock, ...]:
-        """Constrained-space parameter blocks (Tier 2), from BridgeStan."""
+        """Constrained-space parameter blocks, from BridgeStan's ``param_names()``."""
         return _param_blocks(self._bs_model.param_names())
 
     @cached_property
@@ -211,7 +211,7 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
     # -- SupportsLogProb interface ------------------------------------------
 
     def _pack_value(self, **field_kwargs: Any) -> Array:
-        """Keyword form (Tier 2): per-Stan-parameter blocks in the constrained
+        """Keyword form: one array per Stan parameter block in the constrained
         space, assembled into the flat array ``_log_prob`` consumes (see
         :func:`_pack_block_params`). A flat array may still be passed
         positionally."""
@@ -281,7 +281,7 @@ class _UnconstrainedStanView(Distribution[Any], SupportsLogProb):
 
     @cached_property
     def _blocks(self) -> tuple[_StanBlock, ...]:
-        """Unconstrained-space parameter blocks (Tier 2), from BridgeStan."""
+        """Unconstrained-space parameter blocks, from ``param_unc_names()``."""
         return _param_blocks(self._model._bs_model.param_unc_names())
 
     @cached_property
@@ -294,7 +294,7 @@ class _UnconstrainedStanView(Distribution[Any], SupportsLogProb):
         return self.record_template.fields
 
     def _pack_value(self, **field_kwargs: Any) -> Array:
-        """Keyword form (Tier 2): per-Stan-parameter blocks in the unconstrained
+        """Keyword form: one array per Stan parameter block in the unconstrained
         space, assembled into the flat array ``_log_prob`` consumes. A flat
         array may still be passed positionally."""
         return _pack_block_params(

--- a/probpipe/modeling/_stan.py
+++ b/probpipe/modeling/_stan.py
@@ -7,12 +7,15 @@ Inference is handled by registered methods in ``probpipe.inference``.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from collections.abc import Sequence
+from functools import cached_property
+from typing import Any, NamedTuple
 
 import jax.numpy as jnp
 
 from ..core.distribution import Distribution
 from ..core.protocols import SupportsLogProb
+from ..core.record import NumericRecordTemplate
 from ..custom_types import Array, ArrayLike
 from ..inference._approximate_distribution import ApproximateDistribution
 from ._base import ProbabilisticModel
@@ -22,22 +25,86 @@ logger = logging.getLogger(__name__)
 __all__ = ["StanModel"]
 
 
-def _pack_parameters_value(owner: str, field_kwargs: dict[str, Any]) -> Array:
-    """Shared ``_pack_value`` for the Stan keyword form (Tier 1).
+class _StanBlock(NamedTuple):
+    """One Stan parameter block recovered from BridgeStan's flattened names."""
 
-    ``StanModel._log_prob`` (and the unconstrained view) consume a single
-    flat parameter vector, so the keyword form takes one ``parameters=``
-    argument rather than per-Stan-parameter fields. (Tier 2 — issue #228 —
-    will expose the individual Stan parameters as fields built from
-    BridgeStan's ``param_unc_names()``.) *owner* names the class in the
-    error message.
+    name: str
+    shape: tuple[int, ...]      # () for a scalar parameter
+    # advanced-index arrays mapping a ``shape``-shaped array onto the block's
+    # flat slice in BridgeStan's order; () for a scalar.
+    gather: tuple[Array, ...]
+
+
+def _param_blocks(flat_names: Sequence[str]) -> tuple[_StanBlock, ...]:
+    """Group BridgeStan's dot-flattened parameter names into typed blocks.
+
+    BridgeStan reports one flattened name per scalar (``mu``, ``theta.1``,
+    ``L.1.1`` — dot-separated, 1-indexed), with each block's scalars emitted
+    consecutively. This recovers each block's name, its reconstructed
+    multidimensional ``shape`` (``()`` for a scalar), and the advanced-index
+    ``gather`` that maps a ``shape``-shaped array onto the block's slice of the
+    flat parameter vector in BridgeStan's exact order. Placing each scalar by
+    its parsed index makes the round-trip correct for matrices (column-major)
+    and arrays alike, with no assumption about the flattening convention.
     """
-    if set(field_kwargs) != {"parameters"}:
-        raise TypeError(
-            f"{owner} keyword form takes a single 'parameters=' flat array; "
-            f"got {sorted(field_kwargs)}."
+    blocks: list[_StanBlock] = []
+    i, n = 0, len(flat_names)
+    while i < n:
+        block = flat_names[i].split(".", 1)[0]
+        idx_tuples: list[tuple[int, ...]] = []
+        while i < n and flat_names[i].split(".", 1)[0] == block:
+            idx_tuples.append(
+                tuple(int(x) - 1 for x in flat_names[i].split(".")[1:])
+            )
+            i += 1
+        if idx_tuples == [()]:
+            blocks.append(_StanBlock(block, (), ()))
+            continue
+        ndim = len(idx_tuples[0])
+        shape = tuple(max(t[d] for t in idx_tuples) + 1 for d in range(ndim))
+        gather = tuple(
+            jnp.asarray([t[d] for t in idx_tuples]) for d in range(ndim)
         )
-    return field_kwargs["parameters"]
+        blocks.append(_StanBlock(block, shape, gather))
+    return tuple(blocks)
+
+
+def _pack_block_params(
+    owner: str,
+    blocks: tuple[_StanBlock, ...],
+    field_kwargs: dict[str, Any],
+) -> Array:
+    """Assemble the flat Stan parameter vector from per-block keyword values.
+
+    Each value must match its block's declared shape; values are scattered into
+    BridgeStan's flat order via each block's ``gather`` and concatenated. The
+    flat result is exactly what ``_log_prob`` consumes (Tier 2, issue #228); the
+    flat array can also be passed positionally instead.
+    """
+    expected = [b.name for b in blocks]
+    expected_set = set(expected)
+    missing = [name for name in expected if name not in field_kwargs]
+    extra = [k for k in field_kwargs if k not in expected_set]
+    if missing or extra:
+        detail = []
+        if missing:
+            detail.append(f"missing {missing}")
+        if extra:
+            detail.append(f"unexpected {extra}")
+        raise TypeError(
+            f"{owner}: the keyword form expects the Stan parameter blocks "
+            f"{tuple(expected)} — {'; '.join(detail)}."
+        )
+    out: list[Array] = []
+    for b in blocks:
+        arr = jnp.asarray(field_kwargs[b.name])
+        if tuple(arr.shape) != b.shape:
+            raise TypeError(
+                f"{owner}: parameter {b.name!r} expects shape {b.shape}, "
+                f"got {tuple(arr.shape)}."
+            )
+        out.append(jnp.reshape(arr, (1,)) if b.shape == () else arr[b.gather])
+    return jnp.concatenate(out) if out else jnp.zeros((0,))
 
 
 class StanModel(ProbabilisticModel, SupportsLogProb):
@@ -102,12 +169,22 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
 
     # -- Named components interface ------------------------------------------
 
+    @cached_property
+    def _blocks(self) -> tuple[_StanBlock, ...]:
+        """Constrained-space parameter blocks (Tier 2), from BridgeStan."""
+        return _param_blocks(self._bs_model.param_names())
+
+    @cached_property
+    def record_template(self) -> NumericRecordTemplate:
+        """One field per Stan parameter block, shaped from BridgeStan's names."""
+        return NumericRecordTemplate({b.name: b.shape for b in self._blocks})
+
     @property
     def fields(self) -> tuple[str, ...]:
-        return self.parameter_names
+        return self.record_template.fields
 
     def __getitem__(self, key: str) -> Any:
-        if key in self.parameter_names:
+        if key in self.fields:
             return key  # placeholder — Stan doesn't expose sub-distributions
         raise KeyError(f"Unknown component: {key!r}")
 
@@ -115,14 +192,20 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
 
     @property
     def parameter_names(self) -> tuple[str, ...]:
+        # Per-scalar flattened names (the Stan / CmdStan convention) — distinct
+        # from ``fields``, which are the per-block names used by the keyword form.
         return tuple(self._bs_model.param_names())
 
     # -- SupportsLogProb interface ------------------------------------------
 
     def _pack_value(self, **field_kwargs: Any) -> Array:
-        """Keyword form (Tier 1): a single flat constrained ``parameters=``
-        array (see :func:`_pack_parameters_value`)."""
-        return _pack_parameters_value(type(self).__name__, field_kwargs)
+        """Keyword form (Tier 2): per-Stan-parameter blocks in the constrained
+        space, assembled into the flat array ``_log_prob`` consumes (see
+        :func:`_pack_block_params`). A flat array may still be passed
+        positionally."""
+        return _pack_block_params(
+            type(self).__name__, self._blocks, field_kwargs
+        )
 
     def _log_prob(self, value: Any) -> Array:
         """Log-density in the constrained parameter space.
@@ -191,10 +274,27 @@ class _UnconstrainedStanView(Distribution[Any], SupportsLogProb):
     def event_shape(self) -> tuple[int, ...]:
         return self._model.event_shape
 
+    @cached_property
+    def _blocks(self) -> tuple[_StanBlock, ...]:
+        """Unconstrained-space parameter blocks (Tier 2), from BridgeStan."""
+        return _param_blocks(self._model._bs_model.param_unc_names())
+
+    @cached_property
+    def record_template(self) -> NumericRecordTemplate:
+        """One field per unconstrained Stan parameter block."""
+        return NumericRecordTemplate({b.name: b.shape for b in self._blocks})
+
+    @property
+    def fields(self) -> tuple[str, ...]:
+        return self.record_template.fields
+
     def _pack_value(self, **field_kwargs: Any) -> Array:
-        """Keyword form (Tier 1): a single flat ``parameters=`` array in the
-        unconstrained space (see :func:`_pack_parameters_value`)."""
-        return _pack_parameters_value(type(self).__name__, field_kwargs)
+        """Keyword form (Tier 2): per-Stan-parameter blocks in the unconstrained
+        space, assembled into the flat array ``_log_prob`` consumes. A flat
+        array may still be passed positionally."""
+        return _pack_block_params(
+            type(self).__name__, self._blocks, field_kwargs
+        )
 
     def _log_prob(self, value: Any) -> Array:
         """Log-density directly in unconstrained space."""

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -142,8 +142,8 @@ class TestKwargFormSimpleModel:
 
 
 class TestStanViewsPackValue:
-    """StanModel / _UnconstrainedStanView Tier 2: the keyword form takes one
-    array per Stan parameter *block* and assembles BridgeStan's flat vector.
+    """StanModel / _UnconstrainedStanView: the keyword form takes one array per
+    Stan parameter *block* and assembles BridgeStan's flat vector.
 
     bridgestan is not installed in CI, so the model is built via
     ``object.__new__`` with a fake backend supplying the flattened parameter

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -142,27 +142,47 @@ class TestKwargFormSimpleModel:
 
 
 class TestStanViewsPackValue:
-    """StanModel / _UnconstrainedStanView Tier 1: the keyword form takes a
-    single ``parameters=`` flat array.
+    """StanModel / _UnconstrainedStanView Tier 2: the keyword form takes one
+    array per Stan parameter *block* and assembles BridgeStan's flat vector.
 
-    bridgestan is not installed in CI, so ``_pack_value`` is exercised in
-    isolation via ``object.__new__`` (per STYLE_GUIDE §8.4). The method reads
-    no instance state beyond the class name in its error message, so no
-    attribute setup is needed.
+    bridgestan is not installed in CI, so the model is built via
+    ``object.__new__`` with a fake backend supplying the flattened parameter
+    names (per STYLE_GUIDE §8.4). Comprehensive block / shape / error coverage
+    lives in tests/modeling/test_stan_model.py.
     """
 
+    class _FakeBS:
+        def __init__(self, names):
+            self._names = list(names)
+
+        def param_names(self):
+            return self._names
+
+        def param_unc_names(self):
+            return self._names
+
     @pytest.fixture(params=["StanModel", "_UnconstrainedStanView"])
-    def bare_stan(self, request):
+    def stan_view(self, request):
         from probpipe.modeling import _stan
-        return object.__new__(getattr(_stan, request.param))
+        names = ["mu", "theta.1", "theta.2", "theta.3"]
+        base = object.__new__(_stan.StanModel)
+        base._bs_model = self._FakeBS(names)
+        base._name = "m"
+        base._num_params = len(names)
+        if request.param == "StanModel":
+            return base
+        return base.as_unconstrained_distribution()
 
-    def test_pack_value_parameters(self, bare_stan):
-        arr = jnp.array([0.1, 0.2, 0.3])
-        assert jnp.allclose(bare_stan._pack_value(parameters=arr), arr)
+    def test_fields_are_blocks(self, stan_view):
+        assert stan_view.fields == ("mu", "theta")
 
-    def test_pack_value_wrong_kwargs_raises(self, bare_stan):
-        with pytest.raises(TypeError, match="parameters="):
-            bare_stan._pack_value(theta=jnp.array([0.1]))
+    def test_pack_value_assembles_blocks(self, stan_view):
+        flat = stan_view._pack_value(mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]))
+        assert jnp.allclose(flat, jnp.array([0.5, 1.0, 2.0, 3.0]))
+
+    def test_pack_value_wrong_kwargs_raises(self, stan_view):
+        with pytest.raises(TypeError, match="theta"):
+            stan_view._pack_value(mu=0.5)  # missing the theta block
 
 
 class TestKwargErrors:

--- a/tests/modeling/test_stan_model.py
+++ b/tests/modeling/test_stan_model.py
@@ -9,7 +9,7 @@ import pytest
 from unittest.mock import MagicMock, patch, PropertyMock
 
 from probpipe import SupportsLogProb
-from probpipe.modeling._stan import StanModel, _UnconstrainedStanView
+from probpipe.modeling._stan import StanModel, _UnconstrainedStanView, _param_blocks
 
 
 # ---------------------------------------------------------------------------
@@ -17,24 +17,31 @@ from probpipe.modeling._stan import StanModel, _UnconstrainedStanView
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_bs_model(num_params=3, param_names=("alpha", "beta", "sigma")):
+def _make_mock_bs_model(
+    num_params=3, param_names=("alpha", "beta", "sigma"), param_unc_names=None,
+):
     """Create a mock BridgeStan model.
 
     constrain(x) = x + 1, unconstrain(x) = x - 1: a genuine inverse pair
-    so the round-trip test can verify value preservation.
+    so the round-trip test can verify value preservation. ``param_unc_names``
+    defaults to ``param_names`` (no constrained/unconstrained difference).
     """
     mock = MagicMock()
     mock.param_unc_num.return_value = num_params
     mock.param_names.return_value = list(param_names)
+    mock.param_unc_names.return_value = list(param_unc_names or param_names)
     mock.log_density.return_value = -5.0
     mock.param_constrain.side_effect = lambda x: np.asarray(x) + 1.0
     mock.param_unconstrain.side_effect = lambda x: np.asarray(x) - 1.0
     return mock
 
 
-def _make_stan_model(num_params=3, param_names=("alpha", "beta", "sigma"), name="test"):
+def _make_stan_model(
+    num_params=3, param_names=("alpha", "beta", "sigma"), name="test",
+    param_unc_names=None,
+):
     """Create a StanModel with a mocked BridgeStan backend."""
-    mock_bs = _make_mock_bs_model(num_params, param_names)
+    mock_bs = _make_mock_bs_model(num_params, param_names, param_unc_names)
     model = object.__new__(StanModel)
     model._stan_file = "test.stan"
     model._stan_data = None
@@ -215,6 +222,101 @@ class TestUnconstrainedStanView:
 
 
 # ---------------------------------------------------------------------------
+# Tier 2: per-Stan-parameter blocks (fields, shapes, keyword _pack_value)
+# ---------------------------------------------------------------------------
+
+
+class TestParamBlocks:
+    """_param_blocks groups BridgeStan's flat, 1-indexed names into shaped
+    blocks. BridgeStan flattens matrices column-major (L.1.1, L.2.1, ...)."""
+
+    def test_all_scalars(self):
+        blocks = _param_blocks(["mu", "sigma"])
+        assert [(b.name, b.shape) for b in blocks] == [("mu", ()), ("sigma", ())]
+
+    def test_vector(self):
+        blocks = _param_blocks(["theta.1", "theta.2", "theta.3"])
+        assert [(b.name, b.shape) for b in blocks] == [("theta", (3,))]
+
+    def test_matrix(self):
+        blocks = _param_blocks(["L.1.1", "L.2.1", "L.1.2", "L.2.2"])
+        assert [(b.name, b.shape) for b in blocks] == [("L", (2, 2))]
+
+    def test_mixed_blocks(self):
+        names = ["mu", "theta.1", "theta.2", "theta.3",
+                 "L.1.1", "L.2.1", "L.1.2", "L.2.2"]
+        assert [(b.name, b.shape) for b in _param_blocks(names)] == [
+            ("mu", ()), ("theta", (3,)), ("L", (2, 2))]
+
+    def test_empty(self):
+        assert _param_blocks([]) == ()
+
+
+class TestStanModelTier2:
+    """StanModel and its view expose one field per Stan parameter *block*,
+    while ``parameter_names`` keeps BridgeStan's flat per-scalar names."""
+
+    @pytest.fixture
+    def model(self):
+        names = ["mu", "theta.1", "theta.2", "theta.3",
+                 "L.1.1", "L.2.1", "L.1.2", "L.2.2"]
+        return _make_stan_model(num_params=len(names), param_names=names)
+
+    def test_fields_are_blocks(self, model):
+        assert model.fields == ("mu", "theta", "L")
+
+    def test_parameter_names_stay_per_scalar(self, model):
+        assert model.parameter_names == (
+            "mu", "theta.1", "theta.2", "theta.3",
+            "L.1.1", "L.2.1", "L.1.2", "L.2.2")
+
+    def test_record_template_shapes(self, model):
+        assert {f: model.record_template[f] for f in model.fields} == {
+            "mu": (), "theta": (3,), "L": (2, 2)}
+
+    def test_getitem_uses_block_fields(self, model):
+        assert model["theta"] == "theta"
+        with pytest.raises(KeyError, match="Unknown component"):
+            model["theta.1"]  # per-scalar names are no longer components
+
+    def test_pack_value_assembles_column_major(self, model):
+        flat = model._pack_value(
+            mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
+            L=jnp.array([[10.0, 30.0], [20.0, 40.0]]))
+        # L is packed column-major to match BridgeStan: [10, 20, 30, 40].
+        assert jnp.allclose(
+            flat, jnp.array([0.5, 1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0]))
+
+    def test_pack_value_missing_block_raises(self, model):
+        with pytest.raises(TypeError, match="missing"):
+            model._pack_value(mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]))
+
+    def test_pack_value_unexpected_block_raises(self, model):
+        with pytest.raises(TypeError, match="unexpected"):
+            model._pack_value(mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
+                              L=jnp.zeros((2, 2)), zzz=1.0)
+
+    def test_pack_value_wrong_shape_raises(self, model):
+        with pytest.raises(TypeError, match=r"shape \(2, 2\)"):
+            model._pack_value(mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
+                              L=jnp.array([1.0, 2.0, 3.0, 4.0]))  # flat, not (2,2)
+
+    def test_view_uses_unconstrained_blocks(self):
+        # simplex[3] p: constrained names p.1..p.3 (size 3); the unconstrained
+        # parametrization drops one degree of freedom -> p.1, p.2 (size 2).
+        model = _make_stan_model(
+            num_params=3, param_names=["mu", "p.1", "p.2", "p.3"],
+            param_unc_names=["mu", "p.1", "p.2"])
+        assert model.fields == ("mu", "p")
+        assert model.record_template["p"] == (3,)
+        view = model.as_unconstrained_distribution()
+        assert view.fields == ("mu", "p")
+        assert view.record_template["p"] == (2,)
+        flat = view._pack_value(mu=0.5, p=jnp.array([0.1, 0.2]))
+        assert jnp.allclose(flat, jnp.array([0.5, 0.1, 0.2]))
+
+
+# ---------------------------------------------------------------------------
 # StanModel conditioning via registry
 # ---------------------------------------------------------------------------
 
@@ -273,17 +375,16 @@ class TestStanModelImportError:
 # ---------------------------------------------------------------------------
 
 
-_bs = pytest.importorskip("bridgestan")
-
-
 @pytest.fixture(scope="module")
 def tmp_stan_model(tmp_path_factory):
     """Compile a trivial Stan program once per module for integration tests.
 
     The model is Normal(mu, 1) with a unit-variance prior on mu.  This
     gives an analytically tractable log_density for verifying StanModel
-    behaviour against first principles.
+    behaviour against first principles.  ``bridgestan`` is required only for
+    these integration tests; the mock-based tests above run without it.
     """
+    _bs = pytest.importorskip("bridgestan")
     tmp_dir = tmp_path_factory.mktemp("stan_models")
     stan_file = tmp_dir / "normal_mean.stan"
     stan_file.write_text(

--- a/tests/modeling/test_stan_model.py
+++ b/tests/modeling/test_stan_model.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 from probpipe import SupportsLogProb
-from probpipe.modeling._stan import StanModel, _UnconstrainedStanView, _param_blocks
+from probpipe.modeling._stan import StanModel, _param_blocks, _UnconstrainedStanView
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -224,7 +224,7 @@ class TestUnconstrainedStanView:
 
 
 # ---------------------------------------------------------------------------
-# Tier 2: per-Stan-parameter blocks (fields, shapes, keyword _pack_value)
+# Per-Stan-parameter blocks (fields, shapes, keyword _pack_value)
 # ---------------------------------------------------------------------------
 
 
@@ -254,7 +254,7 @@ class TestParamBlocks:
         assert _param_blocks([]) == ()
 
 
-class TestStanModelTier2:
+class TestStanModelParameterBlocks:
     """StanModel and its view expose one field per Stan parameter *block*,
     while ``parameter_names`` keeps BridgeStan's flat per-scalar names."""
 


### PR DESCRIPTION
## Summary

Third PR in the #228 series (after #282 keyword form, #283 `condition_on`
case-mismatch). It makes `StanModel` and its unconstrained view participate
fully in the `log_prob` keyword form by exposing **one field per Stan parameter**
with full multidimensional shapes, rather than a single flat `parameters=`
array.

`StanModel` / `_UnconstrainedStanView` gain a `record_template` with one field
per Stan parameter — `mu` (scalar), `theta` for `vector[3] theta`, `L` for
`matrix[2, 2] L` — reconstructed from BridgeStan's flattened, 1-indexed
parameter names (`param_names()` / `param_unc_names()`). The keyword form then
assembles the flat parameter vector BridgeStan consumes:

```python
log_prob(model, mu=0.0, theta=theta_vec, L=chol)
```

The assembly places each scalar by its parsed index, so matrices pack in
BridgeStan's column-major order and arrays/vectors reconstruct correctly
**without assuming the flattening convention**. A flat array may still be passed
positionally (`log_prob(model, flat_vec)`), unchanged.

### Implementation

- `_param_blocks(flat_names)` groups consecutive dot-prefixed names into
  `(name, shape, gather)` blocks: `shape` is reconstructed as `max(index)+1` per
  dimension; `gather` is the advanced-index mapping a `shape`-shaped array onto
  the block's slice of the flat vector in BridgeStan's exact order.
- `_pack_block_params(owner, blocks, field_kwargs)` validates the keyword set
  and each value's shape, then scatters via `gather` and concatenates.
- `record_template` / `fields` expose the per-parameter names; `parameter_names`
  is unchanged — it keeps BridgeStan's flat, per-scalar names (Stan/CmdStan
  convention).

## Linked issue(s)

Part of #228

## Test plan

- **New unit tests** (`tests/modeling/test_stan_model.py`): `TestParamBlocks`
  (scalar / vector / matrix / mixed / empty grouping) and
  `TestStanModelParameterBlocks` (per-parameter `fields`, `record_template`
  shapes, per-scalar `parameter_names`, `__getitem__`, column-major
  `_pack_value`, missing / unexpected / wrong-shape errors, and the
  constrained-vs-unconstrained difference for a simplex).
- **Keyword-form smoke** (`tests/core/test_log_prob_kwargs.py`):
  `TestStanViewsPackValue` rewritten to the per-parameter form via a fake
  BridgeStan backend (runs in CI without bridgestan).
- **Mocked StanModel tests now run in CI.** The BridgeStan `importorskip` gate
  lives in the integration fixtures (`_stan_toolchain`), not at module scope, so
  the mock-based and per-parameter tests run without bridgestan; only the
  real-compile integration tests are gated.
- `tests/modeling/` + `tests/core/`: **1382 passed, 11 skipped** without
  bridgestan (matching CI). `test_stan_model.py`: **48 passed** with bridgestan
  (integration tests run). Ruff is advisory in CI; these changes add no new
  violations.
- **End-to-end against a real BridgeStan 2.8.0 compile**: for scalar / vector /
  matrix / array / simplex parameters, `_pack_value` produces the exact flat
  vector BridgeStan expects, and `log_prob(model, mu=…, theta=…, L=…)` equals
  the positional form for both the model and its unconstrained view.

## Breaking changes

- **`StanModel.fields` now returns one name per Stan parameter** (e.g. `theta`)
  rather than one per scalar (`theta.1`, `theta.2`, …). The per-scalar names
  remain available unchanged via `parameter_names`. (Pre-1.0; recorded in the
  CHANGELOG under Changed.)

## Documentation

- [x] Docstrings updated for changed public APIs (`fields`, `record_template`,
  `parameter_names`, `_pack_value`, and the two module helpers)
- [x] User Guide / tutorials updated where relevant — the joint-distributions
  example (`docs/examples/04`) now evaluates a `ProductDistribution`'s
  log-density via the keyword form
- [x] CHANGELOG noted (Added: per-parameter keyword form; Changed: `fields`)

## Integrates the BridgeStan real-backend fixes (#286, #287)

This branch merges `main`, which carries the StanModel real-backend fixes
(#286, #287) that landed while this PR was open — a numpy-`float64` coercion at
the BridgeStan boundary and use of the real `bridgestan.StanModel(path, data=)`
constructor, both previously masked by the mock-only tests. They compose with
this PR's per-parameter `_pack_value`: it builds a JAX array and `_log_prob`
coerces it via `_to_f64`, so the keyword form now works **end-to-end against a
real BridgeStan backend** (confirmed above).

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`
- [x] At least one `area:*` label applied (`area:distributions`)
- [x] Linked to an issue above
