### PR TITLE
Removed reserved names in `@workflow_function`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,12 +422,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`WorkflowFunction` controls now live outside user call kwargs.**
   `@workflow_function(...)` configures definition-time controls, and
-  `workflow.with_options(...)(...)` is the preferred call-time override
-  API for `seed`, `n_broadcast_samples`, and `include_inputs`. Wrapped
+  `workflow.with_options(...)(...)` is the call-time override API for
+  `seed`, `n_broadcast_samples`, and `include_inputs`. Wrapped
   functions may now declare and receive those names as ordinary
-  parameters. Legacy call-time option kwargs still work during a
-  transition window when they cannot bind to the wrapped function, but
-  they emit `DeprecationWarning`.
+  parameters. Passing those names as call kwargs no longer configures
+  ProbPipe controls; use `workflow.with_options(...)(...)` instead.
 - **`WorkflowFunction.workflow_kind` and `Module.workflow_kind` now require
   `WorkflowKind` enum members.** String aliases such as `"task"` / `"flow"`
   and `None` are no longer accepted and now raise `TypeError`; use

--- a/probpipe/core/_workflow_call.py
+++ b/probpipe/core/_workflow_call.py
@@ -9,9 +9,8 @@ broadcast planning, execution, or result coercion.
 from __future__ import annotations
 
 import inspect
-import warnings
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Any, get_type_hints
 
 
@@ -32,11 +31,6 @@ class WorkflowCallOptions:
     n_broadcast_samples: int | None = None
     include_inputs: bool | None = None
     seed: int | None = None
-
-
-WORKFLOW_CALL_OPTION_NAMES = frozenset(
-    field.name for field in fields(WorkflowCallOptions)
-)
 
 
 @dataclass(frozen=True)
@@ -118,31 +112,18 @@ def bind_call_inputs(
     default_n_broadcast_samples: int,
     default_include_inputs: bool,
     options: WorkflowCallOptions | None = None,
-    warn_legacy_overrides: bool = False,
 ) -> tuple[dict[str, Any], WorkflowCallOverrides]:
     """Bind user inputs and resolve workflow controls.
 
-    Legacy call-time controls are consumed from ``call_inputs`` only when
-    they cannot bind to the wrapped function. Explicit ``options`` are the
-    preferred control plane and take precedence.
+    Call inputs bind exactly like the wrapped Python function. Workflow
+    controls come only from explicit ``options`` or construction defaults.
     """
-    raw_inputs = dict(call_inputs)
-
-    legacy_options = _pop_legacy_workflow_options(
-        info,
-        raw_inputs,
-        warn=warn_legacy_overrides,
-    )
     explicit_options = options if options is not None else WorkflowCallOptions()
 
     def resolve_option(name: str, default: Any = None) -> Any:
         explicit_value = getattr(explicit_options, name)
         if explicit_value is not None:
             return explicit_value
-
-        legacy_value = getattr(legacy_options, name)
-        if legacy_value is not None:
-            return legacy_value
 
         return default
 
@@ -158,7 +139,7 @@ def bind_call_inputs(
         seed=resolve_option("seed"),
     )
 
-    bound = info.signature.bind_partial(*args, **raw_inputs)
+    bound = info.signature.bind_partial(*args, **call_inputs)
     bound_inputs = _flatten_bound_inputs(info.signature, bound)
 
     return bound_inputs, overrides
