### PR TITLE
Bug fix(linalg): 3 small algebra bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Linear-algebra and Gaussian-conditioning edge cases on the algebra bug-fix
+  branch.** `RootLinOp.diag()` now squares diagonal roots; `CholeskyLinOp`
+  keeps lower-root (`L @ L.T`) and upper-root (`U.T @ U`) representations
+  consistent across `cholesky`, `to_cholesky_representation`, `matvec`,
+  `rmatvec`, `matmat`, `rmatmat`, `diag`, `to_dense`, and `solve`;
+  `JointGaussian.condition_on` uses linear solves instead of forming explicit
+  covariance inverses; and `SumLinOp.matmat` / `rmatmat` preserve the `(n, 1)`
+  matrix shape for single-column inputs.
+
+- **Invalid log-space weights are rejected before normalization.**
+  `Weights(log_weights=...)` now rejects `NaN` entries and zero-total-mass
+  inputs such as all `-inf`, avoiding downstream `nan` normalized weights while
+  still allowing individual `-inf` entries for zero-weight atoms.
+
 - **`StanModel` now works against a real BridgeStan backend.** Two bugs at the
   BridgeStan boundary were hidden by the mocked tests: construction passed a
   `data=` keyword that `bridgestan.StanModel.from_stan_file` does not accept,

--- a/probpipe/_weights.py
+++ b/probpipe/_weights.py
@@ -77,6 +77,13 @@ def _validate_to_log_weights(
                 f"log_weights shape {log_weights.shape} does not match "
                 f"number of items {n}."
             )
+        if jnp.any(jnp.isnan(log_weights)):
+            raise ValueError("log_weights must not contain NaN.")
+        total_log_weight = jax.scipy.special.logsumexp(log_weights)
+        if not jnp.isfinite(total_log_weight):
+            raise ValueError(
+                "log_weights must define a positive finite total weight."
+            )
         return log_weights, False
 
     return None, True
@@ -594,5 +601,4 @@ jax.tree_util.register_pytree_node(
     lambda w: w.tree_flatten(),
     lambda aux, children: Weights.tree_unflatten(aux, children),
 )
-
 

--- a/probpipe/distributions/_joint_gaussian.py
+++ b/probpipe/distributions/_joint_gaussian.py
@@ -7,11 +7,10 @@ from __future__ import annotations
 
 from types import MappingProxyType
 
-import jax
 import jax.numpy as jnp
 
