### PR TITLE
ci(codecov): wait for both uploads before reporting project coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,12 @@
+# Wait for both uploads (`unit` + `bayesflow`) before reporting, so main doesn't
+# briefly show the BayesFlow-only union (~59%) in the gap before the slow
+# full-suite `unit` upload lands. `wait_for_ci` still finalizes a PR that skips
+# the gated BayesFlow leg and uploads only `unit` (bayesflow carried forward).
+codecov:
+  notify:
+    after_n_builds: 2
+    wait_for_ci: true
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary

Fixes Codecov transiently reporting **~59% project coverage on `main`** while a
push build is in progress, when the true coverage is **~91%**. No production or
test code changes — a single `codecov.yml` block.

## Root cause

Project coverage is the **union of two independently-timed uploads**:
- `unit` — the full pytest suite, uploaded by the slow `test (3.12)` job.
- `bayesflow` — the keras-on-jax SBI leg, uploaded by the fast `bayesflow (3.12)` job.

On a push to main both jobs always run, but the BayesFlow leg finishes minutes
before the full suite. Codecov surfaces a commit the instant the first flag
lands, so in the window after `bayesflow` uploads but before `unit` does, the
branch coverage reads the **BayesFlow-only union (~59%)**. It snaps back to ~91%
once `unit` arrives.

Observed on the #285 merge (`3f7e2cf`): `bayesflow (3.12)` finished at 20:19:59,
`test (3.12)` at 20:23:12 — a ~3-minute window during which the Codecov API
reported **1 session at ~59%**, then **2 sessions at 91.08%**.

Beyond the cosmetic flicker there's a latent risk: the `unit` upload step is
implicitly `success()`-gated, so if the full suite ever fails (or trips
`--cov-fail-under`), `unit` is skipped and main would *stick* at ~59% until the
next green full run.

## Fix

`codecov.notify.after_n_builds: 2` holds reporting until both uploads are in (on
a push to main both always run), so no partial union is ever surfaced.
`wait_for_ci: true` (the default, made explicit) still finalizes a commit once
CI completes if fewer than two arrive — e.g. a PR that touches no BayesFlow
files skips that leg and uploads only `unit`, with `bayesflow` carried forward
(unchanged from today).

## Watch after merge

`after_n_builds` is global. On a non-BayesFlow PR (one upload), Codecov should
finalize the status once CI completes via `wait_for_ci`. If such PRs instead
show a perpetually-pending Codecov status, revert this one-block change.
(Codecov can't block merges here — no required status checks — so the downside
is a missing signal, not a blocked PR.)

## Test plan

- `codecov.yml` parses as valid YAML; `codecov.notify = {after_n_builds: 2, wait_for_ci: true}`.
- After merge, confirm on the first push to main that branch coverage goes
  straight to ~91% without dipping to ~59% mid-run.