@@ -230,7 +211,6 @@ def resolve_workflow_call(
     default_n_broadcast_samples: int,
     default_include_inputs: bool,
     options: WorkflowCallOptions | None = None,
-    warn_legacy_overrides: bool = False,
 ) -> ResolvedWorkflowCall:
     """Resolve one ``WorkflowFunction`` call into values plus overrides."""
     bound_inputs, overrides = bind_call_inputs(
@@ -240,7 +220,6 @@ def resolve_workflow_call(
         default_n_broadcast_samples=default_n_broadcast_samples,
         default_include_inputs=default_include_inputs,
         options=options,
-        warn_legacy_overrides=warn_legacy_overrides,
     )
     values = resolve_workflow_values(
         info,
@@ -259,40 +238,6 @@ def _get_type_hints(func: Callable[..., Any]) -> dict[str, Any]:
         return get_type_hints(func)
     localns = {param.__name__: param for param in type_params}
     return get_type_hints(func, localns=localns)
-
-
-def _pop_legacy_workflow_options(
-    info: WorkflowSignatureInfo,
-    raw_inputs: dict[str, Any],
-    *,
-    warn: bool,
-) -> WorkflowCallOptions:
-    consumed: dict[str, Any] = {}
-    for name in WORKFLOW_CALL_OPTION_NAMES:
-        if name not in raw_inputs:
-            continue
-        if _can_bind_as_user_input(info, name):
-            continue
-        consumed[name] = raw_inputs.pop(name)
-
-    if consumed and warn:
-        names = ", ".join(sorted(consumed))
-        warnings.warn(
-            "Passing WorkflowFunction options as call kwargs is deprecated "
-            f"for {names}; use workflow.with_options(...)(...) instead.",
-            DeprecationWarning,
-            stacklevel=6,
-        )
-
-    return WorkflowCallOptions(
-        n_broadcast_samples=consumed.get("n_broadcast_samples"),
-        include_inputs=consumed.get("include_inputs"),
-        seed=consumed.get("seed"),
-    )
-
-
-def _can_bind_as_user_input(info: WorkflowSignatureInfo, name: str) -> bool:
-    return name in info.signature.parameters or info.has_var_keyword
 
 
 def _validate_required_values(

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -430,7 +430,6 @@ class WorkflowFunction(Node):
             default_n_broadcast_samples=self._n_broadcast_samples,
             default_include_inputs=self._include_inputs,
             options=options,
-            warn_legacy_overrides=True,
         )
         if call.overrides.seed is not None:
             self._key = jax.random.PRNGKey(call.overrides.seed)

--- a/tests/core/test_broadcasting.py
+++ b/tests/core/test_broadcasting.py
@@ -156,7 +156,7 @@ class TestBroadcastingNSamples:
             w.with_options(n_broadcast_samples=n_broadcast_samples)(x=g)
 
 
-class TestFormerlyReservedParameterNames:
+class TestWorkflowControlParameterNames:
     def test_n_broadcast_samples_allowed(self):
         def func(x: jnp.ndarray, n_broadcast_samples: int = 10) -> float:
             return float(n_broadcast_samples)

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -234,18 +234,20 @@ class TestProbAndUnnormalizedKwargForm:
         )
 
 
-class TestFormerlyReservedFieldNames:
-    """Controls live only on ``with_options``, so a field whose name matches a
-    former WF control (``seed`` / ``n_broadcast_samples`` / ``include_inputs``)
-    is an ordinary field: construction does not warn, and the keyword form
-    addresses it (issue #228)."""
+class TestWorkflowControlFieldNames:
+    """Workflow control names are ordinary distribution fields.
+
+    Per-call controls live only on ``with_options``, so fields named
+    ``seed``, ``n_broadcast_samples``, or ``include_inputs`` can be addressed
+    through the keyword value form.
+    """
 
     @pytest.mark.parametrize("name", ["seed", "n_broadcast_samples", "include_inputs"])
-    def test_construction_does_not_warn(self, name):
+    def test_construction_does_not_warn_for_control_names(self, name):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             Normal(0.0, 1.0, name=name)
-        assert not any("reserved" in str(w.message).lower() for w in caught)
+        assert not caught
 
     @pytest.mark.parametrize("name", ["seed", "n_broadcast_samples", "include_inputs"])
     def test_keyword_form_addresses_the_field(self, name):
@@ -264,13 +266,9 @@ class TestControlsViaWithOptions:
         "control",
         [{"seed": 3}, {"n_broadcast_samples": 8}, {"include_inputs": True}],
     )
-    def test_with_options_does_not_deprecation_warn(self, control):
+    def test_with_options_accepts_controls(self, control):
         d = Normal(0.0, 1.0, name="x")
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            log_prob.with_options(**control)(d, 1.5)
-        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert not deps, [str(w.message) for w in deps]
+        log_prob.with_options(**control)(d, 1.5)
 
     def test_op_is_its_own_workflow_function(self):
         # No wrapper: log_prob *is* a WorkflowFunction, so with_options is its