-from .._dtype import _as_float_array, _promote_floats
-from ..core._record_distribution import RecordDistribution, _build_record_template
+from .._dtype import _promote_floats
+from ..core._record_distribution import _build_record_template
 from ..core.distribution import (
     NumericRecordDistribution,
     _mc_expectation,
@@ -219,7 +218,7 @@ class JointGaussian(NumericRecordDistribution, SupportsSampling, SupportsLogProb
 
     def _condition_on_impl(
         self, observed_leaves: dict[KeyPath, ArrayLike],
-    ) -> "JointGaussian":
+    ) -> JointGaussian:
         """Condition on observed component values using exact Gaussian formulas.
 
         Returns a new :class:`JointGaussian` over the remaining (unobserved)
@@ -280,10 +279,16 @@ class JointGaussian(NumericRecordDistribution, SupportsSampling, SupportsLogProb
         Sigma_uo = self._cov_mat[jnp.ix_(u_idx, o_idx)]
         Sigma_oo = self._cov_mat[jnp.ix_(o_idx, o_idx)]
 
-        # Gaussian conditioning: mu_u|o = mu_u + Sigma_uo @ Sigma_oo^{-1} @ (o - mu_o)
-        Sigma_oo_inv = jnp.linalg.inv(Sigma_oo)
-        cond_mean = mu_u + Sigma_uo @ Sigma_oo_inv @ (o_vals - mu_o)
-        cond_cov = Sigma_uu - Sigma_uo @ Sigma_oo_inv @ Sigma_uo.T
+        # Gaussian conditioning:
+        #   mu_u|o = mu_u + Sigma_uo Sigma_oo^{-1} (o - mu_o)
+        #   Sigma_u|o = Sigma_uu - Sigma_uo Sigma_oo^{-1} Sigma_ou
+        #
+        # Use solves instead of forming Sigma_oo^{-1}; this is both faster
+        # and numerically more stable.
+        solved_delta = jnp.linalg.solve(Sigma_oo, o_vals - mu_o)
+        solved_cross_cov = jnp.linalg.solve(Sigma_oo, Sigma_uo.T)
+        cond_mean = mu_u + Sigma_uo @ solved_delta
+        cond_cov = Sigma_uu - Sigma_uo @ solved_cross_cov
         # Symmetrise for numerical stability
         cond_cov = (cond_cov + cond_cov.T) / 2
 

--- a/probpipe/linalg/linear_operator.py
+++ b/probpipe/linalg/linear_operator.py
@@ -8,19 +8,21 @@ This file contains:
 """
 from __future__ import annotations
 
-from typing import Any, Iterable, FrozenSet, TypeAlias
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import Any, TypeAlias
+
 import jax.numpy as jnp
 import jax.scipy.linalg as jsla
-from abc import ABC, abstractmethod
-import math
 
-from ..custom_types import Array, ArrayLike
 from .._array_utils import (
-    _ensure_real_scalar,
-    _ensure_vector,
     _ensure_matrix,
+    _ensure_real_scalar,
     _ensure_square_matrix,
+    _ensure_vector,
 )
+from ..custom_types import Array, ArrayLike
+
 
 class LinAlgError(Exception):
     """Linear algebra error (e.g., singular matrix, non-positive-definite)."""
@@ -68,7 +70,7 @@ def _as_linear_operator(A: LinOpLike) -> LinOp:
             raise TypeError(
                 f"Could not convert A to linear operator\n"
                 f"DenseLinOp error: {e}"
-            )
+            ) from e
 
 
 # -----------------------------------------------------------------------------
@@ -221,7 +223,7 @@ class LinOp(ABC):
         return flag in self._flags
 
     @property
-    def flags(self) -> FrozenSet[str]:
+    def flags(self) -> frozenset[str]:
         """Return frozenset of current flags (read-only view)."""
         return frozenset(self._flags)
 
@@ -726,7 +728,7 @@ class RootLinOp(LinOp):
     
     def diag(self) -> Array:
         if isinstance(self.root, DiagonalLinOp):
-            return self.root.diagonal
+            return self.root.diagonal ** 2
 
         S = self.root.to_dense()
         return jnp.einsum('ij,ij->i', S, S)
@@ -757,6 +759,32 @@ class CholeskyLinOp(RootLinOp):
         super().__init__(root)
         self.add_flag("positive_definite")
 
