### PR TITLE
test(modeling): exercise StanModel against real BridgeStan in a dedicated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,101 @@ jobs:
           slug: TARPS-group/prob-pipe
           flags: bayesflow
 
+  stan:
+    # BridgeStan backend. StanModel's behaviour tests compile real Stan
+    # programs (needs a C++ toolchain — ubuntu-latest provides one). Kept
+    # separate from the main matrix so the per-model compile cost stays out of
+    # every leg: the main matrix runs StanModel's pure tests (the name parser,
+    # the bridgestan-missing guard) and skips the compile-backed ones (gated by
+    # the _stan_toolchain fixture). One leg only — BridgeStan is a C++/ctypes
+    # backend, so behaviour doesn't vary by Python version and the compile cost
+    # is paid per leg.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # need full history for git diff
+
+      - name: Check if Stan-relevant files changed
+        id: stan_check
+        # Same gating shape as the bayesflow leg: run on pushes to main, on
+        # foundational changes (deps / this workflow), or when a Stan file
+        # itself changed. Otherwise skip — the `stan` coverage flag carries
+        # forward from base (codecov.yml), so a skipped leg doesn't drag the
+        # union down.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/${{ github.base_ref }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          CHANGED=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD \
+            -- 'probpipe/modeling/_stan.py' 'tests/modeling/test_stan_model.py' || true)
+          CHANGED_ALL=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD || true)
+          RUN_STAN=false
+          if [ "${{ github.event_name }}" = "push" ]; then
+            RUN_STAN=true
+          else
+            for f in $CHANGED_ALL; do
+              case "$f" in
+                pyproject.toml|uv.lock|setup.cfg|setup.py|tests/conftest.py|probpipe/__init__.py|.github/workflows/ci.yml)
+                  RUN_STAN=true ;;
+              esac
+            done
+            [ -n "$CHANGED" ] && RUN_STAN=true
+          fi
+          if [ "$RUN_STAN" = "true" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Running the Stan leg."
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No Stan-relevant changes — skipping (coverage flag carries forward)."
+          fi
+
+      - name: Install uv
+        if: steps.stan_check.outputs.skip != 'true'
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Cache the BridgeStan build
+        # BridgeStan downloads its C++ sources and builds the Stan math + TBB
+        # static libs under ~/.bridgestan on the first compile (minutes). Cache
+        # it so only a cold cache pays that; per-model compiles are then seconds.
+        # Keyed on uv.lock so a bridgestan version bump rebuilds; the version is
+        # a subdirectory there, so a stale restore can't mismatch.
+        if: steps.stan_check.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.bridgestan
+          key: bridgestan-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: bridgestan-${{ runner.os }}-
+
+      - name: Install dependencies
+        if: steps.stan_check.outputs.skip != 'true'
+        # Versions are pinned in uv.lock; --frozen fails if the lockfile drifts.
+        # The `stan` extra brings bridgestan (and cmdstanpy); dev+nutpie match
+        # the other backend legs' base.
+        run: uv sync --frozen --python 3.12 --extra dev --extra nutpie --extra stan
+
+      - name: Run StanModel tests (real BridgeStan)
+        if: steps.stan_check.outputs.skip != 'true'
+        # -n 0 disables xdist so the module-scoped model fixtures compile once,
+        # not once per worker. The suite is small; serial is fine.
+        run: uv run pytest tests/modeling/test_stan_model.py -n 0 --cov-report=xml
+
+      - name: Upload coverage reports to Codecov
+        # The main test job doesn't install [stan], so it measures _stan.py as
+        # (mostly) uncovered. Upload this leg under the `stan` flag so Codecov's
+        # union counts the real-backend coverage.
+        if: steps.stan_check.outputs.skip != 'true'
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: TARPS-group/prob-pipe
+          flags: stan
+
   notebooks:
     # Execute the docs notebooks to keep the reference set honest against the
     # current codebase. Two parallel legs: `examples` (lean — dev+nutpie) and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,10 +368,10 @@ jobs:
     # programs (needs a C++ toolchain — ubuntu-latest provides one). Kept
     # separate from the main matrix so the per-model compile cost stays out of
     # every leg: the main matrix runs StanModel's pure tests (the name parser,
-    # the bridgestan-missing guard) and skips the compile-backed ones (gated by
-    # the _stan_toolchain fixture). One leg only — BridgeStan is a C++/ctypes
-    # backend, so behaviour doesn't vary by Python version and the compile cost
-    # is paid per leg.
+    # the bridgestan-missing guard, the CmdStan import shim) and skips the
+    # compile-backed ones (gated by the _stan_toolchain fixture). One leg only —
+    # BridgeStan is a C++/ctypes backend, so behaviour doesn't vary by Python
+    # version and the compile cost is paid per leg.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -425,8 +425,11 @@ jobs:
         # BridgeStan downloads its C++ sources and builds the Stan math + TBB
         # static libs under ~/.bridgestan on the first compile (minutes). Cache
         # it so only a cold cache pays that; per-model compiles are then seconds.
-        # Keyed on uv.lock so a bridgestan version bump rebuilds; the version is
-        # a subdirectory there, so a stale restore can't mismatch.
+        # The key rotates on every uv.lock change, but restore-keys falls back to
+        # the latest prior build, so an unrelated dependency bump reuses the
+        # existing libs (no rebuild). Only a bridgestan version bump rebuilds —
+        # under its own ~/.bridgestan/<version>/ subdir, so a stale restore can't
+        # mismatch.
         if: steps.stan_check.outputs.skip != 'true'
         uses: actions/cache@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,10 @@ uv sync --extra dev --extra nutpie --extra pymc   # + pymc backend
 
 The `pip install -e ".[dev]"` path still works for contributors with an
 existing pip-based setup, but uv is the recommended path. Optional backends
-not required for tests: `bridgestan`, `pymc`, `bayesflow` (amortized SBI;
-Python 3.12–3.13 only).
+not required to run the test suite locally (their tests skip when the backend
+is absent): `bridgestan`, `pymc`, `bayesflow` (amortized SBI; Python 3.12–3.13
+only). In CI, `bridgestan` and `bayesflow` are exercised in their own dedicated
+legs (the `stan` and `bayesflow` jobs).
 
 ### Running Tests
 
@@ -370,10 +372,15 @@ GitHub Actions (`.github/workflows/ci.yml`):
   matrix that runs in parallel — an `examples` leg (`dev,nutpie`) for
   `docs/examples` and a `tutorials` leg (`dev,nutpie,bayesflow,pymc`) for
   `docs/tutorials` — each scoped to its own directory with independent
-  change detection, so an unrelated leg is skipped (`bridgestan` is not
-  included anywhere by default)
+  change detection, so an unrelated leg is skipped (`bridgestan` is installed
+  only in the `stan` leg, below)
 - A separate `bayesflow` leg (Python 3.12 and 3.13 only — BayesFlow caps
   `<3.14`) syncs `dev,nutpie,bayesflow` and runs the amortized-SBI tests
+- A separate `stan` leg (Python 3.12) syncs `dev,nutpie,stan`, caches the
+  `~/.bridgestan` build, and runs StanModel's compile-backed tests against a
+  real BridgeStan backend; coverage uploads under a `stan` flag. Gated like the
+  bayesflow leg — runs on pushes to main, foundational changes, or Stan-file
+  changes
 - Coverage uploaded to Codecov
 - A `lint (advisory)` job runs `ruff check` and annotates PRs with
   violations but does **not** gate merges yet (see *Linting & pre-commit*)

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -652,8 +652,13 @@ distribution families.
 - `pytest.importorskip("pymc")` for tests requiring optional packages.
 - `patch.dict(sys.modules, ...)` for mock-based isolation of optional
   backends.
-- Stan/nutpie tests use `object.__new__()` + manual attribute setting to
-  avoid requiring compiled models.
+- nutpie tests use `object.__new__()` + manual attribute setting to avoid
+  requiring compiled models.
+- Stan tests compile real programs through BridgeStan, gated by a fixture
+  that `importorskip`s `bridgestan` and probes the C++ toolchain, and run in
+  the dedicated `stan` CI job (`--extra stan`). StanModel's backend-free tests
+  (the parameter-name parser, the bridgestan-missing import guard) need no
+  compiled model and run in the main matrix.
 
 ### 8.5 Test runner
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -463,7 +463,8 @@ def _ensure_nutpie():
 ```
 
 For test files, use `pytest.importorskip("nutpie")` or mock-based
-approaches with `patch.dict(sys.modules)`.
+approaches with `patch.dict(sys.modules)`; see §8.4 for the per-backend
+testing patterns (e.g. the BridgeStan probe-compile fixture for Stan).
 
 ### 4.5 `Callable` and other ABCs
 
@@ -657,8 +658,8 @@ distribution families.
 - Stan tests compile real programs through BridgeStan, gated by a fixture
   that `importorskip`s `bridgestan` and probes the C++ toolchain, and run in
   the dedicated `stan` CI job (`--extra stan`). StanModel's backend-free tests
-  (the parameter-name parser, the bridgestan-missing import guard) need no
-  compiled model and run in the main matrix.
+  (the parameter-name parser, the bridgestan-missing import guard, and the
+  CmdStan import shim) need no compiled model and run in the main matrix.
 
 ### 8.5 Test runner
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -32,7 +32,8 @@ coverage:
 # Carry each flag's coverage forward from the base commit when a PR doesn't
 # upload it, so the project number stays sane and Codecov stops reporting
 # "HEAD has N uploads less than BASE":
-#   - unit: the main pytest suite (probpipe, minus the BayesFlow and Stan backends).
+#   - unit: the main pytest suite (probpipe, minus the BayesFlow backend and
+#     Stan's compiled-model paths).
 #   - bayesflow: the keras-on-jax BayesFlow leg, which only runs when
 #     BayesFlow-relevant files change (see the bayesflow job's gating).
 #   - stan: the BridgeStan leg (StanModel's compile-backed tests), which only

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,11 @@
-# Wait for both uploads (`unit` + `bayesflow`) before reporting, so main doesn't
-# briefly show the BayesFlow-only union (~59%) in the gap before the slow
-# full-suite `unit` upload lands. `wait_for_ci` still finalizes a PR that skips
-# the gated BayesFlow leg and uploads only `unit` (bayesflow carried forward).
+# Wait for all three uploads (`unit` + `bayesflow` + `stan`) before reporting, so
+# main doesn't briefly show a partial union (e.g. the fast BayesFlow-only ~59%)
+# in the gap before the slower legs' uploads land. `wait_for_ci` still finalizes
+# a PR that skips the gated BayesFlow / Stan legs and uploads only `unit` (those
+# flags carried forward).
 codecov:
   notify:
-    after_n_builds: 2
+    after_n_builds: 3
     wait_for_ci: true
 
 coverage:
@@ -31,11 +32,15 @@ coverage:
 # Carry each flag's coverage forward from the base commit when a PR doesn't
 # upload it, so the project number stays sane and Codecov stops reporting
 # "HEAD has N uploads less than BASE":
-#   - unit: the main pytest suite (probpipe, minus the BayesFlow backend).
+#   - unit: the main pytest suite (probpipe, minus the BayesFlow and Stan backends).
 #   - bayesflow: the keras-on-jax BayesFlow leg, which only runs when
 #     BayesFlow-relevant files change (see the bayesflow job's gating).
+#   - stan: the BridgeStan leg (StanModel's compile-backed tests), which only
+#     runs when Stan-relevant files change (see the stan job's gating).
 flags:
   unit:
     carryforward: true
   bayesflow:
+    carryforward: true
+  stan:
     carryforward: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
-import pytest
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from probpipe import EmpiricalDistribution
 
@@ -50,3 +50,21 @@ def cov_matrix(dim):
     A = A.at[0, 1].set(0.3)
     A = A.at[1, 0].set(0.3)
     return A
+
+
+@pytest.fixture(scope="module")
+def _stan_toolchain(tmp_path_factory):
+    """Skip Stan integration tests unless BridgeStan can compile here.
+
+    Compiling a trivial, data-free probe separates a missing C++ toolchain
+    (a legitimate skip) from a real construction failure (a bug that must
+    surface, not skip). Shared by the BridgeStan-backed tests in
+    tests/modeling/ and tests/inference/.
+    """
+    bridgestan = pytest.importorskip("bridgestan")
+    probe = tmp_path_factory.mktemp("stan_probe") / "probe.stan"
+    probe.write_text("parameters { real x; } model { x ~ normal(0, 1); }")
+    try:
+        bridgestan.StanModel(str(probe))
+    except Exception as exc:
+        pytest.skip(f"Stan compilation unavailable: {exc}")

--- a/tests/inference/test_nutpie.py
+++ b/tests/inference/test_nutpie.py
@@ -185,24 +185,9 @@ class TestExtractChains:
 
 # ---------------------------------------------------------------------------
 # Real integration: nutpie + StanModel (requires a BridgeStan toolchain)
+#
+# Uses the shared ``_stan_toolchain`` fixture (tests/conftest.py).
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="module")
-def _stan_toolchain(tmp_path_factory):
-    """Skip the Stan integration test unless BridgeStan can compile here.
-
-    Compiling a trivial, data-free probe separates a missing C++ toolchain
-    (a legitimate skip) from a real construction failure (a bug that must
-    surface), mirroring tests/modeling/test_stan_model.py.
-    """
-    bridgestan = pytest.importorskip("bridgestan")
-    probe = tmp_path_factory.mktemp("stan_probe") / "probe.stan"
-    probe.write_text("parameters { real x; } model { x ~ normal(0, 1); }")
-    try:
-        bridgestan.StanModel(str(probe))
-    except Exception as exc:
-        pytest.skip(f"Stan compilation unavailable: {exc}")
 
 
 class TestNutpieStanIntegration:

--- a/tests/modeling/test_stan_model.py
+++ b/tests/modeling/test_stan_model.py
@@ -95,28 +95,11 @@ class TestStanModelImportError:
 # ---------------------------------------------------------------------------
 # Real BridgeStan backend
 #
-# The gate lives in ``_stan_toolchain`` (not at module scope) so the pure tests
-# above still run when BridgeStan or a C++ toolchain is absent. The model
-# fixtures below depend on it, so they skip together.
+# The model fixtures below depend on the shared ``_stan_toolchain`` fixture
+# (tests/conftest.py), which ``importorskip``s bridgestan and probe-compiles the
+# C++ toolchain — so these tests skip together when the backend is absent, while
+# the pure tests above still run.
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="module")
-def _stan_toolchain(tmp_path_factory):
-    """Skip the integration tests unless BridgeStan can compile here.
-
-    Compiling a trivial, data-free probe separates "is the C++ toolchain
-    present?" (a legitimate skip) from "does StanModel construct correctly?"
-    (a regression that must fail loudly, not skip) — so the model fixtures
-    below construct without a try/except that would swallow real bugs.
-    """
-    bridgestan = pytest.importorskip("bridgestan")
-    probe = tmp_path_factory.mktemp("stan_probe") / "probe.stan"
-    probe.write_text("parameters { real x; } model { x ~ normal(0, 1); }")
-    try:
-        bridgestan.StanModel(str(probe))
-    except Exception as exc:
-        pytest.skip(f"Stan compilation unavailable: {exc}")
 
 
 @pytest.fixture(scope="module")
@@ -221,7 +204,12 @@ class TestStanModelSurface:
 
 
 class TestStanModelDensity:
-    """Density ops against the conjugate model's closed-form log-density."""
+    """Density ops against the conjugate model's closed-form log-density.
+
+    Tolerances cover float64 round-off on a deterministic closed form (Stan's
+    log_density carries no RNG), so they are tight fixed constants, not
+    seed-spread bounds.
+    """
 
     _Y = np.array([1.0, 2.0, 3.0])  # baked into conjugate_model's data
 
@@ -255,10 +243,18 @@ class TestStanModelDensity:
         up = conjugate_model._unnormalized_prob(jnp.asarray([0.5]))
         assert jnp.isfinite(up) and float(up) > 0
 
+    def test_log_prob_accepts_float32_input(self, conjugate_model):
+        # `_to_f64` exists so a float32 array (JAX's default dtype) can cross the
+        # BridgeStan boundary, which rejects anything but float64. Passing one
+        # explicitly exercises that coercion and checks the value survives it.
+        lp = float(conjugate_model._log_prob(jnp.asarray([0.5], dtype=jnp.float32)))
+        np.testing.assert_allclose(lp, self._expected_log_density(0.5), atol=1e-5)
+
 
 class TestStanModelTransforms:
-    """constrain / unconstrain across the JAX <-> float64 boundary. For an
-    unconstrained real both directions are the identity."""
+    """constrain / unconstrain across the JAX <-> float64 boundary. The
+    conjugate model's single real is the identity in both directions; the
+    structured model's simplex exercises a genuine (non-identity) transform."""
 
     def test_param_constrain_identity_for_real(self, conjugate_model):
         x = jnp.asarray([1.23])
@@ -275,6 +271,26 @@ class TestStanModelTransforms:
         round_trip = conjugate_model.param_constrain(
             conjugate_model.param_unconstrain(x))
         np.testing.assert_allclose(np.asarray(round_trip), [1.23], atol=1e-6)
+
+    def test_constrain_yields_valid_simplex(self, structured_model):
+        # param_constrain applies the real (non-identity) transform: the simplex
+        # block of the constrained vector must sum to 1 with positive entries —
+        # a known invariant the identity-only conjugate model can't exercise.
+        constrained = np.asarray(structured_model.param_constrain(jnp.zeros(10)))
+        p = constrained[-3:]  # blocks pack in order; the simplex is last
+        np.testing.assert_allclose(float(p.sum()), 1.0, atol=1e-5)
+        assert (p > 0).all()
+
+    def test_constrain_unconstrain_round_trip_simplex(self, structured_model):
+        # constrain o unconstrain is the identity on a valid constrained point.
+        # The simplex must sum to 1 exactly in float (0.25 + 0.25 + 0.5) for
+        # BridgeStan's strict simplex_free to accept it.
+        constrained = jnp.array([0.5, 0.1, 0.2, 0.3, 1.0, 2.0, 3.0, 4.0,
+                                 0.25, 0.25, 0.5])
+        round_trip = structured_model.param_constrain(
+            structured_model.param_unconstrain(constrained))
+        np.testing.assert_allclose(np.asarray(round_trip),
+                                   np.asarray(constrained), atol=1e-5)
 
 
 class TestBridgestanModel:
@@ -353,9 +369,11 @@ class TestStanModelParameters:
                 p=jnp.array([0.2, 0.3, 0.5]))
 
     def test_keyword_form_equals_positional(self, structured_model):
-        # The simplex sums to 1 exactly in floating point (0.25 + 0.25 + 0.5),
-        # so param_unconstrain accepts it; the keyword form must produce the
-        # same log-density as the equivalent flat vector.
+        # Both forms route through the same _pack_value, so this guards the
+        # keyword->positional dispatch wiring; the column-major packing *order*
+        # is validated by test_pack_value_assembles_column_major and
+        # test_param_blocks_match_real_names. 0.25/0.25/0.5 are exact in float32,
+        # so the simplex sums to 1 and BridgeStan's param_unconstrain accepts it.
         kw = dict(mu=0.5, theta=jnp.array([0.1, 0.2, 0.3]),
                   L=jnp.array([[1.0, 2.0], [3.0, 4.0]]),
                   p=jnp.array([0.25, 0.25, 0.5]))
@@ -398,6 +416,17 @@ class TestUnconstrainedStanView:
         assert jnp.isfinite(lp)
         np.testing.assert_allclose(
             float(view._unnormalized_log_prob(x)), float(lp), atol=1e-6)
+
+    def test_log_prob_finite_difference_in_mu(self, structured_model):
+        # Exact value check: shifting the unconstrained mu coordinate by m moves
+        # the log-density by exactly -0.5*m^2 (the N(0, 1) prior on mu), with the
+        # simplex Jacobian and the other blocks held fixed.
+        view = structured_model.as_unconstrained_distribution()
+        x0 = jnp.zeros(view.event_shape)
+        for m in (0.5, 1.0):
+            delta = (float(view._log_prob(x0.at[0].set(m)))
+                     - float(view._log_prob(x0)))
+            np.testing.assert_allclose(delta, -0.5 * m**2, atol=1e-5)
 
     def test_prob_is_exp_log_prob(self, structured_model):
         view = structured_model.as_unconstrained_distribution()

--- a/tests/modeling/test_stan_model.py
+++ b/tests/modeling/test_stan_model.py
@@ -1,6 +1,14 @@
 """Tests for StanModel.
 
-Uses mocks to test all code paths without requiring a compiled Stan model.
+The behaviour tests compile real Stan programs through BridgeStan. The
+``_stan_toolchain`` fixture gates them with ``importorskip`` plus a probe
+compile, so they run in the dedicated ``stan`` CI job (which installs the
+``stan`` extra) and skip cleanly elsewhere. The pure tests — the
+parameter-name parser, the bridgestan-missing import guard, and the CmdStan
+import shim — need no backend and run in the main matrix.
+
+Models are compiled once per module (BridgeStan caches the shared object, so
+re-instantiating the same ``.stan`` is cheap).
 """
 
 from unittest.mock import MagicMock, patch
@@ -9,50 +17,11 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import SupportsLogProb
+from probpipe import SupportsLogProb, log_prob
 from probpipe.modeling._stan import StanModel, _param_blocks, _UnconstrainedStanView
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_mock_bs_model(
-    num_params=3, param_names=("alpha", "beta", "sigma"), param_unc_names=None,
-):
-    """Create a mock BridgeStan model.
-
-    constrain(x) = x + 1, unconstrain(x) = x - 1: a genuine inverse pair
-    so the round-trip test can verify value preservation. ``param_unc_names``
-    defaults to ``param_names`` (no constrained/unconstrained difference).
-    """
-    mock = MagicMock()
-    mock.param_unc_num.return_value = num_params
-    mock.param_names.return_value = list(param_names)
-    mock.param_unc_names.return_value = list(param_unc_names or param_names)
-    mock.log_density.return_value = -5.0
-    mock.param_constrain.side_effect = lambda x: np.asarray(x) + 1.0
-    mock.param_unconstrain.side_effect = lambda x: np.asarray(x) - 1.0
-    return mock
-
-
-def _make_stan_model(
-    num_params=3, param_names=("alpha", "beta", "sigma"), name="test",
-    param_unc_names=None,
-):
-    """Create a StanModel with a mocked BridgeStan backend."""
-    mock_bs = _make_mock_bs_model(num_params, param_names, param_unc_names)
-    model = object.__new__(StanModel)
-    model._stan_file = "test.stan"
-    model._stan_data = None
-    model._name = name if name else "StanModel"
-    model._bs_model = mock_bs
-    model._num_params = num_params
-    return model
-
-
-# ---------------------------------------------------------------------------
-# StanModel protocol compliance
+# Pure tests — no BridgeStan backend required (run in the main matrix)
 # ---------------------------------------------------------------------------
 
 
@@ -60,177 +29,13 @@ class TestStanModelProtocols:
     def test_supports_log_prob(self):
         assert issubclass(StanModel, SupportsLogProb)
 
-    def test_supports_named_components(self):
-        model = _make_stan_model()
-        assert hasattr(model, 'fields')
-
-
-# ---------------------------------------------------------------------------
-# StanModel with mocked backend
-# ---------------------------------------------------------------------------
-
-
-class TestStanModelMocked:
-    @pytest.fixture
-    def model(self):
-        return _make_stan_model()
-
-    def test_name(self, model):
-        assert model.name == "test"
-
-    def test_event_shape(self, model):
-        assert model.event_shape == (3,)
-
-    def test_fields(self, model):
-        assert model.fields == ("alpha", "beta", "sigma")
-
-    def test_parameter_names(self, model):
-        assert model.parameter_names == ("alpha", "beta", "sigma")
-
-    def test_getitem_returns_name_placeholder(self, model):
-        """StanModel['alpha'] returns the parameter name — BridgeStan doesn't
-        expose sub-distributions, so __getitem__ is a placeholder that merely
-        validates the key. See the comment in StanModel.__getitem__.
-        """
-        assert model["alpha"] == "alpha"
-        assert model["beta"] == "beta"
-        assert model["sigma"] == "sigma"
-
-    def test_getitem_unknown_key_raises(self, model):
-        with pytest.raises(KeyError, match="Unknown component"):
-            model["nonexistent"]
-
-    def test_repr(self, model):
-        r = repr(model)
-        assert "StanModel" in r
-        assert "test.stan" in r
-        assert "num_params=3" in r
-
-    def test_log_prob(self, model):
-        x = jnp.array([1.0, 2.0, 3.0])
-        lp = model._log_prob(x)
-        assert jnp.isfinite(lp)
-        model._bs_model.param_unconstrain.assert_called()
-        model._bs_model.log_density.assert_called()
-
-    def test_unnormalized_log_prob(self, model):
-        x = jnp.array([1.0, 2.0, 3.0])
-        ulp = model._unnormalized_log_prob(x)
-        assert jnp.isfinite(ulp)
-
-    def test_unnormalized_prob(self, model):
-        x = jnp.array([1.0, 2.0, 3.0])
-        up = model._unnormalized_prob(x)
-        assert jnp.isfinite(up)
-        assert float(up) > 0
-
-    def test_prob(self, model):
-        x = jnp.array([1.0, 2.0, 3.0])
-        p = model._prob(x)
-        assert jnp.isfinite(p)
-        assert float(p) > 0
-
-    def test_param_constrain_applies_transform(self, model):
-        """param_constrain should apply the underlying bridgestan transform."""
-        unc = jnp.array([0.5, 1.0, 1.5])
-        result = model.param_constrain(unc)
-        # Mock defines constrain(x) = x + 1.
-        np.testing.assert_allclose(np.asarray(result), np.asarray(unc) + 1.0)
-
-    def test_param_unconstrain_applies_transform(self, model):
-        """param_unconstrain should apply the underlying bridgestan transform."""
-        x = jnp.array([1.0, 2.0, 3.0])
-        result = model.param_unconstrain(x)
-        # Mock defines unconstrain(x) = x - 1.
-        np.testing.assert_allclose(np.asarray(result), np.asarray(x) - 1.0)
-
-    def test_constrain_unconstrain_are_inverses(self, model):
-        """constrain(unconstrain(x)) == x: the wrapper must preserve values."""
-        x = jnp.array([1.0, 2.0, 3.0])
-        roundtrip = model.param_constrain(model.param_unconstrain(x))
-        np.testing.assert_allclose(np.asarray(roundtrip), np.asarray(x), atol=1e-12)
-
-    def test_as_unconstrained_distribution(self, model):
-        view = model.as_unconstrained_distribution()
-        assert isinstance(view, _UnconstrainedStanView)
-
-    def test_bridgestan_model_no_data(self, model):
-        result = model._bridgestan_model()
-        assert result is model._bs_model
-
-    def test_bridgestan_model_with_data(self, model):
-        mock_bs = MagicMock()
-        with patch.dict("sys.modules", {"bridgestan": mock_bs}):
-            result = model._bridgestan_model(data={"N": 10})
-        # The dict is handed straight to BridgeStan's constructor, which
-        # serializes it (via stanio) — we don't pre-encode it ourselves.
-        mock_bs.StanModel.assert_called_once_with("test.stan", data={"N": 10})
-        assert result is mock_bs.StanModel.return_value
-
-
-# ---------------------------------------------------------------------------
-# _UnconstrainedStanView
-# ---------------------------------------------------------------------------
-
-
-class TestUnconstrainedStanView:
-    @pytest.fixture
-    def model(self):
-        return _make_stan_model(name="mymodel")
-
-    @pytest.fixture
-    def view(self, model):
-        return model.as_unconstrained_distribution()
-
-    def test_name_with_base(self, view):
-        assert view.name == "mymodel_unconstrained"
-
-    def test_name_without_base(self):
-        # StanModel without an explicit name now falls back to the
-        # class name ("StanModel") to satisfy the Distribution
-        # metaclass's non-empty-name requirement; the view name
-        # composes accordingly.
-        model = _make_stan_model(name=None)
-        view = model.as_unconstrained_distribution()
-        assert view.name == "StanModel_unconstrained"
-
-    def test_event_shape(self, view):
-        assert view.event_shape == (3,)
-
-    def test_log_prob(self, view):
-        x = jnp.array([0.5, 1.0, 1.5])
-        lp = view._log_prob(x)
-        assert jnp.isfinite(lp)
-
-    def test_unnormalized_log_prob(self, view):
-        x = jnp.array([0.5, 1.0, 1.5])
-        ulp = view._unnormalized_log_prob(x)
-        np.testing.assert_allclose(float(ulp), float(view._log_prob(x)))
-
-    def test_unnormalized_prob(self, view):
-        x = jnp.array([0.5, 1.0, 1.5])
-        up = view._unnormalized_prob(x)
-        assert jnp.isfinite(up)
-
-    def test_prob(self, view):
-        x = jnp.array([0.5, 1.0, 1.5])
-        p = view._prob(x)
-        np.testing.assert_allclose(float(p), float(jnp.exp(view._log_prob(x))))
-
-    def test_repr(self, view):
-        r = repr(view)
-        assert "UnconstrainedStanView" in r
-        assert "StanModel" in r
-
-
-# ---------------------------------------------------------------------------
-# Per-Stan-parameter blocks (fields, shapes, keyword _pack_value)
-# ---------------------------------------------------------------------------
-
 
 class TestParamBlocks:
-    """_param_blocks groups BridgeStan's flat, 1-indexed names into shaped
-    blocks. BridgeStan flattens matrices column-major (L.1.1, L.2.1, ...)."""
+    """``_param_blocks`` groups BridgeStan's flat, 1-indexed names into shaped
+    blocks. BridgeStan flattens matrices column-major (L.1.1, L.2.1, ...). The
+    name lists here are hand-written; ``test_param_blocks_match_real_names``
+    cross-checks the same parser against a compiled model's real names.
+    """
 
     def test_all_scalars(self):
         blocks = _param_blocks(["mu", "sigma"])
@@ -254,94 +59,8 @@ class TestParamBlocks:
         assert _param_blocks([]) == ()
 
 
-class TestStanModelParameterBlocks:
-    """StanModel and its view expose one field per Stan parameter *block*,
-    while ``parameter_names`` keeps BridgeStan's flat per-scalar names."""
-
-    @pytest.fixture
-    def model(self):
-        names = ["mu", "theta.1", "theta.2", "theta.3",
-                 "L.1.1", "L.2.1", "L.1.2", "L.2.2"]
-        return _make_stan_model(num_params=len(names), param_names=names)
-
-    def test_fields_are_blocks(self, model):
-        assert model.fields == ("mu", "theta", "L")
-
-    def test_parameter_names_stay_per_scalar(self, model):
-        assert model.parameter_names == (
-            "mu", "theta.1", "theta.2", "theta.3",
-            "L.1.1", "L.2.1", "L.1.2", "L.2.2")
-
-    def test_record_template_shapes(self, model):
-        assert {f: model.record_template[f] for f in model.fields} == {
-            "mu": (), "theta": (3,), "L": (2, 2)}
-
-    def test_getitem_uses_block_fields(self, model):
-        assert model["theta"] == "theta"
-        with pytest.raises(KeyError, match="Unknown component"):
-            model["theta.1"]  # per-scalar names are no longer components
-
-    def test_pack_value_assembles_column_major(self, model):
-        flat = model._pack_value(
-            mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
-            L=jnp.array([[10.0, 30.0], [20.0, 40.0]]))
-        # L is packed column-major to match BridgeStan: [10, 20, 30, 40].
-        assert jnp.allclose(
-            flat, jnp.array([0.5, 1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0]))
-
-    def test_pack_value_missing_block_raises(self, model):
-        with pytest.raises(TypeError, match="missing"):
-            model._pack_value(mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]))
-
-    def test_pack_value_unexpected_block_raises(self, model):
-        with pytest.raises(TypeError, match="unexpected"):
-            model._pack_value(mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
-                              L=jnp.zeros((2, 2)), zzz=1.0)
-
-    def test_pack_value_wrong_shape_raises(self, model):
-        with pytest.raises(TypeError, match=r"shape \(2, 2\)"):
-            model._pack_value(mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
-                              L=jnp.array([1.0, 2.0, 3.0, 4.0]))  # flat, not (2,2)
-
-    def test_view_uses_unconstrained_blocks(self):
-        # simplex[3] p: constrained names p.1..p.3 (size 3); the unconstrained
-        # parametrization drops one degree of freedom -> p.1, p.2 (size 2).
-        model = _make_stan_model(
-            num_params=3, param_names=["mu", "p.1", "p.2", "p.3"],
-            param_unc_names=["mu", "p.1", "p.2"])
-        assert model.fields == ("mu", "p")
-        assert model.record_template["p"] == (3,)
-        view = model.as_unconstrained_distribution()
-        assert view.fields == ("mu", "p")
-        assert view.record_template["p"] == (2,)
-        flat = view._pack_value(mu=0.5, p=jnp.array([0.1, 0.2]))
-        assert jnp.allclose(flat, jnp.array([0.5, 0.1, 0.2]))
-
-
-# ---------------------------------------------------------------------------
-# StanModel conditioning via registry
-# ---------------------------------------------------------------------------
-
-
-class TestStanModelConditionOn:
-    def test_condition_on_delegates_to_registry(self):
-        """condition_on routes StanModel through the inference registry."""
-        from probpipe import condition_on
-
-        model = _make_stan_model()
-        with patch("probpipe.inference._registry.inference_method_registry.execute") as mock_exec:
-            mock_exec.return_value = MagicMock()
-            condition_on(model, {"y": [1, 2, 3]}, num_results=10)
-            mock_exec.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# CmdStan inference method tests
-# ---------------------------------------------------------------------------
-
-
 class TestCmdStanInferenceMethod:
-    """Test CmdStan inference via the registry method."""
+    """The CmdStan inference method's import shim (cmdstanpy, not BridgeStan)."""
 
     def test_import_cmdstanpy_missing(self):
         from probpipe.inference._cmdstan_method import _import_cmdstanpy
@@ -361,14 +80,11 @@ class TestCmdStanInferenceMethod:
             assert result is mock_cmdstanpy
 
 
-# ---------------------------------------------------------------------------
-# ImportError path
-# ---------------------------------------------------------------------------
-
-
 class TestStanModelImportError:
     def test_missing_bridgestan(self):
-        """StanModel raises ImportError with install instructions when bridgestan missing."""
+        """StanModel raises ImportError with install instructions when bridgestan
+        is missing — this *must* simulate bridgestan's absence, so it patches
+        ``sys.modules`` rather than using a real backend."""
         with (
             patch.dict("sys.modules", {"bridgestan": None}),
             pytest.raises(ImportError, match="pip install bridgestan"),
@@ -377,12 +93,11 @@ class TestStanModelImportError:
 
 
 # ---------------------------------------------------------------------------
-# Real BridgeStan integration (requires a compiled Stan program)
+# Real BridgeStan backend
 #
-# These exercise the path the mocks above cannot: the real BridgeStan
-# constructor signature and its float64-ndarray boundary.  The gate lives in
-# the fixtures (not at module scope) so the mocked tests above still run when
-# BridgeStan is absent.
+# The gate lives in ``_stan_toolchain`` (not at module scope) so the pure tests
+# above still run when BridgeStan or a C++ toolchain is absent. The model
+# fixtures below depend on it, so they skip together.
 # ---------------------------------------------------------------------------
 
 
@@ -392,8 +107,8 @@ def _stan_toolchain(tmp_path_factory):
 
     Compiling a trivial, data-free probe separates "is the C++ toolchain
     present?" (a legitimate skip) from "does StanModel construct correctly?"
-    (a regression that must fail loudly, not skip) — so the model fixture
-    below can construct without a try/except that would swallow real bugs.
+    (a regression that must fail loudly, not skip) — so the model fixtures
+    below construct without a try/except that would swallow real bugs.
     """
     bridgestan = pytest.importorskip("bridgestan")
     probe = tmp_path_factory.mktemp("stan_probe") / "probe.stan"
@@ -405,16 +120,12 @@ def _stan_toolchain(tmp_path_factory):
 
 
 @pytest.fixture(scope="module")
-def tmp_stan_model(_stan_toolchain, tmp_path_factory):
-    """A real StanModel for ``y ~ Normal(mu, 1)`` with a unit prior on ``mu``,
-    built through the public constructor.
-
-    Construction therefore exercises the BridgeStan boundary end to end —
-    ``.stan`` compilation plus serialization of the ``data`` dict.  The
-    toolchain is known good from ``_stan_toolchain``, so any failure here is a
-    real bug, not a missing compiler.  The model is conjugate, so its
-    log-density is known in closed form.
-    """
+def conjugate_stan_file(_stan_toolchain, tmp_path_factory):
+    """Path to a compiled conjugate model ``y ~ Normal(mu, 1)`` with a unit
+    prior on ``mu`` — a single unconstrained real, so its log-density is
+    closed-form and constrain/unconstrain are the identity. Returned as a path
+    so tests can also build name-less / no-data instances cheaply (the compiled
+    shared object is reused)."""
     stan_file = tmp_path_factory.mktemp("stan_models") / "normal_mean.stan"
     stan_file.write_text(
         """
@@ -429,15 +140,90 @@ def tmp_stan_model(_stan_toolchain, tmp_path_factory):
         }
         """
     )
-    return StanModel(str(stan_file), data={"N": 3, "y": [1.0, 2.0, 3.0]},
+    return str(stan_file)
+
+
+@pytest.fixture(scope="module")
+def conjugate_model(conjugate_stan_file):
+    """The conjugate model instantiated with data and an explicit name."""
+    return StanModel(conjugate_stan_file, data={"N": 3, "y": [1.0, 2.0, 3.0]},
                      name="normal_mean")
 
 
-class TestStanModelIntegration:
-    """Real-backend checks against a compiled Stan program."""
+@pytest.fixture(scope="module")
+def structured_model(_stan_toolchain, tmp_path_factory):
+    """A model exercising every parameter kind: a scalar, a vector, a matrix
+    (column-major flattening), and a simplex — whose unconstrained
+    parametrisation has one fewer dimension, so the view's blocks differ from
+    the constrained model's."""
+    stan_file = tmp_path_factory.mktemp("stan_models") / "structured.stan"
+    stan_file.write_text(
+        """
+        parameters {
+          real mu;
+          vector[3] theta;
+          matrix[2, 2] L;
+          simplex[3] p;
+        }
+        model {
+          mu ~ normal(0, 1);
+          theta ~ normal(0, 1);
+          to_vector(L) ~ normal(0, 1);
+          p ~ dirichlet(rep_vector(1.0, 3));
+        }
+        """
+    )
+    return StanModel(str(stan_file), name="structured")
 
-    # Observations baked into tmp_stan_model's data.
-    _Y = np.array([1.0, 2.0, 3.0])
+
+class TestStanModelSurface:
+    """Distribution / ProbabilisticModel surface on a real conjugate model."""
+
+    def test_supports_named_components(self, conjugate_model):
+        assert hasattr(conjugate_model, "fields")
+
+    def test_name(self, conjugate_model):
+        assert conjugate_model.name == "normal_mean"
+
+    def test_event_shape(self, conjugate_model):
+        assert conjugate_model.event_shape == (1,)
+
+    def test_fields(self, conjugate_model):
+        assert conjugate_model.fields == ("mu",)
+
+    def test_parameter_names(self, conjugate_model):
+        assert conjugate_model.parameter_names == ("mu",)
+
+    def test_getitem_returns_name_placeholder(self, conjugate_model):
+        # BridgeStan doesn't expose sub-distributions, so __getitem__ is a
+        # placeholder that merely validates the key.
+        assert conjugate_model["mu"] == "mu"
+
+    def test_getitem_unknown_key_raises(self, conjugate_model):
+        with pytest.raises(KeyError, match="Unknown component"):
+            conjugate_model["nonexistent"]
+
+    def test_repr(self, conjugate_model):
+        r = repr(conjugate_model)
+        assert "StanModel" in r
+        assert "normal_mean.stan" in r
+        assert "num_params=1" in r
+
+    def test_as_unconstrained_distribution(self, conjugate_model):
+        assert isinstance(conjugate_model.as_unconstrained_distribution(),
+                          _UnconstrainedStanView)
+
+    def test_name_defaults_to_class_name(self, conjugate_stan_file):
+        # Without an explicit name, StanModel falls back to the class name to
+        # satisfy the Distribution metaclass's non-empty-name requirement.
+        model = StanModel(conjugate_stan_file, data={"N": 3, "y": [1.0, 2.0, 3.0]})
+        assert model.name == "StanModel"
+
+
+class TestStanModelDensity:
+    """Density ops against the conjugate model's closed-form log-density."""
+
+    _Y = np.array([1.0, 2.0, 3.0])  # baked into conjugate_model's data
 
     def _expected_log_density(self, mu):
         # Stan accumulates target = log N(mu; 0, 1) + sum_i log N(y_i; mu, 1)
@@ -445,26 +231,195 @@ class TestStanModelIntegration:
         # terms vanish and mu (an unconstrained real) carries no Jacobian.
         return -0.5 * mu**2 - 0.5 * float(np.sum((self._Y - mu) ** 2))
 
-    def test_construct_exposes_parameters(self, tmp_stan_model):
-        assert isinstance(tmp_stan_model, StanModel)
-        assert tmp_stan_model.event_shape == (1,)
-        assert tmp_stan_model.parameter_names == ("mu",)
-
-    def test_log_prob_matches_analytical(self, tmp_stan_model):
-        """``_log_prob`` matches the closed-form log-density.
-
-        A JAX array is passed in, so this also covers the JAX -> float64
-        ndarray conversion required at ``param_unconstrain`` / ``log_density``.
-        """
+    def test_log_prob_matches_analytical(self, conjugate_model):
+        """A JAX array is passed in, so this also covers the JAX -> float64
+        ndarray conversion required at ``param_unconstrain`` / ``log_density``."""
         for mu in [-1.0, 0.0, 0.5, 2.0]:
-            lp = float(tmp_stan_model._log_prob(jnp.asarray([mu])))
+            lp = float(conjugate_model._log_prob(jnp.asarray([mu])))
             np.testing.assert_allclose(lp, self._expected_log_density(mu), atol=1e-5)
 
-    def test_param_transforms_round_trip(self, tmp_stan_model):
-        """constrain/unconstrain are identity for an unconstrained real and
-        survive the JAX-array boundary in both directions."""
+    def test_unnormalized_log_prob_equals_log_prob(self, conjugate_model):
+        # Stan's log_density is already the (unnormalized) target, so the two agree.
+        x = jnp.asarray([0.5])
+        np.testing.assert_allclose(
+            float(conjugate_model._unnormalized_log_prob(x)),
+            float(conjugate_model._log_prob(x)), atol=1e-6)
+
+    def test_prob_is_exp_log_prob(self, conjugate_model):
+        x = jnp.asarray([0.5])
+        np.testing.assert_allclose(
+            float(conjugate_model._prob(x)),
+            float(jnp.exp(conjugate_model._log_prob(x))), rtol=1e-6)
+
+    def test_unnormalized_prob_positive(self, conjugate_model):
+        up = conjugate_model._unnormalized_prob(jnp.asarray([0.5]))
+        assert jnp.isfinite(up) and float(up) > 0
+
+
+class TestStanModelTransforms:
+    """constrain / unconstrain across the JAX <-> float64 boundary. For an
+    unconstrained real both directions are the identity."""
+
+    def test_param_constrain_identity_for_real(self, conjugate_model):
         x = jnp.asarray([1.23])
-        constrained = np.asarray(tmp_stan_model.param_constrain(x))
-        np.testing.assert_allclose(constrained, [1.23], atol=1e-6)
-        round_trip = tmp_stan_model.param_constrain(tmp_stan_model.param_unconstrain(x))
+        np.testing.assert_allclose(
+            np.asarray(conjugate_model.param_constrain(x)), [1.23], atol=1e-6)
+
+    def test_param_unconstrain_identity_for_real(self, conjugate_model):
+        x = jnp.asarray([1.23])
+        np.testing.assert_allclose(
+            np.asarray(conjugate_model.param_unconstrain(x)), [1.23], atol=1e-6)
+
+    def test_constrain_unconstrain_round_trip(self, conjugate_model):
+        x = jnp.asarray([1.23])
+        round_trip = conjugate_model.param_constrain(
+            conjugate_model.param_unconstrain(x))
         np.testing.assert_allclose(np.asarray(round_trip), [1.23], atol=1e-6)
+
+
+class TestBridgestanModel:
+    """``_bridgestan_model`` returns the compiled model, or builds a fresh one
+    bound to new data."""
+
+    def test_no_data_returns_compiled_model(self, conjugate_model):
+        assert conjugate_model._bridgestan_model() is conjugate_model._bs_model
+
+    def test_with_data_builds_new_model(self, conjugate_model):
+        rebuilt = conjugate_model._bridgestan_model(data={"N": 2, "y": [0.0, 1.0]})
+        assert rebuilt is not conjugate_model._bs_model
+        assert rebuilt.param_unc_num() == 1  # still one parameter, `mu`
+
+
+class TestStanModelParameters:
+    """One field per Stan parameter *block*, while ``parameter_names`` keeps
+    BridgeStan's flat per-scalar names. Exercised on a model with a scalar, a
+    vector, a matrix, and a simplex."""
+
+    def test_fields_are_blocks(self, structured_model):
+        assert structured_model.fields == ("mu", "theta", "L", "p")
+
+    def test_event_shape_is_unconstrained_size(self, structured_model):
+        # mu(1) + theta(3) + L(4) + p simplex unconstrained(2) = 10.
+        assert structured_model.event_shape == (10,)
+
+    def test_parameter_names_stay_per_scalar(self, structured_model):
+        assert structured_model.parameter_names == (
+            "mu", "theta.1", "theta.2", "theta.3",
+            "L.1.1", "L.2.1", "L.1.2", "L.2.2", "p.1", "p.2", "p.3")
+
+    def test_record_template_shapes(self, structured_model):
+        assert {f: structured_model.record_template[f]
+                for f in structured_model.fields} == {
+            "mu": (), "theta": (3,), "L": (2, 2), "p": (3,)}
+
+    def test_param_blocks_match_real_names(self, structured_model):
+        # The pure name-parser, fed BridgeStan's real param_names(), recovers
+        # the declared shapes — guards against BridgeStan changing its
+        # flattening convention out from under _param_blocks.
+        blocks = _param_blocks(structured_model._bs_model.param_names())
+        assert [(b.name, b.shape) for b in blocks] == [
+            ("mu", ()), ("theta", (3,)), ("L", (2, 2)), ("p", (3,))]
+
+    def test_getitem_uses_block_fields(self, structured_model):
+        assert structured_model["theta"] == "theta"
+        with pytest.raises(KeyError, match="Unknown component"):
+            structured_model["theta.1"]  # per-scalar names are not components
+
+    def test_pack_value_assembles_column_major(self, structured_model):
+        flat = structured_model._pack_value(
+            mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
+            L=jnp.array([[10.0, 30.0], [20.0, 40.0]]),
+            p=jnp.array([0.2, 0.3, 0.5]))
+        # L is packed column-major to match BridgeStan: [10, 20, 30, 40].
+        assert jnp.allclose(flat, jnp.array(
+            [0.5, 1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0, 0.2, 0.3, 0.5]))
+
+    def test_pack_value_missing_block_raises(self, structured_model):
+        with pytest.raises(TypeError, match="missing"):
+            structured_model._pack_value(mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
+                                         L=jnp.zeros((2, 2)))  # no p
+
+    def test_pack_value_unexpected_block_raises(self, structured_model):
+        with pytest.raises(TypeError, match="unexpected"):
+            structured_model._pack_value(
+                mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]), L=jnp.zeros((2, 2)),
+                p=jnp.array([0.2, 0.3, 0.5]), zzz=1.0)
+
+    def test_pack_value_wrong_shape_raises(self, structured_model):
+        with pytest.raises(TypeError, match=r"shape \(2, 2\)"):
+            structured_model._pack_value(
+                mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
+                L=jnp.array([1.0, 2.0, 3.0, 4.0]),  # flat, not (2, 2)
+                p=jnp.array([0.2, 0.3, 0.5]))
+
+    def test_keyword_form_equals_positional(self, structured_model):
+        # The simplex sums to 1 exactly in floating point (0.25 + 0.25 + 0.5),
+        # so param_unconstrain accepts it; the keyword form must produce the
+        # same log-density as the equivalent flat vector.
+        kw = dict(mu=0.5, theta=jnp.array([0.1, 0.2, 0.3]),
+                  L=jnp.array([[1.0, 2.0], [3.0, 4.0]]),
+                  p=jnp.array([0.25, 0.25, 0.5]))
+        lp_kw = float(jnp.asarray(log_prob(structured_model, **kw)))
+        lp_pos = float(jnp.asarray(
+            log_prob(structured_model, structured_model._pack_value(**kw))))
+        np.testing.assert_allclose(lp_kw, lp_pos, atol=1e-6)
+
+
+class TestUnconstrainedStanView:
+    """The unconstrained view. Its blocks follow ``param_unc_names``, so a
+    simplex appears with one fewer dimension than in the constrained model."""
+
+    def test_name_with_base(self, structured_model):
+        assert structured_model.as_unconstrained_distribution().name == \
+            "structured_unconstrained"
+
+    def test_name_without_base(self, conjugate_stan_file):
+        model = StanModel(conjugate_stan_file, data={"N": 3, "y": [1.0, 2.0, 3.0]})
+        view = model.as_unconstrained_distribution()
+        assert view.name == "StanModel_unconstrained"
+
+    def test_event_shape_matches_model(self, structured_model):
+        view = structured_model.as_unconstrained_distribution()
+        assert view.event_shape == structured_model.event_shape == (10,)
+
+    def test_blocks_follow_unconstrained_names(self, structured_model):
+        view = structured_model.as_unconstrained_distribution()
+        assert view.fields == ("mu", "theta", "L", "p")
+        # The simplex is unconstrained in (n-1) free coordinates.
+        assert structured_model.record_template["p"] == (3,)
+        assert view.record_template["p"] == (2,)
+
+    def test_log_prob_finite_and_unnormalized_agrees(self, structured_model):
+        view = structured_model.as_unconstrained_distribution()
+        # An all-zeros unconstrained point is always valid (maps to the centre
+        # of every constrained support).
+        x = jnp.zeros(view.event_shape)
+        lp = view._log_prob(x)
+        assert jnp.isfinite(lp)
+        np.testing.assert_allclose(
+            float(view._unnormalized_log_prob(x)), float(lp), atol=1e-6)
+
+    def test_prob_is_exp_log_prob(self, structured_model):
+        view = structured_model.as_unconstrained_distribution()
+        x = jnp.zeros(view.event_shape)
+        np.testing.assert_allclose(
+            float(view._prob(x)), float(jnp.exp(view._log_prob(x))), rtol=1e-6)
+
+    def test_repr(self, structured_model):
+        r = repr(structured_model.as_unconstrained_distribution())
+        assert "UnconstrainedStanView" in r
+        assert "structured" in r
+
+
+class TestStanModelConditionOn:
+    def test_condition_on_delegates_to_registry(self, conjugate_model):
+        """condition_on routes a StanModel through the inference registry
+        (the registry is patched, so no actual MCMC runs)."""
+        from probpipe import condition_on
+
+        with patch(
+            "probpipe.inference._registry.inference_method_registry.execute"
+        ) as mock_exec:
+            mock_exec.return_value = MagicMock()
+            condition_on(conjugate_model, {"y": [1, 2, 3]}, num_results=10)
+            mock_exec.assert_called_once()


### PR DESCRIPTION
## Summary

Upgrades `StanModel`'s tests to exercise a **real BridgeStan backend** instead of
a `MagicMock`, and runs them in a dedicated `stan` CI job (mirroring the
`bayesflow` leg). Follow-on to #228 (the per-Stan-parameter keyword form, merged
in #285).

Previously `tests/modeling/test_stan_model.py` asserted `StanModel` behaviour
against a hand-written `MagicMock`, so the real BridgeStan boundary — the
constructor signature, the JAX→float64 ndarray coercion, the dot-flattened
parameter names, constrain/unconstrain — was never actually exercised by CI.
(That gap is exactly what hid the two real-backend bugs fixed in #286.)

### What changed

- **Real compiled-model fixtures**, compiled once per module: a **conjugate**
  model (`y ~ Normal(mu, 1)`) with a closed-form log-density and identity
  transforms, and a **structured** model (a scalar, a `vector[3]`, a
  `matrix[2, 2]`, and a `simplex[3]`) covering per-parameter `fields` /
  `record_template` shapes, column-major packing, the keyword form vs. the
  positional flat vector, and the unconstrained view (whose simplex has one
  fewer dimension).
- **Pure tests stay in the main matrix.** The compile-backed tests are gated by
  the `_stan_toolchain` fixture (`importorskip` + a probe compile). The
  parameter-name parser (`_param_blocks`), the bridgestan-missing import guard,
  and the CmdStan import shim need no backend, so they keep running everywhere.
- **Dedicated `stan` CI job.** Installs the `stan` extra, caches the
  `~/.bridgestan` build (so only a cold cache pays the multi-minute Stan-math
  lib build; per-model compiles are then seconds), runs the suite, and uploads
  coverage under a `stan` flag (carryforward) — so `_stan.py`'s real coverage
  lands in Codecov's union even though the main matrix doesn't install
  bridgestan. Gated like the bayesflow leg (push-to-main, foundational changes,
  or Stan-file changes). `codecov.yml`'s `after_n_builds` bumps 2 → 3 for the
  new uploading leg.

## Linked issue(s)

Refs #228

## Test plan

- `tests/modeling/test_stan_model.py`: **47 passed** with bridgestan installed
  (all real-model tests run); **9 passed, 38 skipped** without it (the pure
  tests run; the compile-backed ones skip) — confirming both the `stan` job and
  the main matrix behave correctly.
- Validated against a real BridgeStan 2.8.0 compile (scalar / vector / matrix /
  simplex), including `log_prob` keyword form == positional form and the
  closed-form conjugate log-density.

## Breaking changes

None.

## Documentation

- [ ] Docstrings updated for changed public APIs — N/A (tests + CI only)
- [ ] User Guide / tutorials updated — N/A
- [x] Convention docs updated — STYLE_GUIDE.md §8.4 (Stan tests compile real
  models; nutpie keeps the mock approach) and CONTRIBUTING.md (the `stan` CI
  leg + optional-backend notes)
- [ ] CHANGELOG — N/A (test / CI infrastructure; no user-facing change)

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`
- [x] At least one `area:*` label applied (`area:infrastructure`)
- [x] Linked to an issue above