@@ -335,10 +333,10 @@ class _FieldlessRandomMeasure(Distribution):
 
 class TestRandomMeasureKwargForm:
     """The random_*_log_prob ops keep `value` optional (return the
-    RandomFunction) and apply controls via with_options without deprecation.
-    The keyword form routes to `_pack_value`; since random measures carry no
-    named `fields` yet, it raises a clear "no named fields" error — full
-    RandomMeasure field support is #228 PR 4."""
+    RandomFunction) and apply controls via with_options. The keyword form
+    routes to `_pack_value`; since random measures carry no named `fields` yet,
+    it raises a clear "no named fields" error — full RandomMeasure field
+    support is #228 PR 4."""
 
     @staticmethod
     def _measure():
@@ -349,14 +347,10 @@ class TestRandomMeasureKwargForm:
         lik = GLMLikelihood(tfp_glm.Bernoulli(), x=X)
         return MinibatchedDistribution(prior, lik, Record(X=X, y=y), batch_size=2)
 
-    def test_value_omitted_returns_callable_no_deprecation(self):
+    def test_value_omitted_returns_callable_with_options(self):
         m = self._measure()
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            rf = random_unnormalized_log_prob.with_options(seed=0)(m)
+        rf = random_unnormalized_log_prob.with_options(seed=0)(m)
         assert callable(rf)
-        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert not deps, [str(w.message) for w in deps]
 
     @pytest.mark.parametrize("op", [random_log_prob, random_unnormalized_log_prob])
     def test_kwarg_form_raises_no_named_fields(self, op):

--- a/tests/core/test_workflow_call_resolution.py
+++ b/tests/core/test_workflow_call_resolution.py
@@ -112,19 +112,9 @@ class TestWorkflowCallHelpers:
 
         assert call.values == {"x": 1.0, "kwargs": {"scale": 2.0}}
 
-    def test_legacy_options_are_not_function_inputs_when_unbindable(self, identity_func):
-        call = _resolve_call(
-            identity_func,
-            "value",
-            n_broadcast_samples=6,
-            include_inputs=True,
-            seed=123,
-        )
-
-        assert call.values == {"x": "value"}
-        assert call.overrides.n_broadcast_samples == 6
-        assert call.overrides.include_inputs is True
-        assert call.overrides.seed == 123
+    def test_unbindable_workflow_control_name_raises_like_python(self, identity_func):
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            _resolve_call(identity_func, "value", n_broadcast_samples=6)
 
     def test_workflow_option_names_bind_when_declared(self):
         def identity(x, n_broadcast_samples, include_inputs, seed):

--- a/tests/core/test_workflow_options_namespace.py
+++ b/tests/core/test_workflow_options_namespace.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import warnings
-
 import jax.numpy as jnp
+import pytest
 
 from probpipe import BroadcastDistribution, Normal, WorkflowFunction, workflow_function
 
@@ -23,42 +22,19 @@ def test_workflow_function_decorator_sets_construction_defaults():
     assert result.num_atoms == 7
 
 
-def test_workflow_function_decorator_options_do_not_warn():
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-
-        @workflow_function(n_broadcast_samples=5, dispatch="sequential", seed=0)
-        def identity(x):
-            return x
-
-    result = identity(Normal(loc=0.0, scale=1.0, name="x"))
-    assert not any(
-        issubclass(warning.category, DeprecationWarning)
-        for warning in caught
-    )
-    assert result.num_atoms == 5
-
-
 def test_workflow_function_has_no_options_alias():
     assert not hasattr(workflow_function, "options")
 
 
-def test_bare_decorator_forms_do_not_warn():
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+def test_bare_decorator_forms_wrap_functions():
+    @workflow_function
+    def bare(x):
+        return x
 
-        @workflow_function
-        def bare(x):
-            return x
+    @workflow_function()
+    def bare_parentheses(x):
+        return x
 
-        @workflow_function()
-        def bare_parentheses(x):
-            return x
-
-    assert not any(
-        issubclass(warning.category, DeprecationWarning)
-        for warning in caught
-    )
     assert bare(1.0)["bare"] == 1.0
     assert bare_parentheses(2.0)["bare_parentheses"] == 2.0
 
@@ -130,7 +106,7 @@ def test_with_options_seed_is_separate_from_user_seed_parameter():
     assert jnp.allclose(first.samples["marginal"], base.samples["marginal"] + 7.0)
 
 