+    def matvec(self, x: ArrayLike) -> Array:
+        if self.root.lower:
+            return self.root.matvec(self.root.rmatvec(x))
+        return self.root.rmatvec(self.root.matvec(x))
+
+    def rmatvec(self, x: ArrayLike) -> Array:
+        return self.matvec(x)
+
+    def matmat(self, X: ArrayLike) -> Array:
+        if self.root.lower:
+            return self.root.matmat(self.root.rmatmat(X))
+        return self.root.rmatmat(self.root.matmat(X))
+
+    def rmatmat(self, X: ArrayLike) -> Array:
+        return self.matmat(X)
+
+    def diag(self) -> Array:
+        S = self.root.to_dense()
+        axis = 1 if self.root.lower else 0
+        return jnp.sum(S ** 2, axis=axis)
+
+    def to_dense(self) -> Array:
+        S = self.root.to_dense()
+        if self.root.lower:
+            return S @ S.T
+        return S.T @ S
 
     def solve(self, b: ArrayLike, **kwargs) -> Array:
         """Linear solve using forward backward triangular substitution
@@ -770,16 +798,18 @@ class CholeskyLinOp(RootLinOp):
         b = _ensure_matrix(b, num_rows=self._n)
 
         S = self.root.to_dense()
-        y = jsla.solve_triangular(S, b, lower=self.root.lower)
-        return jsla.solve_triangular(S.T, y, lower=not self.root.lower)
+        if self.root.lower:
+            y = jsla.solve_triangular(S, b, lower=True)
+            return jsla.solve_triangular(S.T, y, lower=False)
+        y = jsla.solve_triangular(S.T, b, lower=True)
+        return jsla.solve_triangular(S, y, lower=False)
     
 
     def cholesky(self, lower: bool = True, **kwargs) -> TriangularLinOp:
         cholesky_factor = self.root
         if lower == cholesky_factor.lower:
             return cholesky_factor
-        else:
-            return cholesky_factor.T
+        return TriangularLinOp(cholesky_factor.to_dense().T, lower=lower)
         
     def to_cholesky_representation(self, lower: bool = True, **kwargs) -> CholeskyLinOp:
         """ Returns a copy of `self` """

--- a/probpipe/linalg/linear_operator.py
+++ b/probpipe/linalg/linear_operator.py
@@ -740,8 +740,11 @@ class RootLinOp(LinOp):
 
 
 class CholeskyLinOp(RootLinOp):
-    """A positive definite linear operator A represented by its lower 
-       L or upper L.T Cholesky factor such that A = L @ L.T"""
+    """Positive-definite operator represented by a Cholesky factor.
+
+    A lower root ``L`` represents ``A = L @ L.T``; an upper root ``U``
+    represents ``A = U.T @ U``.
+    """
 
     def __init__(self, root: TriangularLinOp) -> None:
         if not isinstance(root, TriangularLinOp):
@@ -754,27 +757,33 @@ class CholeskyLinOp(RootLinOp):
         self.add_flag("positive_definite")
 
     def matvec(self, x: ArrayLike) -> Array:
+        """Return ``A @ x`` for the represented SPD operator."""
         if self.root.lower:
             return self.root.matvec(self.root.rmatvec(x))
         return self.root.rmatvec(self.root.matvec(x))
 
     def rmatvec(self, x: ArrayLike) -> Array:
+        """Return ``A.T @ x``; equal to ``A @ x`` for this symmetric operator."""
         return self.matvec(x)
 
     def matmat(self, X: ArrayLike) -> Array:
+        """Return ``A @ X`` without densifying the Cholesky factor."""
         if self.root.lower:
             return self.root.matmat(self.root.rmatmat(X))
         return self.root.rmatmat(self.root.matmat(X))
 
     def rmatmat(self, X: ArrayLike) -> Array:
+        """Return ``A.T @ X``; equal to ``A @ X`` for this symmetric operator."""
         return self.matmat(X)
 
     def diag(self) -> Array:
+        """Return the diagonal of the represented SPD operator."""
         S = self.root.to_dense()
         axis = 1 if self.root.lower else 0
         return jnp.sum(S ** 2, axis=axis)
 
     def to_dense(self) -> Array:
+        """Return the dense matrix represented by the Cholesky factor."""
         S = self.root.to_dense()
         if self.root.lower:
             return S @ S.T
@@ -782,9 +791,11 @@ class CholeskyLinOp(RootLinOp):
 
     def solve(self, b: ArrayLike, **kwargs) -> Array:
         """Linear solve using forward backward triangular substitution
