### PR TITLE
fix(modeling): make StanModel work against a real BridgeStan backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`StanModel` now works against a real BridgeStan backend.** Two bugs at the
+  BridgeStan boundary were hidden by the mocked tests: construction passed a
+  `data=` keyword that `bridgestan.StanModel.from_stan_file` does not accept,
+  and JAX arrays were handed to a ctypes interface that requires `float64`
+  NumPy arrays. Construction now goes through BridgeStan's supported
+  constructor — which takes the `.stan` path directly and serializes the data
+  dict — and every value crossing into `param_constrain` / `param_unconstrain`
+  / `log_density` is coerced to a `float64` ndarray, so `StanModel(stan_file)`
+  and `log_prob(stan_model, ...)` succeed end to end. The `stan` extra now pins
+  `bridgestan>=2.7` (the first release with that constructor), and a
+  compile-gated integration test guards this boundary against future drift.
+
 - **`condition_on` no longer silently ignores a case-mismatched data kwarg
   (#228).** Passing `condition_on(model, x=...)` when the field is `X` used to
   route `x` to the inference parameters, where it was silently dropped (e.g. by

--- a/probpipe/modeling/_stan.py
+++ b/probpipe/modeling/_stan.py
@@ -10,16 +10,28 @@ import logging
 from typing import Any
 
 import jax.numpy as jnp
+import numpy as np
 
 from ..core.distribution import Distribution
 from ..core.protocols import SupportsLogProb
 from ..custom_types import Array, ArrayLike
-from ..inference._approximate_distribution import ApproximateDistribution
 from ._base import ProbabilisticModel
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["StanModel"]
+
+
+def _to_f64(x: ArrayLike) -> np.ndarray:
+    """Coerce *x* to the contiguous ``float64`` ndarray BridgeStan requires.
+
+    BridgeStan's ctypes interface rejects anything that is not a NumPy
+    ``float64`` array — a JAX array fails the ``ndarray`` check, and a
+    ``float32`` array fails the dtype check — so every value crossing into
+    ``param_constrain`` / ``param_unconstrain`` / ``log_density`` passes
+    through here first.
+    """
+    return np.asarray(x, dtype=np.float64)
 
 
 def _pack_parameters_value(owner: str, field_kwargs: dict[str, Any]) -> Array:
@@ -88,10 +100,10 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
         # to the class name when the caller doesn't supply one.
         self._name = name if name else "StanModel"
 
-        # Compile the model
-        self._bs_model = bridgestan.StanModel.from_stan_file(
-            stan_file, data=data or {}
-        )
+        # Compile and instantiate. BridgeStan's constructor takes the
+        # ``.stan`` path directly (compiling on demand) and serializes a
+        # data dict via stanio; ``data=None`` means no data.
+        self._bs_model = bridgestan.StanModel(stan_file, data=data)
         self._num_params = self._bs_model.param_unc_num()
 
     # -- Distribution interface ---------------------------------------------
@@ -130,8 +142,7 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
         Internally unconstrains the parameters before calling Stan's
         log_density.
         """
-        params_constrained = jnp.asarray(value)
-        params_unc = self.param_unconstrain(params_constrained)
+        params_unc = self._bs_model.param_unconstrain(_to_f64(value))
         return jnp.asarray(self._bs_model.log_density(params_unc))
 
     def _unnormalized_log_prob(self, value: Any) -> Array:
@@ -148,15 +159,11 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
 
     def param_constrain(self, params_unc: ArrayLike) -> Array:
         """Transform unconstrained parameters to constrained space."""
-        return jnp.asarray(
-            self._bs_model.param_constrain(jnp.asarray(params_unc))
-        )
+        return jnp.asarray(self._bs_model.param_constrain(_to_f64(params_unc)))
 
     def param_unconstrain(self, params: ArrayLike) -> Array:
         """Transform constrained parameters to unconstrained space."""
-        return jnp.asarray(
-            self._bs_model.param_unconstrain(jnp.asarray(params))
-        )
+        return jnp.asarray(self._bs_model.param_unconstrain(_to_f64(params)))
 
     def as_unconstrained_distribution(self) -> _UnconstrainedStanView:
         """Return a view of this model in the unconstrained parameter space."""
@@ -169,9 +176,7 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
         if data is not None:
             import bridgestan
 
-            return bridgestan.StanModel.from_stan_file(
-                self._stan_file, data=data
-            )
+            return bridgestan.StanModel(self._stan_file, data=data)
         return self._bs_model
 
     def __repr__(self) -> str:
@@ -198,8 +203,7 @@ class _UnconstrainedStanView(Distribution[Any], SupportsLogProb):
 
     def _log_prob(self, value: Any) -> Array:
         """Log-density directly in unconstrained space."""
-        params_unc = jnp.asarray(value)
-        return jnp.asarray(self._model._bs_model.log_density(params_unc))
+        return jnp.asarray(self._model._bs_model.log_density(_to_f64(value)))
 
     def _unnormalized_log_prob(self, value: Any) -> Array:
         return self._log_prob(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ docs = [
   "mkdocstrings[python]",
   "mkdocs-jupyter<0.26",
 ]
-stan = ["bridgestan>=2.0", "cmdstanpy>=1.2"]
+# bridgestan 2.7 is the first release whose StanModel constructor takes a
+# .stan path directly and serializes a data dict (deprecating from_stan_file).
+stan = ["bridgestan>=2.7", "cmdstanpy>=1.2"]
 # pymc 6 is the first release compatible with arviz 1.x (pymc 5.x caps
 # arviz<1.0); matplotlib is required by the pymc 6 sampler progress bar.
 pymc = ["pymc>=6", "matplotlib"]

--- a/tests/modeling/test_stan_model.py
+++ b/tests/modeling/test_stan_model.py
@@ -3,14 +3,14 @@
 Uses mocks to test all code paths without requiring a compiled Stan model.
 """
 
+from unittest.mock import MagicMock, patch
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from unittest.mock import MagicMock, patch, PropertyMock
 
 from probpipe import SupportsLogProb
 from probpipe.modeling._stan import StanModel, _UnconstrainedStanView
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -153,10 +153,12 @@ class TestStanModelMocked:
 
     def test_bridgestan_model_with_data(self, model):
         mock_bs = MagicMock()
-        mock_bs.StanModel.from_stan_file.return_value = MagicMock()
         with patch.dict("sys.modules", {"bridgestan": mock_bs}):
             result = model._bridgestan_model(data={"N": 10})
-            mock_bs.StanModel.from_stan_file.assert_called_once_with("test.stan", data={"N": 10})
+        # The dict is handed straight to BridgeStan's constructor, which
+        # serializes it (via stanio) — we don't pre-encode it ourselves.
+        mock_bs.StanModel.assert_called_once_with("test.stan", data={"N": 10})
+        assert result is mock_bs.StanModel.return_value
 
 
 # ---------------------------------------------------------------------------
@@ -242,9 +244,11 @@ class TestCmdStanInferenceMethod:
     def test_import_cmdstanpy_missing(self):
         from probpipe.inference._cmdstan_method import _import_cmdstanpy
 
-        with patch.dict("sys.modules", {"cmdstanpy": None}):
-            with pytest.raises(ImportError, match="pip install probpipe"):
-                _import_cmdstanpy()
+        with (
+            patch.dict("sys.modules", {"cmdstanpy": None}),
+            pytest.raises(ImportError, match="pip install probpipe"),
+        ):
+            _import_cmdstanpy()
 
     def test_import_cmdstanpy_present(self):
         from probpipe.inference._cmdstan_method import _import_cmdstanpy
@@ -263,63 +267,102 @@ class TestCmdStanInferenceMethod:
 class TestStanModelImportError:
     def test_missing_bridgestan(self):
         """StanModel raises ImportError with install instructions when bridgestan missing."""
-        with patch.dict("sys.modules", {"bridgestan": None}):
-            with pytest.raises(ImportError, match="pip install bridgestan"):
-                StanModel("test.stan")
+        with (
+            patch.dict("sys.modules", {"bridgestan": None}),
+            pytest.raises(ImportError, match="pip install bridgestan"),
+        ):
+            StanModel("test.stan")
 
 
 # ---------------------------------------------------------------------------
 # Real BridgeStan integration (requires a compiled Stan program)
+#
+# These exercise the path the mocks above cannot: the real BridgeStan
+# constructor signature and its float64-ndarray boundary.  The gate lives in
+# the fixtures (not at module scope) so the mocked tests above still run when
+# BridgeStan is absent.
 # ---------------------------------------------------------------------------
 
 
-_bs = pytest.importorskip("bridgestan")
+@pytest.fixture(scope="module")
+def _stan_toolchain(tmp_path_factory):
+    """Skip the integration tests unless BridgeStan can compile here.
+
+    Compiling a trivial, data-free probe separates "is the C++ toolchain
+    present?" (a legitimate skip) from "does StanModel construct correctly?"
+    (a regression that must fail loudly, not skip) — so the model fixture
+    below can construct without a try/except that would swallow real bugs.
+    """
+    bridgestan = pytest.importorskip("bridgestan")
+    probe = tmp_path_factory.mktemp("stan_probe") / "probe.stan"
+    probe.write_text("parameters { real x; } model { x ~ normal(0, 1); }")
+    try:
+        bridgestan.StanModel(str(probe))
+    except Exception as exc:
+        pytest.skip(f"Stan compilation unavailable: {exc}")
 
 
 @pytest.fixture(scope="module")
-def tmp_stan_model(tmp_path_factory):
-    """Compile a trivial Stan program once per module for integration tests.
+def tmp_stan_model(_stan_toolchain, tmp_path_factory):
+    """A real StanModel for ``y ~ Normal(mu, 1)`` with a unit prior on ``mu``,
+    built through the public constructor.
 
-    The model is Normal(mu, 1) with a unit-variance prior on mu.  This
-    gives an analytically tractable log_density for verifying StanModel
-    behaviour against first principles.
+    Construction therefore exercises the BridgeStan boundary end to end —
+    ``.stan`` compilation plus serialization of the ``data`` dict.  The
+    toolchain is known good from ``_stan_toolchain``, so any failure here is a
+    real bug, not a missing compiler.  The model is conjugate, so its
+    log-density is known in closed form.
     """
-    tmp_dir = tmp_path_factory.mktemp("stan_models")
-    stan_file = tmp_dir / "normal_mean.stan"
+    stan_file = tmp_path_factory.mktemp("stan_models") / "normal_mean.stan"
     stan_file.write_text(
         """
+        data {
+          int<lower=0> N;
+          vector[N] y;
+        }
         parameters { real mu; }
-        model { mu ~ normal(0, 1); }
+        model {
+          mu ~ normal(0, 1);
+          y ~ normal(mu, 1);
+        }
         """
     )
-    try:
-        bs_model = _bs.StanModel(str(stan_file))
-    except Exception as exc:
-        pytest.skip(f"Stan compilation unavailable: {exc}")
-    model = object.__new__(StanModel)
-    model._stan_file = str(stan_file)
-    model._stan_data = None
-    model._name = "normal_mean"
-    model._bs_model = bs_model
-    model._num_params = 1
-    return model
+    return StanModel(str(stan_file), data={"N": 3, "y": [1.0, 2.0, 3.0]},
+                     name="normal_mean")
 
 
 class TestStanModelIntegration:
-    """Minimal real-backend checks against a compiled Stan program."""
+    """Real-backend checks against a compiled Stan program."""
 
-    def test_event_shape(self, tmp_stan_model):
+    # Observations baked into tmp_stan_model's data.
+    _Y = np.array([1.0, 2.0, 3.0])
+
+    def _expected_log_density(self, mu):
+        # Stan accumulates target = log N(mu; 0, 1) + sum_i log N(y_i; mu, 1)
+        # and drops every normalizing constant (propto), so the -0.5*log(2*pi)
+        # terms vanish and mu (an unconstrained real) carries no Jacobian.
+        return -0.5 * mu**2 - 0.5 * float(np.sum((self._Y - mu) ** 2))
+
+    def test_construct_exposes_parameters(self, tmp_stan_model):
+        assert isinstance(tmp_stan_model, StanModel)
         assert tmp_stan_model.event_shape == (1,)
+        assert tmp_stan_model.parameter_names == ("mu",)
 
     def test_log_prob_matches_analytical(self, tmp_stan_model):
-        """Stan's log_density for mu ~ N(0, 1) equals -0.5 * mu^2 + const."""
+        """``_log_prob`` matches the closed-form log-density.
+
+        A JAX array is passed in, so this also covers the JAX -> float64
+        ndarray conversion required at ``param_unconstrain`` / ``log_density``.
+        """
         for mu in [-1.0, 0.0, 0.5, 2.0]:
             lp = float(tmp_stan_model._log_prob(jnp.asarray([mu])))
-            # Stan drops the normalizing constant (log(2*pi)/2), so lp = -mu^2/2
-            np.testing.assert_allclose(lp, -0.5 * mu * mu, atol=1e-5)
+            np.testing.assert_allclose(lp, self._expected_log_density(mu), atol=1e-5)
 
-    def test_constrain_identity_for_real(self, tmp_stan_model):
-        """For unconstrained real parameters, constrain is the identity."""
-        x = np.array([1.23])
-        constrained = tmp_stan_model._bs_model.param_constrain(x)
-        np.testing.assert_allclose(constrained, x)
+    def test_param_transforms_round_trip(self, tmp_stan_model):
+        """constrain/unconstrain are identity for an unconstrained real and
+        survive the JAX-array boundary in both directions."""
+        x = jnp.asarray([1.23])
+        constrained = np.asarray(tmp_stan_model.param_constrain(x))
+        np.testing.assert_allclose(constrained, [1.23], atol=1e-6)
+        round_trip = tmp_stan_model.param_constrain(tmp_stan_model.param_unconstrain(x))
+        np.testing.assert_allclose(np.asarray(round_trip), [1.23], atol=1e-6)

--- a/uv.lock
+++ b/uv.lock
@@ -3366,7 +3366,7 @@ requires-dist = [
     { name = "arviz", specifier = ">=1.1,<2.0" },
     { name = "bayesflow", marker = "extra == 'bayesflow'", specifier = ">=2.0,<3" },
     { name = "blackjax", specifier = ">=1.4" },
-    { name = "bridgestan", marker = "extra == 'stan'", specifier = ">=2.0" },
+    { name = "bridgestan", marker = "extra == 'stan'", specifier = ">=2.7" },
     { name = "cmdstanpy", marker = "extra == 'stan'", specifier = ">=1.2" },
     { name = "graphviz", marker = "extra == 'viz'" },
     { name = "ipykernel", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary

`StanModel` passed its mocked tests but could not construct or evaluate against a real BridgeStan install. Two bugs lived at the BridgeStan boundary, both masked because every Stan test mocked the backend:

1. **Construction used an unsupported call.** `__init__` (and `_bridgestan_model`) called `bridgestan.StanModel.from_stan_file(stan_file, data=...)`, but `from_stan_file` has no `data=` parameter — and it is deprecated in BridgeStan 2.7+. Real construction raised `TypeError`.
2. **JAX arrays at the ctypes boundary.** `param_constrain` / `param_unconstrain` / `_log_prob` (and the unconstrained view) passed JAX arrays into BridgeStan, whose ctypes interface requires a `float64` NumPy ndarray (a JAX array fails the `ndarray` check; `float32` fails the dtype check).

Construction now goes through BridgeStan's **supported constructor** — `bridgestan.StanModel(stan_file, data=data)` — which takes the `.stan` path directly (compiling on demand) and serializes a `data` dict via stanio. Every value crossing into `param_constrain` / `param_unconstrain` / `log_density` is coerced to a contiguous `float64` ndarray. As a result, `StanModel(stan_file)` and `log_prob(stan_model, ...)` work end to end.

The supported constructor (`.stan` path + dict `data`) landed in **BridgeStan 2.7.0**, which also deprecated `from_stan_file`, so the `stan` extra's floor rises from `>=2.0` to `>=2.7` (`uv.lock` updated to match).

## Linked issue(s)

N/A — small standalone fix (see CONTRIBUTING.md).

## Test plan

- The Stan test module previously skipped **in its entirety** whenever BridgeStan was absent (a module-level `pytest.importorskip`), so its mocked tests never ran in CI. The gate is moved into the integration fixtures, so the **31 mocked unit tests now run** (and pass) without a backend.
- `tests/modeling/test_stan_model.py`:
  - `test_bridgestan_model_with_data` asserts the supported constructor call.
  - A compile-gated integration block (`pytest.importorskip("bridgestan")` + a compile probe) builds a model through the **real** `StanModel(...)` constructor and checks `_log_prob` against the closed-form log-density with a JAX array — exercising both fixes end to end. It skips where no BridgeStan toolchain is present, including default CI.
- `pytest tests/modeling/test_stan_model.py` → **31 passed, 3 skipped** locally (no BridgeStan).

## Breaking changes

None to the Python API — `StanModel(...)`'s signature is unchanged. The `stan` optional-dependency extra now requires `bridgestan>=2.7` (was `>=2.0`); environments pinning an older BridgeStan for that extra must upgrade.

## Documentation

- [x] CHANGELOG entry added
- Public docstrings unchanged (no public API change); internal-call comments updated.

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`
- [x] At least one `area:*` label applied (`area:inference` covers `probpipe/modeling/**` per the labeler)
- [x] Linked to an issue above — or N/A for a small standalone fix