-def test_formerly_reserved_names_are_user_parameters():
+def test_workflow_control_names_are_user_parameters():
     @workflow_function
     def collect(seed, n_broadcast_samples, include_inputs, name, dispatch):
         return f"{seed}:{n_broadcast_samples}:{include_inputs}:{name}:{dispatch}"
@@ -146,7 +122,7 @@ def test_formerly_reserved_names_are_user_parameters():
     assert result["collect"] == "1:2:True:model:local"
 
 
-def test_var_keyword_receives_formerly_reserved_names():
+def test_var_keyword_receives_workflow_control_names():
     seen = []
 
     def identity(x, **kwargs):
@@ -161,26 +137,20 @@ def test_var_keyword_receives_formerly_reserved_names():
     )
     normal = Normal(loc=0.0, scale=1.0, name="x")
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        result = wf.with_options(n_broadcast_samples=5)(
-            x=normal,
-            seed=42,
-            n_broadcast_samples=99,
-            include_inputs=True,
-        )
+    result = wf.with_options(n_broadcast_samples=5)(
+        x=normal,
+        seed=42,
+        n_broadcast_samples=99,
+        include_inputs=True,
+    )
 
     assert result.num_atoms == 5
-    assert not any(
-        issubclass(warning.category, DeprecationWarning)
-        for warning in caught
-    )
     assert seen == [
         {"seed": 42, "n_broadcast_samples": 99, "include_inputs": True},
     ] * 5
 
 
-def test_legacy_call_time_override_warns_when_name_cannot_bind():
+def test_unbindable_call_time_control_name_is_rejected():
     def identity(x):
         return x
 
@@ -191,22 +161,11 @@ def test_legacy_call_time_override_warns_when_name_cannot_bind():
         seed=0,
     )
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        result = wf(Normal(loc=0.0, scale=1.0, name="x"), n_broadcast_samples=6)
-
-    legacy_warnings = [
-        warning
-        for warning in caught
-        if issubclass(warning.category, DeprecationWarning)
-    ]
-    assert len(legacy_warnings) == 1
-    assert "with_options" in str(legacy_warnings[0].message)
-    assert legacy_warnings[0].filename.endswith("test_workflow_options_namespace.py")
-    assert result.num_atoms == 6
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        wf(Normal(loc=0.0, scale=1.0, name="x"), n_broadcast_samples=6)
 
 
-def test_bindable_formerly_reserved_name_does_not_warn_or_override():
+def test_bindable_workflow_control_name_does_not_override():
     def identity(x, n_broadcast_samples):
         return x + n_broadcast_samples
 
@@ -218,12 +177,6 @@ def test_bindable_formerly_reserved_name_does_not_warn_or_override():
     )
     normal = Normal(loc=0.0, scale=1.0, name="x")
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        result = wf(x=normal, n_broadcast_samples=4)
+    result = wf(x=normal, n_broadcast_samples=4)
 
     assert result.num_atoms == 5
-    assert not any(
-        issubclass(warning.category, DeprecationWarning)
-        for warning in caught
-    )

--- a/tests/inference/test_bayesflow_posteriors.py
+++ b/tests/inference/test_bayesflow_posteriors.py
@@ -628,10 +628,12 @@ class TestBayesFlowMethods:
         assert (r > 0).all()        # forward bijector (Exp) keeps every draw in support
 
     def test_adapter_internal_names_avoid_collisions(self):
-        """No reserved field names: theta fields are re-keyed to internal adapter
-        names, so even fields named like BayesFlow's own keys ("observation",
-        "inference_variables") train and condition, with draws returned under the
-        user's names."""
+        """Theta fields are re-keyed away from BayesFlow adapter internals.
+
+        Fields named like BayesFlow's own keys (``"observation"``,
+        ``"inference_variables"``) train and condition, with draws returned
+        under the user's names.
+        """
         prior = ProductDistribution(
             Normal(loc=0.0, scale=1.0, name="observation"),
             Normal(loc=0.0, scale=1.0, name="inference_variables"),


### PR DESCRIPTION
## Summary

Remove all reserved names and wrappers in `@workflow_function`.

## Linked issue(s)

This is the clean-up stage of #254. There are no functional changes, only the reserved fields have been removed.