-        
-        To compute A^{-1}b = (L @ L.T)^{-1}b first compute y = L^{-1}b
-        then L.T^{-1}y.
+
+        For lower roots, compute ``A^{-1} b = (L @ L.T)^{-1} b`` by
+        solving through ``L`` and then ``L.T``. For upper roots, compute
+        ``A^{-1} b = (U.T @ U)^{-1} b`` by solving through ``U.T`` and
+        then ``U``.
         """
         b = jnp.asarray(b)
         if b.ndim < 2:

--- a/probpipe/linalg/linear_operator.py
+++ b/probpipe/linalg/linear_operator.py
@@ -383,9 +383,6 @@ class SumLinOp(LinOp):
             return self.to_dense() @ X
 
         # General path: sum per-op matmat (respects structured/sparse ops)
-        if X.shape[1] == 1:
-            return self.matvec(X)
-        
         arr = jnp.zeros((self.shape[0], X.shape[1]), dtype=self.dtype)
         for op in self.ops:
             arr = arr + op.matmat(X)
@@ -399,9 +396,6 @@ class SumLinOp(LinOp):
             return self.to_dense().T @ X
 
         # General path: sum per-op matmat (respects structured/sparse ops)
-        if X.shape[1] == 1:
-            return self.rmatvec(X)
-        
         arr = jnp.zeros((self.shape[1], X.shape[1]), dtype=self.dtype)
         for op in self.ops:
             arr = arr + op.rmatmat(X)

--- a/tests/distributions/test_joint_gaussian.py
+++ b/tests/distributions/test_joint_gaussian.py
@@ -297,6 +297,20 @@ class TestConditionOn:
         cond_var = variance(cond)
         np.testing.assert_allclose(float(cond_var["y"][0]), 0.36, atol=1e-5)
 
+    def test_conditioning_uses_linear_solve_not_explicit_inverse(self, monkeypatch):
+        def fail_inverse(_):
+            raise AssertionError("JointGaussian conditioning should not form an inverse")
+
+        monkeypatch.setattr(jnp.linalg, "inv", fail_inverse)
+
+        cov = jnp.array([[1.0, 0.4], [0.4, 2.0]])
+        jg = JointGaussian(mean=jnp.zeros(2), cov=cov, x=1, y=1)
+        cond = condition_on(jg, x=jnp.array([1.0]))
+
+        assert cond.fields == ("y",)
+        cond_mean = mean(cond)
+        np.testing.assert_allclose(float(cond_mean["y"][0]), 0.4, atol=1e-5)
+
     def test_conditional_covariance_schur_complement_3var(self):
         """Conditional covariance matches the Schur complement formula.
 

--- a/tests/linalg/test_linop.py
+++ b/tests/linalg/test_linop.py
@@ -3,8 +3,16 @@ import jax.numpy as jnp
 import pytest
 
 from probpipe.linalg.linear_operator import (
-    DenseLinOp, DiagonalLinOp, TriangularLinOp, TransposedLinOp,
-    ProductLinOp, SumLinOp, ScaledLinOp, ALLOWED_FLAGS, LinAlgError,
+    CholeskyLinOp,
+    DenseLinOp,
+    DiagonalLinOp,
+    LinAlgError,
+    ProductLinOp,
+    RootLinOp,
+    ScaledLinOp,
+    SumLinOp,
+    TransposedLinOp,
+    TriangularLinOp,
 )
 
 
@@ -84,6 +92,13 @@ def test_diagonal_matvec_solve_cholesky_flags():
     assert "positive_definite" in d.flags
 
 
+def test_root_linop_diag_matches_dense_for_diagonal_root():
+    root = DiagonalLinOp(jnp.array([2.0, 3.0]))
+    op = RootLinOp(root)
+
+    assert approx(op.diag(), jnp.diag(op.to_dense()))
+
+
 def test_triangular_solve_and_flags():
     L = jnp.array([[1.0, 0.0], [2.0, 3.0]])
     tri = TriangularLinOp(L, lower=True)
@@ -95,6 +110,24 @@ def test_triangular_solve_and_flags():
     # test rmatvec equivalence
     v = jnp.array([1.0, 2.0])
     assert approx(tri.rmatvec(v), L.T @ v)
+
+
+def test_cholesky_upper_factor_preserves_operator():
+    lower = TriangularLinOp(jnp.array([[2.0, 0.0], [1.0, 3.0]]), lower=True)
+    op = CholeskyLinOp(lower)
+    expected = lower.to_dense() @ lower.to_dense().T
+
+    upper = op.cholesky(lower=False)
+    assert isinstance(upper, TriangularLinOp)
+    assert not upper.lower
+    assert approx(upper.to_dense(), lower.to_dense().T)
+
+    upper_rep = op.to_cholesky_representation(lower=False)
+    assert isinstance(upper_rep, CholeskyLinOp)
+    assert approx(upper_rep.to_dense(), expected)
+
+    b = jnp.array([1.0, 2.0])
+    assert approx(upper_rep.solve(b), jnp.linalg.solve(expected, b))
 
 
 def test_transpose_flags_and_behavior():

--- a/tests/linalg/test_linop.py
+++ b/tests/linalg/test_linop.py
@@ -99,6 +99,14 @@ def test_root_linop_diag_matches_dense_for_diagonal_root():
     assert approx(op.diag(), jnp.diag(op.to_dense()))
 
 
+def test_root_linop_diag_matches_dense_for_full_root():
+    S = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    op = RootLinOp(DenseLinOp(S))
+    expected = S @ S.T
+
+    assert approx(op.diag(), jnp.diag(expected))
+
+
 def test_triangular_solve_and_flags():
     L = jnp.array([[1.0, 0.0], [2.0, 3.0]])
     tri = TriangularLinOp(L, lower=True)
@@ -113,18 +121,32 @@ def test_triangular_solve_and_flags():
 
 
 def test_cholesky_upper_factor_preserves_operator():
-    lower = TriangularLinOp(jnp.array([[2.0, 0.0], [1.0, 3.0]]), lower=True)
+    lower_matrix = jnp.array([[2.0, 0.0], [1.0, 3.0]])
+    lower = TriangularLinOp(lower_matrix, lower=True)
     op = CholeskyLinOp(lower)
-    expected = lower.to_dense() @ lower.to_dense().T
+    expected = lower_matrix @ lower_matrix.T
 
     upper = op.cholesky(lower=False)
     assert isinstance(upper, TriangularLinOp)
     assert not upper.lower
-    assert approx(upper.to_dense(), lower.to_dense().T)
+    assert approx(upper.to_dense(), lower_matrix.T)
+
+    x = jnp.array([1.0, -2.0])
+    X = jnp.array([[1.0, 2.0], [-2.0, 0.5]])
+    assert approx(op.matvec(x), expected @ x)
+    assert approx(op.rmatvec(x), expected.T @ x)
+    assert approx(op.matmat(X), expected @ X)
+    assert approx(op.rmatmat(X), expected.T @ X)
+    assert approx(op.diag(), jnp.diag(expected))
 
     upper_rep = op.to_cholesky_representation(lower=False)
     assert isinstance(upper_rep, CholeskyLinOp)
     assert approx(upper_rep.to_dense(), expected)
+    assert approx(upper_rep.matvec(x), expected @ x)
+    assert approx(upper_rep.rmatvec(x), expected.T @ x)
+    assert approx(upper_rep.matmat(X), expected @ X)
+    assert approx(upper_rep.rmatmat(X), expected.T @ X)
+    assert approx(upper_rep.diag(), jnp.diag(expected))
 
     b = jnp.array([1.0, 2.0])
     assert approx(upper_rep.solve(b), jnp.linalg.solve(expected, b))

--- a/tests/linalg/test_linop.py
+++ b/tests/linalg/test_linop.py
@@ -153,6 +153,12 @@ def test_sum_propagation_and_matmat():
     # sum dtype matches promoted
     assert s.dtype == jnp.result_type(d1.dtype, d2.dtype)
 
+    x_col = jnp.ones((2, 1))
+    assert s.matmat(x_col).shape == (2, 1)
+    assert approx(s.matmat(x_col), s.to_dense() @ x_col)
+    assert s.rmatmat(x_col).shape == (2, 1)
+    assert approx(s.rmatmat(x_col), s.to_dense().T @ x_col)
+
 
 def test_product_dtype_promotion_and_diagonal_product_flag():
     d1 = DiagonalLinOp(jnp.array([1.0, 2.0]))

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -43,6 +43,13 @@ class TestValidation:
         assert is_uniform is False
         npt.assert_allclose(log_w, jnp.array([-1.0, 0.0, -1.0]))
 
+    def test_log_weights_allow_negative_infinity_entries(self):
+        log_w, is_uniform = _validate_to_log_weights(
+            3, log_weights=jnp.array([0.0, -jnp.inf, -1.0])
+        )
+        assert is_uniform is False
+        npt.assert_allclose(log_w, jnp.array([0.0, -jnp.inf, -1.0]))
+
     def test_mutual_exclusivity(self):
         with pytest.raises(ValueError, match="either weights or log_weights"):
             _validate_to_log_weights(
@@ -71,6 +78,18 @@ class TestValidation:
         with pytest.raises(ValueError, match="shape"):
             _validate_to_log_weights(
                 3, log_weights=jnp.zeros(5)
+            )
+
+    def test_log_weights_all_negative_infinity_rejected(self):
+        with pytest.raises(ValueError, match="positive finite"):
+            _validate_to_log_weights(
+                3, log_weights=jnp.full(3, -jnp.inf)
+            )
+
+    def test_log_weights_nan_rejected(self):
+        with pytest.raises(ValueError, match="NaN"):
+            _validate_to_log_weights(
+                3, log_weights=jnp.array([0.0, jnp.nan, -1.0])
             )
 
 
@@ -190,6 +209,10 @@ class TestWeightsConstruction:
         assert w.is_uniform is False
         npt.assert_allclose(jnp.sum(w.normalized), 1.0, atol=1e-6)
 
+    def test_log_weights_allow_zero_mass_entries(self):
+        w = Weights(log_weights=jnp.array([0.0, -jnp.inf]))
+        npt.assert_allclose(w.normalized, jnp.array([1.0, 0.0]), atol=1e-6)
+
     def test_uniform_log_weights(self):
         w = Weights(n=5)
         npt.assert_allclose(w.log_normalized, jnp.full(5, -jnp.log(5.0)), atol=1e-6)
@@ -226,6 +249,10 @@ class TestWeightsConstruction:
     def test_zero_sum_rejected(self):
         with pytest.raises(ValueError, match="positive"):
             Weights(weights=jnp.zeros(3))
+
+    def test_all_negative_infinity_log_weights_rejected(self):
+        with pytest.raises(ValueError, match="positive finite"):
+            Weights(log_weights=jnp.array([-jnp.inf, -jnp.inf]))
 
 
 class TestWeightsProperties:


### PR DESCRIPTION
## Summary

Bug 1: `RootLinOp.diag()` returned an incorrect value for a `DiagonalLinOp` root. It directly returned `self.root.diagonal`, but `RootLinOp` represents `S @ S.T`, so diagonal-root entries must be squared.

Bug 2: `CholeskyLinOp.cholesky(lower=False)` returned a type that did not satisfy its own subsequent interfaces. The Cholesky representation now preserves both lower-root (`L @ L.T`) and upper-root (`U.T @ U`) operator semantics across `matvec`, `rmatvec`, `matmat`, `rmatmat`, `diag`, `to_dense`, and `solve`.

Bug 3: `JointGaussian.condition_on` used explicit matrix inversion. It now uses `jnp.linalg.solve`, avoiding explicit inverse formation while preserving the same conditional Gaussian algebra.

Bug 4: `SumLinOp.matmat` / `rmatmat` returned a 1-D vector for single-column matrix input. They now preserve the matrix contract and return `(n, 1)` / `(m, 1)` results.

Weights hardening: `Weights(log_weights=...)` now rejects `NaN` entries and zero-total-mass inputs such as all `-inf`, while still allowing individual `-inf` entries for zero-weight atoms.

Hygiene: `linear_operator.py` also includes small import/exception modernizations, and `CHANGELOG.md` now records the algebra, SumLinOp, and Weights fixes under `[Unreleased] / Fixed`.

## Test plan

```bash
.venv/bin/python -m pytest -p no:xdist -o "addopts=" --tb=short -q tests/linalg/test_linop.py tests/linalg/test_operations.py tests/distributions/test_joint_gaussian.py tests/test_weights.py
git diff --check
.venv/bin/ruff check --select F,E9 probpipe/linalg/linear_operator.py tests/linalg/test_linop.py CHANGELOG.md
```
