### PR TITLE
style: adopt ruff format for code formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Commits to ignore in `git blame` (mechanical, repo-wide changes).
+# Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# GitHub applies it automatically.
+
+# style: adopt ruff format and reformat the source tree
+9946d1ecd005606c474a4c01327eb7e22002d001

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
   # continue-on-error and scope to changed files. The ruff version is
   # read from .pre-commit-config.yaml (single source of truth) so this job
   # can't drift from the pre-commit pin that `pre-commit autoupdate` bumps;
-  # keep uv.lock's ruff in sync too for local `uv run ruff`. `ruff format`
-  # is intentionally not run (its style conflicts with the conventions in
-  # CONTRIBUTING.md).
+  # keep uv.lock's ruff in sync too for local `uv run ruff`. `ruff format
+  # --check` runs here too and IS blocking — the tree is autoformatted, so a
+  # misformatted file fails CI even while `ruff check` (lint) stays advisory.
   lint:
-    name: lint (advisory)
+    name: lint & format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -56,6 +56,9 @@ jobs:
       - name: Ruff check (advisory — does not gate merges)
         continue-on-error: true
         run: uvx "ruff@${{ steps.ruffver.outputs.ruff }}" check . --output-format=github
+
+      - name: Ruff format check (blocking — the tree is autoformatted)
+        run: uvx "ruff@${{ steps.ruffver.outputs.ruff }}" format --check .
 
   # Advisory pyright type check. Reports but does NOT gate merges
   # (continue-on-error). The source carries a type-debt baseline (much of

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,9 @@
 #
 # Hooks only see the files you're changing, so they ratchet the codebase clean
 # file-by-file rather than demanding a big-bang cleanup. `ruff` here flags but
-# does NOT auto-fix (no `--fix`) — fixes stay intentional and reviewable.
-#
-# Deliberately NOT included: `ruff format`. Its black-style output conflicts
-# with the hand-tuned horizontal-packing conventions documented in
-# CONTRIBUTING.md (§ Code formatting), so formatting stays manual for now.
+# does NOT auto-fix (no `--fix`) — fixes stay intentional and reviewable. The
+# `ruff-format` hook DOES rewrite files (that is its job); notebooks are excluded
+# from formatting via `[tool.ruff.format]` in pyproject.toml.
 #
 # This ruff rev is the single source of truth for the version: the CI lint job
 # reads it from here, and `pre-commit autoupdate` bumps it. Keep uv.lock's ruff
@@ -19,6 +17,8 @@ repos:
       - id: ruff
         name: ruff (lint)
         args: ["--output-format=full"]
+      - id: ruff-format
+        name: ruff (format)
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Adopt `ruff format` for code formatting.** Formatting is now owned by
+  `ruff format` (Black-style) rather than the previous manual horizontal-packing
+  conventions: the source tree was reformatted in one mechanical sweep (recorded
+  in `.git-blame-ignore-revs`), a `ruff-format` pre-commit hook reformats on
+  commit, and `ruff format --check` is a **blocking** CI step (the `ruff check`
+  lint stays advisory). Notebooks are excluded so the docs' tutorial cells keep
+  their hand layout; string quotes normalize to double. See
+  [CONTRIBUTING.md § Code formatting](CONTRIBUTING.md#code-formatting).
+
 - **`provenance_ancestors()` now returns `ParentInfo` descriptors, not live
   Distribution objects (breaking change).**  Under the previous always-live
   model, every element of the returned list was a `Distribution` or `Record`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,57 +179,22 @@ conventions in [STYLE_GUIDE.md § 8.6](STYLE_GUIDE.md#86-numerical-correctness-a
 
 ### Code formatting
 
-Keep Python code compact horizontally. The hard upper bound is 100
-chars per line; the soft target is 80–100. **Do not introduce line
-breaks that aren't needed to stay within that range** — multi-name
-imports should be packed per line rather than spread one name per
-line, and short function calls should stay on one line.
+Formatting is owned by **`ruff format`** (Black-style) — don't hand-format
+Python. The `ruff-format` pre-commit hook reformats on commit; run it directly
+with:
 
-```python
-# Avoid — over-vertical:
-from probpipe import (
-    Normal,
-    Beta,
-    Gamma,
-    sample,
-    log_prob,
-)
-
-# Prefer — packed (drop the parens when the whole import fits one line):
-from probpipe import Normal, Beta, Gamma, sample, log_prob
+```bash
+uv run ruff format .          # reformat the tree
+uv run ruff format --check .  # verify (this is what CI enforces)
 ```
 
-Same idea applies to *where* you break a function call, container
-literal, or import — prefer keeping the first argument on the opener
-line and aligning subsequent lines under it, rather than breaking
-right after the open paren / bracket / brace. Break after `(` only
-when the opener line is already long enough that aligned continuation
-would have too little horizontal room.
-
-```python
-# Avoid — gratuitous break after `(`:
-result = expectation(
-    n, lambda x: jnp.sin(x),
-    key=jax.random.PRNGKey(10),
-)
-
-# Prefer — first arg on opener line, continuation aligned:
-result = expectation(n, lambda x: jnp.sin(x),
-                     key=jax.random.PRNGKey(10))
-
-# OK to break after `(` when the opener is already long:
-result = some.deeply.nested.module.function_with_long_name(
-    arg1, arg2, kwarg=value,
-)
-```
-
-The exception is constructions where each kwarg's value is itself a
-meaningful sub-expression — `MultivariateNormal(loc=..., cov=...)`,
-`xr.DataArray(data, dims=..., coords=...)`, etc. Per-kwarg vertical
-layout helps readability there even when the call would fit on one
-line.
-
-This applies equally to source files and notebook code cells.
+`ruff format --check` is a **blocking** CI step, so a misformatted file fails the
+build (`ruff check`, the linter, stays advisory). A few specifics: the line
+length is 100 (`[tool.ruff]` in `pyproject.toml`); ruff keeps code on one line
+when it fits and explodes imports / call arguments one-item-per-line when it does
+not; string quotes normalize to double. Notebooks are excluded
+(`[tool.ruff.format] exclude` in `pyproject.toml`), so the docs' tutorial cells
+keep their compact, hand-curated layout.
 
 ### Code comments & docstrings
 
@@ -260,7 +225,7 @@ Linting uses [ruff](https://docs.astral.sh/ruff/) (configured in
 uvx pre-commit install      # or: pre-commit install
 ```
 
-Thereafter `ruff` (lint) plus a few file-hygiene hooks run on your staged
+Thereafter `ruff` (lint + format) plus a few file-hygiene hooks run on your staged
 files at commit time. The hooks see only the files you're changing, so the
 codebase cleans up file-by-file rather than in one sweep. To run manually:
 
@@ -276,17 +241,19 @@ files you did not touch. That is expected for now, not a regression.
 
 Two deliberate choices:
 
-- **`ruff check` is advisory in CI for now.** ProbPipe carries a lint
+- **`ruff check` (lint) is advisory in CI for now.** ProbPipe carries a lint
   backlog from a period when ruff wasn't enforced, and several large
-  refactors are in flight. The CI `lint (advisory)` job annotates PRs with
-  violations but does not yet gate merges; it will become blocking once the
-  backlog is burned down. Locally, the pre-commit hook flags issues on the
+  refactors are in flight. The `ruff check` step in the `lint & format` job
+  annotates PRs with violations but does not gate merges; it will become
+  blocking once the backlog is burned down. Locally, the pre-commit hook flags
+  issues on the
   files you touch — fix them when practical; `git commit --no-verify`
   bypasses it for a pre-existing-violation file you'd rather not clean in
   an unrelated change.
-- **`ruff format` is not used.** Its output conflicts with the horizontal
-  packing conventions in *Code formatting* above, so formatting stays
-  manual. Only `ruff check` runs.
+- **`ruff format` is enforced.** Formatting is owned by `ruff format` (see
+  *Code formatting* above): `ruff format --check` is a blocking CI step and the
+  `ruff-format` pre-commit hook reformats on commit. `ruff check` (lint) is the
+  part that stays advisory.
 
 ### Type checking
 

--- a/example_scripts/run_prefect_demo.py
+++ b/example_scripts/run_prefect_demo.py
@@ -24,6 +24,7 @@ Prerequisites
 """
 
 import warnings
+
 warnings.filterwarnings("ignore", message=r"Explicitly requested dtype.*float64.*")
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -37,10 +38,17 @@ import tensorflow_probability.substrates.jax.glm as tfp_glm
 
 import probpipe
 from probpipe import (
-    Record, Normal, ProductDistribution,
-    EmpiricalDistribution, BootstrapReplicateDistribution,
-    GLMLikelihood, SimpleModel, WorkflowKind,
-    condition_on, mean, workflow_function,
+    Record,
+    Normal,
+    ProductDistribution,
+    EmpiricalDistribution,
+    BootstrapReplicateDistribution,
+    GLMLikelihood,
+    SimpleModel,
+    WorkflowKind,
+    condition_on,
+    mean,
+    workflow_function,
 )
 
 
@@ -80,12 +88,8 @@ prior = ProductDistribution(
     slope=Normal(loc=0.0, scale=jnp.sqrt(5.0), name="slope"),
 )
 
-model_poisson = SimpleModel(
-    prior, GLMLikelihood(tfp_glm.Poisson(), data["X"]), name="poisson"
-)
-model_nb = SimpleModel(
-    prior, GLMLikelihood(tfp_glm.NegativeBinomial(), data["X"]), name="negbin"
-)
+model_poisson = SimpleModel(prior, GLMLikelihood(tfp_glm.Poisson(), data["X"]), name="poisson")
+model_nb = SimpleModel(prior, GLMLikelihood(tfp_glm.NegativeBinomial(), data["X"]), name="negbin")
 
 print(f"Observations: {len(data['y'])}")
 print(f"Models: {model_poisson.name}, {model_nb.name}")
@@ -134,9 +138,7 @@ probpipe.prefect_config.workflow_kind = WorkflowKind.OFF
 
 for label, bagged in [("Poisson", bagged_poisson), ("NegBin", bagged_nb)]:
     ind_means = np.array([np.array(mean(p).flatten()) for p in bagged.components])
-    all_draws = np.concatenate(
-        [np.asarray(p.draws().flatten()) for p in bagged.components]
-    )
+    all_draws = np.concatenate([np.asarray(p.draws().flatten()) for p in bagged.components])
     ratio = np.var(ind_means, axis=0) / np.var(all_draws, axis=0)
     print(f"{label}:")
     print(f"  Posterior mean: {np.array2string(np.mean(ind_means, axis=0), precision=3)}")

--- a/example_scripts/run_ray_demo.py
+++ b/example_scripts/run_ray_demo.py
@@ -55,6 +55,7 @@ Ray's serialization and dependency documentation before choosing between
 """
 
 import warnings
+
 warnings.filterwarnings("ignore", message=r"Explicitly requested dtype.*float64.*")
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -68,10 +69,17 @@ import tensorflow_probability.substrates.jax.glm as tfp_glm
 
 import probpipe
 from probpipe import (
-    Record, Normal, ProductDistribution,
-    EmpiricalDistribution, BootstrapReplicateDistribution,
-    GLMLikelihood, SimpleModel, WorkflowKind,
-    condition_on, mean, workflow_function,
+    Record,
+    Normal,
+    ProductDistribution,
+    EmpiricalDistribution,
+    BootstrapReplicateDistribution,
+    GLMLikelihood,
+    SimpleModel,
+    WorkflowKind,
+    condition_on,
+    mean,
+    workflow_function,
 )
 
 
@@ -121,12 +129,8 @@ prior = ProductDistribution(
     slope=Normal(loc=0.0, scale=jnp.sqrt(5.0), name="slope"),
 )
 
-model_poisson = SimpleModel(
-    prior, GLMLikelihood(tfp_glm.Poisson(), data["X"]), name="poisson"
-)
-model_nb = SimpleModel(
-    prior, GLMLikelihood(tfp_glm.NegativeBinomial(), data["X"]), name="negbin"
-)
+model_poisson = SimpleModel(prior, GLMLikelihood(tfp_glm.Poisson(), data["X"]), name="poisson")
+model_nb = SimpleModel(prior, GLMLikelihood(tfp_glm.NegativeBinomial(), data["X"]), name="negbin")
 
 print(f"Observations: {len(data['y'])}")
 print(f"Models: {model_poisson.name}, {model_nb.name}")
@@ -175,9 +179,7 @@ probpipe.prefect_config.workflow_kind = WorkflowKind.OFF
 
 for label, bagged in [("Poisson", bagged_poisson), ("NegBin", bagged_nb)]:
     ind_means = np.array([np.array(mean(p).flatten()) for p in bagged.components])
-    all_draws = np.concatenate(
-        [np.asarray(p.draws().flatten()) for p in bagged.components]
-    )
+    all_draws = np.concatenate([np.asarray(p.draws().flatten()) for p in bagged.components])
     ratio = np.var(ind_means, axis=0) / np.var(all_draws, axis=0)
     print(f"{label}:")
     print(f"  Posterior mean: {np.array2string(np.mean(ind_means, axis=0), precision=3)}")

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -114,7 +114,13 @@ from probpipe.core._array_backend import (
     register_aux,
 )
 from probpipe.core.config import WorkflowKind, prefect_config, provenance_config, ProvenanceMode
-from probpipe.core.node import WorkflowFunction, Module, workflow_function, workflow_method, abstract_workflow_method
+from probpipe.core.node import (
+    WorkflowFunction,
+    Module,
+    workflow_function,
+    workflow_method,
+    abstract_workflow_method,
+)
 from probpipe.core.provenance import ParentInfo, Provenance, provenance_ancestors, provenance_dag
 from probpipe.core.constraints import (
     Constraint,
@@ -137,8 +143,11 @@ from probpipe.core.transition import (
     with_resampling,
 )
 from probpipe.modeling import (
-    GLMLikelihood, Likelihood, ConditionallyIndependentLikelihood,
-    GenerativeLikelihood, IncrementalConditioner,
+    GLMLikelihood,
+    Likelihood,
+    ConditionallyIndependentLikelihood,
+    GenerativeLikelihood,
+    IncrementalConditioner,
 )
 from probpipe.record import Design, FullFactorialDesign
 from probpipe.inference import (

--- a/probpipe/_array_utils.py
+++ b/probpipe/_array_utils.py
@@ -17,6 +17,7 @@ from .custom_types import Array, ArrayLike
 def _is_array(x: Any) -> bool:
     return isinstance(x, jnp.ndarray)
 
+
 def _as_array(x: Any) -> Array:
     try:
         return jnp.asarray(x)
@@ -26,7 +27,8 @@ def _as_array(x: Any) -> Array:
             f"Input type: {type(x).__name__}\n"
             f"Input value: {repr(x)}\n"
             f"Original error: {e}"
-        ) from e  
+        ) from e
+
 
 def _is_numpy_scalar(x: Any) -> bool:
     """Return true if object is a Python scalar or 0-d JAX array."""
@@ -35,7 +37,7 @@ def _is_numpy_scalar(x: Any) -> bool:
     )
 
 
-def _ensure_real_scalar(x: Any, *, as_array: bool = False) -> float|int|Array:
+def _ensure_real_scalar(x: Any, *, as_array: bool = False) -> float | int | Array:
     """
     Return a Python scalar or 0d array for inputs that contain a single real value.
 
@@ -64,7 +66,9 @@ def _ensure_real_scalar(x: Any, *, as_array: bool = False) -> float|int|Array:
 
     arr = _as_array(x)
     if arr.size != 1:
-        raise ValueError(f"_ensure_real_scalar: input must contain exactly one element; got size={arr.size}, shape={arr.shape}")
+        raise ValueError(
+            f"_ensure_real_scalar: input must contain exactly one element; got size={arr.size}, shape={arr.shape}"
+        )
     if jnp.iscomplexobj(arr):
         raise ValueError(f"_ensure_real_scalar: input is complex-valued (shape={arr.shape}).")
 
@@ -97,11 +101,14 @@ def _ensure_scalar(x: Any) -> Any:
     if arr.size == 1:
         return arr.item()
     else:
-        raise ValueError(f"_ensure_scalar: input cannot be converted to a scalar (size={arr.size}, shape={arr.shape})")
+        raise ValueError(
+            f"_ensure_scalar: input cannot be converted to a scalar (size={arr.size}, shape={arr.shape})"
+        )
 
 
-def _ensure_vector(x: ArrayLike, *, as_column: bool = False,
-                   length: int | None = None, copy: bool = True) -> Array:
+def _ensure_vector(
+    x: ArrayLike, *, as_column: bool = False, length: int | None = None, copy: bool = True
+) -> Array:
     """
     Ensure input is returned as a 1-D vector (canonical shape (n,)) by default.
     If as_column=True, return shape (n,1).
@@ -127,7 +134,9 @@ def _ensure_vector(x: ArrayLike, *, as_column: bool = False,
             v = jnp.ravel(arr)
             out = v.reshape((-1, 1)) if as_column else v
         else:
-            raise ValueError(f"_ensure_vector: 2D input has shape {arr.shape}, which is not a vector (expected (n,1) or (1,n)).")
+            raise ValueError(
+                f"_ensure_vector: 2D input has shape {arr.shape}, which is not a vector (expected (n,1) or (1,n))."
+            )
     else:
         raise ValueError(f"_ensure_vector: input has too many dimensions (ndim={arr.ndim}).")
 
@@ -138,10 +147,15 @@ def _ensure_vector(x: ArrayLike, *, as_column: bool = False,
     return out.copy() if copy else out
 
 
-def _ensure_matrix(x: ArrayLike, *, as_row_matrix: bool = False,
-                   num_rows: int | None = None, num_cols: int | None = None,
-                   copy: bool = True) -> Array:
-    """ Ensure input is a 2D matrix
+def _ensure_matrix(
+    x: ArrayLike,
+    *,
+    as_row_matrix: bool = False,
+    num_rows: int | None = None,
+    num_cols: int | None = None,
+    copy: bool = True,
+) -> Array:
+    """Ensure input is a 2D matrix
 
     - Scalar inputs (0D) become arrays of shape (1, 1)
     - 1D inputs become:
@@ -162,7 +176,9 @@ def _ensure_matrix(x: ArrayLike, *, as_row_matrix: bool = False,
     elif arr.ndim == 0:
         out = arr.reshape(1, 1)
     else:
-        raise ValueError(f"_ensure_matrix: Input cannot be converted to a 2D matrix. Shape {arr.shape}")
+        raise ValueError(
+            f"_ensure_matrix: Input cannot be converted to a 2D matrix. Shape {arr.shape}"
+        )
 
     if num_rows is not None and out.shape[0] != num_rows:
         raise ValueError(f"_ensure_matrix: Required {num_rows} rows. Got {out.shape[0]}.")
@@ -190,8 +206,10 @@ def _ensure_square_matrix(x: ArrayLike, n: int | None = None, *, copy: bool = Tr
 # Batch arrays
 # ------------------------------------------------------------------------------
 
-def _ensure_batch_array(x: ArrayLike, value_shape: tuple[int, ...] | None = None,
-                        *, copy: bool = True) -> Array:
+
+def _ensure_batch_array(
+    x: ArrayLike, value_shape: tuple[int, ...] | None = None, *, copy: bool = True
+) -> Array:
     """Ensure `x` has a leading batch axis and optionally enforce value shape.
 
     A batch array is defined as an array with dimension at least two, where the
@@ -243,7 +261,7 @@ def _ensure_batch_array(x: ArrayLike, value_shape: tuple[int, ...] | None = None
         if arr.ndim == 0:
             arr = arr.reshape((1,))  # () -> (1,)
         elif arr.ndim == 1:
-            arr = arr[None, :] # (d,) -> (1,d)
+            arr = arr[None, :]  # (d,) -> (1,d)
 
     # Optionally validate value shape
     if value_shape is not None:
@@ -286,11 +304,12 @@ def _ensure_batch_real_scalar(x: ArrayLike, *, copy: bool = True) -> Array:
         if jnp.iscomplexobj(arr):
             raise ValueError("_ensure_batch_real_scalar: input contains complex values.")
         return arr.copy() if copy else arr
-    raise ValueError(f"_ensure_batch_real_scalar: expected scalar or 1D array. Got shape={arr.shape}.")
+    raise ValueError(
+        f"_ensure_batch_real_scalar: expected scalar or 1D array. Got shape={arr.shape}."
+    )
 
 
-def _ensure_batch_vector(x: ArrayLike, length: int | None = None,
-                         *, copy: bool = True) -> Array:
+def _ensure_batch_vector(x: ArrayLike, length: int | None = None, *, copy: bool = True) -> Array:
     """Ensure `x` is a batch of vectors and return shape (B, d).
 
     This function returns an array of shape (B, d) encoding a batch vector,
@@ -326,13 +345,21 @@ def _ensure_batch_vector(x: ArrayLike, length: int | None = None,
 
     # Validate vector length
     if length is not None and arr.shape[1] != length:
-        raise ValueError(f"_ensure_batch_vector: Required vector length {length}. Got {arr.shape[1]}.")
+        raise ValueError(
+            f"_ensure_batch_vector: Required vector length {length}. Got {arr.shape[1]}."
+        )
 
     return arr.copy() if copy else arr
 
 
-def _ensure_batch_matrix(x: ArrayLike, num_rows: int | None = None, num_cols: int | None = None,
-                         as_row_matrix: bool = True, *, copy: bool = True) -> Array:
+def _ensure_batch_matrix(
+    x: ArrayLike,
+    num_rows: int | None = None,
+    num_cols: int | None = None,
+    as_row_matrix: bool = True,
+    *,
+    copy: bool = True,
+) -> Array:
     """Ensure `x` is a batch of matrices and return shape (B, n, m).
 
     This function returns an array of shape (B, n, m) encoding a batch matrix,
@@ -374,6 +401,7 @@ def _ensure_batch_matrix(x: ArrayLike, num_rows: int | None = None, num_cols: in
         raise ValueError(f"_ensure_batch_matrix: Required {num_cols} rows. Got {arr.shape[2]}.")
 
     return arr.copy() if copy else arr
+
 
 def _slice_leading_axes(value: Any, multi_index: tuple[int, ...]) -> Any:
     """Index the leading ``len(multi_index)`` axes of ``value`` at the given

--- a/probpipe/_weights.py
+++ b/probpipe/_weights.py
@@ -29,6 +29,7 @@ __all__ = [
 # Pure utility functions (internal workhorses)
 # ---------------------------------------------------------------------------
 
+
 def _validate_to_log_weights(
     n: int,
     weights: ArrayLike | None = None,
@@ -59,10 +60,7 @@ def _validate_to_log_weights(
     if weights is not None:
         weights = _as_float_array(weights)
         if weights.shape != (n,):
-            raise ValueError(
-                f"weights shape {weights.shape} does not match "
-                f"number of items {n}."
-            )
+            raise ValueError(f"weights shape {weights.shape} does not match number of items {n}.")
         if jnp.any(weights < 0):
             raise ValueError("weights must be non-negative.")
         total = jnp.sum(weights)
@@ -74,16 +72,13 @@ def _validate_to_log_weights(
         log_weights = _as_float_array(log_weights)
         if log_weights.shape != (n,):
             raise ValueError(
-                f"log_weights shape {log_weights.shape} does not match "
-                f"number of items {n}."
+                f"log_weights shape {log_weights.shape} does not match number of items {n}."
             )
         if jnp.any(jnp.isnan(log_weights)):
             raise ValueError("log_weights must not contain NaN.")
         total_log_weight = jax.scipy.special.logsumexp(log_weights)
         if not jnp.isfinite(total_log_weight):
-            raise ValueError(
-                "log_weights must define a positive finite total weight."
-            )
+            raise ValueError("log_weights must define a positive finite total weight.")
         return log_weights, False
 
     return None, True
@@ -150,7 +145,7 @@ def weighted_variance(
     if mean is None:
         mean = weighted_mean(weights, values)
     diff = values - mean
-    return weighted_mean(weights, diff ** 2)
+    return weighted_mean(weights, diff**2)
 
 
 def weighted_covariance(
@@ -219,7 +214,11 @@ def weighted_choice(
         indices = jax.random.randint(key, shape=shape, minval=0, maxval=n)
     else:
         indices = jax.random.choice(
-            key, n, shape=shape, p=weights, replace=True,
+            key,
+            n,
+            shape=shape,
+            p=weights,
+            replace=True,
         )
 
     if squeeze:
@@ -230,6 +229,7 @@ def weighted_choice(
 # ---------------------------------------------------------------------------
 # Weights class
 # ---------------------------------------------------------------------------
+
 
 class Weights:
     """Normalized probability weights over *n* items.
@@ -343,22 +343,16 @@ class Weights:
         source = None
         if isinstance(weights, Weights):
             if log_weights is not None:
-                raise ValueError(
-                    "Provide either weights or log_weights, not both."
-                )
+                raise ValueError("Provide either weights or log_weights, not both.")
             source = weights
         elif isinstance(log_weights, Weights):
             if weights is not None:
-                raise ValueError(
-                    "Provide either weights or log_weights, not both."
-                )
+                raise ValueError("Provide either weights or log_weights, not both.")
             source = log_weights
 
         if source is not None:
             if n is not None and source._n != n:
-                raise ValueError(
-                    f"Weights length {source._n} does not match n={n}."
-                )
+                raise ValueError(f"Weights length {source._n} does not match n={n}.")
             self._n = source._n
             self._log_weights = source._log_weights
             self._is_uniform = source._is_uniform
@@ -379,13 +373,12 @@ class Weights:
                     raise ValueError("log_weights must be a non-empty 1-D array.")
                 n = log_weights.shape[0]
             else:
-                raise ValueError(
-                    "At least one of n, weights, or log_weights must be "
-                    "provided."
-                )
+                raise ValueError("At least one of n, weights, or log_weights must be provided.")
 
         self._log_weights, self._is_uniform = _validate_to_log_weights(
-            n, weights, log_weights=log_weights,
+            n,
+            weights,
+            log_weights=log_weights,
         )
         self._n = n
 
@@ -520,25 +513,31 @@ class Weights:
     def mean(self, values: Array) -> Array:
         """Compute weighted mean: ``sum_i w_i * values[i]``."""
         return weighted_mean(
-            None if self._is_uniform else self.normalized, values,
+            None if self._is_uniform else self.normalized,
+            values,
         )
 
     def variance(self, values: Array, mean: Array | None = None) -> Array:
         """Compute weighted variance over the leading axis."""
         return weighted_variance(
-            None if self._is_uniform else self.normalized, values, mean=mean,
+            None if self._is_uniform else self.normalized,
+            values,
+            mean=mean,
         )
 
     def covariance(self, values: Array, mean: Array | None = None) -> Array:
         """Compute weighted covariance matrix over the leading axis."""
         return weighted_covariance(
-            None if self._is_uniform else self.normalized, values, mean=mean,
+            None if self._is_uniform else self.normalized,
+            values,
+            mean=mean,
         )
 
     def choice(self, key: PRNGKey, *, shape: tuple[int, ...] = ()) -> Array:
         """Draw weighted random indices from ``0..n-1``."""
         return weighted_choice(
-            key, self._n,
+            key,
+            self._n,
             weights=None if self._is_uniform else self.normalized,
             shape=shape,
         )
@@ -601,4 +600,3 @@ jax.tree_util.register_pytree_node(
     lambda w: w.tree_flatten(),
     lambda aux, children: Weights.tree_unflatten(aux, children),
 )
-

--- a/probpipe/converters/__init__.py
+++ b/probpipe/converters/__init__.py
@@ -7,7 +7,13 @@ conversion** – passing a ``@runtime_checkable`` protocol (e.g.,
 ``SupportsLogProb``) as the target to ``converter_registry.convert()``.
 """
 
-from ._registry import Converter, ConverterRegistry, ConversionInfo, ConversionMethod, converter_registry
+from ._registry import (
+    Converter,
+    ConverterRegistry,
+    ConversionInfo,
+    ConversionMethod,
+    converter_registry,
+)
 
 # -- register built-in converters -------------------------------------------
 
@@ -20,6 +26,7 @@ converter_registry.register(TFPConverter())
 # Optionally register scipy converter
 try:
     from ._scipy import ScipyConverter, _HAS_SCIPY
+
     if _HAS_SCIPY:
         converter_registry.register(ScipyConverter())
 except ImportError:

--- a/probpipe/converters/_probpipe.py
+++ b/probpipe/converters/_probpipe.py
@@ -38,6 +38,7 @@ DEFAULT_NUM_SAMPLES = 1024
 # Moment-matching helpers using expectation()
 # ---------------------------------------------------------------------------
 
+
 def _mm_provenance(source, mean_result=None, var_result=None):
     """Build provenance for a moment-matching conversion.
 
@@ -46,6 +47,7 @@ def _mm_provenance(source, mean_result=None, var_result=None):
     users can inspect conversion error.
     """
     from ..core.distribution import BootstrapDistribution
+
     metadata = {}
     if isinstance(mean_result, BootstrapDistribution):
         metadata["mean_bootstrap"] = mean_result
@@ -61,6 +63,7 @@ def _point_estimate(x):
     as a single-field Record)."""
     from ..core.distribution import BootstrapDistribution
     from ..core._numeric_record import NumericRecord
+
     if isinstance(x, BootstrapDistribution):
         x = x._mean()
     if isinstance(x, NumericRecord) and len(x.fields) == 1:
@@ -75,8 +78,10 @@ def _point_estimate(x):
 #   (source, key, **kwargs) -> Distribution
 # ---------------------------------------------------------------------------
 
+
 def _convert_to_normal(source, key, **kw):
     from ..distributions.continuous import Normal
+
     if isinstance(source, Normal):
         return source
     kw.pop("num_samples", None)
@@ -89,6 +94,7 @@ def _convert_to_normal(source, key, **kw):
 
 def _convert_to_beta(source, key, **kw):
     from ..distributions.continuous import Beta
+
     if isinstance(source, Beta):
         return source
     kw.pop("num_samples", None)
@@ -104,25 +110,27 @@ def _convert_to_beta(source, key, **kw):
 
 def _convert_to_gamma(source, key, **kw):
     from ..distributions.continuous import Gamma
+
     if isinstance(source, Gamma):
         return source
     kw.pop("num_samples", None)
     m_raw, v_raw = source._mean(), source._variance()
     m, v = _point_estimate(m_raw), _point_estimate(v_raw)
-    r = Gamma(concentration=m ** 2 / v, rate=m / v, name=kw.get("name") or source.name)
+    r = Gamma(concentration=m**2 / v, rate=m / v, name=kw.get("name") or source.name)
     r.with_source(_mm_provenance(source, m_raw, v_raw))
     return r
 
 
 def _convert_to_inverse_gamma(source, key, **kw):
     from ..distributions.continuous import InverseGamma
+
     if isinstance(source, InverseGamma):
         return source
     kw.pop("num_samples", None)
     m_raw, v_raw = source._mean(), source._variance()
     m, v = _point_estimate(m_raw), _point_estimate(v_raw)
-    conc = m ** 2 / v + 2
-    scale = m * (m ** 2 / v + 1)
+    conc = m**2 / v + 2
+    scale = m * (m**2 / v + 1)
     r = InverseGamma(concentration=conc, scale=scale, name=kw.get("name") or source.name)
     r.with_source(_mm_provenance(source, m_raw, v_raw))
     return r
@@ -130,6 +138,7 @@ def _convert_to_inverse_gamma(source, key, **kw):
 
 def _convert_to_exponential(source, key, **kw):
     from ..distributions.continuous import Exponential
+
     if isinstance(source, Exponential):
         return source
     kw.pop("num_samples", None)
@@ -142,13 +151,14 @@ def _convert_to_exponential(source, key, **kw):
 
 def _convert_to_lognormal(source, key, **kw):
     from ..distributions.continuous import LogNormal
+
     if isinstance(source, LogNormal):
         return source
     kw.pop("num_samples", None)
     m_raw, v_raw = source._mean(), source._variance()
     m, v = _point_estimate(m_raw), _point_estimate(v_raw)
-    scale = jnp.sqrt(jnp.log(1.0 + v / (m ** 2)))
-    loc = jnp.log(m) - scale ** 2 / 2.0
+    scale = jnp.sqrt(jnp.log(1.0 + v / (m**2)))
+    loc = jnp.log(m) - scale**2 / 2.0
     r = LogNormal(loc=loc, scale=scale, name=kw.get("name") or source.name)
     r.with_source(_mm_provenance(source, m_raw, v_raw))
     return r
@@ -156,6 +166,7 @@ def _convert_to_lognormal(source, key, **kw):
 
 def _convert_to_studentt(source, key, **kw):
     from ..distributions.continuous import StudentT
+
     if isinstance(source, StudentT):
         return source
     kw.pop("num_samples", None)
@@ -163,13 +174,16 @@ def _convert_to_studentt(source, key, **kw):
     m, v = _point_estimate(m_raw), _point_estimate(v_raw)
     # var = scale^2 * df/(df-2) for df>2, so scale = sqrt(var * (df-2)/df)
     df = 5.0
-    r = StudentT(df=df, loc=m, scale=jnp.sqrt(v * (df - 2.0) / df), name=kw.get("name") or source.name)
+    r = StudentT(
+        df=df, loc=m, scale=jnp.sqrt(v * (df - 2.0) / df), name=kw.get("name") or source.name
+    )
     r.with_source(_mm_provenance(source, m_raw, v_raw))
     return r
 
 
 def _convert_to_uniform(source, key, **kw):
     from ..distributions.continuous import Uniform
+
     if isinstance(source, Uniform):
         return source
     kw.pop("num_samples", None)
@@ -183,6 +197,7 @@ def _convert_to_uniform(source, key, **kw):
 
 def _convert_to_cauchy(source, key, **kw):
     from ..distributions.continuous import Cauchy
+
     if isinstance(source, Cauchy):
         return source
     kw.pop("num_samples", None)
@@ -195,6 +210,7 @@ def _convert_to_cauchy(source, key, **kw):
 
 def _convert_to_laplace(source, key, **kw):
     from ..distributions.continuous import Laplace
+
     if isinstance(source, Laplace):
         return source
     kw.pop("num_samples", None)
@@ -207,6 +223,7 @@ def _convert_to_laplace(source, key, **kw):
 
 def _convert_to_halfnormal(source, key, **kw):
     from ..distributions.continuous import HalfNormal
+
     if isinstance(source, HalfNormal):
         return source
     kw.pop("num_samples", None)
@@ -220,6 +237,7 @@ def _convert_to_halfnormal(source, key, **kw):
 
 def _convert_to_halfcauchy(source, key, **kw):
     from ..distributions.continuous import HalfCauchy
+
     if isinstance(source, HalfCauchy):
         return source
     num_samples = kw.pop("num_samples", DEFAULT_NUM_SAMPLES)
@@ -234,6 +252,7 @@ def _convert_to_halfcauchy(source, key, **kw):
 
 def _convert_to_pareto(source, key, **kw):
     from ..distributions.continuous import Pareto
+
     if isinstance(source, Pareto):
         return source
     num_samples = kw.pop("num_samples", DEFAULT_NUM_SAMPLES)
@@ -250,6 +269,7 @@ def _convert_to_pareto(source, key, **kw):
 
 def _convert_to_truncatednormal(source, key, **kw):
     from ..distributions.continuous import TruncatedNormal
+
     if isinstance(source, TruncatedNormal):
         return source
     num_samples = kw.pop("num_samples", DEFAULT_NUM_SAMPLES)
@@ -259,8 +279,10 @@ def _convert_to_truncatednormal(source, key, **kw):
     m, v = _point_estimate(m_raw), _point_estimate(v_raw)
     samples = source._sample(key, (num_samples,))
     r = TruncatedNormal(
-        loc=m, scale=jnp.sqrt(v),
-        low=jnp.min(samples), high=jnp.max(samples),
+        loc=m,
+        scale=jnp.sqrt(v),
+        low=jnp.min(samples),
+        high=jnp.max(samples),
         name=kw.get("name") or source.name,
     )
     r.with_source(_mm_provenance(source, m_raw, v_raw))
@@ -269,8 +291,10 @@ def _convert_to_truncatednormal(source, key, **kw):
 
 # -- discrete ---------------------------------------------------------------
 
+
 def _convert_to_bernoulli(source, key, **kw):
     from ..distributions.discrete import Bernoulli
+
     if isinstance(source, Bernoulli):
         return source
     kw.pop("num_samples", None)
@@ -281,11 +305,14 @@ def _convert_to_bernoulli(source, key, **kw):
 
 def _convert_to_binomial(source, key, **kw):
     from ..distributions.discrete import Binomial
+
     if isinstance(source, Binomial):
         return source
     total_count = kw.pop("total_count", None)
     if total_count is None:
-        raise ValueError("total_count is required when converting to Binomial from a non-Binomial source.")
+        raise ValueError(
+            "total_count is required when converting to Binomial from a non-Binomial source."
+        )
     kw.pop("num_samples", None)
     probs = source._mean() / total_count
     r = Binomial(total_count=total_count, probs=probs, name=kw.get("name") or source.name)
@@ -295,6 +322,7 @@ def _convert_to_binomial(source, key, **kw):
 
 def _convert_to_poisson(source, key, **kw):
     from ..distributions.discrete import Poisson
+
     if isinstance(source, Poisson):
         return source
     kw.pop("num_samples", None)
@@ -305,6 +333,7 @@ def _convert_to_poisson(source, key, **kw):
 
 def _convert_to_categorical(source, key, **kw):
     from ..distributions.discrete import Categorical
+
     if isinstance(source, Categorical):
         return source
     num_samples = kw.pop("num_samples", DEFAULT_NUM_SAMPLES)
@@ -319,11 +348,14 @@ def _convert_to_categorical(source, key, **kw):
 
 def _convert_to_negativebinomial(source, key, **kw):
     from ..distributions.discrete import NegativeBinomial
+
     if isinstance(source, NegativeBinomial):
         return source
     total_count = kw.pop("total_count", None)
     if total_count is None:
-        raise ValueError("total_count is required when converting to NegativeBinomial from a non-NegativeBinomial source.")
+        raise ValueError(
+            "total_count is required when converting to NegativeBinomial from a non-NegativeBinomial source."
+        )
     kw.pop("num_samples", None)
     m = source._mean()
     probs = total_count / (total_count + m)
@@ -334,8 +366,10 @@ def _convert_to_negativebinomial(source, key, **kw):
 
 # -- multivariate -----------------------------------------------------------
 
+
 def _convert_to_multivariatenormal(source, key, **kw):
     from ..distributions.multivariate import MultivariateNormal
+
     num_samples = kw.pop("num_samples", DEFAULT_NUM_SAMPLES)
     name = kw.get("name") or source.name
     if isinstance(source, MultivariateNormal):
@@ -367,6 +401,7 @@ def _convert_to_multivariatenormal(source, key, **kw):
 
 def _convert_to_dirichlet(source, key, **kw):
     from ..distributions.multivariate import Dirichlet
+
     if isinstance(source, Dirichlet):
         return source
     kw.pop("num_samples", None)
@@ -382,11 +417,14 @@ def _convert_to_dirichlet(source, key, **kw):
 
 def _convert_to_multinomial(source, key, **kw):
     from ..distributions.multivariate import Multinomial
+
     if isinstance(source, Multinomial):
         return source
     total_count = kw.pop("total_count", None)
     if total_count is None:
-        raise ValueError("total_count is required when converting to Multinomial from a non-Multinomial source.")
+        raise ValueError(
+            "total_count is required when converting to Multinomial from a non-Multinomial source."
+        )
     kw.pop("num_samples", None)
     m_raw = source._mean()
     m = _point_estimate(m_raw)
@@ -399,6 +437,7 @@ def _convert_to_multinomial(source, key, **kw):
 
 def _convert_to_wishart(source, key, **kw):
     from ..distributions.multivariate import Wishart
+
     if isinstance(source, Wishart):
         return source
     num_samples = kw.pop("num_samples", DEFAULT_NUM_SAMPLES)
@@ -409,13 +448,16 @@ def _convert_to_wishart(source, key, **kw):
     scale_mat = mean_mat / df
     scale_mat = 0.5 * (scale_mat + scale_mat.T)
     scale_mat = scale_mat + 1e-6 * jnp.eye(d)
-    r = Wishart(df=df, scale_tril=jnp.linalg.cholesky(scale_mat), name=kw.get("name") or source.name)
+    r = Wishart(
+        df=df, scale_tril=jnp.linalg.cholesky(scale_mat), name=kw.get("name") or source.name
+    )
     r.with_source(_mm_provenance(source))
     return r
 
 
 def _convert_to_vonmisesfisher(source, key, **kw):
     from ..distributions.multivariate import VonMisesFisher
+
     if isinstance(source, VonMisesFisher):
         return source
     kw.pop("num_samples", None)
@@ -424,9 +466,11 @@ def _convert_to_vonmisesfisher(source, key, **kw):
     R = jnp.linalg.norm(mean_vec)
     mean_dir = mean_vec / jnp.maximum(R, 1e-8)
     d = mean_vec.shape[-1]
-    R2 = R ** 2
+    R2 = R**2
     conc = jnp.maximum(R * (d - R2) / jnp.maximum(1.0 - R2, 1e-8), 0.0)
-    r = VonMisesFisher(mean_direction=mean_dir, concentration=conc, name=kw.get("name") or source.name)
+    r = VonMisesFisher(
+        mean_direction=mean_dir, concentration=conc, name=kw.get("name") or source.name
+    )
     r.with_source(_mm_provenance(source, m_raw))
     return r
 
@@ -502,6 +546,7 @@ def _convert_to_kde(source, key, **kw):
 # Dispatch table: target class name -> conversion function
 # ---------------------------------------------------------------------------
 
+
 def _build_dispatch_table() -> dict[str, callable]:
     """Build the dispatch table lazily to avoid circular imports."""
     return {
@@ -538,6 +583,7 @@ def _build_dispatch_table() -> dict[str, callable]:
 # ---------------------------------------------------------------------------
 # The converter
 # ---------------------------------------------------------------------------
+
 
 class ProbPipeConverter(Converter):
     """Converter for ProbPipe-to-ProbPipe distribution conversions.
@@ -576,7 +622,9 @@ class ProbPipeConverter(Converter):
 
         target_name = target_type.__name__
         if target_name not in self._table:
-            return ConversionInfo(feasible=False, description=f"No converter for target {target_name}")
+            return ConversionInfo(
+                feasible=False, description=f"No converter for target {target_name}"
+            )
 
         # Same class = exact copy
         if isinstance(source, target_type):
@@ -601,7 +649,9 @@ class ProbPipeConverter(Converter):
             description=f"Moment-match {type(source).__name__} -> {target_name}",
         )
 
-    def convert(self, source: Any, target_type: type, *, key: Any | None = None, **kwargs: Any) -> Distribution:
+    def convert(
+        self, source: Any, target_type: type, *, key: Any | None = None, **kwargs: Any
+    ) -> Distribution:
         if key is None:
             key = _auto_key()
         target_name = target_type.__name__

--- a/probpipe/converters/_protocol.py
+++ b/probpipe/converters/_protocol.py
@@ -17,6 +17,7 @@ from ._registry import ConversionInfo, ConversionMethod, Converter
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _is_protocol(tp: Any) -> bool:
     """Return ``True`` if *tp* is a ``@runtime_checkable`` Protocol class.
 
@@ -45,6 +46,7 @@ def _resolve_target_for_log_prob(dist: Any) -> type:
 # ---------------------------------------------------------------------------
 # ProtocolConverter
 # ---------------------------------------------------------------------------
+
 
 class ProtocolConverter(Converter):
     """Converter that resolves ``@runtime_checkable`` protocol targets.
@@ -110,10 +112,7 @@ class ProtocolConverter(Converter):
                 estimated_time=0.0,
                 source_type=type(source),
                 target_type=target_type,
-                description=(
-                    f"{type(source).__name__} already satisfies "
-                    f"{target_type.__name__}"
-                ),
+                description=(f"{type(source).__name__} already satisfies {target_type.__name__}"),
             )
 
         resolver = self._resolvers.get(target_type)
@@ -122,10 +121,7 @@ class ProtocolConverter(Converter):
                 feasible=False,
                 source_type=type(source),
                 target_type=target_type,
-                description=(
-                    f"No protocol resolver registered for "
-                    f"{target_type.__name__}"
-                ),
+                description=(f"No protocol resolver registered for {target_type.__name__}"),
             )
 
         # Resolve and probe the concrete conversion
@@ -141,10 +137,7 @@ class ProtocolConverter(Converter):
         **kwargs: Any,
     ) -> Any:
         if not _is_protocol(target_type):
-            raise TypeError(
-                f"ProtocolConverter only handles protocol targets, "
-                f"got {target_type!r}"
-            )
+            raise TypeError(f"ProtocolConverter only handles protocol targets, got {target_type!r}")
 
         if isinstance(source, target_type):
             return source
@@ -160,14 +153,10 @@ class ProtocolConverter(Converter):
             )
 
         concrete_type = resolver(source)
-        return self._registry.convert(
-            source, concrete_type, key=key, **kwargs
-        )
+        return self._registry.convert(source, concrete_type, key=key, **kwargs)
 
     @property
     def priority(self) -> int:
         # Highest priority so protocol targets are intercepted before
         # concrete converters (which would reject them).
         return 200
-
-

--- a/probpipe/converters/_registry.py
+++ b/probpipe/converters/_registry.py
@@ -63,7 +63,9 @@ class Converter(ABC):
         ...
 
     @abstractmethod
-    def convert(self, source: Any, target_type: type, *, key: Any | None = None, **kwargs: Any) -> Any:
+    def convert(
+        self, source: Any, target_type: type, *, key: Any | None = None, **kwargs: Any
+    ) -> Any:
         """Perform the actual conversion.
 
         Returns an instance of *target_type* (or a compatible subclass).
@@ -132,8 +134,7 @@ class ConverterRegistry:
             if info.feasible:
                 return conv.convert(source, target_type, key=key, **kwargs)
         raise TypeError(
-            f"No converter registered for "
-            f"{type(source).__name__} -> {target_type.__name__}"
+            f"No converter registered for {type(source).__name__} -> {target_type.__name__}"
         )
 
     def is_distribution_type(self, obj: Any) -> bool:
@@ -147,10 +148,7 @@ class ConverterRegistry:
 
         if isinstance(obj, Distribution):
             return True
-        return any(
-            isinstance(obj, tuple(c.source_types()))
-            for c in self._converters
-        )
+        return any(isinstance(obj, tuple(c.source_types())) for c in self._converters)
 
     # -- internals ----------------------------------------------------------
 

--- a/probpipe/converters/_scipy.py
+++ b/probpipe/converters/_scipy.py
@@ -21,6 +21,7 @@ from ._registry import ConversionInfo, ConversionMethod, Converter
 try:
     import scipy.stats as _stats
     from scipy.stats._distn_infrastructure import rv_frozen as _rv_frozen
+
     _HAS_SCIPY = True
 except ImportError:
     _HAS_SCIPY = False
@@ -30,9 +31,16 @@ except ImportError:
 def _build_scipy_to_probpipe() -> dict[type, tuple[str, callable]]:
     """Build scipy.stats type → (ProbPipe class, kwargs extractor)."""
     from ..distributions.continuous import (
-        Normal, Beta, Gamma, Exponential, LogNormal,
-        Uniform, Cauchy, Laplace,
+        Normal,
+        Beta,
+        Gamma,
+        Exponential,
+        LogNormal,
+        Uniform,
+        Cauchy,
+        Laplace,
     )
+
     if not _HAS_SCIPY:
         return {}
 
@@ -50,30 +58,40 @@ def _build_scipy_to_probpipe() -> dict[type, tuple[str, callable]]:
 
     # Keys are distribution *classes* (norm_gen, beta_gen, etc.)
     return {
-        type(_stats.norm): (Normal, lambda d: (
-            lambda s, loc, scale: {"loc": loc, "scale": scale}
-        )(*_extract(d))),
-        type(_stats.beta): (Beta, lambda d: (
-            lambda s, loc, scale: {"alpha": s[0], "beta": s[1]}
-        )(*_extract(d))),
-        type(_stats.gamma): (Gamma, lambda d: (
-            lambda s, loc, scale: {"concentration": s[0], "rate": 1.0 / scale}
-        )(*_extract(d))),
-        type(_stats.expon): (Exponential, lambda d: (
-            lambda s, loc, scale: {"rate": 1.0 / scale}
-        )(*_extract(d))),
-        type(_stats.lognorm): (LogNormal, lambda d: (
-            lambda s, loc, scale: {"loc": jnp.log(scale), "scale": s[0]}
-        )(*_extract(d))),
-        type(_stats.uniform): (Uniform, lambda d: (
-            lambda s, loc, scale: {"low": loc, "high": loc + scale}
-        )(*_extract(d))),
-        type(_stats.cauchy): (Cauchy, lambda d: (
-            lambda s, loc, scale: {"loc": loc, "scale": scale}
-        )(*_extract(d))),
-        type(_stats.laplace): (Laplace, lambda d: (
-            lambda s, loc, scale: {"loc": loc, "scale": scale}
-        )(*_extract(d))),
+        type(_stats.norm): (
+            Normal,
+            lambda d: (lambda s, loc, scale: {"loc": loc, "scale": scale})(*_extract(d)),
+        ),
+        type(_stats.beta): (
+            Beta,
+            lambda d: (lambda s, loc, scale: {"alpha": s[0], "beta": s[1]})(*_extract(d)),
+        ),
+        type(_stats.gamma): (
+            Gamma,
+            lambda d: (lambda s, loc, scale: {"concentration": s[0], "rate": 1.0 / scale})(
+                *_extract(d)
+            ),
+        ),
+        type(_stats.expon): (
+            Exponential,
+            lambda d: (lambda s, loc, scale: {"rate": 1.0 / scale})(*_extract(d)),
+        ),
+        type(_stats.lognorm): (
+            LogNormal,
+            lambda d: (lambda s, loc, scale: {"loc": jnp.log(scale), "scale": s[0]})(*_extract(d)),
+        ),
+        type(_stats.uniform): (
+            Uniform,
+            lambda d: (lambda s, loc, scale: {"low": loc, "high": loc + scale})(*_extract(d)),
+        ),
+        type(_stats.cauchy): (
+            Cauchy,
+            lambda d: (lambda s, loc, scale: {"loc": loc, "scale": scale})(*_extract(d)),
+        ),
+        type(_stats.laplace): (
+            Laplace,
+            lambda d: (lambda s, loc, scale: {"loc": loc, "scale": scale})(*_extract(d)),
+        ),
     }
 
 
@@ -86,7 +104,9 @@ def _build_probpipe_to_scipy() -> dict[str, callable]:
         "Beta": lambda d: _stats.beta(float(d._alpha), float(d._beta)),
         "Gamma": lambda d: _stats.gamma(float(d._concentration), scale=1.0 / float(d._rate)),
         "Exponential": lambda d: _stats.expon(scale=1.0 / float(d._rate)),
-        "Uniform": lambda d: _stats.uniform(loc=float(d._low), scale=float(d._high) - float(d._low)),
+        "Uniform": lambda d: _stats.uniform(
+            loc=float(d._low), scale=float(d._high) - float(d._low)
+        ),
         "Cauchy": lambda d: _stats.cauchy(loc=float(d._loc), scale=float(d._scale)),
         "Laplace": lambda d: _stats.laplace(loc=float(d._loc), scale=float(d._scale)),
     }
@@ -141,21 +161,27 @@ class ScipyConverter(Converter):
                     pp_cls, _ = self._scipy_map[dist_cls]
                     if target_type is pp_cls or issubclass(pp_cls, target_type):
                         return ConversionInfo(
-                            feasible=True, method=ConversionMethod.EXACT,
+                            feasible=True,
+                            method=ConversionMethod.EXACT,
                             estimated_time=0.0,
-                            source_type=type(source), target_type=target_type,
+                            source_type=type(source),
+                            target_type=target_type,
                             description=f"Extract parameters from scipy {dist_cls.__name__}",
                         )
                     return ConversionInfo(
-                        feasible=True, method=ConversionMethod.MOMENT_MATCH,
+                        feasible=True,
+                        method=ConversionMethod.MOMENT_MATCH,
                         estimated_time=0.1,
-                        source_type=type(source), target_type=target_type,
+                        source_type=type(source),
+                        target_type=target_type,
                     )
                 # Unknown scipy dist -> sample
                 return ConversionInfo(
-                    feasible=True, method=ConversionMethod.SAMPLE,
+                    feasible=True,
+                    method=ConversionMethod.SAMPLE,
                     estimated_time=0.2,
-                    source_type=type(source), target_type=target_type,
+                    source_type=type(source),
+                    target_type=target_type,
                     description="Sample from scipy distribution",
                 )
 
@@ -165,14 +191,18 @@ class ScipyConverter(Converter):
                 src_name = type(source).__name__
                 if src_name in self._pp_map:
                     return ConversionInfo(
-                        feasible=True, method=ConversionMethod.EXACT,
+                        feasible=True,
+                        method=ConversionMethod.EXACT,
                         estimated_time=0.0,
-                        source_type=type(source), target_type=target_type,
+                        source_type=type(source),
+                        target_type=target_type,
                     )
 
         return ConversionInfo(feasible=False)
 
-    def convert(self, source: Any, target_type: type, *, key: Any | None = None, **kwargs: Any) -> Any:
+    def convert(
+        self, source: Any, target_type: type, *, key: Any | None = None, **kwargs: Any
+    ) -> Any:
         if not _HAS_SCIPY:
             raise TypeError("scipy is not installed")
 
@@ -188,6 +218,7 @@ class ScipyConverter(Converter):
                 if isinstance(pp_dist, target_type):
                     return pp_dist
                 from ._registry import converter_registry
+
                 return converter_registry.convert(pp_dist, target_type, key=key, **kwargs)
 
             # Unknown scipy: sample -> RecordEmpiricalDistribution
@@ -199,6 +230,7 @@ class ScipyConverter(Converter):
             if issubclass(target_type, RecordEmpiricalDistribution):
                 return emp
             from ._registry import converter_registry
+
             return converter_registry.convert(emp, target_type, key=key, **kwargs)
 
         # Case 2: ProbPipe -> scipy

--- a/probpipe/converters/_tfp.py
+++ b/probpipe/converters/_tfp.py
@@ -25,25 +25,44 @@ from ._registry import ConversionInfo, ConversionMethod, Converter
 # TFP → ProbPipe mapping: (ProbPipe class, parameter extractor)
 # ---------------------------------------------------------------------------
 
+
 def _build_tfp_to_probpipe() -> dict[type, tuple[str, callable]]:
     """Build mapping lazily to avoid circular imports."""
     from ..distributions.continuous import (
-        Normal, Beta, Gamma, InverseGamma, Exponential, LogNormal,
-        StudentT, Uniform, Cauchy, Laplace, HalfNormal, HalfCauchy,
+        Normal,
+        Beta,
+        Gamma,
+        InverseGamma,
+        Exponential,
+        LogNormal,
+        StudentT,
+        Uniform,
+        Cauchy,
+        Laplace,
+        HalfNormal,
+        HalfCauchy,
         Pareto,
     )
     from ..distributions.discrete import (
-        Bernoulli, Binomial, Poisson, Categorical, NegativeBinomial,
+        Bernoulli,
+        Binomial,
+        Poisson,
+        Categorical,
+        NegativeBinomial,
     )
     from ..distributions.multivariate import (
-        MultivariateNormal, Dirichlet,
+        MultivariateNormal,
+        Dirichlet,
     )
 
     return {
         tfd.Normal: (Normal, lambda d: {"loc": d.loc, "scale": d.scale}),
         tfd.Beta: (Beta, lambda d: {"alpha": d.concentration1, "beta": d.concentration0}),
         tfd.Gamma: (Gamma, lambda d: {"concentration": d.concentration, "rate": d.rate}),
-        tfd.InverseGamma: (InverseGamma, lambda d: {"concentration": d.concentration, "scale": d.scale}),
+        tfd.InverseGamma: (
+            InverseGamma,
+            lambda d: {"concentration": d.concentration, "scale": d.scale},
+        ),
         tfd.Exponential: (Exponential, lambda d: {"rate": d.rate}),
         tfd.LogNormal: (LogNormal, lambda d: {"loc": d.loc, "scale": d.scale}),
         tfd.StudentT: (StudentT, lambda d: {"df": d.df, "loc": d.loc, "scale": d.scale}),
@@ -63,7 +82,7 @@ def _build_tfp_to_probpipe() -> dict[type, tuple[str, callable]]:
         ),
         tfd.MultivariateNormalDiag: (
             MultivariateNormal,
-            lambda d: {"loc": d.loc, "cov": jnp.diag(d.scale.diag ** 2)},
+            lambda d: {"loc": d.loc, "cov": jnp.diag(d.scale.diag**2)},
         ),
     }
 
@@ -88,7 +107,9 @@ def _build_probpipe_to_tfp() -> dict[str, callable]:
         "Poisson": lambda d: tfd.Poisson(rate=d._rate),
         "Categorical": lambda d: tfd.Categorical(probs=d._probs),
         "Dirichlet": lambda d: tfd.Dirichlet(concentration=d._concentration),
-        "MultivariateNormal": lambda d: tfd.MultivariateNormalTriL(loc=d.loc, scale_tril=d._scale_tril),
+        "MultivariateNormal": lambda d: tfd.MultivariateNormalTriL(
+            loc=d.loc, scale_tril=d._scale_tril
+        ),
     }
 
 
@@ -126,50 +147,70 @@ class TFPConverter(Converter):
 
     def check(self, source: Any, target_type: type) -> ConversionInfo:
         # Case 1: TFP -> ProbPipe
-        if isinstance(source, tfd.Distribution) and not isinstance(source, NumericRecordDistribution):
+        if isinstance(source, tfd.Distribution) and not isinstance(
+            source, NumericRecordDistribution
+        ):
             if self._is_probpipe_target(target_type):
                 src_cls = type(source)
                 if src_cls in self._tfp_map:
                     pp_cls, _ = self._tfp_map[src_cls]
                     if target_type is pp_cls or issubclass(pp_cls, target_type):
                         return ConversionInfo(
-                            feasible=True, method=ConversionMethod.EXACT,
+                            feasible=True,
+                            method=ConversionMethod.EXACT,
                             estimated_time=0.0,
-                            source_type=src_cls, target_type=target_type,
+                            source_type=src_cls,
+                            target_type=target_type,
                             description=f"Extract parameters from {src_cls.__name__}",
                         )
                     # Known TFP -> natural ProbPipe -> requested ProbPipe
                     return ConversionInfo(
-                        feasible=True, method=ConversionMethod.MOMENT_MATCH,
+                        feasible=True,
+                        method=ConversionMethod.MOMENT_MATCH,
                         estimated_time=0.1,
-                        source_type=src_cls, target_type=target_type,
+                        source_type=src_cls,
+                        target_type=target_type,
                         description=f"TFP {src_cls.__name__} -> ProbPipe -> {target_type.__name__}",
                     )
                 # Unknown TFP type -> sample fallback
-                if issubclass(target_type, (NumericRecordDistribution, RecordEmpiricalDistribution)):
+                if issubclass(
+                    target_type, (NumericRecordDistribution, RecordEmpiricalDistribution)
+                ):
                     return ConversionInfo(
-                        feasible=True, method=ConversionMethod.SAMPLE,
+                        feasible=True,
+                        method=ConversionMethod.SAMPLE,
                         estimated_time=0.2,
-                        source_type=src_cls, target_type=target_type,
+                        source_type=src_cls,
+                        target_type=target_type,
                         description=f"Sample {src_cls.__name__} -> RecordEmpiricalDistribution",
                     )
 
         # Case 2: ProbPipe -> TFP
-        if isinstance(source, NumericRecordDistribution) and isinstance(target_type, type) and issubclass(target_type, tfd.Distribution):
+        if (
+            isinstance(source, NumericRecordDistribution)
+            and isinstance(target_type, type)
+            and issubclass(target_type, tfd.Distribution)
+        ):
             src_name = type(source).__name__
             if src_name in self._pp_map:
                 return ConversionInfo(
-                    feasible=True, method=ConversionMethod.EXACT,
+                    feasible=True,
+                    method=ConversionMethod.EXACT,
                     estimated_time=0.0,
-                    source_type=type(source), target_type=target_type,
+                    source_type=type(source),
+                    target_type=target_type,
                     description=f"Extract parameters from ProbPipe {src_name}",
                 )
 
         return ConversionInfo(feasible=False)
 
-    def convert(self, source: Any, target_type: type, *, key: Any | None = None, **kwargs: Any) -> Any:
+    def convert(
+        self, source: Any, target_type: type, *, key: Any | None = None, **kwargs: Any
+    ) -> Any:
         # Case 1: TFP -> ProbPipe
-        if isinstance(source, tfd.Distribution) and not isinstance(source, NumericRecordDistribution):
+        if isinstance(source, tfd.Distribution) and not isinstance(
+            source, NumericRecordDistribution
+        ):
             if self._is_probpipe_target(target_type):
                 src_cls = type(source)
                 if src_cls in self._tfp_map:
@@ -182,6 +223,7 @@ class TFPConverter(Converter):
                         return pp_dist
                     # Chain: TFP -> natural ProbPipe -> target ProbPipe
                     from ._registry import converter_registry
+
                     return converter_registry.convert(pp_dist, target_type, key=key, **kwargs)
 
                 # Unknown TFP: sample -> RecordEmpiricalDistribution
@@ -195,6 +237,7 @@ class TFPConverter(Converter):
                 if issubclass(target_type, RecordEmpiricalDistribution):
                     return emp
                 from ._registry import converter_registry
+
                 return converter_registry.convert(emp, target_type, key=key, **kwargs)
 
         # Case 2: ProbPipe -> TFP
@@ -205,7 +248,9 @@ class TFPConverter(Converter):
                 return fn(source)
             raise TypeError(f"Cannot convert {src_name} to TFP distribution")
 
-        raise TypeError(f"TFPConverter cannot handle {type(source).__name__} -> {target_type.__name__}")
+        raise TypeError(
+            f"TFPConverter cannot handle {type(source).__name__} -> {target_type.__name__}"
+        )
 
     @property
     def priority(self) -> int:

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -32,6 +32,7 @@ hierarchy. If you need backend-specific reductions or device
 placement, convert to the appropriate type yourself; this module
 only handles round-trip metadata.
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -169,7 +170,9 @@ def _register_xarray() -> None:
         # so xarray sees the original dims and attrs.
         coords = {
             k: xr.DataArray(
-                v["values"], dims=v["dims"], attrs=v.get("attrs", {}),
+                v["values"],
+                dims=v["dims"],
+                attrs=v.get("attrs", {}),
             )
             for k, v in aux["coords"].items()
         }
@@ -236,9 +239,7 @@ def _register_pandas() -> None:
         return df.astype(aux["dtypes"])
 
     register_aux(pd.Series, capture=_series_capture, restore=_series_restore)
-    register_aux(
-        pd.DataFrame, capture=_frame_capture, restore=_frame_restore
-    )
+    register_aux(pd.DataFrame, capture=_frame_capture, restore=_frame_restore)
 
 
 _register_xarray()

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -131,6 +131,7 @@ class _MixtureMarginal[T](Distribution[T]):
 
 # -- Mixture protocol mixins (combined dynamically) -------------------------
 
+
 class _MixtureSampling:
     """SupportsSampling mixin for mixture marginals.
 
@@ -154,10 +155,7 @@ class _MixtureSampling:
         indices = self._w.choice(key1, shape=(n_draws,))
         keys = jax.random.split(key2, n_draws)
 
-        results = [
-            self._components[int(indices[i])]._sample(keys[i], ())
-            for i in range(n_draws)
-        ]
+        results = [self._components[int(indices[i])]._sample(keys[i], ()) for i in range(n_draws)]
 
         # Dispatch on result type so a mixture of Record-returning
         # distributions produces a RecordArray rather than crashing in
@@ -165,10 +163,7 @@ class _MixtureSampling:
         # RecordArray leaves here — ``RecordArray.stack`` expects
         # scalar Records; a mixture over already-batched Record
         # samples isn't supported on this path.
-        if all(
-            isinstance(r, Record) and not isinstance(r, RecordArray)
-            for r in results
-        ):
+        if all(isinstance(r, Record) and not isinstance(r, RecordArray) for r in results):
             stacked_ra = RecordArray.stack(results)
             if sample_shape == ():
                 return stacked_ra[0]
@@ -178,7 +173,9 @@ class _MixtureSampling:
                 for name in stacked_ra.fields
             }
             return type(stacked_ra)(
-                fields, batch_shape=sample_shape, template=stacked_ra.template,
+                fields,
+                batch_shape=sample_shape,
+                template=stacked_ra.template,
             )
 
         try:
@@ -213,7 +210,7 @@ class _MixtureVariance:
         # Law of total variance: E[Var(Y|X)] + Var(E[Y|X])
         e_var = self._w.mean(variances)
         diff = means - overall_mean
-        var_e = self._w.mean(diff ** 2)
+        var_e = self._w.mean(diff**2)
         return e_var + var_e
 
 
@@ -222,9 +219,7 @@ class _MixtureLogProb:
 
     def _log_prob(self, value):
         log_w = self._w.log_normalized
-        component_lps = jnp.stack(
-            [c._log_prob(value) for c in self._components], axis=0
-        )
+        component_lps = jnp.stack([c._log_prob(value) for c in self._components], axis=0)
         return jax.scipy.special.logsumexp(log_w + component_lps)
 
 
@@ -350,13 +345,14 @@ def _make_marginal(
 
     if isinstance(output_samples, jnp.ndarray):
         return _RecordMarginal(
-            output_samples, weights, name=name or "marginal",
+            output_samples,
+            weights,
+            name=name or "marginal",
         )
 
     if isinstance(output_samples, list):
         if output_samples and all(
-            isinstance(r, Record) and not isinstance(r, RecordArray)
-            for r in output_samples
+            isinstance(r, Record) and not isinstance(r, RecordArray) for r in output_samples
         ):
             try:
                 ra = RecordArray.stack(output_samples)
@@ -364,11 +360,11 @@ def _make_marginal(
             except (ValueError, TypeError):
                 pass
         try:
-            stacked = jnp.stack(
-                [jnp.asarray(r) for r in output_samples], axis=0
-            )
+            stacked = jnp.stack([jnp.asarray(r) for r in output_samples], axis=0)
             return _RecordMarginal(
-                stacked, weights, name=name or "marginal",
+                stacked,
+                weights,
+                name=name or "marginal",
             )
         except (ValueError, TypeError):
             pass
@@ -479,13 +475,11 @@ def _make_stack(
             first = outs[0]
             if all(ra.batch_shape == first.batch_shape for ra in outs):
                 fields = {
-                    fname: jnp.stack([ra[fname] for ra in outs], axis=0)
-                    for fname in first.fields
+                    fname: jnp.stack([ra[fname] for ra in outs], axis=0) for fname in first.fields
                 }
                 # Reshape the leading (n_total,) axis to batch_shape.
                 reshaped = {
-                    fname: arr.reshape(batch_shape + arr.shape[1:])
-                    for fname, arr in fields.items()
+                    fname: arr.reshape(batch_shape + arr.shape[1:]) for fname, arr in fields.items()
                 }
                 return type(first)(
                     reshaped,
@@ -499,13 +493,11 @@ def _make_stack(
         # if every leaf is numeric; otherwise fall back to the permissive
         # RecordArray class, building the fields manually so non-numeric
         # leaves (strings, xarray objects, ...) survive.
-        if outs and all(
-            isinstance(o, Record) and not isinstance(o, RecordArray)
-            for o in outs
-        ):
+        if outs and all(isinstance(o, Record) and not isinstance(o, RecordArray) for o in outs):
             # Stack flat, then reshape to batch_shape.
             try:
                 from ._record_array import NumericRecordArray
+
                 flat = NumericRecordArray.stack(list(outs))
             except (TypeError, ValueError):
                 flat = None
@@ -515,9 +507,7 @@ def _make_stack(
                 # Reshape each field's leading axis.
                 n_cur = len(flat.batch_shape)
                 new_fields = {
-                    fname: flat[fname].reshape(
-                        batch_shape + flat[fname].shape[n_cur:]
-                    )
+                    fname: flat[fname].reshape(batch_shape + flat[fname].shape[n_cur:])
                     for fname in flat.fields
                 }
                 return type(flat)(
@@ -529,9 +519,7 @@ def _make_stack(
             # numerically, object-dtype leaves use np.asarray(..., dtype=object).
             first = outs[0]
             if any(o.fields != first.fields for o in outs):
-                raise TypeError(
-                    "_make_stack: Records in list have inconsistent fields."
-                )
+                raise TypeError("_make_stack: Records in list have inconsistent fields.")
             fields: dict[str, Any] = {}
             for fname in first.fields:
                 values = [o[fname] for o in outs]
@@ -544,7 +532,7 @@ def _make_stack(
             tpl_spec: dict[str, Any] = {}
             for fname, v in fields.items():
                 if hasattr(v, "dtype") and getattr(v.dtype, "kind", None) in "biufc":
-                    tpl_spec[fname] = tuple(v.shape[len(batch_shape):])
+                    tpl_spec[fname] = tuple(v.shape[len(batch_shape) :])
                 else:
                     tpl_spec[fname] = None
             return RecordArray(
@@ -557,7 +545,9 @@ def _make_stack(
         # batch_shape.
         if outs and all(isinstance(o, Distribution) for o in outs):
             return _make_distribution_array(
-                outs, batch_shape=batch_shape, name=name,
+                outs,
+                batch_shape=batch_shape,
+                name=name,
             )
 
         # Numeric scalars / arrays → wrap in NumericRecordArray with
@@ -565,13 +555,15 @@ def _make_stack(
         # reshape leading axis to batch_shape.
         try:
             stacked = jnp.stack(
-                [jnp.asarray(o) for o in outs], axis=0,
+                [jnp.asarray(o) for o in outs],
+                axis=0,
             )
         except (TypeError, ValueError):
             stacked = None
 
         if stacked is not None:
             from ._record_array import NumericRecordArray
+
             event_shape = tuple(stacked.shape[1:])
             reshaped = stacked.reshape(batch_shape + event_shape)
             tpl = EventTemplate(**{field_name: event_shape})
@@ -611,6 +603,7 @@ def _make_stack(
                 f"(batch_shape={batch_shape})."
             )
         from ._record_array import NumericRecordArray
+
         event_shape = tuple(inner_outputs.shape[1:])
         reshaped = inner_outputs.reshape(batch_shape + event_shape)
         tpl = EventTemplate(**{field_name: event_shape})
@@ -639,12 +632,17 @@ def _make_stack(
             }
             try:
                 from ._record_array import NumericRecordArray
+
                 return NumericRecordArray(
-                    reshaped_fields, batch_shape=batch_shape, template=tpl,
+                    reshaped_fields,
+                    batch_shape=batch_shape,
+                    template=tpl,
                 )
             except (TypeError, ValueError):
                 return RecordArray(
-                    reshaped_fields, batch_shape=batch_shape, template=tpl,
+                    reshaped_fields,
+                    batch_shape=batch_shape,
+                    template=tpl,
                 )
 
     # Fallback — shouldn't reach here with well-formed vmap output; if
@@ -730,7 +728,7 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
         # Determine n from first broadcast arg
         first_key = list(broadcast_args)[0]
         first_arr = input_samples[first_key]
-        n = first_arr.shape[0] if hasattr(first_arr, 'shape') else len(first_arr)
+        n = first_arr.shape[0] if hasattr(first_arr, "shape") else len(first_arr)
         self._w = Weights(n=n, weights=weights, log_weights=log_weights)
         self._broadcast_args = list(broadcast_args)
         if name is None:
@@ -760,7 +758,7 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
     def samples(self) -> Any:
         """Output samples (forwarded to output marginal for backward compat)."""
         m = self.marginalize()
-        return m.samples if hasattr(m, 'samples') else m.items
+        return m.samples if hasattr(m, "samples") else m.items
 
     # -- Named components ----------------------------------------------------
 
@@ -797,7 +795,7 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
             result["_output"] = self._output_samples[indices]
 
         if sample_shape == ():
-            return jax.tree.map(lambda x: x[0] if hasattr(x, '__getitem__') else x, result)
+            return jax.tree.map(lambda x: x[0] if hasattr(x, "__getitem__") else x, result)
         return result
 
     # -- marginalization ----------------------------------------------------

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -176,9 +176,7 @@ class DistributionArray[T](Distribution[T]):
         # their approximation status; if any component is approximate
         # (a _MixtureMarginal or RecordEmpiricalDistribution), so is
         # the stack.
-        self._approximate = any(
-            getattr(c, "is_approximate", False) for c in components
-        )
+        self._approximate = any(getattr(c, "is_approximate", False) for c in components)
 
     # -- public batched-construction factory --------------------------------
 
@@ -300,17 +298,10 @@ class DistributionArray[T](Distribution[T]):
         components = []
         n = prod(batch_shape)
         for flat in range(n):
-            multi = (
-                np.unravel_index(flat, batch_shape) if batch_shape else ()
-            )
+            multi = np.unravel_index(flat, batch_shape) if batch_shape else ()
             multi_t = tuple(int(x) for x in multi)
-            cell_params = {
-                k: _slice_leading_axes(v, multi_t)
-                for k, v in batched_params.items()
-            }
-            components.append(
-                dist_cls(name=f"{name}_{flat}", **cell_params)
-            )
+            cell_params = {k: _slice_leading_axes(v, multi_t) for k, v in batched_params.items()}
+            components.append(dist_cls(name=f"{name}_{flat}", **cell_params))
         return cls(components, batch_shape=batch_shape, name=name)
 
     # -- backend-delegated constructor --------------------------------------
@@ -384,9 +375,7 @@ class DistributionArray[T](Distribution[T]):
         if self._components is None:
             assert self._backend is not None  # invariant
             n = prod(self._batch_shape)
-            self._components = tuple(
-                self._backend.cell(i) for i in range(n)
-            )
+            self._components = tuple(self._backend.cell(i) for i in range(n))
         return self._components
 
     @property
@@ -474,13 +463,8 @@ class DistributionArray[T](Distribution[T]):
         # ``np.ravel_multi_index`` rejects negative indices, so wrap
         # them into the positive range first (``dists[-1]`` is a
         # common pattern — e.g. "last posterior in an iterate output").
-        if all(
-            isinstance(k, (int, np.integer)) or hasattr(k, "__index__")
-            for k in key_tuple
-        ):
-            indices = tuple(
-                int(k) % dim for k, dim in zip(key_tuple, bshape)
-            )
+        if all(isinstance(k, (int, np.integer)) or hasattr(k, "__index__") for k in key_tuple):
+            indices = tuple(int(k) % dim for k, dim in zip(key_tuple, bshape))
             flat = int(np.ravel_multi_index(indices, bshape))
             if self._backend is not None:
                 return self._backend.cell(flat)
@@ -584,7 +568,8 @@ class DistributionArray[T](Distribution[T]):
 
 
 def _infer_batch_shape(
-    batched_params: dict, declared: tuple[int, ...] | None,
+    batched_params: dict,
+    declared: tuple[int, ...] | None,
 ) -> tuple[int, ...]:
     """Return the broadcast shape of array-valued entries in
     ``batched_params``, or ``declared`` if explicitly supplied.

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import copy as _copy
 from abc import ABC, abstractmethod
+
 # ``_ProtocolMeta`` is technically private (leading underscore in
 # ``typing``), but it's the only way to compose a custom metaclass with
 # ``@runtime_checkable`` protocols without a metaclass conflict.  The
@@ -109,9 +110,7 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
 
     def __init__(self, *, name: str):
         if not isinstance(name, str) or not name:
-            raise TypeError(
-                f"{type(self).__name__} requires a non-empty name= argument"
-            )
+            raise TypeError(f"{type(self).__name__} requires a non-empty name= argument")
         self._name = name
 
     # -- keyword-form value construction ------------------------------------
@@ -148,6 +147,7 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
             match its fields exactly (missing or unexpected names).
         """
         from .record import _pack_fields
+
         fields = getattr(self, "fields", None)
         if not fields:
             raise TypeError(
@@ -277,8 +277,12 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
         # subpackage and importing at module top would create a cycle
         # (DistributionArray inherits from Distribution).
         from ._distribution_array import DistributionArray
+
         return DistributionArray.from_batched_params(
-            cls, name=name, batch_shape=batch_shape, **batched_params,
+            cls,
+            name=name,
+            batch_shape=batch_shape,
+            **batched_params,
         )
 
     # -- repr ---------------------------------------------------------------

--- a/probpipe/core/_empirical.py
+++ b/probpipe/core/_empirical.py
@@ -93,10 +93,7 @@ def _index_record(record_data: Record, idx) -> NumericRecord:
     Returns a :class:`NumericRecord` so single-field results expose the
     ``__jax_array__`` / ``__float__`` shims at downstream call sites.
     """
-    return NumericRecord({
-        f: jnp.asarray(record_data[f])[idx]
-        for f in record_data.fields
-    })
+    return NumericRecord({f: jnp.asarray(record_data[f])[idx] for f in record_data.fields})
 
 
 def _fieldwise_op(record_data: Record, op: Callable) -> NumericRecord:
@@ -106,10 +103,7 @@ def _fieldwise_op(record_data: Record, op: Callable) -> NumericRecord:
     lets single-field consumers use ``jnp.asarray(result)`` /
     ``float(result)`` directly via the existing single-field shims.
     """
-    return NumericRecord({
-        f: op(jnp.asarray(record_data[f]))
-        for f in record_data.fields
-    })
+    return NumericRecord({f: op(jnp.asarray(record_data[f])) for f in record_data.fields})
 
 
 def _wrap_numeric_array_as_record(
@@ -440,7 +434,9 @@ class RecordEmpiricalDistribution(
                     f"{type(samples).__name__}"
                 )
             samples, name = _wrap_numeric_array_as_record(
-                samples, name=name, sample_shape=sample_shape,
+                samples,
+                name=name,
+                sample_shape=sample_shape,
                 role="RecordEmpiricalDistribution",
             )
         elif sample_shape is not None:
@@ -483,10 +479,9 @@ class RecordEmpiricalDistribution(
         # to that rule.
         cached = getattr(self, "_samples_record", None)
         if cached is None:
-            cached = NumericRecord({
-                f: jnp.asarray(self._record_data[f])
-                for f in self._record_data.fields
-            })
+            cached = NumericRecord(
+                {f: jnp.asarray(self._record_data[f]) for f in self._record_data.fields}
+            )
             object.__setattr__(self, "_samples_record", cached)
         return cached
 
@@ -571,24 +566,17 @@ class RecordEmpiricalDistribution(
         raises on multi-field.
         """
         return {
-            f: tuple(jnp.asarray(self._record_data[f]).shape[1:])
-            for f in self._record_data.fields
+            f: tuple(jnp.asarray(self._record_data[f]).shape[1:]) for f in self._record_data.fields
         }
 
     @property
     def dtypes(self) -> dict[str, jnp.dtype]:
-        return {
-            f: jnp.asarray(self._record_data[f]).dtype
-            for f in self._record_data.fields
-        }
+        return {f: jnp.asarray(self._record_data[f]).dtype for f in self._record_data.fields}
 
     @property
     def dim(self) -> int:
         """Flat dimensionality of a single Record draw."""
-        return sum(
-            max(1, prod(shape))
-            for shape in self.event_shapes.values()
-        )
+        return sum(max(1, prod(shape)) for shape in self.event_shapes.values())
 
     @property
     def support(self) -> Constraint:
@@ -674,8 +662,10 @@ class RecordEmpiricalDistribution(
             if key is None:
                 key = _auto_key()
             idx = jax.random.choice(
-                key, self._num_atoms,
-                shape=(num_evaluations,), replace=False,
+                key,
+                self._num_atoms,
+                shape=(num_evaluations,),
+                replace=False,
             )
             f_vals = jnp.stack([f(_row(int(i))) for i in idx])
             sub_w = self._w.subsample(idx)
@@ -786,7 +776,8 @@ class BootstrapReplicateDistribution[T](
             default_replicate_size = replicate_size
             self._init_bootstrap_state(
                 default_replicate_size,
-                replicate_size=replicate_size, name=name,
+                replicate_size=replicate_size,
+                name=name,
             )
             return
 
@@ -800,8 +791,7 @@ class BootstrapReplicateDistribution[T](
             self._data = source
             if self._data.ndim == 0:
                 raise ValueError(
-                    "source must have at least 1 dimension (the leading axis "
-                    "that gets resampled)."
+                    "source must have at least 1 dimension (the leading axis that gets resampled)."
                 )
             if len(self._data) == 0:
                 raise ValueError("source must be a non-empty sequence.")
@@ -815,7 +805,8 @@ class BootstrapReplicateDistribution[T](
             default_replicate_size = len(self._data)
         self._init_bootstrap_state(
             default_replicate_size,
-            replicate_size=replicate_size, name=name,
+            replicate_size=replicate_size,
+            name=name,
         )
 
     def _init_bootstrap_state(
@@ -830,9 +821,7 @@ class BootstrapReplicateDistribution[T](
             self._replicate_size = default_replicate_size
         else:
             if replicate_size < 1:
-                raise ValueError(
-                    f"replicate_size must be positive, got {replicate_size}"
-                )
+                raise ValueError(f"replicate_size must be positive, got {replicate_size}")
             self._replicate_size = replicate_size
         if name is None:
             name = "bootstrap"
@@ -843,11 +832,7 @@ class BootstrapReplicateDistribution[T](
             # ``source_size`` is the actual source size. Fall back to
             # ``default_replicate_size`` when the caller didn't pass it
             # (matches the old behaviour where source size == default).
-            self._source_size = (
-                source_size
-                if source_size is not None
-                else default_replicate_size
-            )
+            self._source_size = source_size if source_size is not None else default_replicate_size
         self._approximate = True
 
     # -- properties ---------------------------------------------------------
@@ -1045,7 +1030,9 @@ class RecordBootstrapReplicateDistribution(
             # error instead of an ``_as_float_array(object_arr)``
             # TypeError later.
             sample_dtype = getattr(
-                source.samples, "dtype", type(source.samples).__name__,
+                source.samples,
+                "dtype",
+                type(source.samples).__name__,
             )
             raise TypeError(
                 f"RecordBootstrapReplicateDistribution does not accept "
@@ -1057,7 +1044,8 @@ class RecordBootstrapReplicateDistribution(
             )
         elif _is_numeric_array(source):
             wrapped, field_name = _wrap_numeric_array_as_record(
-                source, name=name,
+                source,
+                name=name,
                 role="RecordBootstrapReplicateDistribution",
             )
             self._record_data = wrapped
@@ -1078,13 +1066,15 @@ class RecordBootstrapReplicateDistribution(
         self._data = self._record_data
         self._init_bootstrap_state(
             default_replicate_size,
-            replicate_size=replicate_size, name=name,
+            replicate_size=replicate_size,
+            name=name,
             source_size=default_replicate_size,
         )
         # Replicate produces (n, *event_shape) per field; advertise that
         # via the event_template.
         self._event_template = _event_template_from_data(
-            self._record_data, leading_shape=(self._replicate_size,),
+            self._record_data,
+            leading_shape=(self._replicate_size,),
         )
 
     # -- shape ---------------------------------------------------------------
@@ -1099,10 +1089,7 @@ class RecordBootstrapReplicateDistribution(
 
     @property
     def dtypes(self) -> dict[str, jnp.dtype]:
-        return {
-            f: jnp.asarray(self._record_data[f]).dtype
-            for f in self._record_data.fields
-        }
+        return {f: jnp.asarray(self._record_data[f]).dtype for f in self._record_data.fields}
 
     @property
     def event_shape(self) -> tuple[int, ...]:
@@ -1176,8 +1163,7 @@ class RecordBootstrapReplicateDistribution(
     def obs_shapes(self) -> dict[str, tuple[int, ...]]:
         """Per-field observation event shapes (replicate axis stripped)."""
         return {
-            f: tuple(jnp.asarray(self._record_data[f]).shape[1:])
-            for f in self._record_data.fields
+            f: tuple(jnp.asarray(self._record_data[f]).shape[1:]) for f in self._record_data.fields
         }
 
     @property
@@ -1186,10 +1172,7 @@ class RecordBootstrapReplicateDistribution(
 
         Sum across fields of ``n * max(1, prod(obs_event_shape))``.
         """
-        return sum(
-            self._replicate_size * max(1, prod(shape))
-            for shape in self.obs_shapes.values()
-        )
+        return sum(self._replicate_size * max(1, prod(shape)) for shape in self.obs_shapes.values())
 
     @property
     def support(self) -> Constraint:

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -126,9 +126,7 @@ class NumericRecord(Record):
         # ``__slots__`` + the ``__setattr__`` guard holds.
         if _dict is not None:
             if fields:
-                raise ValueError(
-                    "Cannot pass both positional dict and keyword arguments"
-                )
+                raise ValueError("Cannot pass both positional dict and keyword arguments")
             raw_fields = _dict
         else:
             raw_fields = fields
@@ -252,10 +250,12 @@ class NumericRecord(Record):
         ``TypeError`` on non-coercible leaves. Nested ``Record``
         children recurse, preserving structure.
         """
-        return cls({
-            field_name: cls.from_record(val) if isinstance(val, Record) else val
-            for field_name, val in record._store.items()
-        })
+        return cls(
+            {
+                field_name: cls.from_record(val) if isinstance(val, Record) else val
+                for field_name, val in record._store.items()
+            }
+        )
 
     # -- Conversion back to native backends --------------------------------
 
@@ -399,13 +399,9 @@ def _unpickle_numeric_record(store: dict, name: str, source) -> NumericRecord:
 # ---------------------------------------------------------------------------
 
 
-def _numeric_record_unflatten(
-    aux: tuple[str, ...], children: list
-) -> NumericRecord:
+def _numeric_record_unflatten(aux: tuple[str, ...], children: list) -> NumericRecord:
     """Unflatten NumericRecord from JAX pytree traversal."""
     return NumericRecord(dict(zip(aux, children)))
 
 
-jax.tree_util.register_pytree_node(
-    NumericRecord, _record_flatten, _numeric_record_unflatten
-)
+jax.tree_util.register_pytree_node(NumericRecord, _record_flatten, _numeric_record_unflatten)

--- a/probpipe/core/_numeric_record_distribution.py
+++ b/probpipe/core/_numeric_record_distribution.py
@@ -73,6 +73,7 @@ from .protocols import (
 # Sampling & expectation helpers
 # ---------------------------------------------------------------------------
 
+
 def _vmap_sample(
     dist: "NumericRecordDistribution",
     key: PRNGKey,
@@ -95,6 +96,7 @@ def _vmap_sample(
     sample_shape : tuple of int
         Shape prefix for independent draws.
     """
+
     def _one(k: PRNGKey) -> Any:
         return dist._sample(k, ())
 
@@ -150,6 +152,7 @@ def _mc_expectation(
 # ---------------------------------------------------------------------------
 # NumericRecordDistribution — RecordDistribution + numeric shape semantics
 # ---------------------------------------------------------------------------
+
 
 class NumericRecordDistribution(RecordDistribution):
     """Distribution over numeric arrays with Record support.
@@ -240,6 +243,7 @@ class NumericRecordDistribution(RecordDistribution):
         proceed).
         """
         from .record import EventTemplate
+
         tpl = getattr(self, "_event_template", None)
         if tpl is not None:
             return tpl
@@ -254,8 +258,7 @@ class NumericRecordDistribution(RecordDistribution):
             es = self.event_shape
         except NotImplementedError:
             raise TypeError(
-                f"{type(self).__name__} must declare event_shape or "
-                f"set _event_template explicitly."
+                f"{type(self).__name__} must declare event_shape or set _event_template explicitly."
             ) from None
         tpl = EventTemplate(**{name: es})
         object.__setattr__(self, "_event_template", tpl)
@@ -274,11 +277,7 @@ class NumericRecordDistribution(RecordDistribution):
         """
         clone = super().renamed(new_name)
         tpl = getattr(clone, "_event_template", None)
-        if (
-            tpl is not None
-            and len(tpl.fields) == 1
-            and tpl.fields[0] == self._name
-        ):
+        if tpl is not None and len(tpl.fields) == 1 and tpl.fields[0] == self._name:
             object.__setattr__(clone, "_event_template", None)
         return clone
 
@@ -345,7 +344,8 @@ class NumericRecordDistribution(RecordDistribution):
         return self.supports[self._single_field_name()]
 
     def _check_support_compatible(
-        self, source: "NumericRecordDistribution",
+        self,
+        source: "NumericRecordDistribution",
     ) -> None:
         """Raise ``ValueError`` if *source*'s per-field supports are
         incompatible with *self*'s (the target's) per-field supports.
@@ -375,9 +375,7 @@ class NumericRecordDistribution(RecordDistribution):
             for field_name, source_support in source_per_field.items():
                 if _supports_compatible(source_support, target_support):
                     continue
-                field_part = (
-                    f" field {field_name!r}" if multi_leaf_source else ""
-                )
+                field_part = f" field {field_name!r}" if multi_leaf_source else ""
                 raise ValueError(
                     f"Cannot convert {type(source).__name__}{field_part} "
                     f"(support={source_support}) to {type(self).__name__} "
@@ -399,7 +397,8 @@ class NumericRecordDistribution(RecordDistribution):
                 f"Pass check_support=False to override."
             )
         for (s_name, s_sup), (t_name, t_sup) in zip(
-            source_per_field.items(), target_per_field.items(),
+            source_per_field.items(),
+            target_per_field.items(),
         ):
             if _supports_compatible(s_sup, t_sup):
                 continue
@@ -468,10 +467,10 @@ class NumericRecordDistribution(RecordDistribution):
             td = jax.tree.structure(None)
         else:
             from ._numeric_record import NumericRecord
-            placeholder = NumericRecord(**{
-                name: jnp.zeros(tpl.field_event_shape(name))
-                for name in tpl.fields
-            })
+
+            placeholder = NumericRecord(
+                **{name: jnp.zeros(tpl.field_event_shape(name)) for name in tpl.fields}
+            )
             td = jax.tree.structure(placeholder)
         object.__setattr__(self, "_treedef", td)
         return td
@@ -495,13 +494,12 @@ class NumericRecordDistribution(RecordDistribution):
         numeric-leaf shapes; opaque leaves contribute zero.
         """
         from .record import NumericEventTemplate
+
         tpl = self.event_template
         if isinstance(tpl, NumericEventTemplate):
             return tpl.flat_size
         return sum(
-            prod(shape) if shape else 1
-            for shape in tpl.leaf_shapes.values()
-            if shape is not None
+            prod(shape) if shape else 1 for shape in tpl.leaf_shapes.values() if shape is not None
         )
 
     @staticmethod
@@ -517,6 +515,7 @@ class NumericRecordDistribution(RecordDistribution):
         from ._numeric_record import NumericRecord
         from ._record_array import NumericRecordArray
         from .record import Record
+
         if isinstance(value, (NumericRecordArray, NumericRecord)):
             return value.flatten()
         if isinstance(value, Record):
@@ -540,6 +539,7 @@ class NumericRecordDistribution(RecordDistribution):
         """
         from ._numeric_record import NumericRecord
         from ._record_array import NumericRecordArray
+
         flat = jnp.asarray(flat)
         if template is not None and len(template.fields) > 1:
             if flat.ndim < 2:
@@ -607,12 +607,14 @@ class NumericRecordDistribution(RecordDistribution):
         return f"{parts[0]}({', '.join(parts[1:])})"
 
 
-
 # ---------------------------------------------------------------------------
 # BootstrapDistribution
 # ---------------------------------------------------------------------------
 
-class BootstrapDistribution(NumericRecordDistribution, SupportsSampling, SupportsMean, SupportsVariance):
+
+class BootstrapDistribution(
+    NumericRecordDistribution, SupportsSampling, SupportsMean, SupportsVariance
+):
     """Distribution over bootstrap-resampled means of a statistic.
 
     Given *n* evaluations ``f(x_1), ..., f(x_n)`` where ``x_i ~ P``,
@@ -648,7 +650,9 @@ class BootstrapDistribution(NumericRecordDistribution, SupportsSampling, Support
             raise ValueError("evaluations must have at least 1 dimension.")
         self._num_atoms = self._evaluations.shape[0]
         self._w = Weights(
-            n=self._num_atoms, weights=weights, log_weights=log_weights,
+            n=self._num_atoms,
+            weights=weights,
+            log_weights=log_weights,
         )
         if name is None:
             name = "bootstrap_dist"
@@ -692,6 +696,7 @@ class BootstrapDistribution(NumericRecordDistribution, SupportsSampling, Support
         sample_shape: tuple[int, ...] = (),
     ) -> Array:
         """Draw bootstrap resamples of the mean."""
+
         def _one_resample(k):
             idx = self._w.choice(k, shape=(self._num_atoms,))
             return jnp.mean(self._evaluations[idx], axis=0)
@@ -713,7 +718,10 @@ class BootstrapDistribution(NumericRecordDistribution, SupportsSampling, Support
         return_dist: bool | None = None,
     ) -> Any:
         return _mc_expectation(
-            self, f, key=key, num_evaluations=num_evaluations,
+            self,
+            f,
+            key=key,
+            num_evaluations=num_evaluations,
             return_dist=return_dist,
         )
 
@@ -723,10 +731,8 @@ class BootstrapDistribution(NumericRecordDistribution, SupportsSampling, Support
         return self._per_field_dict(real)
 
     def __repr__(self) -> str:
-        return (
-            f"BootstrapDistribution(num_atoms={self._num_atoms}, "
-            f"event_shape={self.event_shape})"
-        )
+        return f"BootstrapDistribution(num_atoms={self._num_atoms}, event_shape={self.event_shape})"
+
 
 # ---------------------------------------------------------------------------
 # FlatNumericRecordDistribution — the flat-shaped subset of NRD
@@ -815,6 +821,7 @@ class FlatNumericRecordDistribution(NumericRecordDistribution):
             If ``self.flat_size`` does not match ``template.flat_size``.
         """
         from .record import NumericEventTemplate
+
         if not isinstance(template, NumericEventTemplate):
             raise TypeError(
                 f"as_record_distribution requires a NumericEventTemplate, "
@@ -864,7 +871,8 @@ def _flattened_distribution_view_class_for_base(base: Distribution) -> type:
         def _sample(self, key: PRNGKey, sample_shape: tuple[int, ...] = ()) -> Array:
             pytree_samples = self._base._sample(key, sample_shape)
             return self._base.flatten_value(
-                pytree_samples, event_shape=self._base.event_shape,
+                pytree_samples,
+                event_shape=self._base.event_shape,
             )
 
         extra_methods["_sample"] = _sample
@@ -875,7 +883,8 @@ def _flattened_distribution_view_class_for_base(base: Distribution) -> type:
         def _log_prob(self, x: ArrayLike) -> Array:
             x = jnp.asarray(x)
             value = self._base.unflatten_value(
-                x, template=self._base.event_template,
+                x,
+                template=self._base.event_template,
             )
             return self._base._log_prob(value)
 
@@ -939,7 +948,10 @@ class FlattenedDistributionView(FlatNumericRecordDistribution):
         return_dist: bool | None = None,
     ) -> Any:
         return _mc_expectation(
-            self, f, key=key, num_evaluations=num_evaluations,
+            self,
+            f,
+            key=key,
+            num_evaluations=num_evaluations,
             return_dist=return_dist,
         )
 
@@ -956,7 +968,8 @@ class FlattenedDistributionView(FlatNumericRecordDistribution):
     def unflatten_sample(self, flat_sample: ArrayLike):
         """Convenience: unflatten a flat sample back to the pytree structure."""
         return self._base.unflatten_value(
-            jnp.asarray(flat_sample), template=self._base.event_template,
+            jnp.asarray(flat_sample),
+            template=self._base.event_template,
         )
 
     def __repr__(self) -> str:
@@ -999,12 +1012,18 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
     from ._record_array import NumericRecordArray
 
     protocols: set[str] = set()
-    if isinstance(base, SupportsSampling):    protocols.add("sample")
-    if isinstance(base, SupportsLogProb):     protocols.add("log_prob")
-    if isinstance(base, SupportsMean):        protocols.add("mean")
-    if isinstance(base, SupportsVariance):    protocols.add("variance")
-    if isinstance(base, SupportsCovariance):  protocols.add("cov")
-    if isinstance(base, SupportsExpectation): protocols.add("expectation")
+    if isinstance(base, SupportsSampling):
+        protocols.add("sample")
+    if isinstance(base, SupportsLogProb):
+        protocols.add("log_prob")
+    if isinstance(base, SupportsMean):
+        protocols.add("mean")
+    if isinstance(base, SupportsVariance):
+        protocols.add("variance")
+    if isinstance(base, SupportsCovariance):
+        protocols.add("cov")
+    if isinstance(base, SupportsExpectation):
+        protocols.add("expectation")
 
     extra_bases: list[type] = []
     extra_methods: dict[str, object] = {}
@@ -1015,13 +1034,16 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
         def _sample(self, key: PRNGKey, sample_shape: tuple[int, ...] = ()):
             base_sample = self._base._sample(key, sample_shape)
             flat = self._base.flatten_value(
-                base_sample, event_shape=self._base.event_shape,
+                base_sample,
+                event_shape=self._base.event_shape,
             )
             tpl = self.event_template
             if sample_shape == ():
                 return NumericRecord.unflatten(flat, template=tpl)
             return NumericRecordArray.unflatten(
-                flat, template=tpl, batch_shape=sample_shape,
+                flat,
+                template=tpl,
+                batch_shape=sample_shape,
             )
 
         extra_methods["_sample"] = _sample
@@ -1035,7 +1057,8 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
             else:
                 flat = jnp.asarray(x)
             value = self._base.unflatten_value(
-                flat, template=self._base.event_template,
+                flat,
+                template=self._base.event_template,
             )
             return self._base._log_prob(value)
 
@@ -1046,7 +1069,8 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
 
         def _mean(self):
             flat = self._base.flatten_value(
-                self._base._mean(), event_shape=self._base.event_shape,
+                self._base._mean(),
+                event_shape=self._base.event_shape,
             )
             return NumericRecord.unflatten(flat, template=self.event_template)
 
@@ -1057,7 +1081,8 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
 
         def _variance(self):
             flat = self._base.flatten_value(
-                self._base._variance(), event_shape=self._base.event_shape,
+                self._base._variance(),
+                event_shape=self._base.event_shape,
             )
             return NumericRecord.unflatten(flat, template=self.event_template)
 
@@ -1096,7 +1121,8 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
             sample_key = key if key is not None else _auto_key()
             base_samples = self._base._sample(sample_key, sample_shape=(n,))
             flat_samples = self._base.flatten_value(
-                base_samples, event_shape=self._base.event_shape,
+                base_samples,
+                event_shape=self._base.event_shape,
             )
             template = self.event_template
 

--- a/probpipe/core/_random_functions.py
+++ b/probpipe/core/_random_functions.py
@@ -59,16 +59,12 @@ class RandomFunction[X, Y](Distribution[Callable[[X], Y]]):
     @property
     def input_shape(self) -> tuple[int, ...]:
         """Shape of a single input point (array-valued case)."""
-        raise NotImplementedError(
-            f"{type(self).__name__} does not define input_shape"
-        )
+        raise NotImplementedError(f"{type(self).__name__} does not define input_shape")
 
     @property
     def output_shape(self) -> tuple[int, ...]:
         """Shape of a single output point (array-valued case)."""
-        raise NotImplementedError(
-            f"{type(self).__name__} does not define output_shape"
-        )
+        raise NotImplementedError(f"{type(self).__name__} does not define output_shape")
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +220,7 @@ class ArrayRandomFunction(RandomFunction[Array, Array]):
         """
         ndim_input = len(self._input_shape)
         n = X.shape[-(ndim_input + 1)]
-        extra_batch = tuple(X.shape[:-(ndim_input + 1)])
+        extra_batch = tuple(X.shape[: -(ndim_input + 1)])
         return extra_batch, n
 
     def _validate_X(self, X: Array) -> None:
@@ -240,13 +236,10 @@ class ArrayRandomFunction(RandomFunction[Array, Array]):
         trailing = tuple(X.shape[-ndim_input:]) if ndim_input > 0 else ()
         if trailing != self._input_shape:
             raise ValueError(
-                f"Trailing dimensions of X {trailing} do not match "
-                f"input_shape={self._input_shape}"
+                f"Trailing dimensions of X {trailing} do not match input_shape={self._input_shape}"
             )
 
-    def _validate_joint_request(
-        self, joint_inputs: bool, joint_outputs: bool
-    ) -> None:
+    def _validate_joint_request(self, joint_inputs: bool, joint_outputs: bool) -> None:
         """Check that the requested joint mode is supported."""
         if joint_inputs and not self.supports_joint_inputs:
             raise ValueError(

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -83,9 +83,7 @@ class RecordArray(Record):
     ):
         if _dict is not None:
             if fields:
-                raise ValueError(
-                    "Cannot pass both positional dict and keyword arguments"
-                )
+                raise ValueError("Cannot pass both positional dict and keyword arguments")
             fields = _dict
         if not fields:
             raise ValueError("RecordArray requires at least one field")
@@ -179,9 +177,7 @@ class RecordArray(Record):
             return self._store[key]
         if isinstance(key, (int, np.integer)):
             return self._get_record(int(key))
-        raise TypeError(
-            f"key must be str or int, got {type(key).__name__}"
-        )
+        raise TypeError(f"key must be str or int, got {type(key).__name__}")
 
     def view(self, field: str) -> "_RecordArrayView":
         """Return a single-field view carrying parent identity.
@@ -361,10 +357,7 @@ class RecordArray(Record):
             else:
                 field_parts.append(f"{name}=...")
         cls_name = type(self).__name__
-        return (
-            f"{cls_name}(batch_shape={self._batch_shape}, "
-            f"{', '.join(field_parts)})"
-        )
+        return f"{cls_name}(batch_shape={self._batch_shape}, {', '.join(field_parts)})"
 
 
 # ---------------------------------------------------------------------------
@@ -425,8 +418,7 @@ class NumericRecordArray(RecordArray):
             kind = getattr(raw.dtype, "kind", None)
             if kind not in _NUMERIC_DTYPE_KINDS:
                 raise TypeError(
-                    f"NumericRecordArray: field {name!r} has non-numeric "
-                    f"dtype {raw.dtype!r}"
+                    f"NumericRecordArray: field {name!r} has non-numeric dtype {raw.dtype!r}"
                 )
             event_shape = spec.shape if isinstance(spec, ArraySpec) else ()
             expected = tuple(batch_shape) + event_shape
@@ -465,8 +457,7 @@ class NumericRecordArray(RecordArray):
             # A nested plain Record whose leaves still carry the batch axis
             # (a non-canonical batched draw): flatten each leaf and concatenate.
             if isinstance(val, Record):
-                return jnp.concatenate(
-                    [_flat_field(val[f]) for f in val.fields], axis=-1)
+                return jnp.concatenate([_flat_field(val[f]) for f in val.fields], axis=-1)
             return jnp.reshape(val, self._batch_shape + (prod(val.shape[n_batch:]),))
 
         parts = [_flat_field(self._store[name]) for name in self._store]
@@ -513,7 +504,9 @@ class NumericRecordArray(RecordArray):
             chunk = flat[..., offset : offset + size]
             if isinstance(spec, EventTemplate):
                 fields[name] = cls.unflatten(
-                    chunk, template=spec, batch_shape=batch_shape,
+                    chunk,
+                    template=spec,
+                    batch_shape=batch_shape,
                 )
             else:
                 # ArraySpec leaf — ``_spec_size`` above rejects every other
@@ -532,13 +525,11 @@ class NumericRecordArray(RecordArray):
         axis: int = 0,
     ) -> NumericRecordArray | Any:
         """Apply a reduction function over a batch axis."""
-        new_batch = self._batch_shape[:axis] + self._batch_shape[axis + 1:]
+        new_batch = self._batch_shape[:axis] + self._batch_shape[axis + 1 :]
         fields = {name: fn(self._store[name], axis) for name in self._store}
         if not new_batch:
             return NumericRecord(fields)
-        return NumericRecordArray(
-            fields, batch_shape=new_batch, template=self._template
-        )
+        return NumericRecordArray(fields, batch_shape=new_batch, template=self._template)
 
     def mean(self, axis: int = 0) -> Any:
         """Mean over a batch axis.
@@ -657,8 +648,7 @@ class _RecordArrayView(RecordArray):
     def __init__(self, parent: RecordArray, field: str):
         if field not in parent._store:
             raise KeyError(
-                f"field {field!r} not in parent "
-                f"{type(parent).__name__}(fields={parent.fields})"
+                f"field {field!r} not in parent {type(parent).__name__}(fields={parent.fields})"
             )
         leaf_spec = parent.template[field]
         store = OrderedDict([(field, parent._store[field])])
@@ -798,9 +788,7 @@ def _numeric_record_array_unflatten(
     )
 
 
-jax.tree_util.register_pytree_node(
-    RecordArray, _record_array_flatten, _record_array_unflatten
-)
+jax.tree_util.register_pytree_node(RecordArray, _record_array_flatten, _record_array_unflatten)
 jax.tree_util.register_pytree_node(
     NumericRecordArray, _record_array_flatten, _numeric_record_array_unflatten
 )

--- a/probpipe/core/_record_distribution.py
+++ b/probpipe/core/_record_distribution.py
@@ -96,6 +96,7 @@ def _view_class_for_parent(parent: Distribution) -> type[_RecordDistributionView
             # over draws for just this field. Requires the parent to
             # expose ``draws()`` (all ApproximateDistribution subclasses do).
             return self._field_draws().mean(axis=0)
+
         extra_methods["_mean"] = _mean
 
     if "variance" in protocols:
@@ -106,6 +107,7 @@ def _view_class_for_parent(parent: Distribution) -> type[_RecordDistributionView
             if isinstance(v, Record):
                 return v[self._key]
             return self._field_draws().var(axis=0)
+
         extra_methods["_variance"] = _variance
 
     if "log_prob" in protocols:
@@ -115,9 +117,8 @@ def _view_class_for_parent(parent: Distribution) -> type[_RecordDistributionView
             components = getattr(self._parent, "_components", None)
             if components is not None and self._key in components:
                 return components[self._key]._log_prob(value)
-            raise NotImplementedError(
-                f"_log_prob not available for view {self._key!r}"
-            )
+            raise NotImplementedError(f"_log_prob not available for view {self._key!r}")
+
         extra_methods["_log_prob"] = _log_prob
 
     if "cov" in protocols:
@@ -127,9 +128,8 @@ def _view_class_for_parent(parent: Distribution) -> type[_RecordDistributionView
             c = self._parent._cov()
             if isinstance(c, Record):
                 return c[self._key]
-            raise NotImplementedError(
-                f"_cov not available for view {self._key!r}"
-            )
+            raise NotImplementedError(f"_cov not available for view {self._key!r}")
+
         extra_methods["_cov"] = _cov
 
     if not extra_bases:
@@ -183,10 +183,7 @@ class _RecordDistributionView(Distribution):
         # (metaclass-enforced on every ``RecordDistribution`` instance).
         template = parent.event_template
         if key not in template:
-            raise KeyError(
-                f"No field {key!r} in event_template "
-                f"(available: {template.fields})"
-            )
+            raise KeyError(f"No field {key!r} in event_template (available: {template.fields})")
         # Bypass Distribution.__init__ validation (view name comes from
         # the field key, not a user-supplied argument).
         self._name = key
@@ -249,6 +246,7 @@ class _RecordDistributionView(Distribution):
     def _extract(self, structured: Any) -> Array:
         """Extract this field from a parent sample (Record, NumericRecordArray, or flat array)."""
         from ._record_array import RecordArray
+
         if isinstance(structured, (Record, RecordArray)):
             return structured[self._key]
         # Flat array — unflatten via the parent's static unflatten_value.
@@ -262,7 +260,8 @@ class _RecordDistributionView(Distribution):
                 f"implement unflatten_value."
             )
         result = unflatten(
-            jnp.asarray(structured), template=self._parent.event_template,
+            jnp.asarray(structured),
+            template=self._parent.event_template,
         )
         if isinstance(result, (Record, RecordArray)):
             return result[self._key]
@@ -280,19 +279,18 @@ class _RecordDistributionView(Distribution):
         expose ``draws()``.
         """
         from ._record_array import NumericRecordArray, RecordArray
+
         draws = self._parent.draws()
         if isinstance(draws, (Record, RecordArray)):
             return jnp.asarray(draws[self._key])
         result = NumericRecordArray.unflatten(
-            jnp.asarray(draws), template=self._parent.event_template,
+            jnp.asarray(draws),
+            template=self._parent.event_template,
         )
         return jnp.asarray(result[self._key])
 
     def __repr__(self) -> str:
-        return (
-            f"_RecordDistributionView(parent={type(self._parent).__name__}, "
-            f"field={self._key!r})"
-        )
+        return f"_RecordDistributionView(parent={type(self._parent).__name__}, field={self._key!r})"
 
 
 # ---------------------------------------------------------------------------
@@ -356,8 +354,7 @@ class _RecordDistributionMeta(_DistributionMeta):
             tpl = instance.event_template
         except (TypeError, NotImplementedError) as exc:
             raise TypeError(
-                f"{cls.__name__}.__init__ left event_template "
-                f"unresolved: {exc}"
+                f"{cls.__name__}.__init__ left event_template unresolved: {exc}"
             ) from exc
         if tpl is None:
             raise TypeError(
@@ -504,7 +501,6 @@ class RecordDistribution(Distribution[Record], metaclass=_RecordDistributionMeta
         return len(self.shape)
 
 
-
 # ---------------------------------------------------------------------------
 # JAX PyTree registration helpers
 # ---------------------------------------------------------------------------
@@ -520,13 +516,15 @@ def _register_dynamic_subclass(cls: type) -> type:
     capturing the top-level key order explicitly so insertion order
     survives the round-trip (JAX's dict treedef is sorted).
     """
+
     def _flatten(dist: Any) -> tuple[list[Any], tuple[Any, str, tuple[str, ...]]]:
         leaves = jax.tree.leaves(dist._components)
         treedef = jax.tree.structure(dist._components)
         return leaves, (treedef, dist._name, tuple(dist._components.keys()))
 
     def _unflatten(
-        aux: tuple[Any, str, tuple[str, ...]], children: list[Any],
+        aux: tuple[Any, str, tuple[str, ...]],
+        children: list[Any],
     ) -> Any:
         treedef, name, key_order = aux
         components = jax.tree.unflatten(treedef, children)

--- a/probpipe/core/_registry.py
+++ b/probpipe/core/_registry.py
@@ -239,14 +239,9 @@ class BaseDispatchRegistry[M: BaseDispatchMethod](ABC):
             same name is already registered.
         """
         if not method.name:
-            raise ValueError(
-                "Method.name must be a non-empty string; "
-                f"got {method.name!r}"
-            )
+            raise ValueError(f"Method.name must be a non-empty string; got {method.name!r}")
         if method.name in self._name_index:
-            raise ValueError(
-                f"Method name {method.name!r} is already registered"
-            )
+            raise ValueError(f"Method name {method.name!r} is already registered")
         self._methods.append(method)
         self._name_index[method.name] = method
         self._sort_methods()
@@ -286,14 +281,10 @@ class BaseDispatchRegistry[M: BaseDispatchMethod](ABC):
         for name in name_to_priority:
             if name not in self._name_index:
                 available = ", ".join(sorted(self._name_index)) or "(none)"
-                raise KeyError(
-                    f"No method named {name!r}. Available: {available}"
-                )
+                raise KeyError(f"No method named {name!r}. Available: {available}")
         for name, new_priority in name_to_priority.items():
             old_priority = self._effective_priority(self._name_index[name])
-            if (old_priority == OPT_IN_ONLY_PRIORITY) != (
-                new_priority == OPT_IN_ONLY_PRIORITY
-            ):
+            if (old_priority == OPT_IN_ONLY_PRIORITY) != (new_priority == OPT_IN_ONLY_PRIORITY):
                 direction = (
                     "out of opt-in-only"
                     if old_priority == OPT_IN_ONLY_PRIORITY
@@ -317,9 +308,7 @@ class BaseDispatchRegistry[M: BaseDispatchMethod](ABC):
             return self._name_index[name]
         except KeyError:
             available = ", ".join(sorted(self._name_index)) or "(none)"
-            raise KeyError(
-                f"No method named {name!r}. Available: {available}"
-            ) from None
+            raise KeyError(f"No method named {name!r}. Available: {available}") from None
 
     def list_methods(self) -> list[str]:
         """Return method names in priority order (highest first)."""
@@ -336,9 +325,7 @@ class BaseDispatchRegistry[M: BaseDispatchMethod](ABC):
         """
         return self._effective_priority(m) != OPT_IN_ONLY_PRIORITY
 
-    def check(
-        self, *args: Any, method: str | None = None, **kwargs: Any
-    ) -> MethodInfo:
+    def check(self, *args: Any, method: str | None = None, **kwargs: Any) -> MethodInfo:
         """Check feasibility.  Auto-selects or uses the named method."""
         if method is not None:
             m = self.get_method(method)
@@ -358,9 +345,7 @@ class BaseDispatchRegistry[M: BaseDispatchMethod](ABC):
             description=f"No applicable method for {self._format_key(key)}",
         )
 
-    def execute(
-        self, *args: Any, method: str | None = None, **kwargs: Any
-    ) -> Any:
+    def execute(self, *args: Any, method: str | None = None, **kwargs: Any) -> Any:
         """Execute using the best (or named) method.
 
         Raises ``TypeError`` if no method is applicable.
@@ -370,9 +355,7 @@ class BaseDispatchRegistry[M: BaseDispatchMethod](ABC):
             m = self.get_method(method)
             info = m.check(*args, **kwargs)
             if not info.feasible:
-                raise TypeError(
-                    f"Method {method!r} is not applicable: {info.description}"
-                )
+                raise TypeError(f"Method {method!r} is not applicable: {info.description}")
             return m.execute(*args, **kwargs)
 
         if not args:
@@ -385,8 +368,7 @@ class BaseDispatchRegistry[M: BaseDispatchMethod](ABC):
                 return m.execute(*args, **kwargs)
 
         raise TypeError(
-            f"No method registered for {self._format_key(key)}. "
-            f"Available: {self.list_methods()}"
+            f"No method registered for {self._format_key(key)}. Available: {self.list_methods()}"
         )
 
     # -- internals (arity-specific overrides) --------------------------------
@@ -438,7 +420,8 @@ class UnaryDispatchRegistry[M: UnaryDispatchMethod](BaseDispatchRegistry[M]):
         """
         if key not in self._type_cache:
             self._type_cache[key] = [
-                m for m in self._methods
+                m
+                for m in self._methods
                 if self._is_auto_dispatchable(m)
                 and any(issubclass(key, st) for st in m.supported_types())
             ]
@@ -482,8 +465,9 @@ class BinaryDispatchRegistry[M: BinaryDispatchMethod](BaseDispatchRegistry[M]):
                 if not self._is_auto_dispatchable(m):
                     continue
                 st = m.supported_types()
-                if (any(issubclass(tl, lt) for lt in st[0])
-                        and any(issubclass(tr, rt) for rt in st[1])):
+                if any(issubclass(tl, lt) for lt in st[0]) and any(
+                    issubclass(tr, rt) for rt in st[1]
+                ):
                     matches.append(m)
             self._type_cache[key] = matches
         return self._type_cache[key]

--- a/probpipe/core/_workflow_call.py
+++ b/probpipe/core/_workflow_call.py
@@ -58,8 +58,7 @@ def make_signature_info(
     hints = _get_type_hints(func)
     param_names = tuple(p for p in signature.parameters if p != "self")
     has_var_keyword = any(
-        p.kind == inspect.Parameter.VAR_KEYWORD
-        for p in signature.parameters.values()
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in signature.parameters.values()
     )
     return WorkflowSignatureInfo(
         signature=signature,

--- a/probpipe/core/_workflow_distribution_broadcast.py
+++ b/probpipe/core/_workflow_distribution_broadcast.py
@@ -175,14 +175,11 @@ def execute_distribution_broadcast(
 
 def _validate_n_broadcast_samples(n_broadcast_samples: int) -> None:
     if not isinstance(n_broadcast_samples, int):
-        raise TypeError(
-            f"n_broadcast_samples must be an integer; got {n_broadcast_samples!r}"
-        )
+        raise TypeError(f"n_broadcast_samples must be an integer; got {n_broadcast_samples!r}")
 
     if n_broadcast_samples <= 0:
         raise ValueError(
-            "n_broadcast_samples must be a positive integer; "
-            f"got {n_broadcast_samples!r}"
+            f"n_broadcast_samples must be a positive integer; got {n_broadcast_samples!r}"
         )
 
     if n_broadcast_samples < MIN_BROADCAST_SAMPLES:
@@ -204,10 +201,7 @@ def _split_empirical_args(
     sample_args: dict[str, Distribution] = {}
     for name in broadcast_args:
         dist = values[name]
-        if (
-            isinstance(dist, EmpiricalDistribution)
-            and dist.num_atoms <= n_broadcast_samples
-        ):
+        if isinstance(dist, EmpiricalDistribution) and dist.num_atoms <= n_broadcast_samples:
             candidates.append((name, dist))
         else:
             sample_args[name] = dist
@@ -270,7 +264,8 @@ def _sample_broadcast_args(
     """
     sampled: dict[str, Array] = {}
     for arg_names in _workflow_plan.group_by_parent(
-        values=values, names=broadcast_args,
+        values=values,
+        names=broadcast_args,
     ).values():
         first = values[arg_names[0]]
         if not isinstance(first, _RecordDistributionView):
@@ -303,9 +298,7 @@ def _broadcast_jax(
     workflow_kind: WorkflowKind,
 ) -> BroadcastDistribution:
     """Execute distribution broadcasting through local ``jax.vmap``."""
-    if workflow_kind in (WorkflowKind.TASK, WorkflowKind.FLOW) and (
-        task is None or flow is None
-    ):
+    if workflow_kind in (WorkflowKind.TASK, WorkflowKind.FLOW) and (task is None or flow is None):
         raise RuntimeError(
             "Prefect task or flow execution was requested, but Prefect is not installed. "
             "Install with: pip install probpipe[prefect]"
@@ -313,7 +306,10 @@ def _broadcast_jax(
 
     key = get_key()
     sampled = _sample_broadcast_args(
-        values, broadcast_args, n_broadcast_samples, key,
+        values,
+        broadcast_args,
+        n_broadcast_samples,
+        key,
     )
     static = {k: v for k, v in values.items() if k not in broadcast_args}
 
@@ -406,8 +402,7 @@ def _broadcast_enumerate(
     results = _workflow_execution.execute_many(request)
 
     all_input_samples = {
-        name: jnp.stack([cv[name] for cv in call_value_list])
-        for name in all_broadcast_args
+        name: jnp.stack([cv[name] for cv in call_value_list]) for name in all_broadcast_args
     }
 
     return BroadcastDistribution(
@@ -433,7 +428,10 @@ def _broadcast_sample(
     """Sample distribution arguments and execute one function call per sample."""
     key = get_key()
     samples_per_arg = _sample_broadcast_args(
-        values, broadcast_args, n_broadcast_samples, key,
+        values,
+        broadcast_args,
+        n_broadcast_samples,
+        key,
     )
 
     call_value_list = []

--- a/probpipe/core/_workflow_execution.py
+++ b/probpipe/core/_workflow_execution.py
@@ -93,8 +93,7 @@ def map_task(
     # columns, so Ray via Prefect relies on this rectangular kwargs shape.
     keys = request.call_value_list[0].keys()
     kwargs_by_param = {
-        key: [call_values[key] for call_values in request.call_value_list]
-        for key in keys
+        key: [call_values[key] for call_values in request.call_value_list] for key in keys
     }
     futures = run_func.map(**kwargs_by_param)
     return [future.result() for future in futures]
@@ -141,13 +140,9 @@ def _validate_max_workers(max_workers: int | None) -> int | None:
         return None
 
     if not isinstance(max_workers, int):
-        raise TypeError(
-            f"max_workers must be None or a positive int; got {max_workers!r}"
-        )
+        raise TypeError(f"max_workers must be None or a positive int; got {max_workers!r}")
     if max_workers < 1:
-        raise ValueError(
-            f"max_workers must be None or a positive int; got {max_workers!r}"
-        )
+        raise ValueError(f"max_workers must be None or a positive int; got {max_workers!r}")
     return max_workers
 
 

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -56,11 +56,14 @@ def build_broadcast_plan(
         is_record_array = isinstance(value, RecordArray)
         is_dist_array = isinstance(value, DistributionArray)
         if (is_record_array or is_dist_array) and len(value.batch_shape) > 0:
-            if _is_same_array_hint(
-                expected,
-                is_record_array=is_record_array,
-                is_dist_array=is_dist_array,
-            ) or expected is Any:
+            if (
+                _is_same_array_hint(
+                    expected,
+                    is_record_array=is_record_array,
+                    is_dist_array=is_dist_array,
+                )
+                or expected is Any
+            ):
                 continue
             array_args.append(name)
             continue
@@ -71,9 +74,7 @@ def build_broadcast_plan(
             dist_args.append(name)
 
     array_groups = group_array_args_by_parent(values=values, names=array_args)
-    sweep_batch_shape = tuple(
-        axis for group in array_groups for axis in group.batch_shape
-    )
+    sweep_batch_shape = tuple(axis for group in array_groups for axis in group.batch_shape)
     n_sweep = prod(sweep_batch_shape)
 
     return BroadcastPlan(

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -165,17 +165,10 @@ def execute_sweep_rows(
     require_jax_traceable: Callable[[dict[str, Any], list[str]], None],
 ) -> Any:
     """Execute pure sweep rows through JAX vmap or row-wise execution."""
-    has_dist_array = any(
-        isinstance(values[name], DistributionArray) for name in array_args
-    )
-    has_view = any(
-        isinstance(values[name], _RecordArrayView) for name in array_args
-    )
+    has_dist_array = any(isinstance(values[name], DistributionArray) for name in array_args)
+    has_view = any(isinstance(values[name], _RecordArrayView) for name in array_args)
     jax_supported = not (
-        has_dist_array
-        or has_view
-        or len(plan.array_groups) > 1
-        or len(array_args) > 1
+        has_dist_array or has_view or len(plan.array_groups) > 1 or len(array_args) > 1
     )
     if requested_dispatch == "jax" and not jax_supported:
         raise ValueError(
@@ -237,9 +230,7 @@ def execute_sweep_rows_jax(
         array_value = values[name]
         n_batch = len(array_value.batch_shape)
         vmap_input[name] = {
-            field: array_value[field].reshape(
-                (n_total, *array_value[field].shape[n_batch:])
-            )
+            field: array_value[field].reshape((n_total, *array_value[field].shape[n_batch:]))
             for field in array_value.fields
         }
     return jax.vmap(single_call)(vmap_input)
@@ -260,10 +251,7 @@ def make_sweep_provenance(
     """
     regime = "nested" if dist_args else "stack"
     array_candidates = [values[name] for name in array_args]
-    dist_candidates = [
-        values[name] for name in dist_args
-        if isinstance(values[name], Distribution)
-    ]
+    dist_candidates = [values[name] for name in dist_args if isinstance(values[name], Distribution)]
     return Provenance.create(
         f"workflow.{regime}",
         parents=array_candidates + dist_candidates,

--- a/probpipe/core/config.py
+++ b/probpipe/core/config.py
@@ -35,6 +35,7 @@ from typing import Any
 # WorkflowKind enum
 # ---------------------------------------------------------------------------
 
+
 class WorkflowKind(Enum):
     """Orchestration mode for ``WorkflowFunction`` instances.
 
@@ -93,6 +94,7 @@ def _initial_workflow_kind() -> WorkflowKind:
 # Task-runner auto-detection
 # ---------------------------------------------------------------------------
 
+
 def _auto_detect_task_runner() -> Any:
     """Return a task runner based on installed packages, or ``None``.
 
@@ -100,11 +102,13 @@ def _auto_detect_task_runner() -> Any:
     """
     try:
         from prefect_ray import RayTaskRunner
+
         return RayTaskRunner()
     except ImportError:
         pass
     try:
         from prefect_dask import DaskTaskRunner
+
         return DaskTaskRunner()
     except ImportError:
         pass
@@ -114,6 +118,7 @@ def _auto_detect_task_runner() -> Any:
 # ---------------------------------------------------------------------------
 # PrefectConfig singleton
 # ---------------------------------------------------------------------------
+
 
 class PrefectConfig:
     """Global Prefect orchestration settings.
@@ -157,8 +162,7 @@ class PrefectConfig:
     def workflow_kind(self, value: WorkflowKind) -> None:
         if not isinstance(value, WorkflowKind):
             raise TypeError(
-                f"workflow_kind must be a WorkflowKind enum member, "
-                f"got {type(value).__name__}"
+                f"workflow_kind must be a WorkflowKind enum member, got {type(value).__name__}"
             )
         self._workflow_kind = value
 
@@ -192,6 +196,7 @@ prefect_config = PrefectConfig()
 # ---------------------------------------------------------------------------
 # ProvenanceMode enum
 # ---------------------------------------------------------------------------
+
 
 class ProvenanceMode(Enum):
     """Controls how much history is retained in provenance chains.
@@ -250,6 +255,7 @@ def _initial_provenance_mode() -> ProvenanceMode:
 # ProvenanceConfig singleton
 # ---------------------------------------------------------------------------
 
+
 class ProvenanceConfig:
     """Global provenance tracking settings.
 
@@ -282,8 +288,7 @@ class ProvenanceConfig:
     def mode(self, value: ProvenanceMode) -> None:
         if not isinstance(value, ProvenanceMode):
             raise TypeError(
-                f"mode must be a ProvenanceMode enum member, "
-                f"got {type(value).__name__}"
+                f"mode must be a ProvenanceMode enum member, got {type(value).__name__}"
             )
         self._mode = value
 

--- a/probpipe/core/constraints.py
+++ b/probpipe/core/constraints.py
@@ -27,6 +27,7 @@ __all__ = [
 # Base class
 # ---------------------------------------------------------------------------
 
+
 class Constraint:
     """Describes the support of a distribution (the set of valid values)."""
 
@@ -48,129 +49,174 @@ class Constraint:
 # Concrete constraints
 # ---------------------------------------------------------------------------
 
+
 class _Real(Constraint):
     """All real numbers."""
+
     def check(self, value: ArrayLike) -> Array:
         return jnp.isfinite(jnp.asarray(value))
+
     def __repr__(self) -> str:
         return "real"
 
+
 class _Positive(Constraint):
     """Strictly positive reals (0, inf)."""
+
     def check(self, value: ArrayLike) -> Array:
         return jnp.asarray(value) > 0
+
     def __repr__(self) -> str:
         return "positive"
 
+
 class _NonNegative(Constraint):
     """Non-negative reals [0, inf)."""
+
     def check(self, value: ArrayLike) -> Array:
         return jnp.asarray(value) >= 0
+
     def __repr__(self) -> str:
         return "non_negative"
 
+
 class _NonNegativeInteger(Constraint):
     """Non-negative integers {0, 1, 2, ...}."""
+
     def check(self, value: ArrayLike) -> Array:
         v = jnp.asarray(value)
         return (v >= 0) & (v == jnp.floor(v))
+
     def __repr__(self) -> str:
         return "non_negative_integer"
 
+
 class _Boolean(Constraint):
     """Binary values {0, 1}."""
+
     def check(self, value: ArrayLike) -> Array:
         v = jnp.asarray(value)
         return (v == 0) | (v == 1)
+
     def __repr__(self) -> str:
         return "boolean"
 
+
 class _UnitInterval(Constraint):
     """Closed unit interval [0, 1]."""
+
     def check(self, value: ArrayLike) -> Array:
         v = jnp.asarray(value)
         return (v >= 0) & (v <= 1)
+
     def __repr__(self) -> str:
         return "unit_interval"
 
+
 class _Simplex(Constraint):
     """Probability simplex (non-negative, sums to 1 along last axis)."""
+
     def check(self, value: ArrayLike) -> Array:
         v = jnp.asarray(value)
         return (jnp.all(v >= 0, axis=-1)) & (jnp.abs(jnp.sum(v, axis=-1) - 1.0) < 1e-5)
+
     def __repr__(self) -> str:
         return "simplex"
 
+
 class _PositiveDefinite(Constraint):
     """Positive-definite matrices."""
+
     def check(self, value: ArrayLike) -> Array:
         v = jnp.asarray(value)
         eigvals = jnp.linalg.eigvalsh(v)
         return jnp.all(eigvals > 0, axis=-1)
+
     def __repr__(self) -> str:
         return "positive_definite"
 
+
 class _Sphere(Constraint):
     """Unit sphere (vectors with unit L2 norm)."""
+
     def check(self, value: ArrayLike) -> Array:
         v = jnp.asarray(value)
         return jnp.abs(jnp.linalg.norm(v, axis=-1) - 1.0) < 1e-5
+
     def __repr__(self) -> str:
         return "sphere"
 
+
 class _Interval(Constraint):
     """Half-open or closed interval [low, high]."""
+
     def __init__(self, low: ArrayLike, high: ArrayLike):
         self.low = low
         self.high = high
+
     def check(self, value: ArrayLike) -> Array:
         v = jnp.asarray(value)
         return (v >= self.low) & (v <= self.high)
+
     def __repr__(self) -> str:
         return f"interval({self.low}, {self.high})"
+
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):
             return False
         return bool(jnp.array_equal(self.low, other.low)) and bool(
             jnp.array_equal(self.high, other.high)
         )
+
     def __hash__(self) -> int:
         # Coarse but valid: equal instances hash equal. Parameterized
         # constraints rarely end up in sets/dicts, and array-valued
         # bounds aren't directly hashable, so we hash on type only.
         return hash(type(self))
 
+
 class _GreaterThan(Constraint):
     """Record strictly greater than a lower bound."""
+
     def __init__(self, lower_bound: ArrayLike):
         self.lower_bound = lower_bound
+
     def check(self, value: ArrayLike) -> Array:
         return jnp.asarray(value) > self.lower_bound
+
     def __repr__(self) -> str:
         return f"greater_than({self.lower_bound})"
+
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):
             return False
         return bool(jnp.array_equal(self.lower_bound, other.lower_bound))
+
     def __hash__(self) -> int:
         return hash(type(self))
 
+
 class _IntegerInterval(Constraint):
     """Integer values in [low, high]."""
+
     def __init__(self, low: ArrayLike, high: ArrayLike):
         self.low = low
         self.high = high
+
     def check(self, value: ArrayLike) -> Array:
         v = jnp.asarray(value)
         return (v >= self.low) & (v <= self.high) & (v == jnp.floor(v))
+
     def __repr__(self) -> str:
         return f"integer_interval({self.low}, {self.high})"
+
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):
             return False
         return bool(jnp.array_equal(self.low, other.low)) and bool(
             jnp.array_equal(self.high, other.high)
         )
+
     def __hash__(self) -> int:
         return hash(type(self))
 
@@ -194,11 +240,14 @@ sphere = _Sphere()
 # Factory functions for parameterized constraints
 # ---------------------------------------------------------------------------
 
+
 def interval(low: ArrayLike, high: ArrayLike) -> _Interval:
     return _Interval(low, high)
 
+
 def greater_than(lower_bound: ArrayLike) -> _GreaterThan:
     return _GreaterThan(lower_bound)
+
 
 def integer_interval(low: ArrayLike, high: ArrayLike) -> _IntegerInterval:
     return _IntegerInterval(low, high)
@@ -280,9 +329,7 @@ def _supports_compatible(source: Constraint, target: Constraint) -> bool:
     # array-valued (per-dim Uniform, TruncatedNormal, ...), so reduce
     # element-wise comparisons with ``jnp.all``.
     if isinstance(source, _Interval) and isinstance(target, _Interval):
-        return bool(jnp.all(source.low >= target.low)) and bool(
-            jnp.all(source.high <= target.high)
-        )
+        return bool(jnp.all(source.low >= target.low)) and bool(jnp.all(source.high <= target.high))
     if isinstance(source, _Interval) and isinstance(target, _Real):
         return True
     if isinstance(source, _GreaterThan) and isinstance(target, _GreaterThan):
@@ -292,9 +339,7 @@ def _supports_compatible(source: Constraint, target: Constraint) -> bool:
     if isinstance(source, (_Positive, _NonNegative)) and isinstance(target, _GreaterThan):
         return True  # (0, inf) or [0, inf) ⊂ (lb, inf) when lb <= 0
     if isinstance(source, _IntegerInterval) and isinstance(target, _IntegerInterval):
-        return bool(jnp.all(source.low >= target.low)) and bool(
-            jnp.all(source.high <= target.high)
-        )
+        return bool(jnp.all(source.low >= target.low)) and bool(jnp.all(source.high <= target.high))
     if isinstance(source, _IntegerInterval) and isinstance(target, (_NonNegativeInteger, _Real)):
         return True
 

--- a/probpipe/core/distribution.py
+++ b/probpipe/core/distribution.py
@@ -34,6 +34,7 @@ def __getattr__(name: str):
         return getattr(_base, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
+
 # -- _record_distribution ---------------------------------------------------
 from ._record_distribution import (
     RecordDistribution,

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -49,9 +49,7 @@ __all__ = [
     "workflow_method",
 ]
 
-_WorkflowFunctionDispatch = Literal[
-    "auto", "jax", "sequential", "thread"
-]
+_WorkflowFunctionDispatch = Literal["auto", "jax", "sequential", "thread"]
 _VALID_DISPATCH_STRATEGIES: tuple[str, ...] = get_args(_WorkflowFunctionDispatch)
 
 
@@ -115,6 +113,7 @@ def workflow_function(_func=None, /, **kwargs):
         Wrapped workflow function for bare usage, or a decorator when called
         with parentheses.
     """
+
     def decorator(func: Callable[..., Any]) -> WorkflowFunction:
         return WorkflowFunction(func=func, name=func.__name__, **kwargs)
 
@@ -243,14 +242,14 @@ class WorkflowFunction(Node):
         func: Callable,
         workflow_kind: WorkflowKind = WorkflowKind.DEFAULT,
         name: str | None = None,
-        bind: dict[str, Any] | None = None,         # construction-time bindings (defaults/config)
-        module: Any | None = None,                  # typically a Module; kept as Any to avoid import cycles
-        n_broadcast_samples: int | None = None,      # default number of samples for broadcasting
-        dispatch: _WorkflowFunctionDispatch = "auto", # "auto" | "jax" | "sequential" | "thread"
-        max_workers: int | None = None,             # ThreadPoolExecutor worker count
-        seed: int = 0,                              # JAX PRNG seed for broadcasting
-        include_inputs: bool = False,                # True → return BroadcastDistribution (joint over inputs+outputs)
-        **kwargs: Any,                              # convenience bindings (merged into bind)
+        bind: dict[str, Any] | None = None,  # construction-time bindings (defaults/config)
+        module: Any | None = None,  # typically a Module; kept as Any to avoid import cycles
+        n_broadcast_samples: int | None = None,  # default number of samples for broadcasting
+        dispatch: _WorkflowFunctionDispatch = "auto",  # "auto" | "jax" | "sequential" | "thread"
+        max_workers: int | None = None,  # ThreadPoolExecutor worker count
+        seed: int = 0,  # JAX PRNG seed for broadcasting
+        include_inputs: bool = False,  # True → return BroadcastDistribution (joint over inputs+outputs)
+        **kwargs: Any,  # convenience bindings (merged into bind)
     ):
         # Validate arguments before setting any instance state.
         if dispatch not in _VALID_DISPATCH_STRATEGIES:
@@ -285,7 +284,11 @@ class WorkflowFunction(Node):
         self.__signature__ = self._signature_info.signature
         self.__module__ = getattr(func, "__module__", None)
         self._module = module
-        self._n_broadcast_samples = n_broadcast_samples if n_broadcast_samples is not None else self.DEFAULT_N_BROADCAST_SAMPLES
+        self._n_broadcast_samples = (
+            n_broadcast_samples
+            if n_broadcast_samples is not None
+            else self.DEFAULT_N_BROADCAST_SAMPLES
+        )
         self._dispatch = dispatch
         self._max_workers = max_workers
         self._key = jax.random.PRNGKey(seed)
@@ -312,11 +315,7 @@ class WorkflowFunction(Node):
         """
         raw = self._workflow_kind_raw
 
-        kind = (
-            raw
-            if raw is not WorkflowKind.DEFAULT
-            else prefect_config.workflow_kind
-        )
+        kind = raw if raw is not WorkflowKind.DEFAULT else prefect_config.workflow_kind
 
         if kind is WorkflowKind.DEFAULT:
             kind = WorkflowKind.OFF
@@ -364,9 +363,7 @@ class WorkflowFunction(Node):
             mode=mode,
             max_workers=self._max_workers if mode == "thread" else None,
             name=self._name,
-            prefect_task_runner=(
-                prefect_config.resolve_task_runner() if is_prefect else None
-            ),
+            prefect_task_runner=(prefect_config.resolve_task_runner() if is_prefect else None),
         )
 
     def with_options(
@@ -435,10 +432,12 @@ class WorkflowFunction(Node):
             self._key = jax.random.PRNGKey(call.overrides.seed)
 
         values = _workflow_distribution_normalization.normalize_distribution_values(
-            values=call.values, hints=self._signature_info.hints,
+            values=call.values,
+            hints=self._signature_info.hints,
         )
         broadcast_plan = _workflow_plan.build_broadcast_plan(
-            values=values, hints=self._signature_info.hints,
+            values=values,
+            hints=self._signature_info.hints,
         )
 
         def execute_distribution_broadcast(
@@ -469,6 +468,7 @@ class WorkflowFunction(Node):
                 dist_args=broadcast_plan.dist_args,
             )
         if broadcast_plan.regime in ("sweep", "nested"):
+
             def distribution_broadcast(
                 row_values: dict[str, Any],
                 dist_args: list[str],
@@ -901,6 +901,7 @@ class Module(Node):
                     f"Got (impl):          {impl_sig}"
                 )
 
+
 class AbstractModule(Module, ABC):
     """
     Base class for modules that declare workflow interfaces via @abstract_workflow_method.
@@ -908,4 +909,5 @@ class AbstractModule(Module, ABC):
     ABCMeta will prevent instantiation until all abstract workflows are implemented
     by a concrete subclass.
     """
+
     pass

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -83,8 +83,7 @@ def sample(
     """
     if not isinstance(dist, SupportsSampling):
         raise TypeError(
-            f"{type(dist).__name__} does not support sampling "
-            f"(does not implement SupportsSampling)"
+            f"{type(dist).__name__} does not support sampling (does not implement SupportsSampling)"
         )
     if isinstance(sample_shape, int):
         sample_shape = (sample_shape,)
@@ -128,15 +127,11 @@ def _resolve_value(
     """
     if field_kwargs:
         if value is not None:
-            raise TypeError(
-                f"{op_name}: pass either a positional value or field kwargs, "
-                f"not both."
-            )
+            raise TypeError(f"{op_name}: pass either a positional value or field kwargs, not both.")
         return dist._pack_value(**field_kwargs)
     if value is None and not allow_none:
         raise TypeError(
-            f"{op_name}: a value is required — pass it positionally or as "
-            f"field keyword arguments."
+            f"{op_name}: a value is required — pass it positionally or as field keyword arguments."
         )
     return value
 
@@ -152,9 +147,7 @@ def log_prob(dist: SupportsLogProb, value: Any = None, **field_kwargs: Any) -> A
     batched evaluation; per-call controls use ``log_prob.with_options(...)``.
     """
     if not isinstance(dist, SupportsLogProb):
-        raise TypeError(
-            f"{type(dist).__name__} does not support log_prob"
-        )
+        raise TypeError(f"{type(dist).__name__} does not support log_prob")
     return dist._log_prob(_resolve_value("log_prob", dist, value, field_kwargs))
 
 
@@ -165,17 +158,16 @@ def prob(dist: SupportsLogProb, value: Any = None, **field_kwargs: Any) -> Array
     See :func:`log_prob` for the positional and keyword call forms.
     """
     if not isinstance(dist, SupportsLogProb):
-        raise TypeError(
-            f"{type(dist).__name__} does not support prob "
-            f"(missing _log_prob method)"
-        )
+        raise TypeError(f"{type(dist).__name__} does not support prob (missing _log_prob method)")
     value = _resolve_value("prob", dist, value, field_kwargs)
     return jnp.exp(dist._log_prob(value))
 
 
 @workflow_function
 def unnormalized_log_prob(
-    dist: SupportsUnnormalizedLogProb, value: Any = None, **field_kwargs: Any,
+    dist: SupportsUnnormalizedLogProb,
+    value: Any = None,
+    **field_kwargs: Any,
 ) -> Array:
     """Evaluate the unnormalized log-density at *value*.
 
@@ -192,7 +184,9 @@ def unnormalized_log_prob(
 
 @workflow_function
 def unnormalized_prob(
-    dist: SupportsUnnormalizedLogProb, value: Any = None, **field_kwargs: Any,
+    dist: SupportsUnnormalizedLogProb,
+    value: Any = None,
+    **field_kwargs: Any,
 ) -> Array:
     """Evaluate the unnormalized density at *value* — ``exp(unnormalized_log_prob)``.
 
@@ -226,8 +220,7 @@ def mean(dist: SupportsMean) -> Any:
     """
     if not isinstance(dist, SupportsMean):
         raise TypeError(
-            f"{type(dist).__name__} does not support mean "
-            f"(does not implement SupportsMean)"
+            f"{type(dist).__name__} does not support mean (does not implement SupportsMean)"
         )
     return dist._mean()
 
@@ -240,8 +233,7 @@ def variance(dist: SupportsVariance) -> Any:
     """
     if not isinstance(dist, SupportsVariance):
         raise TypeError(
-            f"{type(dist).__name__} does not support variance "
-            f"(does not implement SupportsVariance)"
+            f"{type(dist).__name__} does not support variance (does not implement SupportsVariance)"
         )
     return dist._variance()
 
@@ -271,11 +263,12 @@ def expectation(
 ) -> Any:
     """Compute E[f(X)] where X ~ dist."""
     if not isinstance(dist, SupportsExpectation):
-        raise TypeError(
-            f"{type(dist).__name__} does not support expectation"
-        )
+        raise TypeError(f"{type(dist).__name__} does not support expectation")
     return dist._expectation(
-        f, key=key, num_evaluations=num_evaluations, return_dist=return_dist,
+        f,
+        key=key,
+        num_evaluations=num_evaluations,
+        return_dist=return_dist,
     )
 
 
@@ -307,9 +300,7 @@ def random_log_prob(
             f"{type(dist).__name__} does not support random_log_prob "
             f"(does not implement SupportsRandomLogProb)"
         )
-    value = _resolve_value(
-        "random_log_prob", dist, value, field_kwargs, allow_none=True
-    )
+    value = _resolve_value("random_log_prob", dist, value, field_kwargs, allow_none=True)
     rf = dist._random_log_prob()
     return rf if value is None else rf(value)
 
@@ -372,7 +363,7 @@ def _split_data_kwargs(
 
     Returns ``(data_kwargs, inference_kwargs)``.
     """
-    comp_names = tuple(dist.fields) if hasattr(dist, 'fields') else ()
+    comp_names = tuple(dist.fields) if hasattr(dist, "fields") else ()
     comp_set = frozenset(comp_names)
     by_lower = {name.lower(): name for name in comp_names}
 
@@ -462,9 +453,7 @@ def condition_on(
                     f"data kwargs ({', '.join(data_kwargs)})"
                 )
             observed = Record(data_kwargs)
-        return inference_method_registry.execute(
-            dist, observed, method=method, **inference_kwargs
-        )
+        return inference_method_registry.execute(dist, observed, method=method, **inference_kwargs)
 
     # Exact conditioning (conjugate updates, joint marginalization, etc.)
     # All kwargs pass through to _condition_on — it handles its own
@@ -511,6 +500,7 @@ def from_distribution(
         Additional keyword arguments passed to the converter.
     """
     from ..converters import converter_registry
+
     if key is None:
         key = _auto_key()
     return converter_registry.convert(

--- a/probpipe/core/protocols.py
+++ b/probpipe/core/protocols.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
 # Decorator for default moment implementations via expectation
 # ---------------------------------------------------------------------------
 
+
 def compute_expectation(method):
     """Decorator providing a default moment implementation via ``expectation``.
 
@@ -98,12 +99,12 @@ def compute_expectation(method):
 # Expectation & sampling
 # ---------------------------------------------------------------------------
 
+
 @runtime_checkable
 class SupportsExpectation(Protocol):
     """Distribution that can compute ``E[f(X)]``."""
 
-    def _expectation(self, f: Any, *, key: Any, num_evaluations: Any,
-                     return_dist: Any) -> Any: ...
+    def _expectation(self, f: Any, *, key: Any, num_evaluations: Any, return_dist: Any) -> Any: ...
 
 
 @runtime_checkable
@@ -165,6 +166,7 @@ class SupportsSampling(Protocol):
 # Density evaluation
 # ---------------------------------------------------------------------------
 
+
 @runtime_checkable
 class SupportsUnnormalizedLogProb[T](Protocol):
     """Distribution with an unnormalized log-density.
@@ -207,6 +209,7 @@ class SupportsLogProb[T](SupportsUnnormalizedLogProb[T], Protocol):
 # ---------------------------------------------------------------------------
 # Moment protocols
 # ---------------------------------------------------------------------------
+
 
 @runtime_checkable
 class SupportsMean(Protocol):
@@ -267,6 +270,7 @@ class SupportsCovariance(Protocol):
 # Random-measure protocols
 # ---------------------------------------------------------------------------
 
+
 @runtime_checkable
 class SupportsRandomLogProb(Protocol):
     """Distribution over distributions with a random (normalized) log-density.
@@ -306,6 +310,7 @@ class SupportsRandomUnnormalizedLogProb(Protocol):
 # ---------------------------------------------------------------------------
 # Conditioning
 # ---------------------------------------------------------------------------
+
 
 @runtime_checkable
 class SupportsConditioning(Protocol):
@@ -457,7 +462,8 @@ class SupportsArrayBackend(Protocol):
 
 
 def protocols_supported_by_all(
-    leaves: list, candidates: tuple[type, ...],
+    leaves: list,
+    candidates: tuple[type, ...],
 ) -> tuple[type, ...]:
     """Return the subset of *candidates* that every leaf satisfies.
 
@@ -555,6 +561,7 @@ def _default_per_datum_log_likelihood(
     broadcasting overhead inside ``log_likelihood``).
     """
     import jax
+
     batch = jax.tree.map(lambda x: x[None, ...], datum)
     return likelihood.log_likelihood(params, batch)
 
@@ -570,8 +577,11 @@ class GenerativeLikelihood[P, D](Protocol):
     """
 
     def generate_data(
-        self, params: P, num_observations: int,
-        *, key: PRNGKey | None = None,
+        self,
+        params: P,
+        num_observations: int,
+        *,
+        key: PRNGKey | None = None,
     ) -> D:
         """Generate ``num_observations`` synthetic data points from ``params``.
 

--- a/probpipe/core/provenance.py
+++ b/probpipe/core/provenance.py
@@ -27,6 +27,7 @@ __all__ = [
 # ParentInfo descriptor
 # ---------------------------------------------------------------------------
 
+
 @dataclass(frozen=True)
 class ParentInfo:
     """Descriptor for a provenance parent, used in all non-OFF modes.
@@ -68,6 +69,7 @@ class ParentInfo:
 # Provenance dataclass
 # ---------------------------------------------------------------------------
 
+
 @dataclass(frozen=True)
 class Provenance:
     """Tracks how a distribution was created."""
@@ -77,9 +79,7 @@ class Provenance:
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def __repr__(self) -> str:
-        parent_names = ", ".join(
-            p.name or p.type_name for p in self.parents
-        )
+        parent_names = ", ".join(p.name or p.type_name for p in self.parents)
         return f"Provenance({self.operation!r}, parents=[{parent_names}])"
 
     # -- Serialization -----------------------------------------------------
@@ -175,6 +175,7 @@ class Provenance:
 # Graph utilities
 # ---------------------------------------------------------------------------
 
+
 def _parent_key(p: Any) -> Any:
     """Stable dedup key for a parent node.
 
@@ -245,8 +246,7 @@ def provenance_dag(dist: "Distribution"):
         from graphviz import Digraph
     except ImportError:
         raise ImportError(
-            "graphviz is required for provenance_dag(). "
-            "Install it with: pip install graphviz"
+            "graphviz is required for provenance_dag(). Install it with: pip install graphviz"
         )
 
     dot = Digraph(comment="Provenance DAG")

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -443,6 +443,7 @@ class Record:
         # Lazy import to avoid the module-level circular dep:
         # _numeric_record.py imports Record from this module.
         from ._numeric_record import NumericRecord
+
         return NumericRecord.from_record(self)
 
     # -- Coercion -----------------------------------------------------------
@@ -523,8 +524,7 @@ class Record:
         only = next(iter(self._store.values()))
         if not callable(only):
             raise TypeError(
-                f"{type(self).__name__} single field is not callable "
-                f"(got {type(only).__name__})."
+                f"{type(self).__name__} single field is not callable (got {type(only).__name__})."
             )
         return only(*args, **kwargs)
 
@@ -603,8 +603,7 @@ class ArraySpec:
         shape = tuple(self.shape)
         if not all(isinstance(d, int) and d >= 0 for d in shape):
             raise TypeError(
-                f"ArraySpec.shape must be a tuple of non-negative ints, "
-                f"got {self.shape!r}"
+                f"ArraySpec.shape must be a tuple of non-negative ints, got {self.shape!r}"
             )
         object.__setattr__(self, "shape", shape)
 
@@ -721,8 +720,7 @@ def _pack_fields(
             parts.append(f"unexpected {extra}")
         prefix = f"{owner}: " if owner else ""
         raise TypeError(
-            f"{prefix}expected exactly the fields {tuple(fields)} — "
-            f"{'; '.join(parts)}."
+            f"{prefix}expected exactly the fields {tuple(fields)} — {'; '.join(parts)}."
         )
     return Record(**{f: field_kwargs[f] for f in fields})
 
@@ -831,9 +829,7 @@ class EventTemplate:
         source: Mapping[str, _FieldSpecInput]
         if _dict is not None:
             if field_specs:
-                raise ValueError(
-                    "Cannot pass both positional dict and keyword arguments"
-                )
+                raise ValueError("Cannot pass both positional dict and keyword arguments")
             source = _dict
         else:
             source = field_specs
@@ -1003,6 +999,7 @@ class EventTemplate:
         target_cls = cls
         if cls is EventTemplate:
             from ._numeric_record import NumericRecord
+
             if isinstance(record, NumericRecord):
                 target_cls = NumericEventTemplate
         n_batch = len(batch_shape)

--- a/probpipe/core/transition.py
+++ b/probpipe/core/transition.py
@@ -240,12 +240,13 @@ def with_resampling(
                 # Resample per-field (samples is a NumericRecord; index
                 # each field's stacked array along the sample axis).
                 from .record import Record
-                new_record = Record({
-                    f: out_dist.samples[f][indices]
-                    for f in out_dist.samples.fields
-                })
+
+                new_record = Record(
+                    {f: out_dist.samples[f][indices] for f in out_dist.samples.fields}
+                )
                 resampled = EmpiricalDistribution(
-                    new_record, name=out_dist.name,
+                    new_record,
+                    name=out_dist.name,
                 )
                 resampled.with_source(
                     Provenance.create(

--- a/probpipe/distributions/_bijector_dispatch.py
+++ b/probpipe/distributions/_bijector_dispatch.py
@@ -149,8 +149,7 @@ def bijector_for(constraint: Constraint) -> tfb.Bijector:
             return _CONSTRAINT_BIJECTOR_REGISTRY[cls](constraint)
 
     raise NotImplementedError(
-        f"No bijector registered for {constraint!r}. "
-        f"Use ``probpipe.register_bijector`` to add one."
+        f"No bijector registered for {constraint!r}. Use ``probpipe.register_bijector`` to add one."
     )
 
 
@@ -186,9 +185,8 @@ register_bijector(
 # "not registered".
 def _no_smooth_bijector(reason: str) -> BijectorFactory:
     def _raise(c: Constraint) -> tfb.Bijector:
-        raise NotImplementedError(
-            f"{c!r} has no canonical bijector: {reason}"
-        )
+        raise NotImplementedError(f"{c!r} has no canonical bijector: {reason}")
+
     return _raise
 
 
@@ -208,14 +206,11 @@ register_bijector(
 )
 register_bijector(
     _NonNegativeInteger,
-    _no_smooth_bijector(
-        "discrete support; no continuous bijector exists"
-    ),
+    _no_smooth_bijector("discrete support; no continuous bijector exists"),
 )
 register_bijector(
     _IntegerInterval,
     _no_smooth_bijector(
-        "discrete support; consider a continuous relaxation "
-        "(e.g., Gumbel-Softmax) or rounding"
+        "discrete support; consider a continuous relaxation (e.g., Gumbel-Softmax) or rounding"
     ),
 )

--- a/probpipe/distributions/_joint_empirical.py
+++ b/probpipe/distributions/_joint_empirical.py
@@ -218,7 +218,9 @@ class JointEmpirical(RecordDistribution, SupportsSampling, SupportsConditioning)
         return Record(self._resample_rows(key, sample_shape))
 
     def _resample_rows(
-        self, key: PRNGKey, sample_shape: tuple[int, ...],
+        self,
+        key: PRNGKey,
+        sample_shape: tuple[int, ...],
     ) -> dict[str, Any]:
         """Draw ``prod(sample_shape)`` row indices and slice each field.
 
@@ -238,9 +240,7 @@ class JointEmpirical(RecordDistribution, SupportsSampling, SupportsConditioning)
                     # Non-numeric object arrays don't always support reshape.
                     result[cname] = drawn
             else:
-                result[cname] = (
-                    drawn[0] if drawn.shape and drawn.shape[0] == 1 else drawn
-                )
+                result[cname] = drawn[0] if drawn.shape and drawn.shape[0] == 1 else drawn
         return result
 
     # -- Conditioning -------------------------------------------------------
@@ -272,9 +272,7 @@ class JointEmpirical(RecordDistribution, SupportsSampling, SupportsConditioning)
         observed_names = {path[0] for path in observed_leaves}
 
         remaining_samples = {
-            cname: arr
-            for cname, arr in self._joint_samples.items()
-            if cname not in observed_names
+            cname: arr for cname, arr in self._joint_samples.items() if cname not in observed_names
         }
         if not remaining_samples:
             raise ValueError(
@@ -287,10 +285,13 @@ class JointEmpirical(RecordDistribution, SupportsSampling, SupportsConditioning)
             weights=self._w,
             name=self._name,
         )
-        result.with_source(Provenance.create(
-            "condition_on", parents=[self],
-            metadata={"conditioned": list(observed_names)},
-        ))
+        result.with_source(
+            Provenance.create(
+                "condition_on",
+                parents=[self],
+                metadata={"conditioned": list(observed_names)},
+            )
+        )
         return result
 
 
@@ -300,8 +301,10 @@ class JointEmpirical(RecordDistribution, SupportsSampling, SupportsConditioning)
 
 
 class NumericJointEmpirical(
-    JointEmpirical, NumericRecordDistribution,
-    SupportsMean, SupportsVariance,
+    JointEmpirical,
+    NumericRecordDistribution,
+    SupportsMean,
+    SupportsVariance,
 ):
     """Joint empirical where every field is a numeric array.
 
@@ -350,7 +353,10 @@ class NumericJointEmpirical(
             coerced[cname] = _as_float_array(arr)
 
         super().__init__(
-            weights=weights, log_weights=log_weights, name=name, **coerced,
+            weights=weights,
+            log_weights=log_weights,
+            name=name,
+            **coerced,
         )
 
     def _build_component_dists(self) -> dict[str, NumericRecordDistribution]:
@@ -363,10 +369,12 @@ class NumericJointEmpirical(
 
     def _sample_joint_rows(self, key: PRNGKey, sample_shape: tuple[int, ...]):
         from ..core._record_array import NumericRecordArray
+
         result = self._resample_rows(key, sample_shape)
         if sample_shape:
             return NumericRecordArray(
-                result, batch_shape=sample_shape,
+                result,
+                batch_shape=sample_shape,
                 template=self.event_template,
             )
         return Record(result)
@@ -382,19 +390,17 @@ class NumericJointEmpirical(
 
     def _mean(self) -> Record:
         """Per-component weighted means."""
-        return Record({
-            cname: self._w.mean(arr)
-            for cname, arr in self._joint_samples.items()
-        })
+        return Record({cname: self._w.mean(arr) for cname, arr in self._joint_samples.items()})
 
     def _variance(self) -> Record:
         """Per-component weighted variances."""
-        return Record({
-            cname: self._w.variance(arr)
-            for cname, arr in self._joint_samples.items()
-        })
+        return Record({cname: self._w.variance(arr) for cname, arr in self._joint_samples.items()})
 
     def _expectation(self, f, *, key=None, num_evaluations=None, return_dist=None):
         return _mc_expectation(
-            self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist,
+            self,
+            f,
+            key=key,
+            num_evaluations=num_evaluations,
+            return_dist=return_dist,
         )

--- a/probpipe/distributions/_joint_gaussian.py
+++ b/probpipe/distributions/_joint_gaussian.py
@@ -32,7 +32,15 @@ from ._joint_utils import (
 )
 
 
-class JointGaussian(NumericRecordDistribution, SupportsSampling, SupportsLogProb, SupportsMean, SupportsVariance, SupportsCovariance, SupportsConditioning):
+class JointGaussian(
+    NumericRecordDistribution,
+    SupportsSampling,
+    SupportsLogProb,
+    SupportsMean,
+    SupportsVariance,
+    SupportsCovariance,
+    SupportsConditioning,
+):
     """
     Joint Gaussian distribution with named components and cross-covariance.
 
@@ -83,9 +91,7 @@ class JointGaussian(NumericRecordDistribution, SupportsSampling, SupportsLogProb
                 f"({total_dim},) from component shapes {component_shapes}."
             )
         if cov.shape != (total_dim, total_dim):
-            raise ValueError(
-                f"cov shape {cov.shape} does not match ({total_dim}, {total_dim})."
-            )
+            raise ValueError(f"cov shape {cov.shape} does not match ({total_dim}, {total_dim}).")
 
         self._mean_vec = mean
         self._cov_mat = cov
@@ -159,6 +165,7 @@ class JointGaussian(NumericRecordDistribution, SupportsSampling, SupportsLogProb
         sample_shape: tuple[int, ...] = (),
     ):
         from .multivariate import MultivariateNormal as MVN
+
         full_mvn = MVN(loc=self._mean_vec, cov=self._cov_mat, name="_jg_internal")
         flat = full_mvn._sample(key, sample_shape)
         return self._unflatten_flat_vec(flat, sample_shape=sample_shape)
@@ -166,22 +173,26 @@ class JointGaussian(NumericRecordDistribution, SupportsSampling, SupportsLogProb
     def _unflatten_flat_vec(self, flat: Array, sample_shape: tuple[int, ...] = ()):
         """Split a flat Gaussian sample vector into per-component arrays."""
         from ..core._record_array import NumericRecordArray
+
         result = {}
         for cname in self._component_shapes:
             sl = self._component_slices[cname]
             result[cname] = flat[..., sl]
         if sample_shape:
             return NumericRecordArray(
-                result, batch_shape=sample_shape,
+                result,
+                batch_shape=sample_shape,
                 template=self.event_template,
             )
         return Record(result)
 
     def _log_prob(self, value) -> Array:
         from ..core._record_array import RecordArray
+
         if not isinstance(value, (Record, RecordArray)):
             value = Record(value)
         from .multivariate import MultivariateNormal as MVN
+
         full_mvn = MVN(loc=self._mean_vec, cov=self._cov_mat, name="_jg_internal")
         # ``Record``/``RecordArray`` carry their own structure, so the
         # static ``flatten_value`` ignores ``event_shape`` for these
@@ -210,14 +221,17 @@ class JointGaussian(NumericRecordDistribution, SupportsSampling, SupportsLogProb
         return self._cov_mat
 
     def _expectation(self, f, *, key=None, num_evaluations=None, return_dist=None):
-        return _mc_expectation(self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist)
+        return _mc_expectation(
+            self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist
+        )
 
     def _condition_on(self, observed=None, /, **kwargs):
         observed_leaves = _parse_condition_args(self, observed, kwargs)
         return self._condition_on_impl(observed_leaves)
 
     def _condition_on_impl(
-        self, observed_leaves: dict[KeyPath, ArrayLike],
+        self,
+        observed_leaves: dict[KeyPath, ArrayLike],
     ) -> JointGaussian:
         """Condition on observed component values using exact Gaussian formulas.
 
@@ -298,16 +312,16 @@ class JointGaussian(NumericRecordDistribution, SupportsSampling, SupportsLogProb
             name=self._name,
             **u_shapes,
         )
-        result.with_source(Provenance.create(
-            "condition_on",
-            parents=[self],
-            metadata={"conditioned": list(observed.keys())},
-        ))
+        result.with_source(
+            Provenance.create(
+                "condition_on",
+                parents=[self],
+                metadata={"conditioned": list(observed.keys())},
+            )
+        )
         return result
 
     def __repr__(self) -> str:
-        comp_str = ", ".join(
-            f"{k}={v}" for k, v in self._component_shapes.items()
-        )
+        comp_str = ", ".join(f"{k}={v}" for k, v in self._component_shapes.items())
         name_str = f", name='{self._name}'" if self._name else ""
         return f"JointGaussian({comp_str}{name_str})"

--- a/probpipe/distributions/_joint_utils.py
+++ b/probpipe/distributions/_joint_utils.py
@@ -41,9 +41,7 @@ def _normalize_key(key) -> KeyPath:
         return (key,)
     if isinstance(key, tuple) and all(isinstance(k, str) for k in key):
         return key
-    raise TypeError(
-        f"Component key must be a string or tuple of strings, got {key!r}"
-    )
+    raise TypeError(f"Component key must be a string or tuple of strings, got {key!r}")
 
 
 def _walk_pytree(tree, key_path: KeyPath):
@@ -74,9 +72,7 @@ def _walk_pytree(tree, key_path: KeyPath):
                 f"key path prefix; remaining key: {k!r}"
             )
         if k not in node:
-            raise KeyError(
-                f"Key {k!r} not found. Available: {tuple(node.keys())}"
-            )
+            raise KeyError(f"Key {k!r} not found. Available: {tuple(node.keys())}")
         node = node[k]
     return node
 
@@ -117,9 +113,7 @@ def _component_key_paths(components) -> tuple:
     paths_and_leaves = jax.tree_util.tree_leaves_with_path(components)
     key_paths = []
     for path, _leaf in paths_and_leaves:
-        str_path = tuple(
-            k.key if hasattr(k, "key") else str(k) for k in path
-        )
+        str_path = tuple(k.key if hasattr(k, "key") else str(k) for k in path)
         key_paths.append(str_path)
     return tuple(key_paths)
 
@@ -127,6 +121,7 @@ def _component_key_paths(components) -> tuple:
 # ---------------------------------------------------------------------------
 # Conditioning argument parser (module-level helper)
 # ---------------------------------------------------------------------------
+
 
 def _collect_observed_leaves(
     obs_tree: dict,
@@ -252,8 +247,7 @@ def _parse_condition_args(
     """
     if observed is not None and kwargs:
         raise TypeError(
-            "condition_on() accepts either a positional dict or keyword "
-            "arguments, not both."
+            "condition_on() accepts either a positional dict or keyword arguments, not both."
         )
     tree = observed if observed is not None else kwargs
     if not tree:
@@ -265,8 +259,7 @@ def _parse_condition_args(
 
     # Check we're not conditioning on everything
     all_leaf_paths = set(
-        p if isinstance(p, tuple) else (p,)
-        for p in _component_key_paths(joint._components)
+        p if isinstance(p, tuple) else (p,) for p in _component_key_paths(joint._components)
     )
     conditioned_paths = set(observed_leaves.keys())
     if conditioned_paths >= all_leaf_paths:
@@ -312,5 +305,3 @@ def _prune_leaves(tree: dict, remove_paths: set[KeyPath], prefix: tuple = ()) ->
 # ---------------------------------------------------------------------------
 # Batched flatten / unflatten for Record with known event_shapes
 # ---------------------------------------------------------------------------
-
-

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -81,7 +81,8 @@ def _product_class_for_components(components: dict) -> type:
     leaves = jax.tree.leaves(components)
 
     extra_bases = protocols_supported_by_all(
-        leaves, (SupportsLogProb, SupportsMean, SupportsVariance),
+        leaves,
+        (SupportsLogProb, SupportsMean, SupportsVariance),
     )
     all_tfp = all(hasattr(l, "_tfp_dist") for l in leaves)
     all_numeric = all(isinstance(l, NumericRecordDistribution) for l in leaves)
@@ -96,9 +97,7 @@ def _product_class_for_components(components: dict) -> type:
     # API on top of the generic ``ProductDistribution`` base. Listing
     # it before the protocol mixins keeps the MRO consistent with
     # standalone NRDs (numeric API → protocols → object).
-    numeric_mixin: tuple[type, ...] = (
-        (NumericRecordDistribution,) if all_numeric else ()
-    )
+    numeric_mixin: tuple[type, ...] = (NumericRecordDistribution,) if all_numeric else ()
     bases = (base, *numeric_mixin, *extra_bases)
 
     if bases == (base,):
@@ -125,7 +124,8 @@ def _resolve_nested_names(parent_key: str, d: dict) -> dict:
 
 
 def _merge_positional_and_keyword(
-    positional: tuple, keyword: dict,
+    positional: tuple,
+    keyword: dict,
 ) -> dict:
     """Merge positional distributions (keyed by .name) with keyword components."""
     components = {}
@@ -153,7 +153,8 @@ def _merge_positional_and_keyword(
 
 class ProductDistribution(
     RecordDistribution,
-    SupportsSampling, SupportsConditioning,
+    SupportsSampling,
+    SupportsConditioning,
 ):
     """Joint distribution with **independent** leaf components.
 
@@ -241,8 +242,7 @@ class ProductDistribution(
         for leaf in jax.tree.leaves(resolved):
             if not isinstance(leaf, Distribution):
                 raise TypeError(
-                    f"All leaf components must be Distribution instances, "
-                    f"got {type(leaf).__name__}"
+                    f"All leaf components must be Distribution instances, got {type(leaf).__name__}"
                 )
         self._components = resolved
         if name is None:
@@ -274,6 +274,7 @@ class ProductDistribution(
             case), otherwise a plain :class:`RecordArray`.
         """
         from ..core._record_array import NumericRecordArray, RecordArray
+
         names = list(self._components.keys())
         keys = jax.random.split(key, len(names))
         numeric = isinstance(self, NumericRecordDistribution)
@@ -285,8 +286,8 @@ class ProductDistribution(
                 # record-array (canonical, flattenable), not a plain Record.
                 sub_template = self.event_template[name] if sample_shape else None
                 fields[name] = _sample_nested(
-                    comp, subkey, sample_shape,
-                    template=sub_template, numeric=numeric)
+                    comp, subkey, sample_shape, template=sub_template, numeric=numeric
+                )
             else:
                 fields[name] = comp._sample(subkey, sample_shape)
         if sample_shape:
@@ -294,11 +295,13 @@ class ProductDistribution(
             # plain RecordArray which doesn't require numeric leaves.
             if isinstance(self, NumericRecordDistribution):
                 return NumericRecordArray(
-                    fields, batch_shape=sample_shape,
+                    fields,
+                    batch_shape=sample_shape,
                     template=self.event_template,
                 )
             return RecordArray(
-                fields, batch_shape=sample_shape,
+                fields,
+                batch_shape=sample_shape,
                 template=self.event_template,
             )
         return Record(fields)
@@ -316,6 +319,7 @@ class ProductDistribution(
         available there.
         """
         from ..core._record_array import RecordArray
+
         if isinstance(value, jnp.ndarray):
             if not isinstance(self, NumericRecordDistribution):
                 raise TypeError(
@@ -343,11 +347,13 @@ class ProductDistribution(
             value = {k: v for k, v in value.items()}
         if isinstance(value, Record):
             value = value.to_dict()
+
         # Recursively convert nested Record values to dicts
         def _to_dict(v):
             if isinstance(v, Record):
                 return v.to_dict()
             return v
+
         if isinstance(value, dict):
             value = {k: _to_dict(v) for k, v in value.items()}
         lp_tree = jax.tree.map(
@@ -370,7 +376,9 @@ class ProductDistribution(
         return _map_components(self._components, lambda d: d._variance())
 
     def _expectation(self, f, *, key=None, num_evaluations=None, return_dist=None):
-        return _mc_expectation(self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist)
+        return _mc_expectation(
+            self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist
+        )
 
     # -- Component access (for backward compat) ----------------------------
 
@@ -407,15 +415,19 @@ class ProductDistribution(
         return self._condition_on_impl(observed_leaves)
 
     def _condition_on_impl(
-        self, observed_leaves: dict[KeyPath, ArrayLike],
+        self,
+        observed_leaves: dict[KeyPath, ArrayLike],
     ) -> ProductDistribution:
         new_components = _prune_leaves(self._components, set(observed_leaves.keys()))
         result = ProductDistribution(**new_components, name=self._name)
         conditioned_names = [" > ".join(path) for path in observed_leaves]
-        result.with_source(Provenance.create(
-            "condition_on", parents=[self],
-            metadata={"conditioned": conditioned_names},
-        ))
+        result.with_source(
+            Provenance.create(
+                "condition_on",
+                parents=[self],
+                metadata={"conditioned": conditioned_names},
+            )
+        )
         return result
 
     def __repr__(self) -> str:
@@ -527,11 +539,13 @@ def _sample_nested(components: dict, key, sample_shape, template=None, numeric=F
         if isinstance(comp, dict):
             sub_template = template[name] if template is not None else None
             fields[name] = _sample_nested(
-                comp, subkey, sample_shape, template=sub_template, numeric=numeric)
+                comp, subkey, sample_shape, template=sub_template, numeric=numeric
+            )
         else:
             fields[name] = comp._sample(subkey, sample_shape)
     if sample_shape and template is not None:
         from ..core._record_array import NumericRecordArray, RecordArray
+
         cls = NumericRecordArray if numeric else RecordArray
         return cls(fields, batch_shape=sample_shape, template=template)
     return Record(fields)
@@ -551,6 +565,7 @@ def _map_components(components: dict, fn) -> Record:
 # ---------------------------------------------------------------------------
 # Pytree registration
 # ---------------------------------------------------------------------------
+
 
 def _product_flatten(dist):
     """Flatten a ProductDistribution for JAX pytree registration.

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -21,7 +21,8 @@ from ..core.distribution import (
     _mc_expectation,
 )
 from ..core._record_distribution import (
-    RecordDistribution, _build_event_template,
+    RecordDistribution,
+    _build_event_template,
 )
 from ..core.record import Record
 from ..core.provenance import Provenance
@@ -83,7 +84,8 @@ def _sequential_class_for_components(components: dict) -> type:
     """
     leaves = list(components.values())
     extra_bases = protocols_supported_by_all(
-        leaves, (SupportsLogProb, SupportsMean, SupportsVariance),
+        leaves,
+        (SupportsLogProb, SupportsMean, SupportsVariance),
     )
     all_numeric = all(isinstance(l, NumericRecordDistribution) for l in leaves)
 
@@ -93,9 +95,7 @@ def _sequential_class_for_components(components: dict) -> type:
 
     # Order matters: numeric mixin in front of protocol mixins so the
     # MRO matches standalone NRDs (numeric API → protocols → object).
-    numeric_mixin: tuple[type, ...] = (
-        (NumericRecordDistribution,) if all_numeric else ()
-    )
+    numeric_mixin: tuple[type, ...] = (NumericRecordDistribution,) if all_numeric else ()
     bases = (SequentialJointDistribution, *numeric_mixin, *extra_bases)
 
     if bases == (SequentialJointDistribution,):
@@ -108,7 +108,9 @@ def _sequential_class_for_components(components: dict) -> type:
 
 
 class SequentialJointDistribution(
-    RecordDistribution, SupportsSampling, SupportsConditioning,
+    RecordDistribution,
+    SupportsSampling,
+    SupportsConditioning,
 ):
     """
     Joint distribution with autoregressive (sequential) dependence.
@@ -169,8 +171,8 @@ class SequentialJointDistribution(
         if not components:
             raise ValueError("SequentialJointDistribution requires at least one component.")
 
-        self._raw_components: dict[str, Distribution | Callable[..., Distribution]] = (
-            dict(components)
+        self._raw_components: dict[str, Distribution | Callable[..., Distribution]] = dict(
+            components
         )
         if name is None:
             name = "sequential(" + ",".join(components.keys()) + ")"
@@ -254,9 +256,7 @@ class SequentialJointDistribution(
                 bad.append((cname, unconditioned))
         if not bad:
             return None
-        details = "; ".join(
-            f"'{c}' has unconditioned parent(s) {ps}" for c, ps in bad
-        )
+        details = "; ".join(f"'{c}' has unconditioned parent(s) {ps}" for c, ps in bad)
         return (
             f"Cannot sample from this SequentialJointDistribution: "
             f"{details}. Forward sampling would draw these ancestors "
@@ -322,11 +322,13 @@ class SequentialJointDistribution(
         sample_shape: tuple[int, ...] = (),
     ):
         from ..core._record_array import NumericRecordArray
+
         full = self._sample_sequential(key, sample_shape)
         fields = {k: v for k, v in full.items() if k not in self._conditioned_names}
         if sample_shape:
             return NumericRecordArray(
-                fields, batch_shape=sample_shape,
+                fields,
+                batch_shape=sample_shape,
                 template=self.event_template,
             )
         return Record(fields)
@@ -419,14 +421,17 @@ class SequentialJointDistribution(
         return Record({k: v._variance() for k, v in self._proto_components.items()})
 
     def _expectation(self, f, *, key=None, num_evaluations=None, return_dist=None):
-        return _mc_expectation(self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist)
+        return _mc_expectation(
+            self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist
+        )
 
     def _condition_on(self, observed=None, /, **kwargs):
         observed_leaves = _parse_condition_args(self, observed, kwargs)
         return self._condition_on_impl(observed_leaves)
 
     def _condition_on_impl(
-        self, observed_leaves: dict[KeyPath, ArrayLike],
+        self,
+        observed_leaves: dict[KeyPath, ArrayLike],
     ) -> "SequentialJointDistribution":
         """Condition on observed component values.
 
@@ -468,8 +473,7 @@ class SequentialJointDistribution(
         # if every unconditioned leaf is numeric, the result is an
         # NRD; otherwise it's a plain ``SequentialJointDistribution``.
         unconditioned_pre = {
-            k: v for k, v in self._proto_components.items()
-            if k not in all_conditioned
+            k: v for k, v in self._proto_components.items() if k not in all_conditioned
         }
         result_cls = _sequential_class_for_components(unconditioned_pre)
         result = result_cls.__new__(result_cls)
@@ -483,17 +487,21 @@ class SequentialJointDistribution(
             **{k: jnp.asarray(v) for k, v in observed.items()},
         }
         result._sampleable_error = self._compute_sampleable_error(
-            result._conditioned_names, result._callable_parents,
+            result._conditioned_names,
+            result._callable_parents,
         )
 
         # Expose only unconditioned components
         result._components = unconditioned_pre
         result._event_template = _build_event_template(unconditioned_pre)
 
-        result.with_source(Provenance.create(
-            "condition_on", parents=[self],
-            metadata={"conditioned": list(observed)},
-        ))
+        result.with_source(
+            Provenance.create(
+                "condition_on",
+                parents=[self],
+                metadata={"conditioned": list(observed)},
+            )
+        )
         return result
 
     def __repr__(self) -> str:

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -50,7 +50,8 @@ from ..custom_types import Array, ArrayLike, PRNGKey
 # never use the bypass.
 
 _BATCHED_INIT_BYPASS: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    "_BATCHED_INIT_BYPASS", default=False,
+    "_BATCHED_INIT_BYPASS",
+    default=False,
 )
 """Per-context flag consulted by ``TFPDistribution.__init__``'s
 batched-parameters rejection. ``ContextVar`` over a module-level bool
@@ -222,7 +223,10 @@ class TFPDistribution(
         return_dist: bool | None = None,
     ) -> Any:
         return _mc_expectation(
-            self, f, key=key, num_evaluations=num_evaluations,
+            self,
+            f,
+            key=key,
+            num_evaluations=num_evaluations,
             return_dist=return_dist,
         )
 
@@ -363,7 +367,9 @@ class _TFPArrayBackend:
             batched_params = normalised
         self._batched_params = batched_params
         self._batched_dist: TFPDistribution = _construct_batched_dist(
-            dist_cls, name=name, batched_params=batched_params,
+            dist_cls,
+            name=name,
+            batched_params=batched_params,
         )
         # Final sanity check: TFP's inferred batch_shape must match
         # the caller's declaration. Catches the rare case where a
@@ -413,17 +419,14 @@ class _TFPArrayBackend:
         """
         multi, flat = self._normalize_index(index)
         scalar_params = {
-            key: _slice_leading_axes(value, multi)
-            for key, value in self._batched_params.items()
+            key: _slice_leading_axes(value, multi) for key, value in self._batched_params.items()
         }
         return self._dist_cls(
             **scalar_params,
             name=f"{self._name}_{flat}",
         )
 
-    def _normalize_index(
-        self, index: int | tuple[int, ...]
-    ) -> tuple[tuple[int, ...], int]:
+    def _normalize_index(self, index: int | tuple[int, ...]) -> tuple[tuple[int, ...], int]:
         """Return ``(multi_index, flat_index)`` for the given input.
 
         Lets :meth:`cell` slice with the multi-d index *and* name the
@@ -439,8 +442,7 @@ class _TFPArrayBackend:
             if len(bshape) == 1:
                 if not 0 <= i < bshape[0]:
                     raise IndexError(
-                        f"_TFPArrayBackend.cell: index {i} out of range "
-                        f"for batch_shape={bshape}."
+                        f"_TFPArrayBackend.cell: index {i} out of range for batch_shape={bshape}."
                     )
                 return (i,), i
             multi = tuple(int(x) for x in np.unravel_index(i, bshape))
@@ -520,7 +522,9 @@ class _TFPArrayBackend:
         instance._batch_shape = tuple(batch_shape)
         instance._batched_params = dict(zip(keys, children))
         instance._batched_dist = _construct_batched_dist(
-            dist_cls, name=name, batched_params=instance._batched_params,
+            dist_cls,
+            name=name,
+            batched_params=instance._batched_params,
         )
         return instance
 

--- a/probpipe/distributions/continuous.py
+++ b/probpipe/distributions/continuous.py
@@ -88,7 +88,6 @@ class Normal(TFPDistribution):
         return real
 
 
-
 # ---------------------------------------------------------------------------
 # Beta
 # ---------------------------------------------------------------------------
@@ -129,7 +128,6 @@ class Beta(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return unit_interval
-
 
 
 # ---------------------------------------------------------------------------
@@ -174,7 +172,6 @@ class Gamma(TFPDistribution):
         return positive
 
 
-
 # ---------------------------------------------------------------------------
 # InverseGamma
 # ---------------------------------------------------------------------------
@@ -201,9 +198,7 @@ class InverseGamma(TFPDistribution):
         name: str,
     ):
         _, (self._concentration, self._scale) = _promote_floats(concentration, scale)
-        self._tfp_dist = tfd.InverseGamma(
-            concentration=self._concentration, scale=self._scale
-        )
+        self._tfp_dist = tfd.InverseGamma(concentration=self._concentration, scale=self._scale)
         super().__init__(name=name)
 
     @property
@@ -217,7 +212,6 @@ class InverseGamma(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return positive
-
 
 
 # ---------------------------------------------------------------------------
@@ -253,7 +247,6 @@ class Exponential(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return positive
-
 
 
 # ---------------------------------------------------------------------------
@@ -296,7 +289,6 @@ class LogNormal(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return positive
-
 
 
 # ---------------------------------------------------------------------------
@@ -348,7 +340,6 @@ class StudentT(TFPDistribution):
         return real
 
 
-
 # ---------------------------------------------------------------------------
 # Uniform
 # ---------------------------------------------------------------------------
@@ -389,7 +380,6 @@ class Uniform(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return interval(self._low, self._high)
-
 
 
 # ---------------------------------------------------------------------------
@@ -434,7 +424,6 @@ class Cauchy(TFPDistribution):
         return real
 
 
-
 # ---------------------------------------------------------------------------
 # Laplace
 # ---------------------------------------------------------------------------
@@ -477,7 +466,6 @@ class Laplace(TFPDistribution):
         return real
 
 
-
 # ---------------------------------------------------------------------------
 # HalfNormal
 # ---------------------------------------------------------------------------
@@ -511,7 +499,6 @@ class HalfNormal(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return non_negative
-
 
 
 # ---------------------------------------------------------------------------
@@ -556,7 +543,6 @@ class HalfCauchy(TFPDistribution):
         return greater_than(self._loc)
 
 
-
 # ---------------------------------------------------------------------------
 # Pareto
 # ---------------------------------------------------------------------------
@@ -583,9 +569,7 @@ class Pareto(TFPDistribution):
         name: str,
     ):
         _, (self._concentration, self._scale) = _promote_floats(concentration, scale)
-        self._tfp_dist = tfd.Pareto(
-            concentration=self._concentration, scale=self._scale
-        )
+        self._tfp_dist = tfd.Pareto(concentration=self._concentration, scale=self._scale)
         super().__init__(name=name)
 
     @property
@@ -599,7 +583,6 @@ class Pareto(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return greater_than(self._scale)
-
 
 
 # ---------------------------------------------------------------------------
@@ -633,9 +616,7 @@ class TruncatedNormal(TFPDistribution):
         *,
         name: str,
     ):
-        _, (self._loc, self._scale, self._low, self._high) = _promote_floats(
-            loc, scale, low, high
-        )
+        _, (self._loc, self._scale, self._low, self._high) = _promote_floats(loc, scale, low, high)
         self._tfp_dist = tfd.TruncatedNormal(
             loc=self._loc, scale=self._scale, low=self._low, high=self._high
         )
@@ -660,4 +641,3 @@ class TruncatedNormal(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return interval(self._low, self._high)
-

--- a/probpipe/distributions/discrete.py
+++ b/probpipe/distributions/discrete.py
@@ -102,7 +102,6 @@ class Bernoulli(TFPDistribution):
         return (1 - p) * f0 + p * f1
 
 
-
 class Binomial(TFPDistribution):
     """
     Binomial distribution.
@@ -133,15 +132,11 @@ class Binomial(TFPDistribution):
         if probs is not None:
             _, (self._total_count, self._probs) = _promote_floats(total_count, probs)
             self._logits = None
-            self._tfp_dist = tfd.Binomial(
-                total_count=self._total_count, probs=self._probs
-            )
+            self._tfp_dist = tfd.Binomial(total_count=self._total_count, probs=self._probs)
         else:
             _, (self._total_count, self._logits) = _promote_floats(total_count, logits)
             self._probs = None
-            self._tfp_dist = tfd.Binomial(
-                total_count=self._total_count, logits=self._logits
-            )
+            self._tfp_dist = tfd.Binomial(total_count=self._total_count, logits=self._logits)
         super().__init__(name=name)
 
     # -- convenient accessors -----------------------------------------------
@@ -178,15 +173,13 @@ class Binomial(TFPDistribution):
         tc = jnp.asarray(self._total_count)
         if tc.ndim != 0:
             raise ValueError(
-                "Binomial._expectation requires scalar total_count; "
-                f"got shape {tc.shape}"
+                f"Binomial._expectation requires scalar total_count; got shape {tc.shape}"
             )
         n = int(tc) + 1
         support = jnp.arange(n, dtype=self.dtype)
         probs = jnp.exp(self._tfp_dist.log_prob(support))
         f_vals = jax.vmap(f)(support)
         return jnp.einsum("n,n...->...", probs, f_vals)
-
 
 
 class Poisson(TFPDistribution):
@@ -222,7 +215,6 @@ class Poisson(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return non_negative_integer
-
 
 
 class Categorical(TFPDistribution):
@@ -293,7 +285,6 @@ class Categorical(TFPDistribution):
         return jnp.einsum("n,n...->...", probs, f_vals)
 
 
-
 class NegativeBinomial(TFPDistribution):
     """
     Negative binomial distribution.
@@ -324,9 +315,7 @@ class NegativeBinomial(TFPDistribution):
         if probs is not None:
             _, (self._total_count, self._probs) = _promote_floats(total_count, probs)
             self._logits = None
-            self._tfp_dist = tfd.NegativeBinomial(
-                total_count=self._total_count, probs=self._probs
-            )
+            self._tfp_dist = tfd.NegativeBinomial(total_count=self._total_count, probs=self._probs)
         else:
             _, (self._total_count, self._logits) = _promote_floats(total_count, logits)
             self._probs = None
@@ -354,4 +343,3 @@ class NegativeBinomial(TFPDistribution):
     @property
     def support(self) -> Constraint:
         return non_negative_integer
-

--- a/probpipe/distributions/gaussian_random_function.py
+++ b/probpipe/distributions/gaussian_random_function.py
@@ -227,9 +227,7 @@ class GaussianRandomFunction(ArrayRandomFunction):
             )
 
         # -- At least one joint axis — need covariance ------------------------
-        cov = self.predict_covariance(
-            X, joint_inputs=joint_inputs, joint_outputs=joint_outputs
-        )
+        cov = self.predict_covariance(X, joint_inputs=joint_inputs, joint_outputs=joint_outputs)
         d_out = prod(self._output_shape)
         scale_tril = jnp.linalg.cholesky(cov)
 
@@ -338,15 +336,12 @@ class LinearBasisFunction(GaussianRandomFunction, SupportsSampling):
         from . import MultivariateNormal
 
         if not isinstance(weights, MultivariateNormal):
-            raise TypeError(
-                f"weights must be a MultivariateNormal, "
-                f"got {type(weights).__name__}"
-            )
+            raise TypeError(f"weights must be a MultivariateNormal, got {type(weights).__name__}")
 
         self._feature_map = feature_map
         self._weights = weights
-        self._w_mean = weights.loc          # (d_w,)
-        self._w_cov = weights.cov           # (d_w, d_w)
+        self._w_mean = weights.loc  # (d_w,)
+        self._w_cov = weights.cov  # (d_w, d_w)
 
         # Bias inherits dtype from the weight distribution.
         bias_dtype = self._w_mean.dtype
@@ -390,9 +385,7 @@ class LinearBasisFunction(GaussianRandomFunction, SupportsSampling):
         joint_outputs: bool = False,
     ) -> Array:
         if not joint_inputs and not joint_outputs:
-            raise ValueError(
-                "Use predict_variance for fully marginal predictions."
-            )
+            raise ValueError("Use predict_variance for fully marginal predictions.")
 
         phi = self._feature_map(X)  # (*eb, n, [*out,] d_w)
         extra_batch, n = self._parse_X(X)
@@ -401,22 +394,14 @@ class LinearBasisFunction(GaussianRandomFunction, SupportsSampling):
             if self._output_shape:
                 d_out = prod(self._output_shape)
                 phi_flat = phi.reshape(*extra_batch, n, d_out, -1)
-                cov = jnp.einsum(
-                    "...iow,wv,...jov->...oij",
-                    phi_flat, self._w_cov, phi_flat
-                )
+                cov = jnp.einsum("...iow,wv,...jov->...oij", phi_flat, self._w_cov, phi_flat)
                 return cov.reshape(*extra_batch, *self._output_shape, n, n)
-            return jnp.einsum(
-                "...iw,wv,...jv->...ij", phi, self._w_cov, phi
-            )
+            return jnp.einsum("...iw,wv,...jv->...ij", phi, self._w_cov, phi)
 
         if not joint_inputs and joint_outputs:
             d_out = prod(self._output_shape)
             phi_flat = phi.reshape(*extra_batch, n, d_out, -1)
-            return jnp.einsum(
-                "...ow,wv,...pv->...op",
-                phi_flat, self._w_cov, phi_flat
-            )
+            return jnp.einsum("...ow,wv,...pv->...op", phi_flat, self._w_cov, phi_flat)
 
         # Full joint: (*eb, n*d_out, n*d_out)
         d_out = prod(self._output_shape)
@@ -424,9 +409,7 @@ class LinearBasisFunction(GaussianRandomFunction, SupportsSampling):
             phi_flat = phi.reshape(*extra_batch, n * d_out, -1)
         else:
             phi_flat = phi
-        return jnp.einsum(
-            "...iw,wv,...jv->...ij", phi_flat, self._w_cov, phi_flat
-        )
+        return jnp.einsum("...iw,wv,...jv->...ij", phi_flat, self._w_cov, phi_flat)
 
     # -- Function sampling (finite-dimensional) -----------------------------
 
@@ -487,24 +470,17 @@ class _LinearMapGRF(GaussianRandomFunction):
 
     def __init__(self, base: GaussianRandomFunction, A: Array) -> None:
         if not isinstance(base, GaussianRandomFunction):
-            raise TypeError(
-                f"base must be a GaussianRandomFunction, "
-                f"got {type(base).__name__}"
-            )
+            raise TypeError(f"base must be a GaussianRandomFunction, got {type(base).__name__}")
         if len(base.output_shape) != 1:
             raise ValueError(
-                f"A @ grf requires grf.output_shape to be 1-D (d,), "
-                f"got {base.output_shape}"
+                f"A @ grf requires grf.output_shape to be 1-D (d,), got {base.output_shape}"
             )
         if A.ndim != 2:
-            raise ValueError(
-                f"A must be 2-D (d_out, d_w), got shape {A.shape}"
-            )
+            raise ValueError(f"A must be 2-D (d_out, d_w), got shape {A.shape}")
         d_out, d_w = A.shape
         if d_w != base.output_shape[0]:
             raise ValueError(
-                f"A columns ({d_w}) must match "
-                f"grf.output_shape[0] ({base.output_shape[0]})"
+                f"A columns ({d_w}) must match grf.output_shape[0] ({base.output_shape[0]})"
             )
 
         self._base = base
@@ -522,9 +498,7 @@ class _LinearMapGRF(GaussianRandomFunction):
         return jnp.einsum("ow,...w->...o", self._A, g_mean)
 
     def predict_variance(self, X: Array) -> Array:
-        return jnp.diagonal(
-            self._output_covariance_per_point(X), axis1=-2, axis2=-1
-        )
+        return jnp.diagonal(self._output_covariance_per_point(X), axis1=-2, axis2=-1)
 
     def predict_covariance(
         self,
@@ -534,9 +508,7 @@ class _LinearMapGRF(GaussianRandomFunction):
         joint_outputs: bool = False,
     ) -> Array:
         if not joint_inputs and not joint_outputs:
-            raise ValueError(
-                "Use predict_variance for fully marginal predictions."
-            )
+            raise ValueError("Use predict_variance for fully marginal predictions.")
 
         if not joint_inputs and joint_outputs:
             return self._output_covariance_per_point(X)
@@ -553,21 +525,15 @@ class _LinearMapGRF(GaussianRandomFunction):
                 g_full = self._base.predict_covariance(
                     X, joint_inputs=True, joint_outputs=True
                 )  # (*eb, n*d_w, n*d_w)
-                g_full = g_full.reshape(
-                    *extra_batch, n, d_w, n, d_w
-                )
+                g_full = g_full.reshape(*extra_batch, n, d_w, n, d_w)
                 # A_{o,w} * g_{i,w,j,v} * A_{o,v} → result_{o,i,j}
-                return jnp.einsum(
-                    "ow,...iwjv,ov->...oij", self._A, g_full, self._A
-                )
+                return jnp.einsum("ow,...iwjv,ov->...oij", self._A, g_full, self._A)
             else:
                 # Base outputs independent — fast path.
                 g_cov = self._base.predict_covariance(
                     X, joint_inputs=True, joint_outputs=False
                 )  # (*eb, d_w, n, n)
-                return jnp.einsum(
-                    "ow,ov,...wij->...oij", self._A, self._A, g_cov
-                )
+                return jnp.einsum("ow,ov,...wij->...oij", self._A, self._A, g_cov)
 
         # joint_inputs=True, joint_outputs=True
         # Full joint: (*eb, n*d_out, n*d_out).
@@ -577,22 +543,21 @@ class _LinearMapGRF(GaussianRandomFunction):
             )  # (*eb, n*d_w, n*d_w)
             g_full = g_full.reshape(*extra_batch, n, d_w, n, d_w)
             # A_{o,w} * g_{i,w,j,v} * A_{p,v} → result_{i,o,j,p}
-            result = jnp.einsum(
-                "ow,...iwjv,pv->...iojp", self._A, g_full, self._A
-            )
+            result = jnp.einsum("ow,...iwjv,pv->...iojp", self._A, g_full, self._A)
             return result.reshape(*extra_batch, n * d_out, n * d_out)
         else:
             g_cov = self._base.predict_covariance(
                 X, joint_inputs=True, joint_outputs=False
             )  # (*eb, d_w, n, n)
             # A_{o,w} * A_{p,w} * g_{w,i,j} → result block (o,p) at (i,j)
-            cov_block = jnp.einsum(
-                "ow,pw,...wij->...opij", self._A, self._A, g_cov
-            )
+            cov_block = jnp.einsum("ow,pw,...wij->...opij", self._A, self._A, g_cov)
             ndim_eb = len(extra_batch)
             perm = [
                 *range(ndim_eb),
-                ndim_eb + 2, ndim_eb, ndim_eb + 3, ndim_eb + 1,
+                ndim_eb + 2,
+                ndim_eb,
+                ndim_eb + 3,
+                ndim_eb + 1,
             ]
             cov_reordered = cov_block.transpose(perm)
             return cov_reordered.reshape(*extra_batch, n * d_out, n * d_out)
@@ -606,14 +571,10 @@ class _LinearMapGRF(GaussianRandomFunction):
             g_cov = self._base.predict_covariance(
                 X, joint_inputs=False, joint_outputs=True
             )  # (*eb, n, d_w, d_w)
-            return jnp.einsum(
-                "ow,...wv,pv->...op", self._A, g_cov, self._A
-            )
+            return jnp.einsum("ow,...wv,pv->...op", self._A, g_cov, self._A)
         else:
             g_var = self._base.predict_variance(X)  # (*eb, n, d_w)
-            return jnp.einsum(
-                "ow,pw,...w->...op", self._A, self._A, g_var
-            )
+            return jnp.einsum("ow,pw,...w->...op", self._A, self._A, g_var)
 
 
 class _ShiftedGRF(GaussianRandomFunction):
@@ -639,10 +600,16 @@ class _ShiftedGRF(GaussianRandomFunction):
         return self._base.predict_variance(X)
 
     def predict_covariance(
-        self, X: Array, *, joint_inputs: bool = False, joint_outputs: bool = False,
+        self,
+        X: Array,
+        *,
+        joint_inputs: bool = False,
+        joint_outputs: bool = False,
     ) -> Array:
         return self._base.predict_covariance(
-            X, joint_inputs=joint_inputs, joint_outputs=joint_outputs,
+            X,
+            joint_inputs=joint_inputs,
+            joint_outputs=joint_outputs,
         )
 
 
@@ -666,13 +633,19 @@ class _ScaledGRF(GaussianRandomFunction):
         return self._alpha * self._base.predict_mean(X)
 
     def predict_variance(self, X: Array) -> Array:
-        return self._alpha ** 2 * self._base.predict_variance(X)
+        return self._alpha**2 * self._base.predict_variance(X)
 
     def predict_covariance(
-        self, X: Array, *, joint_inputs: bool = False, joint_outputs: bool = False,
+        self,
+        X: Array,
+        *,
+        joint_inputs: bool = False,
+        joint_outputs: bool = False,
     ) -> Array:
-        return self._alpha ** 2 * self._base.predict_covariance(
-            X, joint_inputs=joint_inputs, joint_outputs=joint_outputs,
+        return self._alpha**2 * self._base.predict_covariance(
+            X,
+            joint_inputs=joint_inputs,
+            joint_outputs=joint_outputs,
         )
 
 
@@ -688,7 +661,9 @@ class _IndependentSumGRF(GaussianRandomFunction):
     """
 
     def __init__(
-        self, left: GaussianRandomFunction, right: GaussianRandomFunction,
+        self,
+        left: GaussianRandomFunction,
+        right: GaussianRandomFunction,
     ) -> None:
         if left is right:
             raise ValueError(
@@ -696,44 +671,37 @@ class _IndependentSumGRF(GaussianRandomFunction):
                 "result would not be independent.  Use 2 * grf instead."
             )
         if left.input_shape != right.input_shape:
-            raise ValueError(
-                f"input_shape mismatch: {left.input_shape} vs "
-                f"{right.input_shape}"
-            )
+            raise ValueError(f"input_shape mismatch: {left.input_shape} vs {right.input_shape}")
         if left.output_shape != right.output_shape:
-            raise ValueError(
-                f"output_shape mismatch: {left.output_shape} vs "
-                f"{right.output_shape}"
-            )
+            raise ValueError(f"output_shape mismatch: {left.output_shape} vs {right.output_shape}")
         self._left = left
         self._right = right
         super().__init__(
             input_shape=left.input_shape,
             output_shape=left.output_shape,
         )
-        self.supports_joint_inputs = (
-            left.supports_joint_inputs and right.supports_joint_inputs
-        )
-        self.supports_joint_outputs = (
-            left.supports_joint_outputs and right.supports_joint_outputs
-        )
+        self.supports_joint_inputs = left.supports_joint_inputs and right.supports_joint_inputs
+        self.supports_joint_outputs = left.supports_joint_outputs and right.supports_joint_outputs
 
     def predict_mean(self, X: Array) -> Array:
         return self._left.predict_mean(X) + self._right.predict_mean(X)
 
     def predict_variance(self, X: Array) -> Array:
-        return (
-            self._left.predict_variance(X) + self._right.predict_variance(X)
-        )
+        return self._left.predict_variance(X) + self._right.predict_variance(X)
 
     def predict_covariance(
-        self, X: Array, *, joint_inputs: bool = False, joint_outputs: bool = False,
+        self,
+        X: Array,
+        *,
+        joint_inputs: bool = False,
+        joint_outputs: bool = False,
     ) -> Array:
-        return (
-            self._left.predict_covariance(
-                X, joint_inputs=joint_inputs, joint_outputs=joint_outputs,
-            )
-            + self._right.predict_covariance(
-                X, joint_inputs=joint_inputs, joint_outputs=joint_outputs,
-            )
+        return self._left.predict_covariance(
+            X,
+            joint_inputs=joint_inputs,
+            joint_outputs=joint_outputs,
+        ) + self._right.predict_covariance(
+            X,
+            joint_inputs=joint_inputs,
+            joint_outputs=joint_outputs,
         )

--- a/probpipe/distributions/kde.py
+++ b/probpipe/distributions/kde.py
@@ -229,7 +229,4 @@ class KDEDistribution(TFPDistribution):
         )
 
     def __repr__(self) -> str:
-        return (
-            f"KDEDistribution(num_atoms={self.num_atoms}, "
-            f"event_shape={self.event_shape})"
-        )
+        return f"KDEDistribution(num_atoms={self.num_atoms}, event_shape={self.event_shape})"

--- a/probpipe/distributions/multivariate.py
+++ b/probpipe/distributions/multivariate.py
@@ -74,16 +74,12 @@ class MultivariateNormal(TFPDistribution, FlatNumericRecordDistribution):
 
         if cov is not None:
             if cov.shape != (loc.shape[0], loc.shape[0]):
-                raise ValueError(
-                    f"cov shape {cov.shape} does not match loc length {loc.shape[0]}."
-                )
+                raise ValueError(f"cov shape {cov.shape} does not match loc length {loc.shape[0]}.")
             scale_tril = jnp.linalg.cholesky(cov)
 
         self._loc = loc
         self._scale_tril = scale_tril
-        self._tfp_dist = tfd.MultivariateNormalTriL(
-            loc=loc, scale_tril=scale_tril
-        )
+        self._tfp_dist = tfd.MultivariateNormalTriL(loc=loc, scale_tril=scale_tril)
         super().__init__(name=name)
 
     # -- convenient accessors -----------------------------------------------
@@ -198,16 +194,12 @@ class Multinomial(TFPDistribution, FlatNumericRecordDistribution):
             _, (total_count, probs) = _promote_floats(total_count, probs)
             self._probs = probs
             self._logits = None
-            self._tfp_dist = tfd.Multinomial(
-                total_count=total_count, probs=probs
-            )
+            self._tfp_dist = tfd.Multinomial(total_count=total_count, probs=probs)
         else:
             _, (total_count, logits) = _promote_floats(total_count, logits)
             self._logits = logits
             self._probs = None
-            self._tfp_dist = tfd.Multinomial(
-                total_count=total_count, logits=logits
-            )
+            self._tfp_dist = tfd.Multinomial(total_count=total_count, logits=logits)
 
         self._total_count = total_count
         super().__init__(name=name)
@@ -265,9 +257,7 @@ class Wishart(TFPDistribution):
         name: str,
     ):
         if scale_tril is not None and scale is not None:
-            raise ValueError(
-                "Provide exactly one of scale_tril or scale, not both."
-            )
+            raise ValueError("Provide exactly one of scale_tril or scale, not both.")
         if scale_tril is None and scale is None:
             raise ValueError("One of scale_tril or scale must be provided.")
 
@@ -334,9 +324,7 @@ class VonMisesFisher(TFPDistribution, FlatNumericRecordDistribution):
         *,
         name: str,
     ):
-        _, (mean_direction, concentration) = _promote_floats(
-            mean_direction, concentration
-        )
+        _, (mean_direction, concentration) = _promote_floats(mean_direction, concentration)
 
         self._mean_direction = mean_direction
         self._concentration = concentration
@@ -364,4 +352,3 @@ class VonMisesFisher(TFPDistribution, FlatNumericRecordDistribution):
     @property
     def support(self) -> Constraint:
         return sphere
-

--- a/probpipe/distributions/transformed.py
+++ b/probpipe/distributions/transformed.py
@@ -62,9 +62,12 @@ def _transformed_class_for_base(base: NumericRecordDistribution) -> type:
 
     signature = (supports_sample, supports_log_prob, supports_mean, supports_variance)
     key = frozenset(
-        name for name, flag in zip(
-            ("sample", "log_prob", "mean", "variance"), signature,
-        ) if flag
+        name
+        for name, flag in zip(
+            ("sample", "log_prob", "mean", "variance"),
+            signature,
+        )
+        if flag
     )
     if key in _TRANSFORMED_CLASS_CACHE:
         return _TRANSFORMED_CLASS_CACHE[key]
@@ -95,11 +98,8 @@ def _transformed_class_for_base(base: NumericRecordDistribution) -> type:
             if self._tfp_transformed is not None:
                 return self._tfp_transformed.log_prob(x)
             raw = self._bijector.inverse(x)
-            return (
-                self._base._log_prob(raw)
-                + self._bijector.inverse_log_det_jacobian(
-                    x, event_ndims=len(self.event_shape)
-                )
+            return self._base._log_prob(raw) + self._bijector.inverse_log_det_jacobian(
+                x, event_ndims=len(self.event_shape)
             )
 
         extra_methods["_log_prob"] = _log_prob
@@ -196,11 +196,13 @@ class TransformedDistribution(NumericRecordDistribution):
 
         self._approximate = base.is_approximate
 
-        self.with_source(Provenance.create(
-            "transform",
-            parents=[base],
-            metadata={"bijector": type(bijector).__name__},
-        ))
+        self.with_source(
+            Provenance.create(
+                "transform",
+                parents=[base],
+                metadata={"bijector": type(bijector).__name__},
+            )
+        )
 
     _sampling_cost: str = "low"
     _preferred_orchestration: str | None = None
@@ -223,9 +225,7 @@ class TransformedDistribution(NumericRecordDistribution):
     def event_shape(self) -> tuple[int, ...]:
         if self._tfp_transformed is not None:
             return tuple(self._tfp_transformed.event_shape)
-        return tuple(
-            self._bijector.forward_event_shape(self._base.event_shape)
-        )
+        return tuple(self._bijector.forward_event_shape(self._base.event_shape))
 
     @property
     def dtypes(self) -> dict[str, jnp.dtype]:
@@ -268,7 +268,10 @@ class TransformedDistribution(NumericRecordDistribution):
         return_dist=None,
     ):
         return _mc_expectation(
-            self, f, key=key, num_evaluations=num_evaluations,
+            self,
+            f,
+            key=key,
+            num_evaluations=num_evaluations,
             return_dist=return_dist,
         )
 

--- a/probpipe/inference/__init__.py
+++ b/probpipe/inference/__init__.py
@@ -25,14 +25,17 @@ from ._blackjax_rwmh import rwmh
 from ._blackjax_ess import elliptical_slice
 from ._nutpie import condition_on_nutpie
 from ._minibatch import MinibatchedDistribution
+
 # Amortized SBI (optional ``[bayesflow]`` extra). keras/bayesflow load lazily on
 # first call, so these eager imports stay cheap; the trained artifacts dispatch
 # via ``SupportsConditioning`` (NPE) or plug into ``SimpleModel`` as
 # ``Likelihood`` components (NLE/NRE) -- no inference-registry methods needed.
 from ._bayesflow_posteriors import BayesFlowModel, learn_amortized_posterior
 from ._bayesflow_likelihoods import (
-    BayesFlowLikelihood, BayesFlowRatio,
-    learn_amortized_likelihood, learn_amortized_ratio,
+    BayesFlowLikelihood,
+    BayesFlowRatio,
+    learn_amortized_likelihood,
+    learn_amortized_ratio,
 )
 
 __all__ = [
@@ -94,18 +97,21 @@ inference_method_registry.register(BlackJAXSGHMCMethod())
 
 try:
     from ._nutpie import NutpieNutsMethod
+
     inference_method_registry.register(NutpieNutsMethod())
 except ImportError:
     pass
 
 try:
     from ._cmdstan_method import CmdStanNutsMethod
+
     inference_method_registry.register(CmdStanNutsMethod())
 except ImportError:
     pass
 
 try:
     from ._pymc_method import PyMCNutsMethod, PyMCADVIMethod
+
     inference_method_registry.register(PyMCNutsMethod())
     inference_method_registry.register(PyMCADVIMethod())
 except ImportError:

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -25,7 +25,8 @@ __all__ = ["ApproximateDistribution", "make_posterior"]
 
 
 def _column_permutation(
-    event_template: EventTemplate, field_order: list[str],
+    event_template: EventTemplate,
+    field_order: list[str],
 ) -> list[int]:
     """Column-index permutation mapping a *field_order*-laid-out flat chain
     into ``event_template.fields`` order.
@@ -323,8 +324,7 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
             if include_warmup:
                 warmup = self.warmup_samples
                 if warmup is not None:
-                    parts = [jnp.concatenate([w, c], axis=0)
-                             for w, c in zip(warmup, parts)]
+                    parts = [jnp.concatenate([w, c], axis=0) for w, c in zip(warmup, parts)]
             samples = jnp.concatenate(parts, axis=0)
 
         # Honor any user-supplied template (single-field or multi-field).
@@ -333,6 +333,7 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
         # under the previous numeric-array hierarchy.
         if getattr(self, "_user_template", False):
             from ..core._record_array import NumericRecordArray
+
             return NumericRecordArray.unflatten(samples, template=self.event_template)
         return samples
 
@@ -399,7 +400,9 @@ def make_posterior(
         Posterior with chain structure, auxiliary DataTree, and provenance.
     """
     result = ApproximateDistribution(
-        chains, name="posterior", event_template=event_template,
+        chains,
+        name="posterior",
+        event_template=event_template,
         field_order=field_order,
     )
 
@@ -407,6 +410,8 @@ def make_posterior(
         result._auxiliary = auxiliary
 
     result.with_source(
-        Provenance.create(algorithm, parents=list(parents), metadata={"algorithm": algorithm, **meta})
+        Provenance.create(
+            algorithm, parents=list(parents), metadata={"algorithm": algorithm, **meta}
+        )
     )
     return result

--- a/probpipe/inference/_bayesflow_common.py
+++ b/probpipe/inference/_bayesflow_common.py
@@ -101,9 +101,7 @@ def _validate_learn_inputs(
     """Shared train-time validation for the amortized learners; returns the
     prior's record template. Raises before any simulation runs."""
     if sim_backend not in ("jax", "sequential"):
-        raise ValueError(
-            f"Unknown sim_backend: {sim_backend!r}. Supported: 'jax', 'sequential'."
-        )
+        raise ValueError(f"Unknown sim_backend: {sim_backend!r}. Supported: 'jax', 'sequential'.")
     for _name, _val in counts:
         if not isinstance(_val, (int, np.integer)):
             raise TypeError(f"{_name} must be an integer, got {type(_val).__name__}.")

--- a/probpipe/inference/_bayesflow_likelihoods.py
+++ b/probpipe/inference/_bayesflow_likelihoods.py
@@ -183,7 +183,11 @@ class _BayesFlowLikelihoodBase(ConditionallyIndependentLikelihood, GenerativeLik
         return self._row_scores(theta[None, :], row)[0]
 
     def generate_data(
-        self, params: Any, num_observations: int, *, key: PRNGKey | None = None,
+        self,
+        params: Any,
+        num_observations: int,
+        *,
+        key: PRNGKey | None = None,
     ) -> Any:
         """Delegate to the training simulator (``GenerativeLikelihood`` passthrough)."""
         return self._simulator.generate_data(params, num_observations, key=key)
@@ -240,20 +244,19 @@ class BayesFlowLikelihood(_BayesFlowLikelihoodBase):
         # standardization log-det-jacobian converts that density back to the
         # original y units, making the values equal to the public log_prob.
         if self._dequantized:
-            data_rows = data_rows + 0.5   # midpoint of the trained cell [y, y+1)
+            data_rows = data_rows + 0.5  # midpoint of the trained cell [y, y+1)
         a = self._approximator
         conds = a.standardizer.maybe_standardize(
-            theta_rows, key="inference_conditions", stage="inference")
+            theta_rows, key="inference_conditions", stage="inference"
+        )
         z, ldj = a.standardizer.maybe_standardize(
-            data_rows, key="inference_variables", stage="inference", log_det_jac=True)
+            data_rows, key="inference_variables", stage="inference", log_det_jac=True
+        )
         return a.inference_network.log_prob(z, conditions=conds) + ldj
 
     def __repr__(self) -> str:
         dq = ", dequantized=True" if self._dequantized else ""
-        return (
-            f"BayesFlowLikelihood(theta_dim={self._theta_dim}, "
-            f"data_dim={self._data_dim}{dq})"
-        )
+        return f"BayesFlowLikelihood(theta_dim={self._theta_dim}, data_dim={self._data_dim}{dq})"
 
 
 class BayesFlowRatio(_BayesFlowLikelihoodBase):
@@ -284,16 +287,15 @@ class BayesFlowRatio(_BayesFlowLikelihoodBase):
         # its jacobian cancels -- the logits already live in original units.
         a = self._approximator
         thv = a.standardizer.maybe_standardize(
-            theta_rows, key="inference_variables", stage="inference")
+            theta_rows, key="inference_variables", stage="inference"
+        )
         conds = a.standardizer.maybe_standardize(
-            data_rows, key="inference_conditions", stage="inference")
+            data_rows, key="inference_conditions", stage="inference"
+        )
         return a.logits(thv, conds, stage="inference")
 
     def __repr__(self) -> str:
-        return (
-            f"BayesFlowRatio(theta_dim={self._theta_dim}, "
-            f"data_dim={self._data_dim})"
-        )
+        return f"BayesFlowRatio(theta_dim={self._theta_dim}, data_dim={self._data_dim})"
 
 
 # ---------------------------------------------------------------------------
@@ -328,9 +330,15 @@ def _train_offline(
     simulator stays untouched). Returns ``(approximator, d_y)``.
     """
     event_template = _validate_learn_inputs(
-        prior, simulator, caller=caller, sim_backend=sim_backend,
-        counts=(("num_simulations", num_simulations), ("batch_size", batch_size),
-                ("epochs", epochs)),
+        prior,
+        simulator,
+        caller=caller,
+        sim_backend=sim_backend,
+        counts=(
+            ("num_simulations", num_simulations),
+            ("batch_size", batch_size),
+            ("epochs", epochs),
+        ),
     )
     # Numeric leaves (slash paths for a nested prior; == fields for a flat one).
     # NLE/NRE feed raw theta to the network, so no bijectors -- just the keying.
@@ -349,8 +357,12 @@ def _train_offline(
             # tolerance measured on it -- bit-identical.
             key, k_jitter = jax.random.split(key)
         named, y = _simulate_offline(
-            prior, simulator, num_simulations, key,
-            sim_backend=sim_backend, bijectors=None,   # raw theta: it is a net input
+            prior,
+            simulator,
+            num_simulations,
+            key,
+            sim_backend=sim_backend,
+            bijectors=None,  # raw theta: it is a net input
         )
         if dequantize:
             if float(np.abs(y).max()) >= 2.0**23:
@@ -360,14 +372,16 @@ def _train_offline(
                     "jitter and the midpoint shift. Rescale the observations "
                     "or use learn_amortized_ratio."
                 )
-            y = np.asarray(jnp.asarray(y) + jax.random.uniform(k_jitter, y.shape),
-                           dtype="float32")
+            y = np.asarray(jnp.asarray(y) + jax.random.uniform(k_jitter, y.shape), dtype="float32")
         internal_keys = _adapter_field_keys(leaf_keys)
         sims = {k: named[lk] for k, lk in zip(internal_keys, leaf_keys)}
         sims[_OBSERVATION_KEY] = y
 
-        obs_role = ("inference_variables" if theta_role == "inference_conditions"
-                    else "inference_conditions")
+        obs_role = (
+            "inference_variables"
+            if theta_role == "inference_conditions"
+            else "inference_conditions"
+        )
         adapter = (
             bf.Adapter()
             .convert_dtype("float64", "float32")
@@ -493,14 +507,23 @@ def learn_amortized_likelihood(
         return bf.ContinuousApproximator(inference_network=net, adapter=adapter)
 
     approximator, data_dim = _train_offline(
-        prior, simulator, caller="learn_amortized_likelihood",
-        num_simulations=num_simulations, epochs=epochs, batch_size=batch_size,
-        sim_backend=sim_backend, random_seed=random_seed,
-        theta_role="inference_conditions", build_approximator=_build,
-        optimizer=optimizer, fit_kwargs=fit_kwargs, dequantize=dequantize,
+        prior,
+        simulator,
+        caller="learn_amortized_likelihood",
+        num_simulations=num_simulations,
+        epochs=epochs,
+        batch_size=batch_size,
+        sim_backend=sim_backend,
+        random_seed=random_seed,
+        theta_role="inference_conditions",
+        build_approximator=_build,
+        optimizer=optimizer,
+        fit_kwargs=fit_kwargs,
+        dequantize=dequantize,
     )
-    return BayesFlowLikelihood(approximator, prior, simulator, data_dim=data_dim,
-                               dequantized=dequantize)
+    return BayesFlowLikelihood(
+        approximator, prior, simulator, data_dim=data_dim, dequantized=dequantize
+    )
 
 
 def learn_amortized_ratio(
@@ -572,14 +595,20 @@ def learn_amortized_ratio(
 
     def _build(bf: Any, adapter: Any, data_dim: int) -> Any:
         net = inference_network if inference_network is not None else bf.networks.MLP()
-        return bf.approximators.RatioApproximator(
-            inference_network=net, adapter=adapter)
+        return bf.approximators.RatioApproximator(inference_network=net, adapter=adapter)
 
     approximator, data_dim = _train_offline(
-        prior, simulator, caller="learn_amortized_ratio",
-        num_simulations=num_simulations, epochs=epochs, batch_size=batch_size,
-        sim_backend=sim_backend, random_seed=random_seed,
-        theta_role="inference_variables", build_approximator=_build,
-        optimizer=optimizer, fit_kwargs=fit_kwargs,
+        prior,
+        simulator,
+        caller="learn_amortized_ratio",
+        num_simulations=num_simulations,
+        epochs=epochs,
+        batch_size=batch_size,
+        sim_backend=sim_backend,
+        random_seed=random_seed,
+        theta_role="inference_variables",
+        build_approximator=_build,
+        optimizer=optimizer,
+        fit_kwargs=fit_kwargs,
     )
     return BayesFlowRatio(approximator, prior, simulator, data_dim=data_dim)

--- a/probpipe/inference/_bayesflow_posteriors.py
+++ b/probpipe/inference/_bayesflow_posteriors.py
@@ -81,9 +81,7 @@ def _make_inference_network(
         return bf.networks.FlowMatching()
     if method == "cmpe":
         return bf.networks.ConsistencyModel(total_steps=total_steps)
-    raise ValueError(
-        f"Unknown amortized SBI method: {method!r}. Supported: 'npe', 'fmpe', 'cmpe'."
-    )
+    raise ValueError(f"Unknown amortized SBI method: {method!r}. Supported: 'npe', 'fmpe', 'cmpe'.")
 
 
 def _build_adapter(bf: ModuleType, internal_keys: tuple[str, ...]) -> Adapter:
@@ -253,10 +251,7 @@ class BayesFlowModel(Distribution, SupportsConditioning):
         )
 
     def __repr__(self) -> str:
-        return (
-            f"BayesFlowModel(method={self._method!r}, "
-            f"num_results={self._num_results})"
-        )
+        return f"BayesFlowModel(method={self._method!r}, num_results={self._num_results})"
 
 
 # ---------------------------------------------------------------------------
@@ -366,9 +361,16 @@ def learn_amortized_posterior(
             f"Unknown amortized SBI method: {method!r}. Supported: 'npe', 'fmpe', 'cmpe'."
         )
     event_template = _validate_learn_inputs(
-        prior, simulator, caller="learn_amortized_posterior", sim_backend=sim_backend,
-        counts=(("num_simulations", num_simulations), ("batch_size", batch_size),
-                ("epochs", epochs), ("num_results", num_results)),
+        prior,
+        simulator,
+        caller="learn_amortized_posterior",
+        sim_backend=sim_backend,
+        counts=(
+            ("num_simulations", num_simulations),
+            ("batch_size", batch_size),
+            ("epochs", epochs),
+            ("num_results", num_results),
+        ),
     )
     # Per numeric leaf (slash paths for a nested prior; == fields for a flat
     # one). supports / bijectors are leaf-keyed, so this serves both uniformly.
@@ -388,8 +390,12 @@ def learn_amortized_posterior(
     with _isolated_keras_seeding(random_seed):
         key = jax.random.PRNGKey(random_seed)
         named, y = _simulate_offline(
-            prior, simulator, num_simulations, key,
-            sim_backend=sim_backend, bijectors=bijectors,
+            prior,
+            simulator,
+            num_simulations,
+            key,
+            sim_backend=sim_backend,
+            bijectors=bijectors,
         )
         # Re-key theta leaves to positional internal names so user field names
         # never enter BayesFlow's key namespace (no collision with the
@@ -410,6 +416,12 @@ def learn_amortized_posterior(
         approximator.fit(dataset=dataset, epochs=epochs, **fit_kwargs)
 
     return BayesFlowModel(
-        approximator, prior, simulator, method=method, data_dim=int(y.shape[-1]),
-        num_results=num_results, random_seed=random_seed, bijectors=bijectors,
+        approximator,
+        prior,
+        simulator,
+        method=method,
+        data_dim=int(y.shape[-1]),
+        num_results=num_results,
+        random_seed=random_seed,
+        bijectors=bijectors,
     )

--- a/probpipe/inference/_blackjax_ess.py
+++ b/probpipe/inference/_blackjax_ess.py
@@ -88,7 +88,10 @@ def _gaussian_prior_params(prior: Distribution) -> tuple[Array, Array] | None:
     priors (which have no ``_sample`` to draw the auxiliary from).
     """
     from ..distributions import (
-        JointGaussian, MultivariateNormal, Normal, ProductDistribution,
+        JointGaussian,
+        MultivariateNormal,
+        Normal,
+        ProductDistribution,
     )
 
     if isinstance(prior, MultivariateNormal):
@@ -104,7 +107,7 @@ def _gaussian_prior_params(prior: Distribution) -> tuple[Array, Array] | None:
     if isinstance(prior, Normal):
         loc = jnp.atleast_1d(jnp.asarray(prior.loc))
         scale = jnp.atleast_1d(jnp.asarray(prior.scale))
-        return loc, jnp.diag(scale ** 2)
+        return loc, jnp.diag(scale**2)
 
     if isinstance(prior, ProductDistribution):
         locs: list[Array] = []
@@ -143,7 +146,9 @@ def _run_ess_chains(
     Returns ``(chains, warmup_chains_or_None, sample_stats_dict)``.
     """
     sampler = blackjax.elliptical_slice(
-        loglikelihood_fn, mean=prior_mean, cov=prior_cov,
+        loglikelihood_fn,
+        mean=prior_mean,
+        cov=prior_cov,
     )
     key = jax.random.PRNGKey(random_seed)
     chain_keys = jax.random.split(key, num_chains)
@@ -159,11 +164,12 @@ def _run_ess_chains(
         if num_warmup > 0:
             warmup_keys = jax.random.split(warmup_key, num_warmup)
             state, (warmup_positions, warmup_subiter) = jax.lax.scan(
-                step, state, warmup_keys,
+                step,
+                state,
+                warmup_keys,
             )
         else:
-            warmup_positions = jnp.empty((0, init_position.shape[0]),
-                                         dtype=init_position.dtype)
+            warmup_positions = jnp.empty((0, init_position.shape[0]), dtype=init_position.dtype)
             warmup_subiter = jnp.empty((0,), dtype=jnp.int32)
 
         sample_keys = jax.random.split(sample_key, num_results)
@@ -172,10 +178,7 @@ def _run_ess_chains(
 
     positions_all, warmups_all, subiter_all = parallel_chain_map(run_one_chain, chain_keys)
     chains = [positions_all[c] for c in range(num_chains)]
-    warmups = (
-        [warmups_all[c] for c in range(num_chains)]
-        if num_warmup > 0 else None
-    )
+    warmups = [warmups_all[c] for c in range(num_chains)] if num_warmup > 0 else None
     sample_stats = {"subiter": np.asarray(subiter_all)}
     return chains, warmups, sample_stats
 
@@ -232,10 +235,7 @@ def elliptical_slice(
     likelihood = model._likelihood
     gp = _gaussian_prior_params(prior)
     if gp is None:
-        raise TypeError(
-            "elliptical_slice requires a Gaussian prior; "
-            f"got {type(prior).__name__}"
-        )
+        raise TypeError(f"elliptical_slice requires a Gaussian prior; got {type(prior).__name__}")
     if data is None:
         raise TypeError("elliptical_slice requires observed data")
 
@@ -247,17 +247,27 @@ def elliptical_slice(
     loglikelihood_fn = build_likelihood_flat(prior, likelihood, data)
 
     chains, warmups, sample_stats = _run_ess_chains(
-        loglikelihood_fn, init_state, prior_mean, prior_cov,
-        num_results=num_results, num_warmup=num_warmup,
-        num_chains=num_chains, random_seed=random_seed,
+        loglikelihood_fn,
+        init_state,
+        prior_mean,
+        prior_cov,
+        num_results=num_results,
+        num_warmup=num_warmup,
+        num_chains=num_chains,
+        random_seed=random_seed,
     )
 
     auxiliary = build_mcmc_datatree(chains, sample_stats, warmup_chains=warmups)
     event_template = extract_event_template(model)
     return make_posterior(
-        chains, parents=(prior,), algorithm="elliptical_slice",
-        auxiliary=auxiliary, event_template=event_template,
-        num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
+        chains,
+        parents=(prior,),
+        algorithm="elliptical_slice",
+        auxiliary=auxiliary,
+        event_template=event_template,
+        num_results=num_results,
+        num_warmup=num_warmup,
+        num_chains=num_chains,
     )
 
 
@@ -288,7 +298,8 @@ class BlackJAXESSMethod(InferenceMethod):
     def check(self, dist: Any, observed: Any, **kwargs: Any) -> MethodInfo:
         if not is_simple_model(dist):
             return MethodInfo(
-                feasible=False, method_name=self.name,
+                feasible=False,
+                method_name=self.name,
                 description=(
                     "ESS requires a SimpleModel; bare "
                     "SupportsUnnormalizedLogProb has no prior/likelihood "
@@ -299,20 +310,20 @@ class BlackJAXESSMethod(InferenceMethod):
         gp = _gaussian_prior_params(prior)
         if gp is None:
             return MethodInfo(
-                feasible=False, method_name=self.name,
-                description=(
-                    "ESS requires a Gaussian prior; got "
-                    f"{type(prior).__name__}"
-                ),
+                feasible=False,
+                method_name=self.name,
+                description=(f"ESS requires a Gaussian prior; got {type(prior).__name__}"),
             )
         if observed is None:
             return MethodInfo(
-                feasible=False, method_name=self.name,
+                feasible=False,
+                method_name=self.name,
                 description="ESS requires observed data for the likelihood",
             )
         if isinstance(observed, dict):
             return MethodInfo(
-                feasible=False, method_name=self.name,
+                feasible=False,
+                method_name=self.name,
                 description="Does not support dict-based conditioning",
             )
         # The runner traces the BlackJAX ESS step under ``lax.scan``;
@@ -324,18 +335,22 @@ class BlackJAXESSMethod(InferenceMethod):
             loglikelihood_fn = build_likelihood_flat(prior, likelihood, observed)
             if not is_jax_traceable(loglikelihood_fn, flat_init):
                 return MethodInfo(
-                    feasible=False, method_name=self.name,
+                    feasible=False,
+                    method_name=self.name,
                     description="Log-likelihood is not JAX-traceable",
                 )
         except Exception as e:
             return MethodInfo(
-                feasible=False, method_name=self.name, description=str(e),
+                feasible=False,
+                method_name=self.name,
+                description=str(e),
             )
         return MethodInfo(feasible=True, method_name=self.name)
 
     def execute(self, dist: Any, observed: Any, **kwargs: Any) -> ApproximateDistribution:
         return elliptical_slice(
-            dist, observed,
+            dist,
+            observed,
             num_results=kwargs.get("num_results", 1000),
             num_warmup=kwargs.get("num_warmup", 500),
             num_chains=kwargs.get("num_chains", 1),

--- a/probpipe/inference/_blackjax_mcmc.py
+++ b/probpipe/inference/_blackjax_mcmc.py
@@ -191,12 +191,16 @@ def _run_blackjax_chains(
         if algorithm == "hmc":
             warmup_algorithm = _halton_warmup_algorithm(num_integration_steps)
             warmup = blackjax.window_adaptation(
-                warmup_algorithm, target_log_prob_fn, initial_step_size=step_size,
+                warmup_algorithm,
+                target_log_prob_fn,
+                initial_step_size=step_size,
             )
         else:
             warmup = blackjax.window_adaptation(
-                kernel_factory, target_log_prob_fn,
-                initial_step_size=step_size, **extra_kwargs,
+                kernel_factory,
+                target_log_prob_fn,
+                initial_step_size=step_size,
+                **extra_kwargs,
             )
         (state, params), _ = warmup.run(warmup_key, init_state, num_steps=num_warmup)
         return state, params
@@ -236,7 +240,8 @@ def _run_blackjax_chains(
         return positions, infos, jnp.asarray(adapted_params["step_size"])
 
     all_positions, all_infos, adapted_step_sizes = parallel_chain_map(
-        run_one_chain, chain_keys,
+        run_one_chain,
+        chain_keys,
     )
     chains = [all_positions[c] for c in range(num_chains)]
     sample_stats = _extract_blackjax_sample_stats(all_infos, adapted_step_sizes, num_results)
@@ -244,7 +249,9 @@ def _run_blackjax_chains(
 
 
 def _extract_blackjax_sample_stats(
-    infos: Any, step_sizes: Array, num_results: int,
+    infos: Any,
+    step_sizes: Array,
+    num_results: int,
 ) -> dict[str, np.ndarray]:
     """Pack BlackJAX per-step ``info`` into a TFP-shaped sample-stats dict.
 
@@ -266,7 +273,8 @@ def _extract_blackjax_sample_stats(
             stats[key] = np.asarray(value)
     step_sizes = np.asarray(step_sizes)
     stats["step_size"] = np.broadcast_to(
-        step_sizes[:, None], (step_sizes.shape[0], num_results),
+        step_sizes[:, None],
+        (step_sizes.shape[0], num_results),
     ).copy()
     return stats
 
@@ -298,26 +306,33 @@ class _BlackJAXMCMCMethod(InferenceMethod):
     def check(self, dist: Any, observed: Any, **kwargs: Any) -> MethodInfo:
         if not isinstance(dist, SupportsUnnormalizedLogProb):
             return MethodInfo(
-                feasible=False, method_name=self.name,
+                feasible=False,
+                method_name=self.name,
                 description="Requires SupportsUnnormalizedLogProb",
             )
         try:
             target_flat, flat_init, _ = build_target_log_prob_flat(dist, observed)
             if not is_jax_traceable(target_flat, flat_init):
                 return MethodInfo(
-                    feasible=False, method_name=self.name,
+                    feasible=False,
+                    method_name=self.name,
                     description="Log-prob is not JAX-traceable",
                 )
         except Exception as e:
             return MethodInfo(
-                feasible=False, method_name=self.name, description=str(e),
+                feasible=False,
+                method_name=self.name,
+                description=str(e),
             )
         return MethodInfo(feasible=True, method_name=self.name)
 
     def execute(self, dist: Any, observed: Any, **kwargs: Any) -> ApproximateDistribution:
         random_seed: int = kwargs.get("random_seed", 0)
         target_flat, flat_init, event_template = build_target_log_prob_flat(
-            dist, observed, init=kwargs.get("init"), random_seed=random_seed,
+            dist,
+            observed,
+            init=kwargs.get("init"),
+            random_seed=random_seed,
         )
         num_results: int = kwargs.get("num_results", 1000)
         num_warmup: int = kwargs.get("num_warmup", 500)
@@ -326,7 +341,8 @@ class _BlackJAXMCMCMethod(InferenceMethod):
         num_integration_steps: int = kwargs.get("num_integration_steps", 10)
 
         chains, sample_stats = _run_blackjax_chains(
-            target_flat, flat_init,
+            target_flat,
+            flat_init,
             algorithm=self._algorithm,
             num_results=num_results,
             num_warmup=num_warmup,
@@ -338,9 +354,14 @@ class _BlackJAXMCMCMethod(InferenceMethod):
         auxiliary = build_mcmc_datatree(chains, sample_stats)
         prior = get_prior(dist)
         return make_posterior(
-            chains, parents=(prior,), algorithm=self._method_name,
-            auxiliary=auxiliary, event_template=event_template,
-            num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
+            chains,
+            parents=(prior,),
+            algorithm=self._method_name,
+            auxiliary=auxiliary,
+            event_template=event_template,
+            num_results=num_results,
+            num_warmup=num_warmup,
+            num_chains=num_chains,
         )
 
 

--- a/probpipe/inference/_blackjax_rwmh.py
+++ b/probpipe/inference/_blackjax_rwmh.py
@@ -59,6 +59,7 @@ __all__ = ["rwmh", "BlackJAXRWMHMethod"]
 # Adaptive warmup
 # ---------------------------------------------------------------------------
 
+
 # Roberts-Gelman-Gilks 1997 asymptotic optimal scaling for RWMH on a
 # d-dimensional target: ``proposal_cov = (2.38^2 / d) * Sigma_target``.
 # We use ``2.38 / sqrt(d)`` as the scalar multiplier on the proposal
@@ -126,7 +127,7 @@ def _window_sizes(num_warmup: int, n_windows: int, ratio: float = 2.0) -> list[i
     n = min(int(n_windows), max_windows)
     if n <= 1:
         return [num_warmup]
-    weights = np.asarray([ratio ** i for i in range(n)], dtype=float)
+    weights = np.asarray([ratio**i for i in range(n)], dtype=float)
     weights = weights / weights.sum()
     sizes = np.maximum(1, np.round(weights * num_warmup).astype(int))
     sizes[-1] += num_warmup - int(sizes.sum())
@@ -186,7 +187,9 @@ def _adaptive_warmup_fast(
         k, sub = jax.random.split(k)
         keys = jax.random.split(sub, w_size)
         (rw_state, welf_state), positions = jax.lax.scan(
-            step, (rw_state, welf_state), keys,
+            step,
+            (rw_state, welf_state),
+            keys,
         )
         window_positions.append(positions)
 
@@ -321,7 +324,11 @@ def _fixed_sigma_warmup(
         return init_state, None
     sample_fn = _sample_chain_fast if traceable else _sample_chain_eager
     warmup_positions, _ = sample_fn(
-        target_log_prob_fn, init_state, sigma, num_warmup, key,
+        target_log_prob_fn,
+        init_state,
+        sigma,
+        num_warmup,
+        key,
     )
     return warmup_positions[-1], warmup_positions
 
@@ -352,13 +359,20 @@ def _run_one_chain(
         # branch uses rather than running adaptive warmup.
         sigma = proposal_sigma_override
         init_position, warmup_positions = _fixed_sigma_warmup(
-            target_log_prob_fn, init_state, sigma, num_warmup, warmup_key,
+            target_log_prob_fn,
+            init_state,
+            sigma,
+            num_warmup,
+            warmup_key,
             traceable=traceable,
         )
     elif adapt and num_warmup > 0:
         warmup_fn = _adaptive_warmup_fast if traceable else _adaptive_warmup_eager
         rw_state, cov, warmup_positions = warmup_fn(
-            target_log_prob_fn, init_state, warmup_key, num_warmup,
+            target_log_prob_fn,
+            init_state,
+            warmup_key,
+            num_warmup,
             n_windows=n_windows,
         )
         sigma = _production_sigma(cov, d)
@@ -366,13 +380,21 @@ def _run_one_chain(
     else:
         sigma = jnp.eye(d) * step_size
         init_position, warmup_positions = _fixed_sigma_warmup(
-            target_log_prob_fn, init_state, sigma, num_warmup, warmup_key,
+            target_log_prob_fn,
+            init_state,
+            sigma,
+            num_warmup,
+            warmup_key,
             traceable=traceable,
         )
 
     sample_fn = _sample_chain_fast if traceable else _sample_chain_eager
     chain, sample_stats = sample_fn(
-        target_log_prob_fn, init_position, sigma, num_results, sample_key,
+        target_log_prob_fn,
+        init_position,
+        sigma,
+        num_results,
+        sample_key,
     )
     return chain, warmup_positions, sample_stats
 
@@ -401,15 +423,21 @@ def _run_blackjax_rwmh(
     chain_keys = jax.random.split(key, num_chains)
 
     if traceable:
+
         def run_one(chain_key):
             return _run_one_chain(
-                target_log_prob_fn, init_state, chain_key,
-                num_results=num_results, num_warmup=num_warmup,
-                adapt=adapt, step_size=step_size,
+                target_log_prob_fn,
+                init_state,
+                chain_key,
+                num_results=num_results,
+                num_warmup=num_warmup,
+                adapt=adapt,
+                step_size=step_size,
                 proposal_sigma_override=proposal_sigma_override,
                 n_windows=n_windows,
                 traceable=True,
             )
+
         chains_arr, warmups_arr, stats_arr = parallel_chain_map(run_one, chain_keys)
         chains = [chains_arr[c] for c in range(num_chains)]
         warmups = (
@@ -417,9 +445,7 @@ def _run_blackjax_rwmh(
             if warmups_arr is not None and warmups_arr.shape[0] == num_chains
             else None
         )
-        sample_stats = {
-            k: np.asarray(v) for k, v in stats_arr.items()
-        }
+        sample_stats = {k: np.asarray(v) for k, v in stats_arr.items()}
     else:
         chains_l: list[Array] = []
         warmups_l: list[Array] = []
@@ -427,9 +453,13 @@ def _run_blackjax_rwmh(
         is_acc_l: list[np.ndarray] = []
         for chain_key in chain_keys:
             ch, wm, st = _run_one_chain(
-                target_log_prob_fn, init_state, chain_key,
-                num_results=num_results, num_warmup=num_warmup,
-                adapt=adapt, step_size=step_size,
+                target_log_prob_fn,
+                init_state,
+                chain_key,
+                num_results=num_results,
+                num_warmup=num_warmup,
+                adapt=adapt,
+                step_size=step_size,
                 proposal_sigma_override=proposal_sigma_override,
                 n_windows=n_windows,
                 traceable=False,
@@ -552,9 +582,11 @@ def rwmh(
         )
 
     if log_prob_fn is not None and data is not None:
+
         def target_log_prob(params):
             return dist._unnormalized_log_prob(params) + log_prob_fn(params, data)
     else:
+
         def target_log_prob(params):
             return dist._unnormalized_log_prob(params)
 
@@ -586,10 +618,17 @@ def rwmh(
     auxiliary = build_mcmc_datatree(chains, sample_stats, warmup_chains=warmups)
     event_template = extract_event_template(dist)
     return make_posterior(
-        chains, parents=(dist,), algorithm="blackjax_rwmh",
-        auxiliary=auxiliary, event_template=event_template,
-        num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
-        step_size=step_size, accept_rate=accept_rate, adapt=adapt,
+        chains,
+        parents=(dist,),
+        algorithm="blackjax_rwmh",
+        auxiliary=auxiliary,
+        event_template=event_template,
+        num_results=num_results,
+        num_warmup=num_warmup,
+        num_chains=num_chains,
+        step_size=step_size,
+        accept_rate=accept_rate,
+        adapt=adapt,
         n_windows=n_windows,
     )
 
@@ -623,12 +662,14 @@ class BlackJAXRWMHMethod(InferenceMethod):
         prior = get_prior(dist)
         if not isinstance(prior, SupportsUnnormalizedLogProb):
             return MethodInfo(
-                feasible=False, method_name=self.name,
+                feasible=False,
+                method_name=self.name,
                 description="Requires SupportsUnnormalizedLogProb",
             )
         if observed is not None and isinstance(observed, dict):
             return MethodInfo(
-                feasible=False, method_name=self.name,
+                feasible=False,
+                method_name=self.name,
                 description="Does not support dict-based conditioning",
             )
         return MethodInfo(feasible=True, method_name=self.name)
@@ -646,7 +687,8 @@ class BlackJAXRWMHMethod(InferenceMethod):
             init = get_init_state(dist, None, random_seed=random_seed)
 
         return rwmh(
-            prior, observed,
+            prior,
+            observed,
             log_prob_fn=log_prob_fn,
             num_results=kwargs.get("num_results", 1000),
             num_warmup=kwargs.get("num_warmup", 500),

--- a/probpipe/inference/_blackjax_sgmcmc.py
+++ b/probpipe/inference/_blackjax_sgmcmc.py
@@ -97,6 +97,7 @@ class _BlackJAXSGMCMCMethod(InferenceMethod):
         # Filter at the registry-level by Distribution; the SimpleModel +
         # ConditionallyIndependentLikelihood constraint is enforced in check().
         from ..core._distribution_base import Distribution
+
         return (Distribution,)
 
     @property
@@ -111,15 +112,14 @@ class _BlackJAXSGMCMCMethod(InferenceMethod):
 
         if not is_simple_model(dist):
             return MethodInfo(
-                feasible=False, method_name=self.name,
-                description=(
-                    f"{self.name} requires a SimpleModel; got "
-                    f"{type(dist).__name__}."
-                ),
+                feasible=False,
+                method_name=self.name,
+                description=(f"{self.name} requires a SimpleModel; got {type(dist).__name__}."),
             )
         if not isinstance(dist.likelihood, ConditionallyIndependentLikelihood):
             return MethodInfo(
-                feasible=False, method_name=self.name,
+                feasible=False,
+                method_name=self.name,
                 description=(
                     f"{self.name} requires model.likelihood to satisfy "
                     f"ConditionallyIndependentLikelihood; got "
@@ -128,7 +128,8 @@ class _BlackJAXSGMCMCMethod(InferenceMethod):
             )
         if "batch_size" not in kwargs:
             return MethodInfo(
-                feasible=False, method_name=self.name,
+                feasible=False,
+                method_name=self.name,
                 description=(
                     f"{self.name} requires an explicit batch_size= kwarg. "
                     f"There is no canonical default for a stochastic sampler."
@@ -151,7 +152,9 @@ class _BlackJAXSGMCMCMethod(InferenceMethod):
         # grads. ``dist`` is a SimpleModel (validated by ``check()``);
         # unpack its prior + CIL likelihood for the random measure.
         measure = MinibatchedDistribution(
-            dist.prior, dist.likelihood, observed,
+            dist.prior,
+            dist.likelihood,
+            observed,
             batch_size=batch_size,
             with_replacement=with_replacement,
         )
@@ -163,14 +166,20 @@ class _BlackJAXSGMCMCMethod(InferenceMethod):
         # Initial position from prior or user-supplied init.
         prior = dist.prior
         init = get_init_state(
-            dist, kwargs.get("init"), random_seed=random_seed,
+            dist,
+            kwargs.get("init"),
+            random_seed=random_seed,
         )
         state = algorithm.init(init)
 
         # Iterate. The kernel itself jits within run_loop's step closure.
         positions = _run_sgmcmc_loop(
-            algorithm, state, as_prng_key(random_seed),
-            step_size, num_warmup, num_results,
+            algorithm,
+            state,
+            as_prng_key(random_seed),
+            step_size,
+            num_warmup,
+            num_results,
         )
 
         # ``check()`` rejects any non-SimpleModel target, and a
@@ -179,9 +188,14 @@ class _BlackJAXSGMCMCMethod(InferenceMethod):
         chain = jnp.stack(positions, axis=0)
         event_template = prior.event_template
         return make_posterior(
-            [chain], parents=(prior,), algorithm=self._method_name,
-            auxiliary=None, event_template=event_template,
-            num_results=num_results, num_warmup=num_warmup, num_chains=1,
+            [chain],
+            parents=(prior,),
+            algorithm=self._method_name,
+            auxiliary=None,
+            event_template=event_template,
+            num_results=num_results,
+            num_warmup=num_warmup,
+            num_chains=1,
         )
 
     # -- subclass hook -------------------------------------------------------
@@ -275,5 +289,6 @@ class BlackJAXSGHMCMethod(_BlackJAXSGMCMCMethod):
         return blackjax.sghmc(
             grad_estimator,
             num_integration_steps=num_integration_steps,
-            alpha=alpha, beta=beta,
+            alpha=alpha,
+            beta=beta,
         )

--- a/probpipe/inference/_cmdstan_method.py
+++ b/probpipe/inference/_cmdstan_method.py
@@ -16,6 +16,7 @@ def _import_cmdstanpy():
     """Import cmdstanpy or raise a helpful error."""
     try:
         import cmdstanpy
+
         return cmdstanpy
     except ImportError as e:
         raise ImportError(
@@ -29,6 +30,7 @@ class CmdStanNutsMethod(InferenceMethod):
 
     def __init__(self) -> None:
         from ..modeling._stan import StanModel
+
         self._model_type = StanModel
 
     @property
@@ -47,8 +49,9 @@ class CmdStanNutsMethod(InferenceMethod):
 
     def check(self, dist: Any, observed: Any, **kwargs: Any) -> MethodInfo:
         if not isinstance(dist, self._model_type):
-            return MethodInfo(feasible=False, method_name=self.name,
-                              description="Requires StanModel")
+            return MethodInfo(
+                feasible=False, method_name=self.name, description="Requires StanModel"
+            )
         return MethodInfo(feasible=True, method_name=self.name)
 
     def execute(self, dist: Any, observed: Any, **kwargs: Any) -> ApproximateDistribution:
@@ -82,7 +85,11 @@ class CmdStanNutsMethod(InferenceMethod):
         inference_data = azb.from_cmdstanpy(fit)
 
         return make_posterior(
-            chains, parents=(dist,), algorithm="cmdstan_nuts",
+            chains,
+            parents=(dist,),
+            algorithm="cmdstan_nuts",
             auxiliary=inference_data,
-            num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
+            num_results=num_results,
+            num_warmup=num_warmup,
+            num_chains=num_chains,
         )

--- a/probpipe/inference/_inference_utils.py
+++ b/probpipe/inference/_inference_utils.py
@@ -65,8 +65,11 @@ __all__ = [
 # Chain extraction
 # ---------------------------------------------------------------------------
 
+
 def extract_chain_columns(
-    trace: Any, names: list[str], num_chains: int,
+    trace: Any,
+    names: list[str],
+    num_chains: int,
 ) -> list[Array]:
     """Per-chain flat sample matrices from an ArviZ-like trace.
 
@@ -140,6 +143,7 @@ def posterior_var_order(trace: Any, keep: Iterable[str]) -> list[str]:
 # JAX-traceability probe
 # ---------------------------------------------------------------------------
 
+
 def is_jax_traceable(fn: Callable, init_state: jnp.ndarray) -> bool:
     """Probe whether *fn* can be traced by JAX at *init_state*.
 
@@ -169,6 +173,7 @@ def as_prng_key(seed: int | Array) -> Array:
 # ---------------------------------------------------------------------------
 # Initial-state heuristics
 # ---------------------------------------------------------------------------
+
 
 def get_init_state(
     dist: Distribution,
@@ -210,6 +215,7 @@ def get_init_state(
     target_dtype = getattr(prior, "dtype", None)
     if not isinstance(target_dtype, jnp.dtype):
         from .._dtype import _default_float_dtype
+
         target_dtype = _default_float_dtype()
 
     if init is not None:
@@ -222,20 +228,25 @@ def get_init_state(
             s = prior._sample(key, sample_shape=())
             if isinstance(s, Record):
                 from ..core._numeric_record import NumericRecord
+
                 if not isinstance(s, NumericRecord):
                     s = NumericRecord.from_record(s)
                 s = s.flatten()
             return jnp.atleast_1d(jnp.asarray(s, dtype=target_dtype))
         except Exception:
             logger.debug(
-                "get_init_state: prior._sample failed for %r; falling "
-                "back to Uniform(-2, 2)", prior, exc_info=True,
+                "get_init_state: prior._sample failed for %r; falling back to Uniform(-2, 2)",
+                prior,
+                exc_info=True,
             )
 
     if hasattr(prior, "event_shape"):
         return jax.random.uniform(
-            key, shape=prior.event_shape,
-            minval=-2.0, maxval=2.0, dtype=target_dtype,
+            key,
+            shape=prior.event_shape,
+            minval=-2.0,
+            maxval=2.0,
+            dtype=target_dtype,
         )
 
     raise ValueError(
@@ -249,9 +260,11 @@ def get_init_state(
 # SimpleModel detection and prior extraction
 # ---------------------------------------------------------------------------
 
+
 def is_simple_model(dist: Distribution) -> bool:
     """Check whether *dist* is a SimpleModel (lazy import for circularity)."""
     from ..modeling._simple import SimpleModel
+
     return isinstance(dist, SimpleModel)
 
 
@@ -276,8 +289,10 @@ def extract_event_template(dist: Distribution) -> EventTemplate | None:
 # Target log-density construction
 # ---------------------------------------------------------------------------
 
+
 def build_target_log_prob(
-    dist: Distribution, observed: ArrayLike | Record | None,
+    dist: Distribution,
+    observed: ArrayLike | Record | None,
 ) -> Callable[[Any], Array]:
     """Build a ``target_log_prob_fn(params)`` from *dist* and *observed*.
 
@@ -302,11 +317,13 @@ def build_target_log_prob(
     its own input types).
     """
     if is_simple_model(dist):
+
         def target_log_prob_fn(params):
             lp = dist._prior._log_prob(params)
             if observed is not None:
                 lp = lp + dist._likelihood.log_likelihood(
-                    params=params, data=observed,
+                    params=params,
+                    data=observed,
                 )
             return lp
 
@@ -319,7 +336,8 @@ def build_target_log_prob(
 
 
 def build_target_log_prob_flat(
-    dist: Distribution, observed: ArrayLike | Record | None,
+    dist: Distribution,
+    observed: ArrayLike | Record | None,
     *,
     init: ArrayLike | None = None,
     random_seed: int | Array = 0,
@@ -446,12 +464,15 @@ def build_mcmc_datatree(
         n_chains, n_warmup = warmup_array.shape[:2]
         event_dims = [f"params_dim_{i}" for i in range(warmup_array.ndim - 2)]
         dims = ["chain", "draw"] + event_dims
-        warmup_ds = xr.Dataset({
-            "params": xr.DataArray(
-                warmup_array, dims=dims,
-                coords={"chain": np.arange(n_chains), "draw": np.arange(n_warmup)},
-            ),
-        })
+        warmup_ds = xr.Dataset(
+            {
+                "params": xr.DataArray(
+                    warmup_array,
+                    dims=dims,
+                    coords={"chain": np.arange(n_chains), "draw": np.arange(n_warmup)},
+                ),
+            }
+        )
         dt["warmup"] = xr.DataTree(dataset=warmup_ds)
 
     return dt
@@ -482,6 +503,7 @@ def run_chain_scan(
     Used by both the NUTS / HMC and the RWMH / ESS backends; the
     contract is identical because BlackJAX samplers share it.
     """
+
     def one_step(state, step_key):
         state, info = sampler.step(step_key, state)
         return state, (state.position, info)

--- a/probpipe/inference/_minibatch.py
+++ b/probpipe/inference/_minibatch.py
@@ -108,14 +108,16 @@ def _index_along_leading(data: Any, indices: Array) -> Any:
     """
     if isinstance(data, Record):
         # Covers Record and RecordArray (the latter via subclass).
-        return Record({
-            f: jnp.asarray(data[f])[indices] for f in data.fields
-        })
+        return Record({f: jnp.asarray(data[f])[indices] for f in data.fields})
     return jnp.asarray(data)[indices]
 
 
 def _draw_indices(
-    key: PRNGKey, n: int, batch_size: int, *, with_replacement: bool,
+    key: PRNGKey,
+    n: int,
+    batch_size: int,
+    *,
+    with_replacement: bool,
 ) -> Array:
     """Draw ``batch_size`` indices uniformly from ``range(n)``."""
     if with_replacement:
@@ -214,9 +216,7 @@ class MinibatchedDistribution(
         # Validate data + batch_size.
         n = _data_size(data)
         if batch_size < 1 or batch_size > n:
-            raise ValueError(
-                f"batch_size must be in [1, len(data)={n}]; got {batch_size}."
-            )
+            raise ValueError(f"batch_size must be in [1, len(data)={n}]; got {batch_size}.")
 
         self._prior = prior
         self._likelihood = likelihood
@@ -275,7 +275,9 @@ class MinibatchedDistribution(
     def _draw_one(self, key: PRNGKey) -> _FixedMinibatchDistribution:
         """Draw one minibatch and return the corresponding fixed-minibatch target."""
         indices = _draw_indices(
-            key, self._n, self._batch_size,
+            key,
+            self._n,
+            self._batch_size,
             with_replacement=self._with_replacement,
         )
         batch = _index_along_leading(self._data, indices)
@@ -373,14 +375,13 @@ class _FixedMinibatchDistribution(
     def _unnormalized_log_prob(self, theta: Any) -> Array:
         """Stochastic-surrogate unnormalized log-density at ``theta``."""
         per_datum = jax.vmap(
-            self._likelihood.per_datum_log_likelihood, in_axes=(None, 0),
+            self._likelihood.per_datum_log_likelihood,
+            in_axes=(None, 0),
         )(theta, self._batch)
         return self._prior._log_prob(theta) + self._rescale_factor * jnp.sum(per_datum)
 
     def __repr__(self) -> str:
-        return (
-            f"_FixedMinibatchDistribution(rescale_factor={self._rescale_factor:.3g})"
-        )
+        return f"_FixedMinibatchDistribution(rescale_factor={self._rescale_factor:.3g})"
 
 
 # ---------------------------------------------------------------------------
@@ -423,7 +424,9 @@ class _RandomMinibatchLogProb(
     # -- SupportsSampling (returns a callable) ------------------------------
 
     def _sample(
-        self, key: PRNGKey, sample_shape: tuple[int, ...] = (),
+        self,
+        key: PRNGKey,
+        sample_shape: tuple[int, ...] = (),
     ) -> Callable[[Any], Array]:
         """Return a deterministic ``theta -> log~D_B(theta)`` callable.
 
@@ -473,9 +476,12 @@ class _MinibatchLogProbAtPoint(Distribution[Array], SupportsSampling):
         self._theta = theta
 
     def _sample(
-        self, key: PRNGKey, sample_shape: tuple[int, ...] = (),
+        self,
+        key: PRNGKey,
+        sample_shape: tuple[int, ...] = (),
     ) -> Array:
         """Draw minibatched log-density values at the fixed ``theta``."""
+
         def _one_draw(k: PRNGKey) -> Array:
             inner = self._measure._draw_one(k)
             return inner._unnormalized_log_prob(self._theta)

--- a/probpipe/inference/_nutpie.py
+++ b/probpipe/inference/_nutpie.py
@@ -42,8 +42,7 @@ def condition_on_nutpie(
         import nutpie
     except ImportError as e:
         raise ImportError(
-            "nutpie is required for condition_on_nutpie. "
-            "Install it with: pip install nutpie"
+            "nutpie is required for condition_on_nutpie. Install it with: pip install nutpie"
         ) from e
 
     compiled, pymc_build = _compile_for_nutpie(model, data)
@@ -59,8 +58,12 @@ def condition_on_nutpie(
         event_template = getattr(model, "event_template", None)
 
     trace = nutpie.sample(
-        compiled, draws=num_results, tune=num_warmup,
-        chains=num_chains, seed=random_seed, **kwargs,
+        compiled,
+        draws=num_results,
+        tune=num_warmup,
+        chains=num_chains,
+        seed=random_seed,
+        **kwargs,
     )
 
     # Extract in nutpie's natural ``data_vars`` order (it sorts
@@ -74,9 +77,15 @@ def condition_on_nutpie(
         chains, _ = _extract_chains(trace, num_chains)
 
     return make_posterior(
-        chains, parents=(model,), algorithm="nutpie_nuts",
-        auxiliary=trace, event_template=event_template, field_order=field_order,
-        num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
+        chains,
+        parents=(model,),
+        algorithm="nutpie_nuts",
+        auxiliary=trace,
+        event_template=event_template,
+        field_order=field_order,
+        num_results=num_results,
+        num_warmup=num_warmup,
+        num_chains=num_chains,
     )
 
 
@@ -95,6 +104,7 @@ def _compile_for_nutpie(model: Any, data: Any) -> tuple[Any, Any | None]:
     """
     if hasattr(model, "_bridgestan_model"):
         import nutpie
+
         if isinstance(data, dict):
             # Keep the data the model was built with — StanModel(file, data=...)
             # stores it on ``_stan_data`` — and let the conditioning data
@@ -106,6 +116,7 @@ def _compile_for_nutpie(model: Any, data: Any) -> tuple[Any, Any | None]:
 
     if hasattr(model, "_pymc_model"):
         import nutpie
+
         pymc_build = model._pymc_model(data=data)
         return nutpie.compile_pymc_model(pymc_build), pymc_build
 
@@ -116,7 +127,10 @@ def _compile_for_nutpie(model: Any, data: Any) -> tuple[Any, Any | None]:
 
 
 def _extract_chains(
-    trace: Any, num_chains: int, *, keep_names: list[str] | None = None,
+    trace: Any,
+    num_chains: int,
+    *,
+    keep_names: list[str] | None = None,
 ) -> tuple[list, list]:
     """Extract per-chain sample arrays from a nutpie ArviZ trace.
 
@@ -139,9 +153,7 @@ def _extract_chains(
         order.
     """
     if not hasattr(trace, "posterior"):
-        raise TypeError(
-            f"Cannot extract chains from nutpie trace of type {type(trace).__name__}"
-        )
+        raise TypeError(f"Cannot extract chains from nutpie trace of type {type(trace).__name__}")
     if keep_names is not None:
         param_names = list(keep_names)
     else:
@@ -161,11 +173,13 @@ class NutpieNutsMethod(InferenceMethod):
         types: list[type] = []
         try:
             from ..modeling._stan import StanModel
+
             types.append(StanModel)
         except ImportError:
             pass
         try:
             from ..modeling._pymc import PyMCModel
+
             types.append(PyMCModel)
         except ImportError:
             pass
@@ -188,13 +202,15 @@ class NutpieNutsMethod(InferenceMethod):
 
     def check(self, dist: Any, observed: Any, **kwargs: Any) -> MethodInfo:
         if not isinstance(dist, self._supported):
-            return MethodInfo(feasible=False, method_name=self.name,
-                              description="Requires StanModel or PyMCModel")
+            return MethodInfo(
+                feasible=False, method_name=self.name, description="Requires StanModel or PyMCModel"
+            )
         try:
             import nutpie  # noqa: F401
         except ImportError:
-            return MethodInfo(feasible=False, method_name=self.name,
-                              description="nutpie not installed")
+            return MethodInfo(
+                feasible=False, method_name=self.name, description="nutpie not installed"
+            )
         return MethodInfo(feasible=True, method_name=self.name)
 
     def execute(self, dist: Any, observed: Any, **kwargs: Any) -> ApproximateDistribution:

--- a/probpipe/inference/_pymc_method.py
+++ b/probpipe/inference/_pymc_method.py
@@ -16,6 +16,7 @@ class PyMCNutsMethod(InferenceMethod):
 
     def __init__(self) -> None:
         from ..modeling._pymc import PyMCModel
+
         self._model_type = PyMCModel
 
     @property
@@ -36,8 +37,9 @@ class PyMCNutsMethod(InferenceMethod):
 
     def check(self, dist: Any, observed: Any, **kwargs: Any) -> MethodInfo:
         if not isinstance(dist, self._model_type):
-            return MethodInfo(feasible=False, method_name=self.name,
-                              description="Requires PyMCModel")
+            return MethodInfo(
+                feasible=False, method_name=self.name, description="Requires PyMCModel"
+            )
         return MethodInfo(feasible=True, method_name=self.name)
 
     def execute(self, dist: Any, observed: Any, **kwargs: Any) -> ApproximateDistribution:
@@ -77,9 +79,15 @@ class PyMCNutsMethod(InferenceMethod):
         chains = extract_chain_columns(trace, order, num_chains)
 
         return make_posterior(
-            chains, parents=(dist,), algorithm="pymc_nuts",
-            auxiliary=trace, event_template=event_template, field_order=order,
-            num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
+            chains,
+            parents=(dist,),
+            algorithm="pymc_nuts",
+            auxiliary=trace,
+            event_template=event_template,
+            field_order=order,
+            num_results=num_results,
+            num_warmup=num_warmup,
+            num_chains=num_chains,
         )
 
 
@@ -88,6 +96,7 @@ class PyMCADVIMethod(InferenceMethod):
 
     def __init__(self) -> None:
         from ..modeling._pymc import PyMCModel
+
         self._model_type = PyMCModel
 
     @property
@@ -110,8 +119,9 @@ class PyMCADVIMethod(InferenceMethod):
 
     def check(self, dist: Any, observed: Any, **kwargs: Any) -> MethodInfo:
         if not isinstance(dist, self._model_type):
-            return MethodInfo(feasible=False, method_name=self.name,
-                              description="Requires PyMCModel")
+            return MethodInfo(
+                feasible=False, method_name=self.name, description="Requires PyMCModel"
+            )
         return MethodInfo(feasible=True, method_name=self.name)
 
     def execute(self, dist: Any, observed: Any, **kwargs: Any) -> ApproximateDistribution:
@@ -138,7 +148,11 @@ class PyMCADVIMethod(InferenceMethod):
         algorithm = f"pymc_{vi_method}"
 
         return make_posterior(
-            chains, parents=(dist,), algorithm=algorithm,
-            auxiliary=trace, event_template=event_template, field_order=order,
+            chains,
+            parents=(dist,),
+            algorithm=algorithm,
+            auxiliary=trace,
+            event_template=event_template,
+            field_order=order,
             num_iterations=num_iterations,
         )

--- a/probpipe/inference/_registry.py
+++ b/probpipe/inference/_registry.py
@@ -22,6 +22,4 @@ InferenceMethod = UnaryDispatchMethod
 
 # The singleton registry — a plain UnaryDispatchRegistry, no subclass
 # needed.
-inference_method_registry: UnaryDispatchRegistry[UnaryDispatchMethod] = (
-    UnaryDispatchRegistry()
-)
+inference_method_registry: UnaryDispatchRegistry[UnaryDispatchMethod] = UnaryDispatchRegistry()

--- a/probpipe/inference/_tfp_mcmc.py
+++ b/probpipe/inference/_tfp_mcmc.py
@@ -144,20 +144,26 @@ class _TFPGradientMethod(InferenceMethod):
         # selecting a gradient-based method that would fail at execute() time.
         # The cost is ~one JAX trace, cached by JAX on subsequent calls.
         if not isinstance(dist, SupportsUnnormalizedLogProb):
-            return MethodInfo(feasible=False, method_name=self.name,
-                              description="Requires SupportsUnnormalizedLogProb")
+            return MethodInfo(
+                feasible=False,
+                method_name=self.name,
+                description="Requires SupportsUnnormalizedLogProb",
+            )
         try:
             target = build_target_log_prob(dist, observed)
             init = get_init_state(
-                dist, kwargs.get("init"),
+                dist,
+                kwargs.get("init"),
                 random_seed=kwargs.get("random_seed", 0),
             )
             if not is_jax_traceable(target, init):
-                return MethodInfo(feasible=False, method_name=self.name,
-                                  description="Log-prob is not JAX-traceable")
+                return MethodInfo(
+                    feasible=False,
+                    method_name=self.name,
+                    description="Log-prob is not JAX-traceable",
+                )
         except Exception as e:
-            return MethodInfo(feasible=False, method_name=self.name,
-                              description=str(e))
+            return MethodInfo(feasible=False, method_name=self.name, description=str(e))
         return MethodInfo(feasible=True, method_name=self.name)
 
     def execute(self, dist: Any, observed: Any, **kwargs: Any) -> ApproximateDistribution:
@@ -165,7 +171,9 @@ class _TFPGradientMethod(InferenceMethod):
         target = build_target_log_prob(dist, observed)
         prior = get_prior(dist)
         init = get_init_state(
-            dist, kwargs.get("init"), random_seed=random_seed,
+            dist,
+            kwargs.get("init"),
+            random_seed=random_seed,
         )
         event_template = extract_event_template(dist)
 
@@ -174,7 +182,8 @@ class _TFPGradientMethod(InferenceMethod):
         num_chains = kwargs.get("num_chains", 1)
 
         chains, sample_stats = _run_tfp_chains(
-            target, init,
+            target,
+            init,
             algorithm=self._algorithm,
             num_results=num_results,
             num_warmup=num_warmup,
@@ -184,9 +193,14 @@ class _TFPGradientMethod(InferenceMethod):
         )
         auxiliary = build_mcmc_datatree(chains, sample_stats)
         return make_posterior(
-            chains, parents=(prior,), algorithm=self._method_name,
-            auxiliary=auxiliary, event_template=event_template,
-            num_results=num_results, num_warmup=num_warmup, num_chains=num_chains,
+            chains,
+            parents=(prior,),
+            algorithm=self._method_name,
+            auxiliary=auxiliary,
+            event_template=event_template,
+            num_results=num_results,
+            num_warmup=num_warmup,
+            num_chains=num_chains,
         )
 
 

--- a/probpipe/linalg/linear_operator.py
+++ b/probpipe/linalg/linear_operator.py
@@ -1,11 +1,12 @@
 # linear_operator.py
 """
 This file contains:
-    1. the base abstract LinOp class  
-    2. subclasses that represent views of linear operations resulting from 
+    1. the base abstract LinOp class
+    2. subclasses that represent views of linear operations resulting from
        various operations (sum, product, etc.).
     3. concrete linear operator subclasses representing structured matrices
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -27,6 +28,7 @@ from ..custom_types import Array, ArrayLike
 class LinAlgError(Exception):
     """Linear algebra error (e.g., singular matrix, non-positive-definite)."""
 
+
 __all__ = [
     "LinOp",
     "DenseLinOp",
@@ -43,19 +45,23 @@ __all__ = [
 # -----------------------------------------------------------------------------
 
 # Set of allowed flags to mark properties possessed by particular linear operators
-ALLOWED_FLAGS = frozenset({
-    "symmetric",
-    "positive_definite",
-    "diagonal",
-    "triangular_lower",
-    "triangular_upper",
-    "unit_diagonal",
-    "dense",
-})
+ALLOWED_FLAGS = frozenset(
+    {
+        "symmetric",
+        "positive_definite",
+        "diagonal",
+        "triangular_lower",
+        "triangular_upper",
+        "unit_diagonal",
+        "dense",
+    }
+)
+
 
 def _promote_dtype(*dtypes: Any) -> Any:
     """Return promoted dtype for given dtypes/arrays."""
     return jnp.result_type(*dtypes)
+
 
 def _as_linear_operator(A: LinOpLike) -> LinOp:
     """
@@ -67,15 +73,13 @@ def _as_linear_operator(A: LinOpLike) -> LinOp:
         try:
             return DenseLinOp(A)
         except Exception as e:
-            raise TypeError(
-                f"Could not convert A to linear operator\n"
-                f"DenseLinOp error: {e}"
-            ) from e
+            raise TypeError(f"Could not convert A to linear operator\nDenseLinOp error: {e}") from e
 
 
 # -----------------------------------------------------------------------------
 # Core abstract linear operator class
 # -----------------------------------------------------------------------------
+
 
 class LinOp(ABC):
     """Abstract base class for a linear operator.
@@ -121,15 +125,15 @@ class LinOp(ABC):
     def is_dense(self) -> bool:
         """Default is False; DenseLinOp overrides to True"""
         return False
-    
+
     # ---- Utility methods for validation ----
 
     def _check_square(self) -> None:
-        """ Throw error if operator is not square """
+        """Throw error if operator is not square"""
         n_out, n_in = self.shape
         if n_out != n_in:
             raise LinAlgError(f"Linear operator is not square. Has shape ({n_out}, {n_in})")
-    
+
     # ---- Optional convenience methods that implementors may override for speed ----
     def matvec(self, x: ArrayLike) -> Array:
         """Return A @ x for x shape (n_in,) -> (n_out,)."""
@@ -156,7 +160,7 @@ class LinOp(ABC):
         self._check_square()
         n, _ = self.shape
         dense_op = self.to_dense()
-        
+
         b = jnp.asarray(b)
         if b.ndim < 2:
             b = _ensure_vector(b, as_column=True)
@@ -168,7 +172,7 @@ class LinOp(ABC):
         """Return triangular LinOp L (lower) or L.T (upper) such that A = L @ L.T.
 
         Defaults to densifying the operator and then computing the Cholesky decomposition.
-        Subclasses may return other valid LinOp types that are more structured than 
+        Subclasses may return other valid LinOp types that are more structured than
         TriangularLinOp; for example, DiagonalLinOp.
         """
         self._check_square()
@@ -176,14 +180,14 @@ class LinOp(ABC):
         if not lower:
             L = L.T
         return TriangularLinOp(L, lower=lower)
-    
-    def to_cholesky_representation(self, lower: bool = True, **kwargs) -> CholeskyRepresentation:
-        """ Return representation of `self` in terms of its Cholesky factor.
 
-        In general, this represents an alternative represetation of the 
+    def to_cholesky_representation(self, lower: bool = True, **kwargs) -> CholeskyRepresentation:
+        """Return representation of `self` in terms of its Cholesky factor.
+
+        In general, this represents an alternative represetation of the
         operator. Defaults to computing the Cholesky factor and wrapping
-        the result in CholeskyLinOp. Subclasses may return other valid 
-        LinOp types when more structure is present; for example, 
+        the result in CholeskyLinOp. Subclasses may return other valid
+        LinOp types when more structure is present; for example,
         DiagonalRootLinOp.
         """
         return CholeskyLinOp(self.cholesky(lower=lower, **kwargs))
@@ -227,7 +231,6 @@ class LinOp(ABC):
         """Return frozenset of current flags (read-only view)."""
         return frozenset(self._flags)
 
-
     # ---- Basic operator algebra builds (do not densify unless unavoidable) ----
     def __matmul__(self, other: LinOp) -> LinOp:
         """Return operator representing self @ other (composition)."""
@@ -265,10 +268,10 @@ class LinOp(ABC):
         return f"{self.__class__.__name__}(shape={self.shape}, dtype={self.dtype})"
 
 
-
 # -----------------------------------------------------------------------------
 # Composite linear operator views
-# ----------------------------------------------------------------------------- 
+# -----------------------------------------------------------------------------
+
 
 class ProductLinOp(LinOp):
     """Operator representing composition A @ B where A and B are LinOp and shapes agree."""
@@ -507,13 +510,14 @@ class TransposedLinOp(LinOp):
 
 # -----------------------------------------------------------------------------
 # Concrete linear operator subclasses
-# ----------------------------------------------------------------------------- 
+# -----------------------------------------------------------------------------
+
 
 class DenseLinOp(LinOp):
     """A light wrapper around a two dimensional array.
-    
+
     A LinearOperator that is represented by storing the complete dense array
-    representation of the operator. 
+    representation of the operator.
     """
 
     def __init__(self, arr: ArrayLike, copy: bool = True) -> None:
@@ -529,7 +533,7 @@ class DenseLinOp(LinOp):
     @property
     def dtype(self) -> Any:
         return self._dtype
-    
+
     @property
     def is_dense(self) -> bool:
         return True
@@ -669,14 +673,17 @@ class TriangularLinOp(LinOp):
         b_arr = _ensure_matrix(b_arr, num_rows=self._n)
 
         return jsla.solve_triangular(
-            self.tri, b_arr, lower=self.lower, unit_diagonal=unit_diagonal,
+            self.tri,
+            b_arr,
+            lower=self.lower,
+            unit_diagonal=unit_diagonal,
         )
 
 
 class RootLinOp(LinOp):
     """A linear operator A represented by its square root S such that A = S @ S.T
-       A is guaranteed to be symmetric positive semidefinite, but not necessarily 
-       positive definite."""
+    A is guaranteed to be symmetric positive semidefinite, but not necessarily
+    positive definite."""
 
     def __init__(self, root: LinOp | ArrayLike) -> None:
         super().__init__()
@@ -704,10 +711,10 @@ class RootLinOp(LinOp):
 
     def rmatmat(self, X: ArrayLike) -> Array:
         return self.matmat(X)
-    
+
     def solve(self, b: ArrayLike, **kwargs) -> Array:
         """Linear solve using forward backward substitution
-        
+
         To compute A^{-1}b = (S @ S.T)^{-1}b first compute y = S^{-1}b
         then S.T^{-1}y.
         """
@@ -719,17 +726,17 @@ class RootLinOp(LinOp):
         S = self.root.to_dense()
         y = jnp.linalg.solve(S, b)
         return jnp.linalg.solve(S.T, y)
-    
+
     def diag(self) -> Array:
         if isinstance(self.root, DiagonalLinOp):
-            return self.root.diagonal ** 2
+            return self.root.diagonal**2
 
         S = self.root.to_dense()
-        return jnp.einsum('ij,ij->i', S, S)
-    
+        return jnp.einsum("ij,ij->i", S, S)
+
     def trace(self) -> float:
         if isinstance(self.root, DiagonalLinOp):
-            return jnp.sum(self.root.diagonal ** 2)
+            return jnp.sum(self.root.diagonal**2)
 
         S = self.root.to_dense()
         return jnp.sum(S**2)
@@ -749,8 +756,7 @@ class CholeskyLinOp(RootLinOp):
     def __init__(self, root: TriangularLinOp) -> None:
         if not isinstance(root, TriangularLinOp):
             raise ValueError(
-                f"CholeskyLinOp requires `root` to be a TriangularLinOp object."
-                f"Got {type(root)}."
+                f"CholeskyLinOp requires `root` to be a TriangularLinOp object.Got {type(root)}."
             )
 
         super().__init__(root)
@@ -780,7 +786,7 @@ class CholeskyLinOp(RootLinOp):
         """Return the diagonal of the represented SPD operator."""
         S = self.root.to_dense()
         axis = 1 if self.root.lower else 0
-        return jnp.sum(S ** 2, axis=axis)
+        return jnp.sum(S**2, axis=axis)
 
     def to_dense(self) -> Array:
         """Return the dense matrix represented by the Cholesky factor."""
@@ -808,34 +814,32 @@ class CholeskyLinOp(RootLinOp):
             return jsla.solve_triangular(S.T, y, lower=False)
         y = jsla.solve_triangular(S.T, b, lower=True)
         return jsla.solve_triangular(S, y, lower=False)
-    
 
     def cholesky(self, lower: bool = True, **kwargs) -> TriangularLinOp:
         cholesky_factor = self.root
         if lower == cholesky_factor.lower:
             return cholesky_factor
         return TriangularLinOp(cholesky_factor.to_dense().T, lower=lower)
-        
+
     def to_cholesky_representation(self, lower: bool = True, **kwargs) -> CholeskyLinOp:
-        """ Returns a copy of `self` """
+        """Returns a copy of `self`"""
         return CholeskyLinOp(self.cholesky(lower=lower))
 
 
 class DiagonalRootLinOp(DiagonalLinOp):
-    """A linear operator A represented by its diagonal square root 
-       S = diag(s1, ..., sd) such that A = S @ S.T = diag(s1^2, ..., sd^2).
-       A is guaranteed to be symmetric positive semidefinite, and is strictly
-       positive definite if all entries of all of the si are non-zero."""
-    
+    """A linear operator A represented by its diagonal square root
+    S = diag(s1, ..., sd) such that A = S @ S.T = diag(s1^2, ..., sd^2).
+    A is guaranteed to be symmetric positive semidefinite, and is strictly
+    positive definite if all entries of all of the si are non-zero."""
+
     def __init__(self, root: DiagonalLinOp) -> None:
         if not isinstance(root, DiagonalLinOp):
             raise ValueError(
-                f"DiagonalRootLinOp requires `root` to be a DiagonalLinOp object."
-                f"Got {type(root)}."
+                f"DiagonalRootLinOp requires `root` to be a DiagonalLinOp object.Got {type(root)}."
             )
 
         # Call DiagonalLinOp constructor
-        super().__init__(root.diagonal ** 2)
+        super().__init__(root.diagonal**2)
         self.root = root
 
     def cholesky(self, lower: bool = True, **kwargs) -> DiagonalLinOp:
@@ -847,7 +851,7 @@ class DiagonalRootLinOp(DiagonalLinOp):
 
 # -----------------------------------------------------------------------------
 # Type Aliases
-# ----------------------------------------------------------------------------- 
+# -----------------------------------------------------------------------------
 
 LinOpLike: TypeAlias = LinOp | ArrayLike
 CholeskyFactor: TypeAlias = TriangularLinOp | DiagonalLinOp

--- a/probpipe/linalg/operations.py
+++ b/probpipe/linalg/operations.py
@@ -1,7 +1,7 @@
 # linalg/operations.py
 """
-Functions that accept linear operator inputs, potentially also returning 
-linear operator outputs. This includes the core basic operations like 
+Functions that accept linear operator inputs, potentially also returning
+linear operator outputs. This includes the core basic operations like
 `solve()` that are also implemented as `LinOp` methods. This allows users
 to call the method via `solve(linop, ...)` rather than `linop.solve(...)`.
 Also included are more specialized operations like `mah_dist_squared()`
@@ -14,57 +14,63 @@ from typing import Any, TypeAlias
 
 from ..custom_types import Array, ArrayLike
 from .._array_utils import _is_array, _ensure_matrix
-from .linear_operator import (
-    _as_linear_operator, 
-    LinOpLike,
-    CholeskyFactor
-)
+from .linear_operator import _as_linear_operator, LinOpLike, CholeskyFactor
 
 
 # -----------------------------------------------------------------------------
 # Expose LinOp methods as functions
 # -----------------------------------------------------------------------------
 
+
 def shape(A: LinOpLike) -> tuple[int, int]:
     return _as_linear_operator(A).shape
+
 
 def dtype(A: LinOpLike) -> Any:
     return _as_linear_operator(A).dtype
 
+
 def diag(A: LinOpLike) -> Array:
     return _as_linear_operator(A).diag()
 
+
 def to_dense(A: LinOpLike) -> Array:
     return _as_linear_operator(A).to_dense()
-    
+
+
 def solve(A: LinOpLike, b: ArrayLike, **kwargs) -> Array:
     return _as_linear_operator(A).solve(b, **kwargs)
+
 
 def cholesky(A: LinOpLike, lower: bool = True, **kwargs) -> CholeskyFactor:
     return _as_linear_operator(A).cholesky(lower=lower, **kwargs)
 
+
 def logdet(A: LinOpLike) -> float:
     return _as_linear_operator(A).logdet()
 
+
 def trace(A: LinOpLike) -> float:
     return _as_linear_operator(A).trace()
+
 
 # -----------------------------------------------------------------------------
 # Other specialized operations, not core LinOp methods
 # -----------------------------------------------------------------------------
 
+
 def trace_Ainv_B(A: LinOpLike, B: LinOpLike) -> float:
-    """ Compute the trace of the product of an inverse of a matrix times another matrix
+    """Compute the trace of the product of an inverse of a matrix times another matrix
 
     For square matrices :math:`A` and :math:`B` of equal dimension, with :math:`A`
     invertible, this function computes :math:`\text{trace}(A^{-1}B)`. At present,
-    this function will exploit structure in the linear operator :math:`A`, but 
+    this function will exploit structure in the linear operator :math:`A`, but
     :math:`B` will be handled as a dense matrix.
 
     Args:
         A: LinOpLike, square (d, d) and invertible matrix.
         B: LinOpLik, square (d, d) matrix.
-    
+
     Returns:
         float, the trace.
     """
@@ -74,17 +80,15 @@ def trace_Ainv_B(A: LinOpLike, B: LinOpLike) -> float:
     B._check_square()
     if A.shape[1] != B.shape[0]:
         raise LinAlgError(
-            f"trace_Ainv_B requires A and B to be square and of equal dimension.\n" 
+            f"trace_Ainv_B requires A and B to be square and of equal dimension.\n"
             f"Got A and B with shapes {A.shape} and {B.shape}, respectively."
         )
-     
+
     return trace(solve(A, to_dense(B)))
 
 
-def mah_dist_squared(x: ArrayLike,
-                     A: LinOpLike, 
-                     y: ArrayLike | None = None) -> Array:
-    """ Compute squared Mahalanobis distance(s) between one or more vectors
+def mah_dist_squared(x: ArrayLike, A: LinOpLike, y: ArrayLike | None = None) -> Array:
+    """Compute squared Mahalanobis distance(s) between one or more vectors
 
     The squared Mahalanobis distance between vectors :math:`x` and :math:`y`
     with respect to the invertible weight matrix :math:`A` is defined as:
@@ -93,7 +97,7 @@ def mah_dist_squared(x: ArrayLike,
 
         D^2(x, y; A) = (x - y)^\\top A^{-1} (x - m)
 
-    If multiple observations are provided as rows in the matrix 
+    If multiple observations are provided as rows in the matrix
     :math:`x \\in \\mathbb{R}^{n \\times d}` or :math:`y \\in \\mathbb{R}^{n \\times d}`
     the function computes:
 
@@ -101,11 +105,11 @@ def mah_dist_squared(x: ArrayLike,
 
         D_i^2 = (x_i - y_i)^\\top A^{-1} (x_i - y_i), \\quad i = 1, \\ldots, n.
 
-    In this case, either `x` and `y` must both contain the same number of rows, or 
-    one of them must specify a single point (in which case the point will be 
-    repeated to match the length of the other input). If `y` is `None`, then it 
+    In this case, either `x` and `y` must both contain the same number of rows, or
+    one of them must specify a single point (in which case the point will be
+    repeated to match the length of the other input). If `y` is `None`, then it
     will be set to the zero vector.
-    
+
     Args:
         x: ArrayLike, of shape (d,) or (n,d).
         A: LinOpLike, invertible and shape (d,d).
@@ -114,7 +118,7 @@ def mah_dist_squared(x: ArrayLike,
     Notes:
         Strictly speaking, the Mahalanobis distance requires :math:`A` to be positive definite.
         However, the quadratic form can be computed so long as :math:`A` is invertible. This
-        function only requires this weaker condition. 
+        function only requires this weaker condition.
 
     Returns:
         Array of shape (n,)
@@ -126,8 +130,10 @@ def mah_dist_squared(x: ArrayLike,
     if y is not None:
         Y = _ensure_matrix(y, as_row_matrix=True, num_cols=d)
         if Y.shape[0] not in (1, X.shape[0]):
-            raise ValueError("y must have same batch dimension `n` as x, or have batch dimension one.")
+            raise ValueError(
+                "y must have same batch dimension `n` as x, or have batch dimension one."
+            )
         X = X - Y
 
-    Ainv_Xt = solve(A, X.T).T # (n, d)
+    Ainv_Xt = solve(A, X.T).T  # (n, d)
     return jnp.sum(X * Ainv_Xt, axis=1)

--- a/probpipe/linalg/utils.py
+++ b/probpipe/linalg/utils.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 from ..custom_types import Array, ArrayLike
-from .._array_utils import (
-    _ensure_real_scalar,
-    _ensure_square_matrix
-)
+from .._array_utils import _ensure_real_scalar, _ensure_square_matrix
 
 
-def add_diag_jitter(matrix: ArrayLike, jitter: float | ArrayLike = 1e-6, *, copy: bool = True) -> Array:
+def add_diag_jitter(
+    matrix: ArrayLike, jitter: float | ArrayLike = 1e-6, *, copy: bool = True
+) -> Array:
     """
     Return a new matrix = matrix + jitter * I.
 
@@ -33,39 +32,51 @@ def add_diag_jitter(matrix: ArrayLike, jitter: float | ArrayLike = 1e-6, *, copy
     # Normalize jitter into a 1D real array of length n (or scalar)
     try:
         jitter_scalar = _ensure_real_scalar(jitter)
-        jitter_arr = jnp.full((n,), jitter_scalar, dtype=jnp.result_type(mat.dtype, jnp.array(jitter_scalar).dtype))
+        jitter_arr = jnp.full(
+            (n,), jitter_scalar, dtype=jnp.result_type(mat.dtype, jnp.array(jitter_scalar).dtype)
+        )
     except ValueError:
         # Not a scalar real: try array-like
         jitter_arr = jnp.asarray(jitter)
         if jitter_arr.ndim == 0:
             jitter_scalar = _ensure_real_scalar(jitter_arr)
-            jitter_arr = jnp.full((n,), jitter_scalar, dtype=jnp.result_type(mat.dtype, jnp.array(jitter_scalar).dtype))
+            jitter_arr = jnp.full(
+                (n,),
+                jitter_scalar,
+                dtype=jnp.result_type(mat.dtype, jnp.array(jitter_scalar).dtype),
+            )
         elif jitter_arr.ndim == 1:
             if jitter_arr.shape != (n,):
-                raise ValueError(f"add_diag_jitter: jitter must be scalar or shape ({n},). Got {jitter_arr.shape}.")
+                raise ValueError(
+                    f"add_diag_jitter: jitter must be scalar or shape ({n},). Got {jitter_arr.shape}."
+                )
             if jnp.iscomplexobj(jitter_arr):
                 raise ValueError("add_diag_jitter: jitter contains complex values.")
         else:
-            raise ValueError(f"add_diag_jitter: jitter must be scalar or 1D array. Got ndim={jitter_arr.ndim}.")
+            raise ValueError(
+                f"add_diag_jitter: jitter must be scalar or 1D array. Got ndim={jitter_arr.ndim}."
+            )
 
     # Add jitter to diagonal (JAX arrays are immutable; always returns new array)
     idx = jnp.arange(n)
     return mat.at[idx, idx].add(jitter_arr)
 
 
-def symmetrize_pd(matrix: ArrayLike, 
-                  *,
-                  symmetrize: bool = True,
-                  add_jitter: bool = True,
-                  jitter: float = 1e-6,
-                  copy: bool = True) -> Array:
+def symmetrize_pd(
+    matrix: ArrayLike,
+    *,
+    symmetrize: bool = True,
+    add_jitter: bool = True,
+    jitter: float = 1e-6,
+    copy: bool = True,
+) -> Array:
     """
     Modify a square matrix to promote (but not guarantee) numerical positive
     definiteness.
 
-    Optionally symmetrize the matrix by taking the average of the matrix with 
-    its transpose. In addition, optionally add a constant to the diagonal 
-    of the matrix. If both true (default), performs these two steps in this 
+    Optionally symmetrize the matrix by taking the average of the matrix with
+    its transpose. In addition, optionally add a constant to the diagonal
+    of the matrix. If both true (default), performs these two steps in this
     order.
 
     Args:

--- a/probpipe/modeling/__init__.py
+++ b/probpipe/modeling/__init__.py
@@ -8,8 +8,10 @@ concrete probabilistic model classes that wrap external PPL backends
 from ._base import ProbabilisticModel
 from ._glm import GLMLikelihood
 from ._likelihood import (
-    ConditionallyIndependentLikelihood, GenerativeLikelihood,
-    IncrementalConditioner, Likelihood,
+    ConditionallyIndependentLikelihood,
+    GenerativeLikelihood,
+    IncrementalConditioner,
+    Likelihood,
 )
 from ._simple import SimpleModel
 from ._simple_generative import SimpleGenerativeModel

--- a/probpipe/modeling/_glm.py
+++ b/probpipe/modeling/_glm.py
@@ -150,7 +150,9 @@ class GLMLikelihood:
         return jnp.sum(self.family.log_prob(y, eta))
 
     def per_datum_log_likelihood(
-        self, params: ArrayLike | Record, datum: Record,
+        self,
+        params: ArrayLike | Record,
+        datum: Record,
     ) -> Array:
         """Log-density of a single observation given parameters.
 
@@ -176,8 +178,7 @@ class GLMLikelihood:
         """
         if not (isinstance(datum, Record) and "X" in datum and "y" in datum):
             raise TypeError(
-                "GLMLikelihood.per_datum_log_likelihood requires "
-                "datum=Record(X=x_i, y=y_i)."
+                "GLMLikelihood.per_datum_log_likelihood requires datum=Record(X=x_i, y=y_i)."
             )
         # `atleast_1d` accommodates the single-covariate case where the
         # per-observation X leaf is naturally scalar — the matmul below

--- a/probpipe/modeling/_likelihood.py
+++ b/probpipe/modeling/_likelihood.py
@@ -207,10 +207,9 @@ class IncrementalConditioner[P, D](Module):
         """
         if kwargs:
             if data is not None:
-                raise ValueError(
-                    "Cannot provide both `data` and named data kwargs"
-                )
+                raise ValueError("Cannot provide both `data` and named data kwargs")
             from ..core.record import Record
+
             data = Record(kwargs)
         posterior = self._step(self._curr_posterior, data)
         self._curr_posterior = posterior

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -30,6 +30,7 @@ def _to_numpy(value: Any) -> Any:
     values that don't expose ``__array__`` (e.g. plain Python ints).
     """
     import numpy as _np
+
     if hasattr(value, "__array__"):
         return _np.asarray(value)
     return value
@@ -72,8 +73,7 @@ class PyMCModel(ProbabilisticModel):
             import pymc  # noqa: F401
         except ImportError as e:
             raise ImportError(
-                "pymc is required for PyMCModel. "
-                "Install it with: pip install pymc"
+                "pymc is required for PyMCModel. Install it with: pip install pymc"
             ) from e
 
         self._model_fn = model_fn
@@ -88,9 +88,7 @@ class PyMCModel(ProbabilisticModel):
 
         sig = inspect.signature(model_fn)
         self._observed_names = tuple(
-            name
-            for name, p in sig.parameters.items()
-            if p.default is None
+            name for name, p in sig.parameters.items() if p.default is None
         )
 
         # Build the model once without data to discover free parameters.
@@ -98,15 +96,15 @@ class PyMCModel(ProbabilisticModel):
         self._unconditioned_model = model_fn()
         observed_set = set(self._observed_names)
         self._param_names = tuple(
-            rv.name
-            for rv in self._unconditioned_model.free_RVs
-            if rv.name not in observed_set
+            rv.name for rv in self._unconditioned_model.free_RVs if rv.name not in observed_set
         )
 
     # -- Distribution interface ---------------------------------------------
 
     def _param_rvs(
-        self, model: Any, names: tuple[str, ...] | list[str],
+        self,
+        model: Any,
+        names: tuple[str, ...] | list[str],
     ) -> Iterator[tuple[str, Any]]:
         """Yield ``(name, rv)`` for each name in *names*, looked up in
         *model*'s free RVs, in the given order.
@@ -182,7 +180,9 @@ class PyMCModel(ProbabilisticModel):
         return (self.event_template.flat_size,)
 
     def _event_template_for(
-        self, model: Any, names: tuple[str, ...] | list[str],
+        self,
+        model: Any,
+        names: tuple[str, ...] | list[str],
     ) -> NumericEventTemplate:
         """Parameter template over *names*, read from a PyMC *model* build.
 
@@ -234,7 +234,8 @@ class PyMCModel(ProbabilisticModel):
         :meth:`_event_template_for`; this property reflects neither.
         """
         return self._event_template_for(
-            self._unconditioned_model, self._param_names,
+            self._unconditioned_model,
+            self._param_names,
         )
 
     # -- Named components interface ------------------------------------------
@@ -309,12 +310,15 @@ class PyMCModel(ProbabilisticModel):
             return self._model_fn(**{k: _to_numpy(v) for k, v in data.items()})
         # Local import to avoid a modeling→core cycle at module load.
         from ..core.record import Record
+
         if isinstance(data, Record):
-            return self._model_fn(**{
-                name: _to_numpy(data[name])
-                for name in self._observed_names
-                if name in data.fields
-            })
+            return self._model_fn(
+                **{
+                    name: _to_numpy(data[name])
+                    for name in self._observed_names
+                    if name in data.fields
+                }
+            )
         return self._model_fn(**{self._observed_names[0]: _to_numpy(data)})
 
     def __repr__(self) -> str:

--- a/probpipe/modeling/_simple.py
+++ b/probpipe/modeling/_simple.py
@@ -58,6 +58,7 @@ class SimpleModel[P, D](ProbabilisticModel[tuple[P, D]], SupportsLogProb):
         # ``RecordDistribution`` (so its ``event_template`` is a
         # required, non-``None`` ``EventTemplate``).
         from ..core.distribution import RecordDistribution
+
         if not isinstance(prior, SupportsLogProb):
             raise TypeError(
                 f"SimpleModel requires a prior that supports SupportsLogProb, "
@@ -85,7 +86,7 @@ class SimpleModel[P, D](ProbabilisticModel[tuple[P, D]], SupportsLogProb):
         # the metaclass invariant); ``data_tpl`` may be ``None`` for
         # likelihoods that don't declare a data template.
         prior_tpl: EventTemplate = prior.event_template
-        data_tpl = getattr(likelihood, 'data_template', None)
+        data_tpl = getattr(likelihood, "data_template", None)
         # Convert legacy ``Record``-typed data templates to
         # ``EventTemplate``. ``Record`` and ``EventTemplate`` are
         # unrelated types, so the ``Record`` check is sufficient on
@@ -95,9 +96,7 @@ class SimpleModel[P, D](ProbabilisticModel[tuple[P, D]], SupportsLogProb):
         if data_tpl is not None:
             overlap = set(prior_tpl.fields) & set(data_tpl.fields)
             if overlap:
-                raise ValueError(
-                    f"Parameter and data field names overlap: {overlap}"
-                )
+                raise ValueError(f"Parameter and data field names overlap: {overlap}")
             merged: dict[str, Any] = {}
             for f in prior_tpl.fields:
                 merged[f] = prior_tpl[f]
@@ -146,7 +145,7 @@ class SimpleModel[P, D](ProbabilisticModel[tuple[P, D]], SupportsLogProb):
     @property
     def _data_fields(self) -> tuple[str, ...]:
         """Likelihood data field names in template (insertion) order."""
-        tpl = getattr(self._likelihood, 'data_template', None)
+        tpl = getattr(self._likelihood, "data_template", None)
         return tpl.fields if tpl is not None else ()
 
     def __getitem__(self, key: str) -> Distribution | Likelihood:
@@ -159,10 +158,7 @@ class SimpleModel[P, D](ProbabilisticModel[tuple[P, D]], SupportsLogProb):
             return self._likelihood
         if key == "parameters":
             return self._prior
-        raise KeyError(
-            f"Unknown component: {key!r}; "
-            f"available: {self.fields}"
-        )
+        raise KeyError(f"Unknown component: {key!r}; available: {self.fields}")
 
     # -- ProbabilisticModel interface ---------------------------------------
 
@@ -222,9 +218,7 @@ class SimpleModel[P, D](ProbabilisticModel[tuple[P, D]], SupportsLogProb):
                     f"fields (no data_template); pass a (params, data) pair "
                     f"positionally instead."
                 )
-            params = self._prior._pack_value(
-                **{f: value[f] for f in self._prior_fields}
-            )
+            params = self._prior._pack_value(**{f: value[f] for f in self._prior_fields})
             data = Record(**{f: value[f] for f in data_fields})
             return params, data
         raise TypeError(

--- a/probpipe/modeling/_simple_generative.py
+++ b/probpipe/modeling/_simple_generative.py
@@ -121,10 +121,7 @@ class SimpleGenerativeModel[P, D](ProbabilisticModel[tuple[P, D]], SupportsSampl
             return self._prior
         if key == "data":
             return self._likelihood
-        raise KeyError(
-            f"Unknown component: {key!r}; "
-            f"available: {self.fields}"
-        )
+        raise KeyError(f"Unknown component: {key!r}; available: {self.fields}")
 
     # -- ProbabilisticModel interface ---------------------------------------
 

--- a/probpipe/modeling/_stan.py
+++ b/probpipe/modeling/_stan.py
@@ -41,7 +41,7 @@ class _StanBlock(NamedTuple):
     """One Stan parameter block recovered from BridgeStan's flattened names."""
 
     name: str
-    shape: tuple[int, ...]      # () for a scalar parameter
+    shape: tuple[int, ...]  # () for a scalar parameter
     # advanced-index arrays mapping a ``shape``-shaped array onto the block's
     # flat slice in BridgeStan's order; () for a scalar.
     gather: tuple[Array, ...]
@@ -65,18 +65,14 @@ def _param_blocks(flat_names: Sequence[str]) -> tuple[_StanBlock, ...]:
         block = flat_names[i].split(".", 1)[0]
         idx_tuples: list[tuple[int, ...]] = []
         while i < n and flat_names[i].split(".", 1)[0] == block:
-            idx_tuples.append(
-                tuple(int(x) - 1 for x in flat_names[i].split(".")[1:])
-            )
+            idx_tuples.append(tuple(int(x) - 1 for x in flat_names[i].split(".")[1:]))
             i += 1
         if idx_tuples == [()]:
             blocks.append(_StanBlock(block, (), ()))
             continue
         ndim = len(idx_tuples[0])
         shape = tuple(max(t[d] for t in idx_tuples) + 1 for d in range(ndim))
-        gather = tuple(
-            jnp.asarray([t[d] for t in idx_tuples]) for d in range(ndim)
-        )
+        gather = tuple(jnp.asarray([t[d] for t in idx_tuples]) for d in range(ndim))
         blocks.append(_StanBlock(block, shape, gather))
     return tuple(blocks)
 
@@ -112,8 +108,7 @@ def _pack_block_params(
         arr = jnp.asarray(field_kwargs[b.name])
         if tuple(arr.shape) != b.shape:
             raise TypeError(
-                f"{owner}: parameter {b.name!r} expects shape {b.shape}, "
-                f"got {tuple(arr.shape)}."
+                f"{owner}: parameter {b.name!r} expects shape {b.shape}, got {tuple(arr.shape)}."
             )
         out.append(jnp.reshape(arr, (1,)) if b.shape == () else arr[b.gather])
     return jnp.concatenate(out) if out else jnp.zeros((0,))
@@ -157,8 +152,7 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
             import bridgestan
         except ImportError as e:
             raise ImportError(
-                "bridgestan is required for StanModel. "
-                "Install it with: pip install bridgestan"
+                "bridgestan is required for StanModel. Install it with: pip install bridgestan"
             ) from e
 
         self._stan_file = stan_file
@@ -215,9 +209,7 @@ class StanModel(ProbabilisticModel, SupportsLogProb):
         space, assembled into the flat array ``_log_prob`` consumes (see
         :func:`_pack_block_params`). A flat array may still be passed
         positionally."""
-        return _pack_block_params(
-            type(self).__name__, self._blocks, field_kwargs
-        )
+        return _pack_block_params(type(self).__name__, self._blocks, field_kwargs)
 
     def _log_prob(self, value: Any) -> Array:
         """Log-density in the constrained parameter space.
@@ -297,9 +289,7 @@ class _UnconstrainedStanView(Distribution[Any], SupportsLogProb):
         """Keyword form: one array per Stan parameter block in the unconstrained
         space, assembled into the flat array ``_log_prob`` consumes. A flat
         array may still be passed positionally."""
-        return _pack_block_params(
-            type(self).__name__, self._blocks, field_kwargs
-        )
+        return _pack_block_params(type(self).__name__, self._blocks, field_kwargs)
 
     def _log_prob(self, value: Any) -> Array:
         """Log-density directly in unconstrained space."""

--- a/probpipe/record/design.py
+++ b/probpipe/record/design.py
@@ -50,7 +50,9 @@ def _is_numeric_sequence(seq: Any) -> bool:
 
 
 def _seq_to_column(
-    values: Sequence, *, indices,
+    values: Sequence,
+    *,
+    indices,
 ) -> tuple[Any, tuple[int, ...] | None]:
     """Materialise ``values[indices]`` as a column array.
 
@@ -153,9 +155,7 @@ class FullFactorialDesign(Design):
 
     def __init__(self, **marginals: Sequence) -> None:
         if not marginals:
-            raise ValueError(
-                "FullFactorialDesign requires at least one marginal"
-            )
+            raise ValueError("FullFactorialDesign requires at least one marginal")
         names = list(marginals)
         lists = [list(marginals[n]) for n in names]
         sizes = [len(v) for v in lists]
@@ -170,23 +170,24 @@ class FullFactorialDesign(Design):
         # lexicographic row-major traversal over the marginals in
         # insertion order.
         grids = np.meshgrid(
-            *(np.arange(s) for s in sizes), indexing="ij",
+            *(np.arange(s) for s in sizes),
+            indexing="ij",
         )
-        flat_indices = {
-            name: grid.reshape(-1) for name, grid in zip(names, grids)
-        }
+        flat_indices = {name: grid.reshape(-1) for name, grid in zip(names, grids)}
 
         fields: dict[str, Any] = {}
         template_spec: dict[str, Any] = {}
         for name, values in zip(names, lists):
             col, leaf_shape = _seq_to_column(
-                values, indices=flat_indices[name],
+                values,
+                indices=flat_indices[name],
             )
             fields[name] = col
             template_spec[name] = leaf_shape
 
         RecordArray.__init__(
-            self, fields,
+            self,
+            fields,
             batch_shape=(n_total,),
             template=EventTemplate(template_spec),
             name=f"FullFactorialDesign({','.join(names)})",

--- a/probpipe/validation/_predictive_check.py
+++ b/probpipe/validation/_predictive_check.py
@@ -85,9 +85,7 @@ def predictive_check[P, D](
     """
     if num_observations is None:
         if observed_data is None:
-            raise ValueError(
-                "num_observations is required when observed_data is not provided"
-            )
+            raise ValueError("num_observations is required when observed_data is not provided")
         num_observations = len(observed_data)
 
     if key is None:
@@ -96,17 +94,26 @@ def predictive_check[P, D](
     # -- Fast path: batched generation + vmap test_fn -----------------------
     if _supports_key_arg(generative_likelihood):
         stats_array = _predictive_check_batched(
-            distribution, generative_likelihood, test_fn,
-            num_observations, num_replications, key,
+            distribution,
+            generative_likelihood,
+            test_fn,
+            num_observations,
+            num_replications,
+            key,
         )
     else:
         stats_array = _predictive_check_loop(
-            distribution, generative_likelihood, test_fn,
-            num_observations, num_replications, key,
+            distribution,
+            generative_likelihood,
+            test_fn,
+            num_observations,
+            num_replications,
+            key,
         )
 
     replicated_dist = RecordEmpiricalDistribution(
-        stats_array, name="replicated_statistics",
+        stats_array,
+        name="replicated_statistics",
     )
 
     test_fn_name = getattr(test_fn, "__name__", repr(test_fn))
@@ -219,7 +226,9 @@ def _predictive_check_batched(
 
     # Generate all replicated datasets in one call
     y_rep_batch = generative_likelihood.generate_data(
-        params_batch, num_observations, key=key_data,
+        params_batch,
+        num_observations,
+        key=key_data,
     )
 
     # Apply test_fn to each replicate — try vmap, fall back to loop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,14 @@ markers = [
 target-version = "py312"
 line-length = 100
 
+[tool.ruff.format]
+# Formatting is owned by ruff format (Black-style, at the line-length above).
+# quote-style normalizes string quotes to double; notebooks are excluded so the
+# docs' tutorial cells keep their compact, hand-curated layout (they are still
+# linted — see the per-file-ignores below).
+quote-style = "double"
+exclude = ["*.ipynb"]
+
 [tool.ruff.lint]
 select = [
   "E",    # pycodestyle errors

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Backward-compatibility shim. All configuration lives in pyproject.toml."""
+
 from setuptools import setup
 
 setup()

--- a/tests/converters/test_converters.py
+++ b/tests/converters/test_converters.py
@@ -8,15 +8,34 @@ import pytest
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from probpipe import (
-    Normal, Beta, Gamma, Exponential, MultivariateNormal,
-    Bernoulli, Poisson, Categorical,
-    RecordEmpiricalDistribution, EmpiricalDistribution, NumericRecordDistribution,
-    converter_registry, ConversionInfo, ConversionMethod, Converter,
+    Normal,
+    Beta,
+    Gamma,
+    Exponential,
+    MultivariateNormal,
+    Bernoulli,
+    Poisson,
+    Categorical,
+    RecordEmpiricalDistribution,
+    EmpiricalDistribution,
+    NumericRecordDistribution,
+    converter_registry,
+    ConversionInfo,
+    ConversionMethod,
+    Converter,
     from_distribution,
 )
 from probpipe.distributions.continuous import (
-    InverseGamma, LogNormal, StudentT, Uniform, Cauchy, Laplace,
-    HalfNormal, HalfCauchy, Pareto, TruncatedNormal,
+    InverseGamma,
+    LogNormal,
+    StudentT,
+    Uniform,
+    Cauchy,
+    Laplace,
+    HalfNormal,
+    HalfCauchy,
+    Pareto,
+    TruncatedNormal,
 )
 from probpipe.distributions.discrete import Binomial, NegativeBinomial
 from probpipe.distributions.multivariate import Dirichlet, Multinomial, Wishart, VonMisesFisher
@@ -26,8 +45,8 @@ from probpipe.distributions.multivariate import Dirichlet, Multinomial, Wishart,
 # Registry basics
 # ---------------------------------------------------------------------------
 
-class TestConverterRegistry:
 
+class TestConverterRegistry:
     def test_check_returns_conversioninfo(self):
         info = converter_registry.check(Normal(0, 1, name="x"), Normal)
         assert isinstance(info, ConversionInfo)
@@ -43,7 +62,9 @@ class TestConverterRegistry:
 
     def test_is_distribution_type_probpipe(self):
         assert converter_registry.is_distribution_type(Normal(0, 1, name="x"))
-        assert converter_registry.is_distribution_type(EmpiricalDistribution(jnp.ones((5, 1)), name="x"))
+        assert converter_registry.is_distribution_type(
+            EmpiricalDistribution(jnp.ones((5, 1)), name="x")
+        )
 
     def test_is_distribution_type_tfp(self):
         assert converter_registry.is_distribution_type(tfd.Normal(0, 1))
@@ -57,8 +78,8 @@ class TestConverterRegistry:
 # ProbPipe ↔ ProbPipe
 # ---------------------------------------------------------------------------
 
-class TestProbPipeConverter:
 
+class TestProbPipeConverter:
     def test_same_class_exact(self):
         n = Normal(loc=2.0, scale=0.5, name="x")
         info = converter_registry.check(n, Normal)
@@ -124,16 +145,30 @@ class TestProbPipeConverter:
 # Cross-family moment-matching (exercises all _convert_to_* functions)
 # ---------------------------------------------------------------------------
 
+
 class TestAllCrossFamilyConversions:
     """Exercise every _convert_to_* path with a cross-family source."""
 
     key = jax.random.PRNGKey(42)
 
-    @pytest.mark.parametrize("target_cls", [
-        Normal, Beta, InverseGamma, Exponential, LogNormal,
-        Uniform, Cauchy, Laplace, HalfNormal, HalfCauchy, Pareto,
-        TruncatedNormal, StudentT,
-    ])
+    @pytest.mark.parametrize(
+        "target_cls",
+        [
+            Normal,
+            Beta,
+            InverseGamma,
+            Exponential,
+            LogNormal,
+            Uniform,
+            Cauchy,
+            Laplace,
+            HalfNormal,
+            HalfCauchy,
+            Pareto,
+            TruncatedNormal,
+            StudentT,
+        ],
+    )
     def test_continuous_from_gamma(self, target_cls):
         """Convert Gamma(9,1) to each continuous type (skip support issues)."""
         g = Gamma(concentration=9.0, rate=1.0, name="g")
@@ -177,27 +212,24 @@ class TestAllCrossFamilyConversions:
             converter_registry.convert(p, NegativeBinomial, check_support=False)
 
     def test_dirichlet_from_mvn(self):
-        mvn = MultivariateNormal(loc=jnp.array([0.3, 0.5, 0.2]),
-                                  cov=0.01 * jnp.eye(3), name="z")
+        mvn = MultivariateNormal(loc=jnp.array([0.3, 0.5, 0.2]), cov=0.01 * jnp.eye(3), name="z")
         result = converter_registry.convert(mvn, Dirichlet, check_support=False, num_samples=500)
         assert isinstance(result, Dirichlet)
 
     def test_multinomial_from_mvn(self):
-        mvn = MultivariateNormal(loc=jnp.array([3.0, 5.0, 2.0]),
-                                  cov=jnp.eye(3), name="z")
-        result = converter_registry.convert(mvn, Multinomial, check_support=False,
-                                             total_count=10, num_samples=500)
+        mvn = MultivariateNormal(loc=jnp.array([3.0, 5.0, 2.0]), cov=jnp.eye(3), name="z")
+        result = converter_registry.convert(
+            mvn, Multinomial, check_support=False, total_count=10, num_samples=500
+        )
         assert isinstance(result, Multinomial)
 
     def test_multinomial_requires_total_count(self):
-        mvn = MultivariateNormal(loc=jnp.array([3.0, 5.0]),
-                                  cov=jnp.eye(2), name="z")
+        mvn = MultivariateNormal(loc=jnp.array([3.0, 5.0]), cov=jnp.eye(2), name="z")
         with pytest.raises(ValueError, match="total_count"):
             converter_registry.convert(mvn, Multinomial, check_support=False)
 
     def test_wishart_from_mvn(self):
-        mvn = MultivariateNormal(loc=jnp.array([1.0, 0.0]),
-                                  cov=jnp.eye(2), name="z")
+        mvn = MultivariateNormal(loc=jnp.array([1.0, 0.0]), cov=jnp.eye(2), name="z")
         # Wishart samples are matrices; use Wishart as source for itself
         w = Wishart(df=5.0, scale_tril=jnp.eye(2), name="w")
         result = converter_registry.convert(w, Wishart)
@@ -210,8 +242,9 @@ class TestAllCrossFamilyConversions:
         assert result.num_atoms == 50
 
     def test_vonmisesfisher_same_class(self):
-        vmf = VonMisesFisher(mean_direction=jnp.array([1.0, 0.0, 0.0]),
-                              concentration=5.0, name="vmf")
+        vmf = VonMisesFisher(
+            mean_direction=jnp.array([1.0, 0.0, 0.0]), concentration=5.0, name="vmf"
+        )
         result = converter_registry.convert(vmf, VonMisesFisher)
         assert result is vmf
 
@@ -232,8 +265,8 @@ class TestAllCrossFamilyConversions:
 # TFP ↔ ProbPipe
 # ---------------------------------------------------------------------------
 
-class TestTFPConverter:
 
+class TestTFPConverter:
     def test_tfp_normal_to_probpipe(self):
         tfp_n = tfd.Normal(loc=2.0, scale=0.5)
         info = converter_registry.check(tfp_n, Normal)
@@ -362,14 +395,15 @@ class TestTFPConverter:
 # Scipy ↔ ProbPipe (optional)
 # ---------------------------------------------------------------------------
 
-class TestScipyConverter:
 
+class TestScipyConverter:
     @pytest.fixture(autouse=True)
     def _check_scipy(self):
         pytest.importorskip("scipy")
 
     def test_scipy_norm_to_probpipe(self):
         import scipy.stats as ss
+
         result = converter_registry.convert(ss.norm(loc=1.0, scale=2.0), Normal)
         assert isinstance(result, Normal)
         np.testing.assert_allclose(float(result._loc), 1.0)
@@ -377,6 +411,7 @@ class TestScipyConverter:
 
     def test_scipy_beta_to_probpipe(self):
         import scipy.stats as ss
+
         result = converter_registry.convert(ss.beta(2.0, 5.0), Beta)
         assert isinstance(result, Beta)
         np.testing.assert_allclose(float(result._alpha), 2.0)
@@ -384,6 +419,7 @@ class TestScipyConverter:
 
     def test_scipy_gamma_to_probpipe(self):
         import scipy.stats as ss
+
         result = converter_registry.convert(ss.gamma(3.0, scale=2.0), Gamma)
         assert isinstance(result, Gamma)
         np.testing.assert_allclose(float(result._concentration), 3.0)
@@ -392,6 +428,7 @@ class TestScipyConverter:
     def test_probpipe_to_scipy(self):
         import scipy.stats as ss
         from scipy.stats._distn_infrastructure import rv_frozen
+
         n = Normal(loc=3.0, scale=1.0, name="x")
         result = converter_registry.convert(n, rv_frozen)
         assert isinstance(result, rv_frozen)
@@ -400,6 +437,7 @@ class TestScipyConverter:
 
     def test_scipy_provenance(self):
         import scipy.stats as ss
+
         result = converter_registry.convert(ss.norm(0, 1), Normal)
         assert result.source is not None
         assert result.source.operation == "convert_from_scipy"
@@ -407,6 +445,7 @@ class TestScipyConverter:
     def test_scipy_norm_positional_args(self):
         """Scipy norm created with positional args should still extract correctly."""
         import scipy.stats as ss
+
         result = converter_registry.convert(ss.norm(1.0, 2.0), Normal)
         assert isinstance(result, Normal)
         np.testing.assert_allclose(float(result._loc), 1.0)
@@ -415,6 +454,7 @@ class TestScipyConverter:
     def test_scipy_beta_keyword_args(self):
         """Scipy beta created with keyword args should extract correctly."""
         import scipy.stats as ss
+
         result = converter_registry.convert(ss.beta(a=2.0, b=5.0), Beta)
         assert isinstance(result, Beta)
         np.testing.assert_allclose(float(result._alpha), 2.0)
@@ -422,12 +462,14 @@ class TestScipyConverter:
 
     def test_scipy_expon_to_probpipe(self):
         import scipy.stats as ss
+
         result = converter_registry.convert(ss.expon(scale=2.0), Exponential)
         assert isinstance(result, Exponential)
         np.testing.assert_allclose(float(result._rate), 0.5)
 
     def test_scipy_uniform_to_probpipe(self):
         import scipy.stats as ss
+
         result = converter_registry.convert(ss.uniform(loc=1.0, scale=3.0), Uniform)
         assert isinstance(result, Uniform)
         np.testing.assert_allclose(float(result._low), 1.0)
@@ -435,6 +477,7 @@ class TestScipyConverter:
 
     def test_scipy_laplace_to_probpipe(self):
         import scipy.stats as ss
+
         result = converter_registry.convert(ss.laplace(loc=2.0, scale=0.5), Laplace)
         assert isinstance(result, Laplace)
         np.testing.assert_allclose(float(result._loc), 2.0)
@@ -442,6 +485,7 @@ class TestScipyConverter:
 
     def test_probpipe_gamma_to_scipy(self):
         from scipy.stats._distn_infrastructure import rv_frozen
+
         g = Gamma(concentration=3.0, rate=0.5, name="g")
         result = converter_registry.convert(g, rv_frozen)
         assert isinstance(result, rv_frozen)
@@ -449,6 +493,7 @@ class TestScipyConverter:
 
     def test_probpipe_exponential_to_scipy(self):
         from scipy.stats._distn_infrastructure import rv_frozen
+
         e = Exponential(rate=2.0, name="e")
         result = converter_registry.convert(e, rv_frozen)
         assert isinstance(result, rv_frozen)
@@ -456,6 +501,7 @@ class TestScipyConverter:
 
     def test_probpipe_beta_to_scipy(self):
         from scipy.stats._distn_infrastructure import rv_frozen
+
         b = Beta(alpha=2.0, beta=5.0, name="b")
         result = converter_registry.convert(b, rv_frozen)
         assert isinstance(result, rv_frozen)
@@ -464,19 +510,24 @@ class TestScipyConverter:
     def test_unknown_scipy_fallback_to_sampling(self):
         """Unknown scipy distribution type falls back to sampling."""
         import scipy.stats as ss
+
         # Use a scipy distribution we haven't mapped (e.g., chi2)
-        result = converter_registry.convert(ss.chi2(df=3), RecordEmpiricalDistribution, num_samples=100)
+        result = converter_registry.convert(
+            ss.chi2(df=3), RecordEmpiricalDistribution, num_samples=100
+        )
         assert isinstance(result, RecordEmpiricalDistribution)
         assert result.num_atoms == 100
 
     def test_scipy_check_unknown_type(self):
         import scipy.stats as ss
+
         info = converter_registry.check(ss.chi2(df=3), Normal)
         assert info.feasible
         assert info.method == ConversionMethod.SAMPLE
 
     def test_is_distribution_type_scipy(self):
         import scipy.stats as ss
+
         assert converter_registry.is_distribution_type(ss.norm(0, 1))
 
 
@@ -484,8 +535,8 @@ class TestScipyConverter:
 # Custom converter registration
 # ---------------------------------------------------------------------------
 
-class TestCustomConverter:
 
+class TestCustomConverter:
     def test_register_custom_converter(self):
         class DummyDist:
             def __init__(self, val):
@@ -494,14 +545,18 @@ class TestCustomConverter:
         class DummyConverter(Converter):
             def source_types(self):
                 return (DummyDist,)
+
             def target_types(self):
                 return (Normal,)
+
             def check(self, source, target_type):
                 if isinstance(source, DummyDist) and target_type is Normal:
                     return ConversionInfo(feasible=True, method=ConversionMethod.EXACT)
                 return ConversionInfo(feasible=False)
+
             def convert(self, source, target_type, *, key=None, **kwargs):
                 return Normal(loc=source.val, scale=1.0, name="x")
+
             @property
             def priority(self):
                 return 10
@@ -516,8 +571,7 @@ class TestCustomConverter:
         finally:
             # Clean up: remove the dummy converter
             converter_registry._converters = [
-                c for c in converter_registry._converters
-                if not isinstance(c, DummyConverter)
+                c for c in converter_registry._converters if not isinstance(c, DummyConverter)
             ]
             converter_registry._type_cache.clear()
 
@@ -525,6 +579,7 @@ class TestCustomConverter:
 # ---------------------------------------------------------------------------
 # from_distribution() backward compatibility
 # ---------------------------------------------------------------------------
+
 
 class TestFromDistributionDelegation:
     """Verify from_distribution() delegates to the registry."""
@@ -569,6 +624,7 @@ class TestFromDistributionDelegation:
 # Edge cases
 # ---------------------------------------------------------------------------
 
+
 class TestBootstrapMetadata:
     """Verify bootstrap distributions are stored in provenance metadata
     when the source distribution uses MC fallback for mean/variance."""
@@ -610,7 +666,6 @@ class TestBootstrapMetadata:
 
 
 class TestEdgeCases:
-
     def test_convert_none_raises(self):
         with pytest.raises(TypeError):
             converter_registry.convert(None, Normal)
@@ -658,7 +713,9 @@ class TestProtocolConversion:
         assert isinstance(result, KDEDistribution)
         np.testing.assert_allclose(float(result._mean()), float(emp._mean()), atol=0.01)
         np.testing.assert_allclose(
-            float(result._variance()), float(emp._variance()), atol=0.3,
+            float(result._variance()),
+            float(emp._variance()),
+            atol=0.3,
         )
 
     def test_multivariate_empirical_to_supports_log_prob(self):
@@ -671,7 +728,9 @@ class TestProtocolConversion:
         assert isinstance(result, SupportsLogProb)
         assert isinstance(result, KDEDistribution)
         np.testing.assert_allclose(
-            np.array(result._mean()), np.array(emp._mean()), atol=0.2,
+            np.array(result._mean()),
+            np.array(emp._mean()),
+            atol=0.2,
         )
 
     def test_multi_field_record_empirical_to_kde(self):
@@ -747,7 +806,8 @@ class TestProtocolConversion:
         """
         emp = EmpiricalDistribution(["a", "b", "c"])
         with pytest.raises(
-            TypeError, match="generic .object-array. EmpiricalDistribution",
+            TypeError,
+            match="generic .object-array. EmpiricalDistribution",
         ):
             converter_registry.convert(emp, SupportsLogProb)
 
@@ -888,7 +948,9 @@ class TestKDEDistribution:
         samples = jax.random.normal(jax.random.PRNGKey(0), (500,))
         kde = KDEDistribution(samples)
         np.testing.assert_allclose(
-            float(kde._mean()), float(jnp.mean(samples)), atol=0.01,
+            float(kde._mean()),
+            float(jnp.mean(samples)),
+            atol=0.01,
         )
 
     def test_variance_larger_than_sample_variance(self):
@@ -931,7 +993,9 @@ class TestKDEDistribution:
         assert isinstance(kde, KDEDistribution)
         assert kde.num_atoms == 200
         np.testing.assert_allclose(
-            float(kde._mean()), float(emp._mean()), atol=0.01,
+            float(kde._mean()),
+            float(emp._mean()),
+            atol=0.01,
         )
 
     def test_convert_normal_to_kde(self):

--- a/tests/core/test_array_backend.py
+++ b/tests/core/test_array_backend.py
@@ -1,4 +1,5 @@
 """Tests for probpipe.core._array_backend (aux registry + Record/NumericRecord round-trip)."""
+
 from __future__ import annotations
 
 import jax
@@ -81,6 +82,7 @@ class TestRegistryLookup:
         """An instance of a registered type's subclass picks up the
         base-class hooks (regression for the MRO-walk semantics
         documented at ``_array_backend.py:103-108``)."""
+
         class Base:
             pass
 
@@ -102,6 +104,7 @@ class TestRegistryLookup:
     def test_register_aux_overwrites_silently(self):
         """Re-registering an existing leaf type silently overwrites the
         previous hooks (documented at ``_array_backend.py:93-99``)."""
+
         class MyType:
             pass
 
@@ -187,7 +190,8 @@ class TestXarrayRoundTrip:
         assert isinstance(inner, Record)
         assert inner["temps"].dims == ("t",)
         np.testing.assert_array_equal(
-            inner["temps"].coords["t"].values, [10, 20, 30],
+            inner["temps"].coords["t"].values,
+            [10, 20, 30],
         )
         assert inner["temps"].attrs == {"units": "meters"}
 
@@ -211,7 +215,8 @@ class TestXarrayRoundTrip:
         assert back.coords["t"].attrs == {"unit": "s"}
         assert back.coords["area"].dims == ("x", "t")
         np.testing.assert_array_equal(
-            back.coords["area"].values, area,
+            back.coords["area"].values,
+            area,
         )
 
 
@@ -229,9 +234,7 @@ def pd_module():
 def datetime_series(pd_module):
     return pd_module.Series(
         [10.0, 20.0, 30.0],
-        index=pd_module.DatetimeIndex(
-            ["2024-01-01", "2024-01-02", "2024-01-03"]
-        ),
+        index=pd_module.DatetimeIndex(["2024-01-01", "2024-01-02", "2024-01-03"]),
         name="counts",
     )
 
@@ -287,9 +290,7 @@ class TestMixedBackendRecord:
 @pytest.fixture
 def da_simple():
     xr = pytest.importorskip("xarray")
-    return xr.DataArray(
-        [1.0, 2.0, 3.0], dims=["t"], coords={"t": [10, 20, 30]}
-    )
+    return xr.DataArray([1.0, 2.0, 3.0], dims=["t"], coords={"t": [10, 20, 30]})
 
 
 class TestPathEquivalence:
@@ -313,9 +314,7 @@ class TestPathEquivalence:
         b2 = Record(x=da_simple, y=2.5).to_numeric().to_native()
         # xarray fields restored identically (dims + coord values).
         assert b1["x"].dims == b2["x"].dims
-        np.testing.assert_array_equal(
-            b1["x"].coords["t"].values, b2["x"].coords["t"].values
-        )
+        np.testing.assert_array_equal(b1["x"].coords["t"].values, b2["x"].coords["t"].values)
         # Numeric pass-through fields.
         np.testing.assert_array_equal(np.asarray(b1["y"]), np.asarray(b2["y"]))
 
@@ -351,9 +350,7 @@ class TestNonCoercibleLeavesRaise:
 @pytest.fixture
 def da_zero_indexed():
     xr = pytest.importorskip("xarray")
-    return xr.DataArray(
-        [1.0, 2.0, 3.0], dims=["t"], coords={"t": [0, 1, 2]}
-    )
+    return xr.DataArray([1.0, 2.0, 3.0], dims=["t"], coords={"t": [0, 1, 2]})
 
 
 class TestTransformsDropAux:
@@ -387,8 +384,7 @@ class TestRecordArrayStackDropsAux:
         # Build per-row NumericRecords carrying xarray leaves so the
         # source records *do* carry aux.
         records = [
-            NumericRecord(x=xr.DataArray([float(i), float(i + 1)], dims=["t"]))
-            for i in range(3)
+            NumericRecord(x=xr.DataArray([float(i), float(i + 1)], dims=["t"])) for i in range(3)
         ]
         # Each source record has aux for ``x``.
         assert all(r.aux is not None for r in records)

--- a/tests/core/test_array_distribution.py
+++ b/tests/core/test_array_distribution.py
@@ -24,6 +24,7 @@ from probpipe import log_prob, sample, unnormalized_log_prob
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def key():
     return jax.random.PRNGKey(42)
@@ -57,6 +58,7 @@ def matrix_mvn():
 # Hierarchy checks
 # ---------------------------------------------------------------------------
 
+
 class TestHierarchy:
     def test_arraydist_is_pytreearraydist(self, scalar_normal):
         assert isinstance(scalar_normal, NumericRecordDistribution)
@@ -75,13 +77,16 @@ class TestHierarchy:
 # Distribution[T] base class methods
 # ---------------------------------------------------------------------------
 
+
 class TestDistributionBase:
     """Tests for methods defined on Distribution[T] itself."""
 
     def test_log_prob_raises_by_default(self):
         """Distribution[T] without SupportsLogProb raises TypeError."""
+
         class StubDist(Distribution):
             pass
+
         d = StubDist(name="stub")
         with pytest.raises(TypeError, match="does not support log_prob"):
             log_prob(d, jnp.array(0.0))
@@ -119,6 +124,7 @@ class TestDistributionBase:
 # NumericRecordDistribution trivial pytree interface
 # ---------------------------------------------------------------------------
 
+
 class TestArrayDistributionPyTreeInterface:
     def test_treedef_scalar(self, scalar_normal):
         td = scalar_normal.treedef
@@ -153,6 +159,7 @@ class TestArrayDistributionPyTreeInterface:
 # flatten_value / unflatten_value on NumericRecordDistribution
 # ---------------------------------------------------------------------------
 
+
 class TestArrayDistFlattenUnflatten:
     def test_flatten_vector_sample(self, vector_mvn, key):
         s = sample(vector_mvn, key=key)
@@ -164,18 +171,21 @@ class TestArrayDistFlattenUnflatten:
         s = sample(vector_mvn, key=key)
         flat = vector_mvn.flatten_value(s, event_shape=vector_mvn.event_shape)
         restored = vector_mvn.unflatten_value(
-            flat, template=vector_mvn.event_template,
+            flat,
+            template=vector_mvn.event_template,
         )
         np.testing.assert_allclose(restored, s, atol=1e-6)
 
     def test_flatten_unflatten_roundtrip_batched(self, vector_mvn, key):
         samples = jnp.asarray(sample(vector_mvn, key=key, sample_shape=(5,)))
         flat = vector_mvn.flatten_value(
-            samples, event_shape=vector_mvn.event_shape,
+            samples,
+            event_shape=vector_mvn.event_shape,
         )
         assert flat.shape == (5, 3)
         restored = vector_mvn.unflatten_value(
-            flat, template=vector_mvn.event_template,
+            flat,
+            template=vector_mvn.event_template,
         )
         np.testing.assert_allclose(restored, samples, atol=1e-6)
 
@@ -184,7 +194,8 @@ class TestArrayDistFlattenUnflatten:
         flat = matrix_mvn.flatten_value(s, event_shape=matrix_mvn.event_shape)
         assert flat.shape == (4,)
         restored = matrix_mvn.unflatten_value(
-            flat, template=matrix_mvn.event_template,
+            flat,
+            template=matrix_mvn.event_template,
         )
         np.testing.assert_allclose(restored, s, atol=1e-6)
 
@@ -192,6 +203,7 @@ class TestArrayDistFlattenUnflatten:
 # ---------------------------------------------------------------------------
 # as_flat_distribution / FlattenedDistributionView
 # ---------------------------------------------------------------------------
+
 
 class TestFlattenedDistributionView:
     def test_as_flat_returns_flattened_view(self, vector_mvn):
@@ -221,7 +233,8 @@ class TestFlattenedDistributionView:
         flat_dist = vector_mvn.as_flat_distribution()
         s = sample(vector_mvn, key=key)
         flat_sample = vector_mvn.flatten_value(
-            s, event_shape=vector_mvn.event_shape,
+            s,
+            event_shape=vector_mvn.event_shape,
         )
 
         lp_original = log_prob(vector_mvn, s)
@@ -239,7 +252,8 @@ class TestFlattenedDistributionView:
         np.testing.assert_allclose(
             restored,
             vector_mvn.unflatten_value(
-                flat_sample, template=vector_mvn.event_template,
+                flat_sample,
+                template=vector_mvn.event_template,
             ),
             atol=1e-6,
         )
@@ -258,7 +272,8 @@ class TestFlattenedDistributionView:
         flat_dist = matrix_mvn.as_flat_distribution()
         s = sample(matrix_mvn, key=key)
         flat_sample = matrix_mvn.flatten_value(
-            s, event_shape=matrix_mvn.event_shape,
+            s,
+            event_shape=matrix_mvn.event_shape,
         )
 
         lp_original = log_prob(matrix_mvn, s)
@@ -270,10 +285,12 @@ class TestFlattenedDistributionView:
 # supports property
 # ---------------------------------------------------------------------------
 
+
 class TestSupports:
     def test_supports_is_per_field_dict(self, scalar_normal):
         """supports returns a per-field dict of constraints."""
         from probpipe import real
+
         result = scalar_normal.supports
         assert isinstance(result, dict)
         assert len(result) == 1
@@ -332,6 +349,7 @@ class TestCanonicalConvenience:
             @property
             def supports(self):
                 from probpipe import real
+
                 return {"a": real, "b": real}
 
             def _sample(self, key, sample_shape=()):
@@ -368,7 +386,8 @@ class TestCanonicalConvenience:
             _ = multi_leaf_dist.support
 
     def test_check_support_compatible_includes_field_name_on_multi_leaf(
-        self, multi_leaf_dist,
+        self,
+        multi_leaf_dist,
     ):
         """``_check_support_compatible`` reads canonical ``supports``
         (per-leaf) on the source. For a multi-leaf source, the field
@@ -380,14 +399,17 @@ class TestCanonicalConvenience:
         check raises with its name.
         """
         from probpipe import Gamma
+
         target = Gamma(concentration=1.0, rate=1.0, name="gamma_target")
         with pytest.raises(
-            ValueError, match=r"TwoField field 'a' \(support=real\)",
+            ValueError,
+            match=r"TwoField field 'a' \(support=real\)",
         ):
             target._check_support_compatible(multi_leaf_dist)
 
     def test_check_support_compatible_multi_field_target_field_count_mismatch(
-        self, multi_leaf_dist,
+        self,
+        multi_leaf_dist,
     ):
         """Multi-field target with a different field count from the
         source raises ``ValueError`` rather than silently truncating
@@ -413,10 +435,12 @@ class TestCanonicalConvenience:
             @property
             def supports(self):
                 from probpipe import positive
+
                 return {"a": positive, "b": positive, "c": positive}
 
             def _sample(self, key, sample_shape=()):  # pragma: no cover
                 from probpipe import NumericRecord
+
                 return NumericRecord(
                     a=jnp.zeros(sample_shape),
                     b=jnp.zeros(sample_shape),
@@ -456,7 +480,8 @@ class TestCanonicalConvenience:
 
             def _sample(self, key, sample_shape=()):  # pragma: no cover
                 return NumericRecord(
-                    s1=jnp.zeros(sample_shape), s2=jnp.zeros(sample_shape),
+                    s1=jnp.zeros(sample_shape),
+                    s2=jnp.zeros(sample_shape),
                 )
 
         class TwoFieldTarget(NumericRecordDistribution):
@@ -474,7 +499,8 @@ class TestCanonicalConvenience:
 
             def _sample(self, key, sample_shape=()):  # pragma: no cover
                 return NumericRecord(
-                    t1=jnp.zeros(sample_shape), t2=jnp.zeros(sample_shape),
+                    t1=jnp.zeros(sample_shape),
+                    t2=jnp.zeros(sample_shape),
                 )
 
         source = TwoFieldSource(name="source")
@@ -491,6 +517,7 @@ class TestCanonicalConvenience:
         leaves) are treated as "unknown" — the check returns silently
         rather than raising ``AttributeError``.
         """
+
         class _NoSupportsSource:
             """Pretends to be a source but has no ``supports`` attribute."""
 
@@ -499,7 +526,8 @@ class TestCanonicalConvenience:
         scalar_normal._check_support_compatible(_NoSupportsSource())  # no raise
 
     def test_check_support_compatible_skips_when_supports_not_implemented(
-        self, scalar_normal,
+        self,
+        scalar_normal,
     ):
         """A source whose ``supports`` property raises
         ``NotImplementedError`` (the default for any
@@ -531,8 +559,10 @@ class TestCanonicalConvenience:
 
             def _sample(self, key, sample_shape=()):  # pragma: no cover
                 from probpipe import NumericRecord
+
                 return NumericRecord(
-                    a=jnp.zeros(sample_shape), b=jnp.zeros(sample_shape),
+                    a=jnp.zeros(sample_shape),
+                    b=jnp.zeros(sample_shape),
                 )
 
         scalar_normal._check_support_compatible(
@@ -548,9 +578,8 @@ class TestCanonicalConvenience:
         with the same field names — locks the relationship between
         ``event_template`` and the sample pytree."""
         from probpipe import NumericRecord
-        expected = jax.tree.structure(
-            NumericRecord(a=jnp.zeros(()), b=jnp.zeros((2,)))
-        )
+
+        expected = jax.tree.structure(NumericRecord(a=jnp.zeros(()), b=jnp.zeros((2,))))
         assert multi_leaf_dist.treedef == expected
 
     def test_treedef_is_cached(self, multi_leaf_dist):
@@ -573,6 +602,7 @@ class TestCanonicalConvenience:
         ``NumericRecord``.
         """
         from probpipe import NumericRecord
+
         out = multi_leaf_dist._sample(jax.random.PRNGKey(0), ())
         assert isinstance(out, NumericRecord)
         assert tuple(out.keys()) == ("a", "b")
@@ -593,16 +623,19 @@ class TestIntegerDtypeReporting:
 
     def test_bernoulli_dtype_is_int32(self):
         from probpipe import Bernoulli
+
         assert Bernoulli(probs=0.5, name="x").dtype == jnp.int32
 
     def test_categorical_dtype_is_int32(self):
         from probpipe import Categorical
+
         assert Categorical(probs=jnp.array([0.5, 0.5]), name="x").dtype == jnp.int32
 
     def test_normal_dtype_is_float(self):
         """Normal continues to report float (no regression on the
         always-float family)."""
         from probpipe import Normal
+
         assert jnp.issubdtype(Normal(loc=0.0, scale=1.0, name="x").dtype, jnp.floating)
 
     def test_poisson_dtype_is_float(self):
@@ -612,12 +645,14 @@ class TestIntegerDtypeReporting:
         CHANGELOG-documented behaviour.
         """
         from probpipe import Poisson
+
         assert Poisson(rate=2.0, name="x").dtype == jnp.float32
 
 
 # ---------------------------------------------------------------------------
 # FlattenedDistributionView on EmpiricalDistribution
 # ---------------------------------------------------------------------------
+
 
 class TestFlattenedDistributionViewEmpirical:
     def test_empirical_flatten_roundtrip(self, key):

--- a/tests/core/test_bootstrap_replicate.py
+++ b/tests/core/test_bootstrap_replicate.py
@@ -182,6 +182,7 @@ class TestSampleableSource:
 
     def _normal(self):
         from probpipe import Normal
+
         return Normal(loc=0.0, scale=1.0, name="x")
 
     def test_construction_keeps_generic_base(self):
@@ -266,7 +267,9 @@ class TestProperties:
         assert dist.is_uniform is True
 
     def test_is_uniform_from_weighted_empirical(self):
-        emp = EmpiricalDistribution(jnp.ones((5, 2)), weights=jnp.array([1., 2., 3., 4., 5.]), name="x")
+        emp = EmpiricalDistribution(
+            jnp.ones((5, 2)), weights=jnp.array([1.0, 2.0, 3.0, 4.0, 5.0]), name="x"
+        )
         dist = BootstrapReplicateDistribution(emp, name="x")
         assert dist.is_uniform is False
 
@@ -275,7 +278,7 @@ class TestProperties:
         np.testing.assert_allclose(dist.weights, jnp.ones(5) / 5)
 
     def test_weights_from_weighted_empirical(self):
-        weights = jnp.array([1., 2., 3.])
+        weights = jnp.array([1.0, 2.0, 3.0])
         emp = EmpiricalDistribution(jnp.ones((3, 2)), weights=weights, name="x")
         dist = BootstrapReplicateDistribution(emp, name="x")
         assert dist.weights is not None
@@ -371,6 +374,7 @@ class TestExpectation:
 class TestRecordBootstrapReplicateDistribution:
     def test_support(self):
         from probpipe.core.constraints import real
+
         dist = RecordBootstrapReplicateDistribution(jnp.ones((5, 2)), name="x")
         assert dist.support == real
 
@@ -402,10 +406,12 @@ class TestRecordBootstrapReplicateDistribution:
         bubble up).
         """
         from probpipe.core._empirical import RecordEmpiricalDistribution
+
         emp = EmpiricalDistribution(["a", "b", "c"])
         assert not isinstance(emp, RecordEmpiricalDistribution)
         with pytest.raises(
-            TypeError, match="generic .object-array. EmpiricalDistribution",
+            TypeError,
+            match="generic .object-array. EmpiricalDistribution",
         ):
             RecordBootstrapReplicateDistribution(emp)
 
@@ -462,6 +468,7 @@ class TestValuesEmpiricalDistribution:
 
     def test_dispatch(self, values_data):
         from probpipe.core._empirical import RecordEmpiricalDistribution
+
         emp = EmpiricalDistribution(values_data, name="x")
         assert isinstance(emp, RecordEmpiricalDistribution)
 
@@ -505,6 +512,7 @@ class TestValuesEmpiricalDistribution:
 
     def test_getitem_returns_view(self, values_data):
         from probpipe.core._record_distribution import _RecordDistributionView
+
         emp = EmpiricalDistribution(values_data, name="x")
         view = emp["X"]
         assert isinstance(view, _RecordDistributionView)
@@ -550,12 +558,14 @@ class TestValuesBootstrapReplicateDistribution:
 
     def test_dispatch_from_empirical(self, values_data):
         from probpipe.core._empirical import RecordBootstrapReplicateDistribution
+
         emp = EmpiricalDistribution(values_data, name="x")
         boot = BootstrapReplicateDistribution(emp, name="x")
         assert isinstance(boot, RecordBootstrapReplicateDistribution)
 
     def test_dispatch_from_values(self, values_data):
         from probpipe.core._empirical import RecordBootstrapReplicateDistribution
+
         boot = BootstrapReplicateDistribution(values_data, name="x")
         assert isinstance(boot, RecordBootstrapReplicateDistribution)
 
@@ -594,6 +604,7 @@ class TestValuesBootstrapReplicateDistribution:
 
     def test_getitem_returns_view(self, bootstrap):
         from probpipe.core._record_distribution import _RecordDistributionView
+
         view = bootstrap["X"]
         assert isinstance(view, _RecordDistributionView)
 

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -106,7 +106,7 @@ class TestBroadcastDistributionProtocols:
             weights=None,
             broadcast_args=["x"],
         )
-        assert hasattr(bd, 'fields')
+        assert hasattr(bd, "fields")
 
 
 # ---------------------------------------------------------------------------
@@ -307,7 +307,10 @@ class TestMixtureMarginal:
         assert jnp.isfinite(lp)
 
     def test_sample_draws(self, key):
-        components = [Normal(loc=-100.0, scale=0.01, name="a"), Normal(loc=100.0, scale=0.01, name="b")]
+        components = [
+            Normal(loc=-100.0, scale=0.01, name="a"),
+            Normal(loc=100.0, scale=0.01, name="b"),
+        ]
         m = _make_mixture_marginal(components, None)
         draws = m._sample(key, (1000,))
         # Should be bimodal around -100 and 100
@@ -519,7 +522,7 @@ class TestArrayMarginalAdditional:
         """Full expectation over all samples."""
         samples = jnp.array([[1.0], [2.0], [3.0]])
         m = _RecordMarginal(samples, None)
-        result = m._expectation(lambda x: x ** 2)
+        result = m._expectation(lambda x: x**2)
         # E[X^2] = (1+4+9)/3 = 14/3
         np.testing.assert_allclose(result, jnp.array([14.0 / 3]), atol=1e-4)
 
@@ -544,9 +547,7 @@ class TestArrayMarginalAdditional:
         """Subsampled expectation with return_dist=False returns array."""
         samples = jnp.arange(100, dtype=jnp.float32).reshape(-1, 1)
         m = _RecordMarginal(samples, None)
-        result = m._expectation(
-            lambda x: x, key=key, num_evaluations=20, return_dist=False
-        )
+        result = m._expectation(lambda x: x, key=key, num_evaluations=20, return_dist=False)
         assert isinstance(result, jnp.ndarray)
 
     def test_expectation_subsampled_weighted(self, key):
@@ -566,9 +567,7 @@ class TestArrayMarginalAdditional:
         samples = jnp.arange(n, dtype=jnp.float32).reshape(-1, 1)
         w = jnp.ones(n) / n
         m = _RecordMarginal(samples, w)
-        result = m._expectation(
-            lambda x: x, key=key, num_evaluations=10, return_dist=False
-        )
+        result = m._expectation(lambda x: x, key=key, num_evaluations=10, return_dist=False)
         assert isinstance(result, jnp.ndarray)
 
     def test_cov_weighted(self):
@@ -670,6 +669,7 @@ class TestRecordArrayMarginal:
         @workflow_function
         def transform(x, y):
             return Record(sum=x + y, diff=x - y)
+
         return transform
 
     @pytest.fixture
@@ -680,7 +680,9 @@ class TestRecordArrayMarginal:
         )
 
     def test_record_output_produces_record_array_marginal(
-        self, record_workflow, prior,
+        self,
+        record_workflow,
+        prior,
     ):
         result = record_workflow(**prior.select("x", "y"))
         assert isinstance(result, _RecordMarginal)
@@ -729,6 +731,7 @@ class TestMakeStack:
     def test_list_of_scalars_wraps_as_numeric_record_array(self):
         from probpipe import NumericRecordArray
         from probpipe.core._broadcast_distributions import _make_stack
+
         out = _make_stack([1.0, 2.0, 3.0, 4.0], n=4, field_name="demo")
         assert isinstance(out, NumericRecordArray)
         assert out.batch_shape == (4,)
@@ -738,6 +741,7 @@ class TestMakeStack:
     def test_list_of_arrays_preserves_event_shape(self):
         from probpipe import NumericRecordArray
         from probpipe.core._broadcast_distributions import _make_stack
+
         values = [jnp.arange(3.0) + 10.0 * i for i in range(4)]
         out = _make_stack(values, n=4, field_name="demo")
         assert isinstance(out, NumericRecordArray)
@@ -747,6 +751,7 @@ class TestMakeStack:
     def test_list_of_numeric_records_promotes_to_numeric_array(self):
         from probpipe import NumericRecord, NumericRecordArray
         from probpipe.core._broadcast_distributions import _make_stack
+
         records = [NumericRecord(a=float(i), b=float(i) * 2) for i in range(5)]
         out = _make_stack(records, n=5, field_name="demo")
         assert isinstance(out, NumericRecordArray)
@@ -761,6 +766,7 @@ class TestMakeStack:
         opaque leaves via ``np.asarray(dtype=object)``."""
         from probpipe import NumericRecordArray, Record, RecordArray
         from probpipe.core._broadcast_distributions import _make_stack
+
         records = [Record(a=float(i), label=f"row{i}") for i in range(3)]
         out = _make_stack(records, n=3, field_name="demo")
         assert isinstance(out, RecordArray)
@@ -771,6 +777,7 @@ class TestMakeStack:
     def test_list_of_distributions_gives_distribution_array(self):
         from probpipe import DistributionArray, Normal
         from probpipe.core._broadcast_distributions import _make_stack
+
         comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
         out = _make_stack(comps, n=3, field_name="demo")
         assert isinstance(out, DistributionArray)
@@ -782,10 +789,9 @@ class TestMakeStack:
         n of them produces a RecordArray with batch_shape (n, m)."""
         from probpipe import NumericRecord, NumericRecordArray
         from probpipe.core._broadcast_distributions import _make_stack
+
         inner = [
-            NumericRecordArray.stack(
-                [NumericRecord(x=float(i * 10 + j)) for j in range(4)]
-            )
+            NumericRecordArray.stack([NumericRecord(x=float(i * 10 + j)) for j in range(4)])
             for i in range(3)
         ]
         out = _make_stack(inner, n=3, field_name="demo")
@@ -799,6 +805,7 @@ class TestMakeStack:
         output for scalar-returning fns) wraps without unstacking."""
         from probpipe import NumericRecordArray
         from probpipe.core._broadcast_distributions import _make_stack
+
         arr = jnp.arange(12.0).reshape(4, 3)
         out = _make_stack(arr, n=4, field_name="demo")
         assert isinstance(out, NumericRecordArray)
@@ -811,6 +818,7 @@ class TestMakeStack:
         input form for the pytree branch of ``_make_stack``."""
         from probpipe import NumericRecordArray, Record
         from probpipe.core._broadcast_distributions import _make_stack
+
         rec = Record(x=jnp.arange(5.0), y=jnp.arange(5.0) + 10)
         out = _make_stack(rec, n=5, field_name="demo")
         assert isinstance(out, NumericRecordArray)
@@ -818,11 +826,13 @@ class TestMakeStack:
 
     def test_length_mismatch_raises(self):
         from probpipe.core._broadcast_distributions import _make_stack
+
         with pytest.raises(ValueError, match=r"expected prod\(batch_shape\)=5"):
             _make_stack([1.0, 2.0, 3.0], n=5, field_name="demo")
 
     def test_ndarray_leading_axis_mismatch_raises(self):
         from probpipe.core._broadcast_distributions import _make_stack
+
         with pytest.raises(ValueError, match="expected leading axis"):
             _make_stack(jnp.arange(6.0), n=4, field_name="demo")
 
@@ -840,6 +850,7 @@ class TestCoerceOutput:
 
     def test_wrap_mode_with_no_provenance_wraps_scalar(self):
         from probpipe.core import _workflow_result
+
         out = _workflow_result._coerce_output(
             3.14,
             broadcast_mode=_workflow_result.BROADCAST_WRAP,
@@ -853,9 +864,8 @@ class TestCoerceOutput:
     def test_stack_mode_attaches_to_recordarray(self):
         from probpipe import NumericRecord, NumericRecordArray
         from probpipe.core._workflow_result import _coerce_output
-        ra = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(3)]
-        )
+
+        ra = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(3)])
         assert ra.source is None
         prov = Provenance("sweep", parents=())
         out = _coerce_output(ra, broadcast_mode="stack", provenance=prov, field_name="f")
@@ -866,6 +876,7 @@ class TestCoerceOutput:
         from probpipe import DistributionArray, Normal
         from probpipe.core._broadcast_distributions import _make_stack
         from probpipe.core._workflow_result import _coerce_output
+
         da = _make_stack(
             [Normal(loc=0.0, scale=1.0, name=f"d{i}") for i in range(3)],
             n=3,
@@ -884,6 +895,7 @@ class TestCoerceOutput:
         existing source must remain."""
         from probpipe import NumericRecord
         from probpipe.core._workflow_result import _coerce_output
+
         nr = NumericRecord(x=1.0).with_source(Provenance("inner", parents=()))
         # Second set would normally raise RuntimeError; _coerce_output
         # swallows it.

--- a/tests/core/test_broadcasting.py
+++ b/tests/core/test_broadcasting.py
@@ -22,6 +22,7 @@ def key():
 # Basic broadcasting (loop backend) - default returns marginal
 # ---------------------------------------------------------------------------
 
+
 class TestBroadcastingBasic:
     def test_returns_marginal_by_default(self):
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
@@ -31,7 +32,7 @@ class TestBroadcastingBasic:
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g)
         assert not isinstance(result, BroadcastDistribution)
-        assert hasattr(result, 'samples')
+        assert hasattr(result, "samples")
         assert result.num_atoms == 50
 
     def test_output_values_correct(self):
@@ -48,7 +49,9 @@ class TestBroadcastingBasic:
         def compute_norm(x: jnp.ndarray) -> float:
             return float(jnp.linalg.norm(x))
 
-        w = WorkflowFunction(func=compute_norm, n_broadcast_samples=20, dispatch="sequential", seed=2)
+        w = WorkflowFunction(
+            func=compute_norm, n_broadcast_samples=20, dispatch="sequential", seed=2
+        )
         mvn = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="x")
         result = w(x=mvn)
         assert not isinstance(result, BroadcastDistribution)
@@ -77,7 +80,7 @@ class TestBroadcastingBasic:
         # Positional with distribution triggers broadcasting
         g = Normal(loc=0.0, scale=0.1, name="x")
         result = add(g, y=jnp.array(1.0))
-        assert hasattr(result, 'samples')
+        assert hasattr(result, "samples")
         assert result.num_atoms == 30
 
     def test_no_input_samples_by_default(self):
@@ -87,7 +90,7 @@ class TestBroadcastingBasic:
         w = WorkflowFunction(func=double_it, n_broadcast_samples=20, dispatch="sequential", seed=0)
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g)
-        assert not hasattr(result, 'input_samples')
+        assert not hasattr(result, "input_samples")
 
 
 class TestBroadcastingMultipleArgs:
@@ -237,6 +240,7 @@ class TestNoBroadcasting:
 # Empirical enumeration
 # ---------------------------------------------------------------------------
 
+
 class TestBroadcastingEnumeration:
     def test_single_empirical(self):
         def identity(x: jnp.ndarray) -> jnp.ndarray:
@@ -264,12 +268,17 @@ class TestBroadcastingEnumeration:
 
     def test_greedy_cutoff(self):
         """When product exceeds budget, largest empiricals are sampled instead."""
+
         def sum_three(a: jnp.ndarray, b: jnp.ndarray, c: jnp.ndarray) -> jnp.ndarray:
             return a + b + c
 
-        ed_small = EmpiricalDistribution(jnp.array([[1.0], [2.0]]), name="x")          # n=2
-        ed_medium = EmpiricalDistribution(jnp.arange(5).reshape(-1, 1).astype(jnp.float32), name="x")  # n=5
-        ed_large = EmpiricalDistribution(jnp.arange(20).reshape(-1, 1).astype(jnp.float32), name="x")  # n=20
+        ed_small = EmpiricalDistribution(jnp.array([[1.0], [2.0]]), name="x")  # n=2
+        ed_medium = EmpiricalDistribution(
+            jnp.arange(5).reshape(-1, 1).astype(jnp.float32), name="x"
+        )  # n=5
+        ed_large = EmpiricalDistribution(
+            jnp.arange(20).reshape(-1, 1).astype(jnp.float32), name="x"
+        )  # n=20
 
         w = WorkflowFunction(func=sum_three, n_broadcast_samples=50, dispatch="sequential", seed=9)
         result = w(a=ed_small, b=ed_medium, c=ed_large)
@@ -290,6 +299,7 @@ class TestBroadcastingEnumeration:
 
     def test_enumeration_input_samples_aligned(self):
         """Input samples should be aligned with output samples when include_inputs=True."""
+
         def identity(x: jnp.ndarray) -> jnp.ndarray:
             return x
 
@@ -310,6 +320,7 @@ class TestBroadcastingEnumeration:
 # Non-numeric results
 # ---------------------------------------------------------------------------
 
+
 class TestBroadcastingNonNumeric:
     def test_string_results(self):
         def describe(x: jnp.ndarray) -> str:
@@ -327,6 +338,7 @@ class TestBroadcastingNonNumeric:
 # ---------------------------------------------------------------------------
 # JAX vmap backend
 # ---------------------------------------------------------------------------
+
 
 class TestBroadcastingJAX:
     def test_basic_vmap(self):
@@ -383,6 +395,7 @@ class TestBroadcastingJAX:
 
     def test_vmap_input_samples(self):
         """include_inputs=True preserves input-output alignment for vmap."""
+
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
@@ -394,9 +407,7 @@ class TestBroadcastingJAX:
         assert result.input_samples["x"].shape[0] == 30
         # Output should be 2x input
         marginal = result.marginalize()
-        np.testing.assert_allclose(
-            marginal.samples, result.input_samples["x"] * 2, atol=1e-5
-        )
+        np.testing.assert_allclose(marginal.samples, result.input_samples["x"] * 2, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------
@@ -454,7 +465,10 @@ class TestAutoDispatch:
             return jnp.asarray(joint["x"] + joint["y"])
 
         w = WorkflowFunction(
-            func=consume, n_broadcast_samples=10, dispatch="auto", seed=32,
+            func=consume,
+            n_broadcast_samples=10,
+            dispatch="auto",
+            seed=32,
         )
         joint = ProductDistribution(
             x=Normal(loc=0.0, scale=1.0, name="x"),
@@ -472,6 +486,7 @@ class TestAutoDispatch:
 # ---------------------------------------------------------------------------
 # Seed / key management
 # ---------------------------------------------------------------------------
+
 
 class TestSeedManagement:
     def test_different_seeds_give_different_results(self):
@@ -505,13 +520,19 @@ class TestSeedManagement:
 # include_inputs argument
 # ---------------------------------------------------------------------------
 
+
 class TestIncludeInputsArgument:
     def test_include_inputs_at_construction(self):
         def double_it(x: jnp.ndarray) -> jnp.ndarray:
             return x * 2
 
-        w = WorkflowFunction(func=double_it, n_broadcast_samples=20, dispatch="sequential",
-                             seed=0, include_inputs=True)
+        w = WorkflowFunction(
+            func=double_it,
+            n_broadcast_samples=20,
+            dispatch="sequential",
+            seed=0,
+            include_inputs=True,
+        )
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g)
         assert isinstance(result, BroadcastDistribution)
@@ -536,7 +557,7 @@ class TestIncludeInputsArgument:
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w(x=g)
         assert not isinstance(result, BroadcastDistribution)
-        assert not hasattr(result, 'input_samples')
+        assert not hasattr(result, "input_samples")
 
     def test_include_inputs_has_named_components(self):
         def add_them(a: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:
@@ -555,6 +576,7 @@ class TestIncludeInputsArgument:
 # ---------------------------------------------------------------------------
 # Named components (require include_inputs=True)
 # ---------------------------------------------------------------------------
+
 
 class TestNamedComponents:
     def test_fields(self):
@@ -588,7 +610,7 @@ class TestNamedComponents:
         g = Normal(loc=1.0, scale=0.5, name="x")
         result = w.with_options(include_inputs=True)(x=g)
         out = result["_output"]
-        assert hasattr(out, 'samples')
+        assert hasattr(out, "samples")
 
 
 # ---------------------------------------------------------------------------
@@ -611,66 +633,81 @@ class TestDispatchConsistency:
 
     def _run(self, mode, func, **kwargs):
         w = WorkflowFunction(
-            func=func, n_broadcast_samples=kwargs.pop("n_broadcast_samples", 100),
-            dispatch=mode, seed=0,
+            func=func,
+            n_broadcast_samples=kwargs.pop("n_broadcast_samples", 100),
+            dispatch=mode,
+            seed=0,
         )
         return w(**kwargs)
 
     def test_two_empiricals_cartesian_all_modes(self):
         """Cartesian enumeration of two small empiricals must give the
         exact same samples and weights in every backend."""
+
         def add_them(a, b):
             return a + b
 
         ed1 = EmpiricalDistribution(jnp.array([[1.0], [2.0]]), name="x")
         ed2 = EmpiricalDistribution(jnp.array([[10.0], [20.0], [30.0]]), name="x")
 
-        results = {
-            m: self._run(m, add_them, a=ed1, b=ed2)
-            for m in self.ROWWISE_DISPATCH_MODES
-        }
+        results = {m: self._run(m, add_them, a=ed1, b=ed2) for m in self.ROWWISE_DISPATCH_MODES}
         # Same size (2 x 3 = 6) in every mode - regression guard.
         for mode, r in results.items():
             assert r.num_atoms == 6, f"{mode}: expected n=6, got {r.num_atoms}"
+
         # Same sample set (order may differ; compare sorted).
         def _samples_array(d):
             return d.samples[d.samples.fields[0]]
+
         ref = sorted(_samples_array(results["sequential"]).ravel().tolist())
         for mode in ("auto", "thread"):
             got = sorted(_samples_array(results[mode]).ravel().tolist())
             np.testing.assert_allclose(
-                got, ref,
+                got,
+                ref,
                 err_msg=f"{mode} samples diverged from sequential: {got} vs {ref}",
             )
         # Weights: uniform 1/6 in every mode (inputs unweighted).
         for mode, r in results.items():
-            np.testing.assert_allclose(r.weights, jnp.full(6, 1 / 6), atol=1e-5,
-                                        err_msg=f"{mode} weights diverged")
+            np.testing.assert_allclose(
+                r.weights, jnp.full(6, 1 / 6), atol=1e-5, err_msg=f"{mode} weights diverged"
+            )
 
     def test_weighted_empiricals_preserve_weights_all_modes(self):
         """Exact empirical weights survive the product in every backend."""
+
         def add_them(a, b):
             return a + b
 
         ed1 = EmpiricalDistribution(
-            jnp.array([[1.0], [2.0]]), weights=jnp.array([0.8, 0.2]), name="x")
+            jnp.array([[1.0], [2.0]]), weights=jnp.array([0.8, 0.2]), name="x"
+        )
         ed2 = EmpiricalDistribution(
-            jnp.array([[10.0], [20.0]]), weights=jnp.array([0.25, 0.75]), name="x")
-        expected_weights = sorted([
-            0.8 * 0.25, 0.8 * 0.75, 0.2 * 0.25, 0.2 * 0.75,
-        ])
+            jnp.array([[10.0], [20.0]]), weights=jnp.array([0.25, 0.75]), name="x"
+        )
+        expected_weights = sorted(
+            [
+                0.8 * 0.25,
+                0.8 * 0.75,
+                0.2 * 0.25,
+                0.2 * 0.75,
+            ]
+        )
         for mode in self.ROWWISE_DISPATCH_MODES:
             r = self._run(mode, add_them, a=ed1, b=ed2)
             assert r.num_atoms == 4
             got = sorted(np.asarray(r.weights).tolist())
             np.testing.assert_allclose(
-                got, expected_weights, atol=1e-5,
+                got,
+                expected_weights,
+                atol=1e-5,
                 err_msg=f"{mode} weights diverged: {got} vs {expected_weights}",
             )
 
     def test_mixed_empirical_and_parametric_count_all_modes(self):
         """Mixed empirical + continuous: total evaluations (k combos x reps)
         must match across backends even though the sampled values differ."""
+
         def add_them(a, b):
             return a + b
 
@@ -687,11 +724,11 @@ class TestDispatchConsistency:
         """When a single empirical exceeds the sample budget, every
         backend falls back to resampling and returns exactly
         ``n_broadcast_samples`` evaluations."""
+
         def identity(x):
             return x
 
-        big = EmpiricalDistribution(
-            jnp.arange(200).reshape(-1, 1).astype(jnp.float32), name="x")
+        big = EmpiricalDistribution(jnp.arange(200).reshape(-1, 1).astype(jnp.float32), name="x")
         for mode in self.SAMPLE_DISPATCH_MODES:
             r = self._run(mode, identity, x=big, n_broadcast_samples=20)
             assert r.num_atoms == 20, f"{mode}: expected n=20, got {r.num_atoms}"
@@ -700,6 +737,7 @@ class TestDispatchConsistency:
         """Without empirical inputs every backend samples the full
         budget (values differ - different RNG paths - but count is
         identical)."""
+
         def add_them(a, b):
             return a + b
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -11,7 +11,6 @@ from probpipe.core.config import (
 
 
 class TestProvenanceModeEnvVar:
-
     def test_unset_defaults_to_lightweight(self, monkeypatch):
         monkeypatch.delenv(_PROVENANCE_MODE_ENV_VAR, raising=False)
         assert _initial_provenance_mode() is ProvenanceMode.LIGHTWEIGHT
@@ -36,6 +35,7 @@ class TestProvenanceModeEnvVar:
     def test_reset_re_reads_env_var(self, monkeypatch):
         """ProvenanceConfig.reset() picks up a changed env var."""
         import probpipe
+
         monkeypatch.setenv(_PROVENANCE_MODE_ENV_VAR, "off")
         probpipe.provenance_config.reset()
         assert probpipe.provenance_config.mode is ProvenanceMode.OFF

--- a/tests/core/test_distribution_array.py
+++ b/tests/core/test_distribution_array.py
@@ -91,6 +91,7 @@ class TestConstruction:
         comps = [Normal(loc=0.0, scale=1.0, name="d0")]
         da = _make_distribution_array(comps)
         from probpipe.core._distribution_base import Distribution
+
         assert isinstance(da, Distribution)
 
     def test_repr(self):
@@ -134,6 +135,7 @@ class TestContainerSurface:
 
     def test_len_is_leading_axis_multi_d(self):
         from probpipe import DistributionArray
+
         da = DistributionArray.from_batched_params(
             Normal,
             batch_shape=(2, 3),
@@ -150,6 +152,7 @@ class TestContainerSurface:
 
     def test_size_is_total_cells_multi_d(self):
         from probpipe import DistributionArray
+
         da = DistributionArray.from_batched_params(
             Normal,
             batch_shape=(2, 3),
@@ -162,6 +165,7 @@ class TestContainerSurface:
     def test_size_matches_numpy_convention(self):
         """``da.size`` follows the numpy / jax rule ``size == prod(shape)``."""
         from probpipe import DistributionArray
+
         da = DistributionArray.from_batched_params(
             Normal,
             batch_shape=(2, 3),
@@ -183,6 +187,7 @@ class TestContainerSurface:
         """Multi-d iteration yields leading-axis slices as sub-arrays
         (mirrors ``iter(np.zeros((2, 3)))``)."""
         from probpipe import DistributionArray
+
         da = DistributionArray.from_batched_params(
             Normal,
             batch_shape=(2, 3),
@@ -207,6 +212,7 @@ class TestContainerSurface:
         Fully-joint GRF predictions with no extra batch axes return
         a 0-d DA."""
         from probpipe import DistributionArray, MultivariateNormal as _MVN
+
         da = DistributionArray.from_batched_params(
             _MVN,
             batch_shape=(),
@@ -225,6 +231,7 @@ class TestContainerSurface:
         ``len(da)`` on a 0-d ``DistributionArray``. ``da.size``
         still works."""
         from probpipe import DistributionArray, MultivariateNormal as _MVN
+
         da = DistributionArray.from_batched_params(
             _MVN,
             batch_shape=(),
@@ -264,6 +271,7 @@ class TestZeroDDispatch:
         GRF with ``joint_inputs=joint_outputs=True`` produces when
         there are no extra batch axes."""
         from probpipe import DistributionArray, MultivariateNormal
+
         return DistributionArray.from_batched_params(
             MultivariateNormal,
             batch_shape=(),
@@ -298,6 +306,7 @@ class TestZeroDDispatch:
         # path under test (which goes ``log_prob(da)`` → unwrap to
         # the single cell → MVN ``_log_prob``).
         import math
+
         expected = -0.5 * 3 * math.log(2 * math.pi)
         np.testing.assert_allclose(float(jnp.asarray(lp)), expected, atol=1e-5)
 
@@ -306,6 +315,7 @@ class TestZeroDDispatch:
         return a 1-element batch, not a scalar. Only ``batch_shape
         == ()`` collapses."""
         from probpipe import DistributionArray
+
         da = DistributionArray.from_batched_params(
             Normal,
             batch_shape=(1,),
@@ -352,14 +362,12 @@ class TestSampleViaSweep:
     def test_components_drive_samples(self):
         """Per-cell mean of the 1000-sample draw concentrates at each
         component's own mean — confirms cell-by-cell dispatch."""
-        comps = [Normal(loc=float(i) * 100, scale=1e-3, name=f"d{i}")
-                 for i in range(3)]
+        comps = [Normal(loc=float(i) * 100, scale=1e-3, name=f"d{i}") for i in range(3)]
         da = _make_distribution_array(comps)
         s = sample(da, sample_shape=(1000,))
         # batch_shape (3,), leaf (1000,) → field shape (3, 1000).
         means = s["sample"].mean(axis=-1)
-        np.testing.assert_allclose(means, jnp.array([0.0, 100.0, 200.0]),
-                                   atol=0.2)
+        np.testing.assert_allclose(means, jnp.array([0.0, 100.0, 200.0]), atol=0.2)
 
     def test_multi_d_batch_shape(self):
         comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(6)]
@@ -379,6 +387,7 @@ class TestSampleViaSweep:
         da = _make_distribution_array(comps)
         s = sample(da)
         from probpipe import RecordArray
+
         assert isinstance(s, RecordArray)
         assert s.batch_shape == (3,)
         np.testing.assert_allclose(s["x"], [0.0, 1.0, 2.0], atol=1e-2)
@@ -437,6 +446,7 @@ class TestMeanVianSweep:
         da = _make_distribution_array(comps)
         m = mean(da)
         from probpipe import RecordArray
+
         assert isinstance(m, RecordArray)
         assert m.batch_shape == (3,)
         np.testing.assert_allclose(m["x"], [0.0, 1.0, 2.0])
@@ -445,8 +455,7 @@ class TestMeanVianSweep:
 
 class TestVarianceViaSweep:
     def test_scalar_components_variance(self):
-        comps = [Normal(loc=0.0, scale=float(i + 1), name=f"d{i}")
-                 for i in range(3)]
+        comps = [Normal(loc=0.0, scale=float(i + 1), name=f"d{i}") for i in range(3)]
         da = _make_distribution_array(comps)
         v = variance(da)
         assert isinstance(v, NumericRecordArray)
@@ -475,8 +484,7 @@ class TestLogProbViaSweep:
         # Cell i evaluates Normal(i, 1) at 0 → gaussian log-density at
         # distance ``i`` from the mean.
         expected = jnp.array(
-            [Normal(loc=float(i), scale=1.0, name=f"d{i}")._log_prob(0.0)
-             for i in range(3)]
+            [Normal(loc=float(i), scale=1.0, name=f"d{i}")._log_prob(0.0) for i in range(3)]
         )
         np.testing.assert_allclose(lp["log_prob"], expected, rtol=1e-5)
 
@@ -515,6 +523,7 @@ class TestBackendDelegatedStorage:
 
     def _make_backend(self, n=5):
         from probpipe import Normal
+
         return Normal._make_array_backend(
             name="x",
             batch_shape=(n,),
@@ -524,6 +533,7 @@ class TestBackendDelegatedStorage:
 
     def test_from_backend_returns_distribution_array(self):
         from probpipe import DistributionArray
+
         backend = self._make_backend(n=5)
         da = DistributionArray._from_backend(backend, name="batched_x")
         assert isinstance(da, DistributionArray)
@@ -535,6 +545,7 @@ class TestBackendDelegatedStorage:
 
     def test_from_backend_does_not_materialise_components_eagerly(self):
         from probpipe import DistributionArray
+
         backend = self._make_backend(n=5)
         da = DistributionArray._from_backend(backend, name="x")
         # Components stay None until first .components access; the
@@ -543,6 +554,7 @@ class TestBackendDelegatedStorage:
 
     def test_indexing_routes_through_backend_cell(self):
         from probpipe import DistributionArray, Normal
+
         backend = self._make_backend(n=5)
         da = DistributionArray._from_backend(backend, name="x")
         # Each int access fabricates fresh; identity differs.
@@ -558,6 +570,7 @@ class TestBackendDelegatedStorage:
 
     def test_flat_component_routes_through_backend_cell(self):
         from probpipe import DistributionArray, Normal
+
         backend = self._make_backend(n=4)
         da = DistributionArray._from_backend(backend, name="x")
         for i in range(4):
@@ -568,6 +581,7 @@ class TestBackendDelegatedStorage:
 
     def test_iteration_lazy_via_backend(self):
         from probpipe import DistributionArray, Normal
+
         backend = self._make_backend(n=4)
         da = DistributionArray._from_backend(backend, name="x")
         cells = list(da)
@@ -581,6 +595,7 @@ class TestBackendDelegatedStorage:
 
     def test_components_property_materialises_lazily_and_caches(self):
         from probpipe import DistributionArray
+
         backend = self._make_backend(n=3)
         da = DistributionArray._from_backend(backend, name="x")
         c1 = da.components
@@ -594,6 +609,7 @@ class TestBackendDelegatedStorage:
 
     def test_slice_indexing_materialises_components(self):
         from probpipe import DistributionArray
+
         backend = self._make_backend(n=5)
         da = DistributionArray._from_backend(backend, name="x")
         sub = da[1:4]
@@ -604,6 +620,7 @@ class TestBackendDelegatedStorage:
 
     def test_repr_indicates_backend_mode(self):
         from probpipe import DistributionArray
+
         backend = self._make_backend(n=3)
         backed = DistributionArray._from_backend(backend, name="x")
         assert "backend=True" in repr(backed)
@@ -612,6 +629,7 @@ class TestBackendDelegatedStorage:
         """Construction via the explicit components list still works
         identically — no _backend, eager _components tuple."""
         from probpipe import DistributionArray, Normal
+
         comps = [Normal(loc=float(i), scale=1.0, name=f"c_{i}") for i in range(3)]
         da = DistributionArray(comps, name="literal")
         assert da._backend is None
@@ -621,9 +639,13 @@ class TestBackendDelegatedStorage:
 
     def test_multi_d_batch_shape_via_backend(self):
         from probpipe import DistributionArray, Normal
+
         loc = jnp.arange(6.0).reshape(2, 3)
         backend = Normal._make_array_backend(
-            name="g", batch_shape=(2, 3), loc=loc, scale=1.0,
+            name="g",
+            batch_shape=(2, 3),
+            loc=loc,
+            scale=1.0,
         )
         da = DistributionArray._from_backend(backend, name="g")
         assert da.batch_shape == (2, 3)
@@ -643,8 +665,12 @@ class TestFromBatchedParams:
     def test_normal_uses_tfp_backend(self):
         from probpipe import Normal, DistributionArray
         from probpipe.distributions._tfp_base import _TFPArrayBackend
+
         da = DistributionArray.from_batched_params(
-            Normal, loc=jnp.arange(5.0), scale=1.0, name="x",
+            Normal,
+            loc=jnp.arange(5.0),
+            scale=1.0,
+            name="x",
         )
         assert isinstance(da, DistributionArray)
         assert isinstance(da._backend, _TFPArrayBackend)
@@ -654,8 +680,12 @@ class TestFromBatchedParams:
 
     def test_per_cell_name_auto_suffix(self):
         from probpipe import Normal, DistributionArray
+
         da = DistributionArray.from_batched_params(
-            Normal, loc=jnp.arange(3.0), scale=jnp.ones(3), name="weights",
+            Normal,
+            loc=jnp.arange(3.0),
+            scale=jnp.ones(3),
+            name="weights",
         )
         assert da[0].name == "weights_0"
         assert da[1].name == "weights_1"
@@ -663,35 +693,49 @@ class TestFromBatchedParams:
 
     def test_per_cell_params_correctly_sliced(self):
         from probpipe import Normal, DistributionArray
+
         da = DistributionArray.from_batched_params(
-            Normal, loc=jnp.arange(4.0), scale=jnp.linspace(0.1, 0.4, 4),
+            Normal,
+            loc=jnp.arange(4.0),
+            scale=jnp.linspace(0.1, 0.4, 4),
             name="x",
         )
         for i in range(4):
             cell = da[i]
             assert float(cell.loc) == float(i)
             np.testing.assert_allclose(
-                float(cell.scale), 0.1 + 0.1 * i, atol=1e-6,
+                float(cell.scale),
+                0.1 + 0.1 * i,
+                atol=1e-6,
             )
 
     def test_scalar_param_broadcasts_through_cells(self):
         from probpipe import Normal, DistributionArray
+
         da = DistributionArray.from_batched_params(
-            Normal, loc=jnp.zeros(3), scale=2.5, name="x",
+            Normal,
+            loc=jnp.zeros(3),
+            scale=2.5,
+            name="x",
         )
         for i in range(3):
             assert float(da[i].scale) == 2.5
 
     def test_inferred_batch_shape_uses_broadcast(self):
         from probpipe import Normal, DistributionArray
+
         # Both arrays imply batch_shape=(4,) — broadcast convention.
         da = DistributionArray.from_batched_params(
-            Normal, loc=jnp.arange(4.0), scale=jnp.ones(4), name="x",
+            Normal,
+            loc=jnp.arange(4.0),
+            scale=jnp.ones(4),
+            name="x",
         )
         assert da.batch_shape == (4,)
 
     def test_explicit_batch_shape_honored(self):
         from probpipe import Normal, DistributionArray
+
         da = DistributionArray.from_batched_params(
             Normal,
             batch_shape=(2, 3),
@@ -706,9 +750,13 @@ class TestFromBatchedParams:
 
     def test_no_array_params_requires_explicit_batch_shape(self):
         from probpipe import Normal, DistributionArray
+
         with pytest.raises(ValueError, match="batch_shape"):
             DistributionArray.from_batched_params(
-                Normal, loc=0.0, scale=1.0, name="x",
+                Normal,
+                loc=0.0,
+                scale=1.0,
+                name="x",
             )
 
     def test_multivariate_normal_via_factory(self):
@@ -717,6 +765,7 @@ class TestFromBatchedParams:
         ``(*batch, d)``, ``scale_tril`` is ``(*batch, d, d)``)."""
         from probpipe import MultivariateNormal, DistributionArray
         from probpipe.distributions._tfp_base import _TFPArrayBackend
+
         d = 3
         da = DistributionArray.from_batched_params(
             MultivariateNormal,
@@ -734,6 +783,7 @@ class TestFromBatchedParams:
         """Without explicit ``batch_shape``, MVN-style heterogeneous
         event-rank params raise a clear ``ValueError``."""
         from probpipe import MultivariateNormal, DistributionArray
+
         d = 3
         with pytest.raises(ValueError, match="batch_shape"):
             DistributionArray.from_batched_params(
@@ -765,7 +815,9 @@ class TestFromBatchedParams:
                 return ()
 
         da = DistributionArray.from_batched_params(
-            MyDist, value=jnp.arange(3.0), name="m",
+            MyDist,
+            value=jnp.arange(3.0),
+            name="m",
         )
         # Fallback path: literal components, no backend.
         assert da._backend is None
@@ -787,24 +839,24 @@ class TestFromBatchedParams:
         """
         from probpipe import Normal, DistributionArray
         import tensorflow_probability.substrates.jax.distributions as tfd
+
         loc = jnp.array([0.5, -1.2, 3.7, 0.0])
         scale = jnp.array([0.1, 0.2, 0.3, 0.4])
 
         native = tfd.Normal(loc=loc, scale=scale)
         da = DistributionArray.from_batched_params(
-            Normal, loc=loc, scale=scale, name="x",
+            Normal,
+            loc=loc,
+            scale=scale,
+            name="x",
         )
         # Sample shapes match.
         key = jax.random.PRNGKey(42)
         native_samples = native.sample(seed=key)
         da_samples = da._backend._sample(key)
-        np.testing.assert_allclose(
-            np.asarray(native_samples), np.asarray(da_samples)
-        )
+        np.testing.assert_allclose(np.asarray(native_samples), np.asarray(da_samples))
         # Mean / variance match.
-        np.testing.assert_allclose(
-            np.asarray(native.mean()), np.asarray(da._backend._mean())
-        )
+        np.testing.assert_allclose(np.asarray(native.mean()), np.asarray(da._backend._mean()))
         np.testing.assert_allclose(
             np.asarray(native.variance()),
             np.asarray(da._backend._variance()),
@@ -812,8 +864,12 @@ class TestFromBatchedParams:
 
     def test_iteration_matches_indexing(self):
         from probpipe import Normal, DistributionArray
+
         da = DistributionArray.from_batched_params(
-            Normal, loc=jnp.arange(4.0), scale=jnp.ones(4), name="x",
+            Normal,
+            loc=jnp.arange(4.0),
+            scale=jnp.ones(4),
+            name="x",
         )
         for i, cell in enumerate(da):
             assert float(cell.loc) == float(da[i].loc)
@@ -833,7 +889,9 @@ class TestDistributionFromBatchedParamsAlias:
         from probpipe.distributions._tfp_base import _TFPArrayBackend
 
         da = Normal.from_batched_params(
-            loc=jnp.arange(5.0), scale=1.0, name="x",
+            loc=jnp.arange(5.0),
+            scale=1.0,
+            name="x",
         )
         assert isinstance(da, DistributionArray)
         assert isinstance(da._backend, _TFPArrayBackend)
@@ -842,14 +900,20 @@ class TestDistributionFromBatchedParamsAlias:
 
     def test_alias_matches_classmethod_call(self):
         from probpipe import Normal, DistributionArray
+
         loc = jnp.arange(4.0)
         scale = jnp.linspace(0.1, 0.4, 4)
 
         via_alias = Normal.from_batched_params(
-            loc=loc, scale=scale, name="x",
+            loc=loc,
+            scale=scale,
+            name="x",
         )
         via_factory = DistributionArray.from_batched_params(
-            Normal, loc=loc, scale=scale, name="x",
+            Normal,
+            loc=loc,
+            scale=scale,
+            name="x",
         )
         # Same backend type, same per-cell parameters / names.
         assert type(via_alias._backend) is type(via_factory._backend)
@@ -863,17 +927,21 @@ class TestDistributionFromBatchedParamsAlias:
     def test_alias_inherited_by_all_distribution_subclasses(self):
         from probpipe.core._distribution_base import Distribution
         from probpipe import (
-            Normal, Beta, Gamma, MultivariateNormal,
+            Normal,
+            Beta,
+            Gamma,
+            MultivariateNormal,
             EmpiricalDistribution,
         )
+
         # Every Distribution subclass inherits the alias.
-        for cls in (Distribution, Normal, Beta, Gamma,
-                    MultivariateNormal, EmpiricalDistribution):
+        for cls in (Distribution, Normal, Beta, Gamma, MultivariateNormal, EmpiricalDistribution):
             assert hasattr(cls, "from_batched_params")
             assert callable(cls.from_batched_params)
 
     def test_alias_with_explicit_batch_shape(self):
         from probpipe import MultivariateNormal
+
         d = 3
         da = MultivariateNormal.from_batched_params(
             batch_shape=(2,),

--- a/tests/core/test_distribution_base.py
+++ b/tests/core/test_distribution_base.py
@@ -22,8 +22,10 @@ from probpipe.distributions.kde import KDEDistribution
 
 def _make_transformed():
     import tensorflow_probability.substrates.jax.bijectors as tfb
+
     return TransformedDistribution(
-        Normal(loc=0.0, scale=1.0, name="x"), tfb.Exp(),
+        Normal(loc=0.0, scale=1.0, name="x"),
+        tfb.Exp(),
     )
 
 
@@ -128,7 +130,9 @@ class TestRenamedSampling:
         n2 = n.renamed("z")
         x = jnp.asarray(1.23)
         np.testing.assert_allclose(
-            float(n._log_prob(x)), float(n2._log_prob(x)), atol=1e-6,
+            float(n._log_prob(x)),
+            float(n2._log_prob(x)),
+            atol=1e-6,
         )
 
     def test_event_shape_matches(self):
@@ -165,24 +169,29 @@ class TestNoBatchShape:
 
     def test_no_batch_shape_on_base_class(self):
         from probpipe import Distribution
+
         assert not hasattr(Distribution, "batch_shape")
 
     @pytest.mark.parametrize(
-        "make_dist", _NO_BATCH_SHAPE_DISTS,
+        "make_dist",
+        _NO_BATCH_SHAPE_DISTS,
     )
     def test_no_batch_shape_on_instance(self, make_dist):
         dist = make_dist()
         assert not hasattr(dist, "batch_shape"), (
-            f"{type(dist).__name__} unexpectedly exposes a "
-            f"batch_shape attribute."
+            f"{type(dist).__name__} unexpectedly exposes a batch_shape attribute."
         )
 
     def test_distribution_array_keeps_batch_shape(self):
         """Container types are unaffected: ``DistributionArray``
         retains its own ``batch_shape`` (the array's outer shape)."""
         from probpipe import DistributionArray
+
         da = DistributionArray.from_batched_params(
-            Normal, loc=jnp.zeros(5), scale=1.0, name="x",
+            Normal,
+            loc=jnp.zeros(5),
+            scale=1.0,
+            name="x",
         )
         assert da.batch_shape == (5,)
 
@@ -280,7 +289,10 @@ class TestRenamedTemplateRoundtrip:
         import jax.numpy as jnp
 
         jg = JointGaussian(
-            mean=jnp.zeros(2), cov=jnp.eye(2), x=1, y=1,
+            mean=jnp.zeros(2),
+            cov=jnp.eye(2),
+            x=1,
+            y=1,
         )
         original_fields = jg.event_template.fields
         clone = jg.renamed("renamed_jg")

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -319,6 +319,7 @@ class TestFromRecord:
 
     def test_roundtrip_flat_size(self):
         from probpipe.core._numeric_record import NumericRecord
+
         r = NumericRecord(a=1.0, b=jnp.zeros(4), c=jnp.zeros((2, 3)))
         tpl = EventTemplate.from_record(r)
         # Auto-promoted to NumericEventTemplate because the input was a
@@ -333,6 +334,7 @@ class TestFromRecord:
         that needs ``flat_size`` keeps working without the caller having
         to name the subclass explicitly."""
         from probpipe.core._numeric_record import NumericRecord
+
         r = NumericRecord(a=1.0, b=jnp.zeros(2))
         tpl = EventTemplate.from_record(r)
         assert isinstance(tpl, NumericEventTemplate)
@@ -360,6 +362,7 @@ class TestFromRecord:
         """The opposite end of the list-leaf story: wrapping the list
         in ``np.asarray`` produces a numeric template entry."""
         import numpy as np
+
         r = Record(xs=np.asarray([1.0, 2.0, 3.0]))
         tpl = EventTemplate.from_record(r)
         assert tpl["xs"] == ArraySpec((3,))
@@ -467,9 +470,7 @@ class TestLeafSpecs:
         assert DistributionSpec(inner_template=inner) == DistributionSpec(inner_template=inner)
         assert FunctionSpec(
             input_template=EventTemplate(x=()), output_template=EventTemplate(y=())
-        ) == FunctionSpec(
-            input_template=EventTemplate(x=()), output_template=EventTemplate(y=())
-        )
+        ) == FunctionSpec(input_template=EventTemplate(x=()), output_template=EventTemplate(y=()))
 
     def test_array_and_opaque_specs_are_distinct(self):
         assert ArraySpec(()) != OpaqueSpec()
@@ -553,9 +554,7 @@ class TestAutoPromotionSpecs:
 
     def test_numeric_rejects_distribution_spec(self):
         with pytest.raises(TypeError, match="non-numeric"):
-            NumericEventTemplate(
-                x=(), d=DistributionSpec(inner_template=EventTemplate(a=()))
-            )
+            NumericEventTemplate(x=(), d=DistributionSpec(inner_template=EventTemplate(a=())))
 
     def test_numeric_rejects_function_spec(self):
         with pytest.raises(TypeError, match="non-numeric"):

--- a/tests/core/test_expectation.py
+++ b/tests/core/test_expectation.py
@@ -81,7 +81,6 @@ class TestBootstrapDistribution:
         assert mean(bd).shape == (3,)
 
 
-
 # ---------------------------------------------------------------------------
 # Expectation — returns BootstrapDistribution by default
 # ---------------------------------------------------------------------------
@@ -148,8 +147,8 @@ class TestExpectationSampleBased:
         loc, scale = 2.0, 1.5
         d = Normal(loc=loc, scale=scale, name="x")
         key = jax.random.PRNGKey(1)
-        result = expectation(d, lambda x: x ** 2, key=key, num_evaluations=10_000, return_dist=False)
-        expected = loc ** 2 + scale ** 2
+        result = expectation(d, lambda x: x**2, key=key, num_evaluations=10_000, return_dist=False)
+        expected = loc**2 + scale**2
         # Second moment has higher variance than first moment (kurtosis effect)
         np.testing.assert_allclose(float(result), expected, atol=0.15)
 
@@ -158,9 +157,9 @@ class TestExpectationSampleBased:
         d = Normal(loc=loc, scale=scale, name="x")
         key1, key2 = jax.random.split(jax.random.PRNGKey(2))
         ex = expectation(d, lambda x: x, key=key1, num_evaluations=10_000, return_dist=False)
-        ex2 = expectation(d, lambda x: x ** 2, key=key2, num_evaluations=10_000, return_dist=False)
+        ex2 = expectation(d, lambda x: x**2, key=key2, num_evaluations=10_000, return_dist=False)
         var_est = float(ex2) - float(ex) ** 2
-        np.testing.assert_allclose(var_est, scale ** 2, atol=0.15)
+        np.testing.assert_allclose(var_est, scale**2, atol=0.15)
 
     def test_gamma_mean(self):
         conc, rate = 3.0, 2.0
@@ -173,7 +172,9 @@ class TestExpectationSampleBased:
         conc, rate = 3.0, 2.0
         d = Gamma(concentration=conc, rate=rate, name="x")
         key = jax.random.PRNGKey(4)
-        result = expectation(d, lambda x: jnp.log(x), key=key, num_evaluations=20_000, return_dist=False)
+        result = expectation(
+            d, lambda x: jnp.log(x), key=key, num_evaluations=20_000, return_dist=False
+        )
         expected = float(jsp.digamma(conc)) - float(jnp.log(rate))
         np.testing.assert_allclose(float(result), expected, atol=0.05)
 
@@ -188,7 +189,9 @@ class TestExpectationSampleBased:
         a, b = 2.0, 5.0
         d = Beta(alpha=a, beta=b, name="x")
         key = jax.random.PRNGKey(6)
-        result = expectation(d, lambda x: jnp.log(x), key=key, num_evaluations=20_000, return_dist=False)
+        result = expectation(
+            d, lambda x: jnp.log(x), key=key, num_evaluations=20_000, return_dist=False
+        )
         expected = float(jsp.digamma(a)) - float(jsp.digamma(a + b))
         np.testing.assert_allclose(float(result), expected, atol=0.05)
 
@@ -196,8 +199,8 @@ class TestExpectationSampleBased:
         rate = 3.0
         d = Exponential(rate=rate, name="x")
         key = jax.random.PRNGKey(7)
-        result = expectation(d, lambda x: x ** 2, key=key, num_evaluations=10_000, return_dist=False)
-        np.testing.assert_allclose(float(result), 2.0 / rate ** 2, atol=0.03)
+        result = expectation(d, lambda x: x**2, key=key, num_evaluations=10_000, return_dist=False)
+        np.testing.assert_allclose(float(result), 2.0 / rate**2, atol=0.03)
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +209,6 @@ class TestExpectationSampleBased:
 
 
 class TestExpectationExact:
-
     def test_bernoulli_identity(self):
         p = 0.7
         d = Bernoulli(probs=p, name="x")
@@ -229,7 +231,7 @@ class TestExpectationExact:
     def test_categorical_custom_function(self):
         probs = [0.25, 0.5, 0.25]
         d = Categorical(probs=probs, name="x")
-        result = expectation(d, lambda x: x ** 2)
+        result = expectation(d, lambda x: x**2)
         expected = 0 * 0.25 + 1 * 0.5 + 4 * 0.25
         np.testing.assert_allclose(float(result), expected, atol=1e-5)
 
@@ -242,7 +244,7 @@ class TestExpectationExact:
     def test_binomial_second_moment(self):
         n, p = 10, 0.3
         d = Binomial(total_count=n, probs=p, name="x")
-        result = expectation(d, lambda x: x ** 2)
+        result = expectation(d, lambda x: x**2)
         expected = n * p * (1 - p) + (n * p) ** 2
         np.testing.assert_allclose(float(result), expected, atol=1e-3)
 
@@ -253,7 +255,6 @@ class TestExpectationExact:
 
 
 class TestExpectationEmpirical:
-
     def test_uniform_mean(self):
         samples = jnp.array([1.0, 2.0, 3.0, 4.0])
         d = EmpiricalDistribution(samples, name="x")
@@ -271,7 +272,7 @@ class TestExpectationEmpirical:
         samples = jnp.array([1.0, 2.0, 3.0])
         weights = jnp.array([0.2, 0.5, 0.3])
         d = EmpiricalDistribution(samples, weights=weights, name="x")
-        result = expectation(d, lambda x: x ** 2)
+        result = expectation(d, lambda x: x**2)
         expected = 0.2 * 1.0 + 0.5 * 4.0 + 0.3 * 9.0
         np.testing.assert_allclose(float(result), expected, atol=1e-5)
 
@@ -302,7 +303,6 @@ class TestExpectationEmpirical:
 
 
 class TestBootstrapErrorTracking:
-
     def test_variance_decreases_with_n(self):
         """More evaluations → smaller MC error variance."""
         d = Normal(loc=0.0, scale=1.0, name="x")
@@ -356,7 +356,6 @@ class TestMCFallbackMethods:
 
 
 class TestIsApproximate:
-
     def test_tfp_distribution_exact(self):
         assert not Normal(loc=0.0, scale=1.0, name="x").is_approximate
         assert not Gamma(concentration=1.0, rate=1.0, name="x").is_approximate
@@ -402,7 +401,6 @@ class TestIsApproximate:
 
 
 class TestGlobalDefaults:
-
     def test_set_default_num_evaluations(self):
         old = dist_mod.DEFAULT_NUM_EVALUATIONS
         try:
@@ -461,7 +459,7 @@ class _MCNormalDist(SupportsExpectation):
 
     @compute_expectation
     def _second_moment(self):
-        return lambda x: x ** 2
+        return lambda x: x**2
 
 
 class TestComputeExpectationDecorator:

--- a/tests/core/test_iteration_protocol.py
+++ b/tests/core/test_iteration_protocol.py
@@ -13,6 +13,7 @@ The rule (codified in STYLE_GUIDE.md §1.11):
   samples on ``.samples`` / ``.draws()`` with ``.n`` reporting the
   count; parametric distributions do not have ``.n``.
 """
+
 from __future__ import annotations
 
 import jax
@@ -51,8 +52,11 @@ def _make_transformed():
     enough to warrant deferring.
     """
     import tensorflow_probability.substrates.jax.bijectors as tfb
+
     return TransformedDistribution(
-        Normal(loc=0.0, scale=1.0, name="base"), tfb.Exp(), name="td",
+        Normal(loc=0.0, scale=1.0, name="base"),
+        tfb.Exp(),
+        name="td",
     )
 
 
@@ -69,7 +73,9 @@ DISTRIBUTIONS = [
     pytest.param(lambda: Gamma(concentration=2.0, rate=1.0, name="x"), id="Gamma"),
     pytest.param(
         lambda: MultivariateNormal(
-            loc=jnp.zeros(3), cov=jnp.eye(3), name="x",
+            loc=jnp.zeros(3),
+            cov=jnp.eye(3),
+            name="x",
         ),
         id="MultivariateNormal",
     ),
@@ -90,19 +96,22 @@ DISTRIBUTIONS = [
     ),
     pytest.param(
         lambda: EmpiricalDistribution(
-            jnp.zeros((10, 3)), name="theta",
+            jnp.zeros((10, 3)),
+            name="theta",
         ),
         id="RecordEmpiricalDistribution",
     ),
     pytest.param(
         lambda: BootstrapReplicateDistribution(
-            jnp.zeros((10, 2)), name="obs",
+            jnp.zeros((10, 2)),
+            name="obs",
         ),
         id="RecordBootstrapReplicateDistribution",
     ),
     pytest.param(
         lambda: BootstrapReplicateDistribution(
-            Normal(loc=0.0, scale=1.0, name="x"), replicate_size=5,
+            Normal(loc=0.0, scale=1.0, name="x"),
+            replicate_size=5,
         ),
         id="BootstrapReplicateDistribution_sampleable",
     ),
@@ -123,6 +132,7 @@ DISTRIBUTIONS = [
 def _make_minibatched_distribution():
     """Build a MinibatchedDistribution at parametrise time."""
     import tensorflow_probability.substrates.jax.glm as tfp_glm
+
     X = jnp.eye(4)
     y = jnp.array([1.0, 0.0, 1.0, 0.0])
     prior = MultivariateNormal(loc=jnp.zeros(4), cov=jnp.eye(4), name="theta")
@@ -174,6 +184,7 @@ def test_numeric_record_iterates_field_names():
 
 def test_record_array_iterates_field_names():
     from probpipe.core.record import EventTemplate
+
     ra = RecordArray(
         a=jnp.zeros((5,)),
         b=jnp.zeros((5,)),
@@ -185,6 +196,7 @@ def test_record_array_iterates_field_names():
 
 def test_numeric_record_array_iterates_field_names():
     from probpipe.core.record import NumericEventTemplate
+
     nra = NumericRecordArray(
         a=jnp.zeros((4,)),
         b=jnp.zeros((4,)),

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -109,9 +109,7 @@ class TestKwargFormSimpleModel:
             def log_likelihood(self, params, data):
                 return jnp.asarray(0.0)
 
-        prior = ProductDistribution(
-            Normal(0.0, 1.0, name="a"), Normal(0.0, 1.0, name="b")
-        )
+        prior = ProductDistribution(Normal(0.0, 1.0, name="a"), Normal(0.0, 1.0, name="b"))
         model = SimpleModel(prior, _NoTemplateLikelihood(), name="m")
         with pytest.raises(TypeError, match="no named data fields"):
             log_prob(model, a=0.5, b=0.5)
@@ -130,9 +128,7 @@ class TestKwargFormSimpleModel:
                 # params is the bare scalar from the single-field prior
                 return -0.5 * jnp.sum((data["y"] - params) ** 2)
 
-        model = SimpleModel(
-            Normal(0.0, 1.0, name="theta"), _ScalarLikelihood(), name="m"
-        )
+        model = SimpleModel(Normal(0.0, 1.0, name="theta"), _ScalarLikelihood(), name="m")
         y = jnp.array([0.2, -0.1, 0.4])
         kw = log_prob(model, theta=0.5, y=y)
         rec = log_prob(model, Record(theta=0.5, y=y))
@@ -164,6 +160,7 @@ class TestStanViewsPackValue:
     @pytest.fixture(params=["StanModel", "_UnconstrainedStanView"])
     def stan_view(self, request):
         from probpipe.modeling import _stan
+
         names = ["mu", "theta.1", "theta.2", "theta.3"]
         base = object.__new__(_stan.StanModel)
         base._bs_model = self._FakeBS(names)
@@ -214,9 +211,7 @@ class TestProbAndUnnormalizedKwargForm:
 
     def test_unnormalized_log_prob_kwarg(self):
         d = Normal(0.0, 1.0, name="x")
-        assert jnp.allclose(
-            unnormalized_log_prob(d, x=1.2), unnormalized_log_prob(d, 1.2)
-        )
+        assert jnp.allclose(unnormalized_log_prob(d, x=1.2), unnormalized_log_prob(d, 1.2))
 
     def test_unnormalized_prob_kwarg(self):
         d = Normal(0.0, 1.0, name="x")
@@ -274,6 +269,7 @@ class TestControlsViaWithOptions:
         # No wrapper: log_prob *is* a WorkflowFunction, so with_options is its
         # own bound method — not a re-implementation.
         from probpipe.core.node import WorkflowFunction
+
         assert isinstance(log_prob, WorkflowFunction)
         assert log_prob.with_options.__self__ is log_prob
 
@@ -341,6 +337,7 @@ class TestRandomMeasureKwargForm:
     @staticmethod
     def _measure():
         import tensorflow_probability.substrates.jax.glm as tfp_glm
+
         X = jnp.eye(4)
         y = jnp.array([1.0, 0.0, 1.0, 0.0])
         prior = MultivariateNormal(loc=jnp.zeros(4), cov=jnp.eye(4), name="theta")

--- a/tests/core/test_numeric_record.py
+++ b/tests/core/test_numeric_record.py
@@ -35,10 +35,12 @@ class TestConstruction:
     def test_bool_accepted(self):
         """Python ``bool`` is a numeric leaf (JAX treats it as dtype bool)."""
         import jax.numpy as jnp
+
         v = NumericRecord(flag=True)
         assert v["flag"].dtype == jnp.bool_
         # ``bool`` array fields also work.
         import numpy as np
+
         v2 = NumericRecord(mask=np.array([True, False, True]))
         assert v2["mask"].dtype == jnp.bool_
 
@@ -92,7 +94,9 @@ class TestConstruction:
         metadata."""
         xr = pytest.importorskip("xarray")
         da = xr.DataArray(
-            [1.0, 2.0, 3.0], dims=["time"], coords={"time": [10, 20, 30]},
+            [1.0, 2.0, 3.0],
+            dims=["time"],
+            coords={"time": [10, 20, 30]},
         )
         nr = NumericRecord(y=da)
         assert isinstance(nr["y"], jnp.ndarray)
@@ -140,10 +144,12 @@ class TestConstruction:
         the two validation sites drift silently — this test pins down
         that they consume the same frozenset."""
         from probpipe.core._numeric_record import _NUMERIC_DTYPE_KINDS
+
         assert _NUMERIC_DTYPE_KINDS == frozenset("biufc")
         # Import path is also the import path used by
         # NumericRecordArray._validate_fields (see _record_array.py).
         from probpipe.core import _record_array
+
         assert _record_array._NUMERIC_DTYPE_KINDS is _NUMERIC_DTYPE_KINDS
 
 
@@ -189,6 +195,7 @@ class TestFlattenUnflatten:
 
     def test_roundtrip_nested_template(self):
         from probpipe.core.record import NumericEventTemplate
+
         inner_tpl = NumericEventTemplate(x=(), y=(2,))
         outer_tpl = NumericEventTemplate(params=inner_tpl, z=(3,))
         flat = jnp.arange(6.0)  # x=0, y=[1,2], z=[3,4,5]

--- a/tests/core/test_numeric_record_distribution_view.py
+++ b/tests/core/test_numeric_record_distribution_view.py
@@ -133,10 +133,10 @@ class TestSampling:
         rec_draw = rec._sample(key)
         flat_draw = mvn4._sample(key)
         ref = NumericRecord.unflatten(flat_draw, template=split_template)
-        np.testing.assert_allclose(jnp.asarray(rec_draw["intercept"]),
-                                   jnp.asarray(ref["intercept"]))
-        np.testing.assert_allclose(jnp.asarray(rec_draw["slope"]),
-                                   jnp.asarray(ref["slope"]))
+        np.testing.assert_allclose(
+            jnp.asarray(rec_draw["intercept"]), jnp.asarray(ref["intercept"])
+        )
+        np.testing.assert_allclose(jnp.asarray(rec_draw["slope"]), jnp.asarray(ref["slope"]))
 
     def test_chain_flatten_then_lift_on_product(self):
         """``ProductDistribution.as_flat_distribution().as_record_distribution(...)``
@@ -186,7 +186,9 @@ class TestLogProb:
         key = jax.random.PRNGKey(5)
         flat_xs = mvn4._sample(key, sample_shape=(10,))
         rec_xs = NumericRecordArray.unflatten(
-            flat_xs, template=split_template, batch_shape=(10,),
+            flat_xs,
+            template=split_template,
+            batch_shape=(10,),
         )
         lp_rec = jnp.asarray(log_prob(rec, rec_xs))
         lp_flat = jnp.asarray(log_prob(mvn4, flat_xs))
@@ -201,15 +203,13 @@ class TestMoments:
         rec = mvn4.as_record_distribution(template=split_template)
         m = mean(rec)
         np.testing.assert_allclose(jnp.asarray(m["intercept"]), 1.0, rtol=1e-5)
-        np.testing.assert_allclose(jnp.asarray(m["slope"]),
-                                   jnp.array([-1.0, 2.0, 0.5]), rtol=1e-5)
+        np.testing.assert_allclose(jnp.asarray(m["slope"]), jnp.array([-1.0, 2.0, 0.5]), rtol=1e-5)
 
     def test_variance_unflattens(self, mvn4, split_template):
         rec = mvn4.as_record_distribution(template=split_template)
         v = variance(rec)
         np.testing.assert_allclose(jnp.asarray(v["intercept"]), 0.5, rtol=1e-5)
-        np.testing.assert_allclose(jnp.asarray(v["slope"]),
-                                   jnp.array([1.0, 1.5, 2.0]), rtol=1e-5)
+        np.testing.assert_allclose(jnp.asarray(v["slope"]), jnp.array([1.0, 1.5, 2.0]), rtol=1e-5)
 
     def test_cov_stays_flat(self, mvn4, split_template):
         """cov(rec) is the same (event_size, event_size) matrix as cov(source)."""
@@ -232,14 +232,17 @@ class TestMoments:
             return r["intercept"] ** 2 + jnp.sum(r["slope"] ** 2)
 
         est = expectation(
-            rec, f, key=jax.random.PRNGKey(0),
-            num_evaluations=5000, return_dist=False,
+            rec,
+            f,
+            key=jax.random.PRNGKey(0),
+            num_evaluations=5000,
+            return_dist=False,
         )
         # E[X^2] = loc^2 + var per coordinate. 5k samples puts MC SE
         # around ~0.15 for these parameters; atol=0.2 stays meaningful.
         loc = jnp.array([1.0, -1.0, 2.0, 0.5])
         var = jnp.array([0.5, 1.0, 1.5, 2.0])
-        analytic = float(jnp.sum(loc ** 2 + var))
+        analytic = float(jnp.sum(loc**2 + var))
         np.testing.assert_allclose(float(jnp.asarray(est)), analytic, atol=0.2)
 
 
@@ -379,5 +382,3 @@ class TestLiftFromOtherFlatParametrics:
         draw = sample(rec, key=jax.random.PRNGKey(0))
         # Simplex invariant must survive the lift.
         np.testing.assert_allclose(float(jnp.sum(draw["probs"])), 1.0, rtol=1e-5)
-
-

--- a/tests/core/test_ops.py
+++ b/tests/core/test_ops.py
@@ -22,6 +22,7 @@ from probpipe.core import ops
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def normal():
     return Normal(loc=2.0, scale=0.5, name="x")
@@ -46,6 +47,7 @@ def joint():
 # ---------------------------------------------------------------------------
 # sample
 # ---------------------------------------------------------------------------
+
 
 class TestSample:
     def test_sample_scalar(self, normal):
@@ -88,6 +90,7 @@ class TestSample:
 # log_prob
 # ---------------------------------------------------------------------------
 
+
 class TestLogProb:
     def test_log_prob_scalar(self, normal):
         lp = ops.log_prob(normal, jnp.array(2.0))
@@ -107,6 +110,7 @@ class TestLogProb:
 # prob
 # ---------------------------------------------------------------------------
 
+
 class TestProb:
     def test_prob_matches_scipy(self, normal):
         """prob(Normal, x) must match scipy.stats.norm.pdf — independent baseline."""
@@ -119,6 +123,7 @@ class TestProb:
 # ---------------------------------------------------------------------------
 # unnormalized_log_prob
 # ---------------------------------------------------------------------------
+
 
 class TestUnnormalizedLogProb:
     def test_equals_log_prob_for_normalized(self, normal):
@@ -137,6 +142,7 @@ class TestUnnormalizedLogProb:
 # ---------------------------------------------------------------------------
 # mean
 # ---------------------------------------------------------------------------
+
 
 class TestMean:
     def test_exact_mean_normal(self, normal):
@@ -164,13 +170,18 @@ class TestMean:
         class NoMeanDist(NumericRecordDistribution, SupportsSampling, SupportsExpectation):
             _sampling_cost = "low"
             _preferred_orchestration = None
+
             @property
             def event_shape(self):
                 return ()
+
             def _sample(self, key, sample_shape=()):
                 return jax.random.normal(key, sample_shape)
+
             def _expectation(self, f, *, key=None, num_evaluations=None, return_dist=None):
-                return _mc_expectation(self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist)
+                return _mc_expectation(
+                    self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist
+                )
 
         with pytest.raises(TypeError, match="does not support mean"):
             ops.mean(NoMeanDist(name="test"))
@@ -179,6 +190,7 @@ class TestMean:
 # ---------------------------------------------------------------------------
 # variance
 # ---------------------------------------------------------------------------
+
 
 class TestVariance:
     def test_exact_variance_normal(self, normal):
@@ -194,6 +206,7 @@ class TestVariance:
 # cov
 # ---------------------------------------------------------------------------
 
+
 class TestCov:
     def test_exact_cov_empirical(self, empirical):
         c = jnp.asarray(ops.cov(empirical))
@@ -205,10 +218,12 @@ class TestCov:
 # expectation
 # ---------------------------------------------------------------------------
 
+
 class TestExpectation:
     def test_expectation_identity(self, normal):
         result = ops.expectation(
-            normal, lambda x: x,
+            normal,
+            lambda x: x,
             key=jax.random.PRNGKey(0),
             num_evaluations=5000,
             return_dist=False,
@@ -217,7 +232,8 @@ class TestExpectation:
 
     def test_expectation_returns_bootstrap(self, normal):
         result = ops.expectation(
-            normal, lambda x: x,
+            normal,
+            lambda x: x,
             key=jax.random.PRNGKey(0),
             num_evaluations=500,
             return_dist=True,
@@ -228,6 +244,7 @@ class TestExpectation:
 # ---------------------------------------------------------------------------
 # condition_on
 # ---------------------------------------------------------------------------
+
 
 class TestConditionOn:
     def test_condition_product(self, joint):
@@ -258,16 +275,16 @@ class TestConditionOn:
 # WorkflowFunction routing
 # ---------------------------------------------------------------------------
 
+
 class TestWorkflowFunctionRouting:
     """Verify public ops are WorkflowFunction instances."""
 
     def test_ops_are_workflow_functions(self):
         from probpipe.core.node import WorkflowFunction
+
         for name in ops.__all__:
             fn = getattr(ops, name)
-            assert isinstance(fn, WorkflowFunction), (
-                f"ops.{name} is not a WorkflowFunction"
-            )
+            assert isinstance(fn, WorkflowFunction), f"ops.{name} is not a WorkflowFunction"
 
     def test_public_ops_are_callable(self):
         for name in ops.__all__:
@@ -294,23 +311,28 @@ class TestWorkflowFunctionRouting:
 # Top-level imports work
 # ---------------------------------------------------------------------------
 
+
 class TestTopLevelImports:
     """Verify ops are importable from probpipe top level."""
 
     def test_import_sample(self):
         from probpipe import sample as s
+
         assert callable(s)
 
     def test_import_mean(self):
         from probpipe import mean as m
+
         assert callable(m)
 
     def test_import_log_prob(self):
         from probpipe import log_prob as lp
+
         assert callable(lp)
 
     def test_import_condition_on(self):
         from probpipe import condition_on as co
+
         assert callable(co)
 
 
@@ -318,11 +340,13 @@ class TestTopLevelImports:
 # _split_data_kwargs
 # ---------------------------------------------------------------------------
 
+
 class TestSplitDataKwargs:
     """Unit tests for the _split_data_kwargs helper."""
 
     def test_empty_kwargs(self):
         from probpipe.core.ops import _split_data_kwargs
+
         dist = ProductDistribution(x=Normal(0.0, 1.0, name="x"))
         data, inference = _split_data_kwargs(dist, {})
         assert data == {}
@@ -330,27 +354,33 @@ class TestSplitDataKwargs:
 
     def test_all_data_kwargs(self):
         from probpipe.core.ops import _split_data_kwargs
+
         dist = ProductDistribution(x=Normal(0.0, 1.0, name="x"), y=Normal(0.0, 1.0, name="y"))
         data, inference = _split_data_kwargs(
-            dist, {"x": jnp.array(1.0), "y": jnp.array(2.0)},
+            dist,
+            {"x": jnp.array(1.0), "y": jnp.array(2.0)},
         )
         assert set(data.keys()) == {"x", "y"}
         assert inference == {}
 
     def test_all_inference_kwargs(self):
         from probpipe.core.ops import _split_data_kwargs
+
         dist = ProductDistribution(x=Normal(0.0, 1.0, name="x"))
         data, inference = _split_data_kwargs(
-            dist, {"num_results": 100, "random_seed": 42},
+            dist,
+            {"num_results": 100, "random_seed": 42},
         )
         assert data == {}
         assert set(inference.keys()) == {"num_results", "random_seed"}
 
     def test_mixed_kwargs(self):
         from probpipe.core.ops import _split_data_kwargs
+
         dist = ProductDistribution(x=Normal(0.0, 1.0, name="x"), y=Normal(0.0, 1.0, name="y"))
         data, inference = _split_data_kwargs(
-            dist, {"x": jnp.array(1.0), "num_results": 100},
+            dist,
+            {"x": jnp.array(1.0), "num_results": 100},
         )
         assert set(data.keys()) == {"x"}
         assert set(inference.keys()) == {"num_results"}
@@ -358,9 +388,11 @@ class TestSplitDataKwargs:
     def test_no_fields(self):
         """Distribution without fields → all kwargs are inference."""
         from probpipe.core.ops import _split_data_kwargs
+
         dist = Normal(0.0, 1.0, name="x")
         data, inference = _split_data_kwargs(
-            dist, {"num_results": 100},
+            dist,
+            {"num_results": 100},
         )
         assert data == {}
         assert set(inference.keys()) == {"num_results"}
@@ -370,9 +402,8 @@ class TestSplitDataKwargs:
         raise with the correct casing rather than silently routing it to
         inference params (issue #228)."""
         from probpipe.core.ops import _split_data_kwargs
-        dist = ProductDistribution(
-            X=Normal(0.0, 1.0, name="X"), y=Normal(0.0, 1.0, name="y")
-        )
+
+        dist = ProductDistribution(X=Normal(0.0, 1.0, name="X"), y=Normal(0.0, 1.0, name="y"))
         with pytest.raises(TypeError, match="did you mean X"):
             _split_data_kwargs(dist, {"x": jnp.array(1.0)})
 
@@ -380,11 +411,11 @@ class TestSplitDataKwargs:
         """An unknown kwarg that is *not* a case-variant of any field is a
         genuine inference parameter — no false positive."""
         from probpipe.core.ops import _split_data_kwargs
-        dist = ProductDistribution(
-            X=Normal(0.0, 1.0, name="X"), y=Normal(0.0, 1.0, name="y")
-        )
+
+        dist = ProductDistribution(X=Normal(0.0, 1.0, name="X"), y=Normal(0.0, 1.0, name="y"))
         data, inference = _split_data_kwargs(
-            dist, {"X": jnp.array(1.0), "num_results": 100},
+            dist,
+            {"X": jnp.array(1.0), "num_results": 100},
         )
         assert set(data.keys()) == {"X"}
         assert set(inference.keys()) == {"num_results"}

--- a/tests/core/test_prefect_config.py
+++ b/tests/core/test_prefect_config.py
@@ -31,6 +31,7 @@ from probpipe.core.config import (
 # WorkflowKind enum
 # ---------------------------------------------------------------------------
 
+
 class TestWorkflowKindEnum:
     """Verify enum has the expected members and values."""
 
@@ -62,6 +63,7 @@ class TestWorkflowKindEnum:
 # ---------------------------------------------------------------------------
 # PrefectConfig singleton
 # ---------------------------------------------------------------------------
+
 
 class TestPrefectConfigDefaults:
     """Verify default values and reset behavior."""
@@ -116,6 +118,7 @@ class TestTaskRunnerAutoDetection:
     def test_returns_none_when_nothing_installed(self, monkeypatch):
         # Block both runner imports
         import builtins
+
         real_import = builtins.__import__
 
         monkeypatch.delitem(sys.modules, "prefect_ray", raising=False)
@@ -168,6 +171,7 @@ class TestTaskRunnerAutoDetection:
     def test_resolve_with_no_explicit_runner(self, monkeypatch):
         # When no explicit runner and no runner packages, resolve returns None
         import builtins
+
         real_import = builtins.__import__
 
         monkeypatch.delitem(sys.modules, "prefect_ray", raising=False)
@@ -186,6 +190,7 @@ class TestTaskRunnerAutoDetection:
 # ---------------------------------------------------------------------------
 # effective_workflow_kind resolution
 # ---------------------------------------------------------------------------
+
 
 class TestEffectiveWorkflowKind:
     """Test the resolution logic on WorkflowFunction instances."""
@@ -228,9 +233,13 @@ class TestEffectiveWorkflowKind:
             return x
 
         wf = WorkflowFunction(
-            func=noop, workflow_kind=WorkflowKind.TASK, dispatch="sequential", seed=0,
+            func=noop,
+            workflow_kind=WorkflowKind.TASK,
+            dispatch="sequential",
+            seed=0,
         )
         import probpipe.core.node as node_mod
+
         if node_mod.task is not None:
             assert wf.effective_workflow_kind is WorkflowKind.TASK
 
@@ -244,13 +253,17 @@ class TestEffectiveWorkflowKind:
             return x
 
         wf = WorkflowFunction(
-            func=noop, workflow_kind=WorkflowKind.OFF, dispatch="sequential", seed=0,
+            func=noop,
+            workflow_kind=WorkflowKind.OFF,
+            dispatch="sequential",
+            seed=0,
         )
         assert wf.effective_workflow_kind is WorkflowKind.OFF
 
     def test_explicit_task_warns_without_prefect(self, monkeypatch):
         """Per-instance TASK + Prefect missing → warning + OFF."""
         import probpipe.core.node as node_mod
+
         monkeypatch.setattr(node_mod, "task", None)
         monkeypatch.setattr(node_mod, "flow", None)
 
@@ -260,7 +273,10 @@ class TestEffectiveWorkflowKind:
             return x
 
         wf = WorkflowFunction(
-            func=noop, workflow_kind=WorkflowKind.TASK, dispatch="sequential", seed=0,
+            func=noop,
+            workflow_kind=WorkflowKind.TASK,
+            dispatch="sequential",
+            seed=0,
         )
         with pytest.warns(UserWarning, match="Prefect is not installed"):
             kind = wf.effective_workflow_kind
@@ -269,6 +285,7 @@ class TestEffectiveWorkflowKind:
     def test_global_task_falls_back_without_prefect(self, monkeypatch):
         """Global TASK + Prefect missing → OFF (graceful)."""
         import probpipe.core.node as node_mod
+
         monkeypatch.setattr(node_mod, "task", None)
         monkeypatch.setattr(node_mod, "flow", None)
 
@@ -293,6 +310,7 @@ class TestEffectiveWorkflowKind:
 
         wf = WorkflowFunction(func=noop, dispatch="sequential", seed=0)
         import probpipe.core.node as node_mod
+
         if node_mod.task is not None:
             assert wf.effective_workflow_kind is WorkflowKind.FLOW
 
@@ -309,6 +327,7 @@ class TestEffectiveWorkflowKind:
 
         prefect_config.workflow_kind = WorkflowKind.FLOW
         import probpipe.core.node as node_mod
+
         if node_mod.task is not None:
             assert wf.effective_workflow_kind is WorkflowKind.FLOW
 
@@ -316,6 +335,7 @@ class TestEffectiveWorkflowKind:
 # ---------------------------------------------------------------------------
 # Strict constructor workflow_kind validation
 # ---------------------------------------------------------------------------
+
 
 class TestWorkflowKindConstructorValidation:
     """Verify constructors reject old-style workflow_kind values."""
@@ -365,6 +385,7 @@ class TestWorkflowKindConstructorValidation:
 # Module inherits global config
 # ---------------------------------------------------------------------------
 
+
 class TestModuleInheritsConfig:
     """Module with DEFAULT propagates global config to children."""
 
@@ -413,6 +434,7 @@ class TestModuleInheritsConfig:
 # ---------------------------------------------------------------------------
 # PROBPIPE_WORKFLOW_KIND environment variable
 # ---------------------------------------------------------------------------
+
 
 class TestEnvVarOverride:
     """The ``PROBPIPE_WORKFLOW_KIND`` env var sets the initial workflow_kind."""

--- a/tests/core/test_prefect_orchestration.py
+++ b/tests/core/test_prefect_orchestration.py
@@ -52,6 +52,7 @@ def normal_dist():
 # Helper functions for workflows
 # ---------------------------------------------------------------------------
 
+
 def add_one(x: jnp.ndarray) -> jnp.ndarray:
     return x + 1.0
 
@@ -67,6 +68,7 @@ def sum_xy(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
 # ---------------------------------------------------------------------------
 # workflow_kind=WorkflowKind.TASK with sequential dispatch
 # ---------------------------------------------------------------------------
+
 
 class TestPrefectTaskRowWise:
     """Exercises Prefect task execution via row-wise dispatch."""
@@ -94,7 +96,9 @@ class TestPrefectTaskRowWise:
         result = wf(x=normal_dist)
         # Mean should be ~2.0 (1.0 + 1.0)
         np.testing.assert_allclose(
-            float(jnp.mean(result.samples)), 2.0, atol=0.15,
+            float(jnp.mean(result.samples)),
+            2.0,
+            atol=0.15,
         )
 
     def test_multiple_broadcast_args(self, normal_dist):
@@ -114,6 +118,7 @@ class TestPrefectTaskRowWise:
 # ---------------------------------------------------------------------------
 # workflow_kind=WorkflowKind.FLOW with sequential dispatch
 # ---------------------------------------------------------------------------
+
 
 class TestPrefectFlowRowWise:
     """Exercises Prefect flow execution via row-wise dispatch."""
@@ -141,13 +146,16 @@ class TestPrefectFlowRowWise:
         result = wf(x=normal_dist)
         # Mean should be ~2.0 (1.0 * 2)
         np.testing.assert_allclose(
-            float(jnp.mean(result.samples)), 2.0, atol=0.15,
+            float(jnp.mean(result.samples)),
+            2.0,
+            atol=0.15,
         )
 
 
 # ---------------------------------------------------------------------------
 # workflow_kind=WorkflowKind.TASK with JAX dispatch
 # ---------------------------------------------------------------------------
+
 
 class TestPrefectTaskJax:
     """Exercises the Prefect-wrapped distribution-broadcast JAX path."""
@@ -174,13 +182,16 @@ class TestPrefectTaskJax:
         )
         result = wf(x=normal_dist)
         np.testing.assert_allclose(
-            float(jnp.mean(result.samples)), 2.0, atol=0.15,
+            float(jnp.mean(result.samples)),
+            2.0,
+            atol=0.15,
         )
 
 
 # ---------------------------------------------------------------------------
 # workflow_kind=WorkflowKind.FLOW with JAX dispatch
 # ---------------------------------------------------------------------------
+
 
 class TestPrefectFlowJax:
     """Exercises Prefect flow-wrapped jax.vmap path."""
@@ -207,13 +218,16 @@ class TestPrefectFlowJax:
         )
         result = wf(x=normal_dist)
         np.testing.assert_allclose(
-            float(jnp.mean(result.samples)), 2.0, atol=0.15,
+            float(jnp.mean(result.samples)),
+            2.0,
+            atol=0.15,
         )
 
 
 # ---------------------------------------------------------------------------
 # Provenance metadata
 # ---------------------------------------------------------------------------
+
 
 class TestPrefectProvenance:
     """Verify provenance includes orchestration info."""
@@ -261,6 +275,7 @@ class TestPrefectProvenance:
 # Non-broadcast calls with workflow_kind
 # ---------------------------------------------------------------------------
 
+
 class TestPrefectNonBroadcast:
     """When concrete args are passed, Prefect wrapping still applies."""
 
@@ -290,11 +305,13 @@ class TestPrefectNonBroadcast:
 # Import guard
 # ---------------------------------------------------------------------------
 
+
 class TestPrefectImportGuard:
     """When Prefect is not installed, workflow_kind should warn and fall back to OFF."""
 
     def test_task_warns_without_prefect(self, normal_dist, monkeypatch):
         import probpipe.core.node as node_mod
+
         monkeypatch.setattr(node_mod, "task", None)
         monkeypatch.setattr(node_mod, "flow", None)
 
@@ -311,6 +328,7 @@ class TestPrefectImportGuard:
 
     def test_flow_warns_without_prefect(self, normal_dist, monkeypatch):
         import probpipe.core.node as node_mod
+
         monkeypatch.setattr(node_mod, "task", None)
         monkeypatch.setattr(node_mod, "flow", None)
 
@@ -327,6 +345,7 @@ class TestPrefectImportGuard:
 
     def test_jax_warns_without_prefect(self, normal_dist, monkeypatch):
         import probpipe.core.node as node_mod
+
         monkeypatch.setattr(node_mod, "task", None)
         monkeypatch.setattr(node_mod, "flow", None)
 

--- a/tests/core/test_protocols.py
+++ b/tests/core/test_protocols.py
@@ -36,6 +36,7 @@ from probpipe.core.protocols import (
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def normal():
     return Normal(loc=0.0, scale=1.0, name="x")
@@ -62,16 +63,20 @@ def joint():
 # SupportsSampling
 # ---------------------------------------------------------------------------
 
+
 class TestSupportsSampling:
     """All distributions should support sampling."""
 
-    @pytest.mark.parametrize("dist_cls,kwargs", [
-        (Normal, {"loc": 0.0, "scale": 1.0, "name": "x"}),
-        (Beta, {"alpha": 2.0, "beta": 5.0, "name": "b"}),
-        (Gamma, {"concentration": 3.0, "rate": 1.0, "name": "g"}),
-        (Bernoulli, {"probs": 0.5, "name": "d"}),
-        (MultivariateNormal, {"loc": jnp.zeros(2), "cov": jnp.eye(2), "name": "z"}),
-    ])
+    @pytest.mark.parametrize(
+        "dist_cls,kwargs",
+        [
+            (Normal, {"loc": 0.0, "scale": 1.0, "name": "x"}),
+            (Beta, {"alpha": 2.0, "beta": 5.0, "name": "b"}),
+            (Gamma, {"concentration": 3.0, "rate": 1.0, "name": "g"}),
+            (Bernoulli, {"probs": 0.5, "name": "d"}),
+            (MultivariateNormal, {"loc": jnp.zeros(2), "cov": jnp.eye(2), "name": "z"}),
+        ],
+    )
     def test_tfp_distributions(self, dist_cls, kwargs):
         dist = dist_cls(**kwargs)
         assert isinstance(dist, SupportsSampling)
@@ -90,6 +95,7 @@ class TestSupportsSampling:
 # SupportsExpectation
 # ---------------------------------------------------------------------------
 
+
 class TestSupportsExpectation:
     def test_normal(self, normal):
         assert isinstance(normal, SupportsExpectation)
@@ -105,12 +111,16 @@ class TestSupportsExpectation:
 # SupportsLogProb
 # ---------------------------------------------------------------------------
 
+
 class TestSupportsLogProb:
-    @pytest.mark.parametrize("dist_cls,kwargs", [
-        (Normal, {"loc": 0.0, "scale": 1.0, "name": "x"}),
-        (Beta, {"alpha": 2.0, "beta": 5.0, "name": "b"}),
-        (MultivariateNormal, {"loc": jnp.zeros(2), "cov": jnp.eye(2), "name": "z"}),
-    ])
+    @pytest.mark.parametrize(
+        "dist_cls,kwargs",
+        [
+            (Normal, {"loc": 0.0, "scale": 1.0, "name": "x"}),
+            (Beta, {"alpha": 2.0, "beta": 5.0, "name": "b"}),
+            (MultivariateNormal, {"loc": jnp.zeros(2), "cov": jnp.eye(2), "name": "z"}),
+        ],
+    )
     def test_tfp_distributions(self, dist_cls, kwargs):
         dist = dist_cls(**kwargs)
         assert isinstance(dist, SupportsLogProb)
@@ -122,6 +132,7 @@ class TestSupportsLogProb:
 # ---------------------------------------------------------------------------
 # Protocol hierarchy
 # ---------------------------------------------------------------------------
+
 
 class TestProtocolHierarchy:
     """Verify that protocol inheritance relationships hold."""
@@ -165,6 +176,7 @@ class TestProtocolHierarchy:
 # SupportsMean / SupportsVariance / SupportsCovariance
 # ---------------------------------------------------------------------------
 
+
 class TestSupportsMean:
     """Only distributions with exact (non-MC) moments satisfy these."""
 
@@ -201,6 +213,7 @@ class TestSupportsMean:
 # SupportsConditioning
 # ---------------------------------------------------------------------------
 
+
 class TestSupportsConditioning:
     def test_product_distribution(self, joint):
         assert isinstance(joint, SupportsConditioning)
@@ -229,9 +242,10 @@ class TestSupportsConditioning:
 # Named components (duck-typing check)
 # ---------------------------------------------------------------------------
 
+
 class TestNamedComponents:
     def test_product_distribution(self, joint):
-        assert hasattr(joint, 'fields')
+        assert hasattr(joint, "fields")
 
     def test_normal_fields_has_name(self, normal):
         assert normal.fields == ("x",)
@@ -240,6 +254,7 @@ class TestNamedComponents:
 # ---------------------------------------------------------------------------
 # Orchestration hints
 # ---------------------------------------------------------------------------
+
 
 class TestOrchestrationHints:
     def test_default_sampling_cost(self, normal):
@@ -264,7 +279,8 @@ class TestRecordDistributionViewDynamicProtocols:
         SupportsSampling / SupportsMean / SupportsVariance."""
         from probpipe.core._distribution_base import Distribution
         from probpipe.core._record_distribution import (
-            RecordDistribution, _RecordDistributionView,
+            RecordDistribution,
+            _RecordDistributionView,
         )
         from probpipe.core.record import EventTemplate
 
@@ -276,6 +292,7 @@ class TestRecordDistributionViewDynamicProtocols:
 
             def _log_prob(self, value):
                 import jax.numpy as jnp
+
                 return jnp.asarray(0.0)
 
         parent = _LogProbOnlyParent()
@@ -303,6 +320,7 @@ class TestFlattenedDistributionViewDynamicProtocols:
 
     def test_flattened_view_inherits_sampling_and_log_prob(self):
         from probpipe.core._numeric_record_distribution import FlattenedDistributionView
+
         dist = ProductDistribution(
             x=Normal(loc=0.0, scale=1.0, name="x"),
             y=Normal(loc=0.0, scale=1.0, name="y"),
@@ -317,7 +335,8 @@ class TestFlattenedDistributionViewDynamicProtocols:
         import jax.numpy as jnp
         import jax
         from probpipe.core._numeric_record_distribution import (
-            FlattenedDistributionView, NumericRecordDistribution,
+            FlattenedDistributionView,
+            NumericRecordDistribution,
         )
         from probpipe.core.record import EventTemplate
 
@@ -344,7 +363,8 @@ class TestFlattenedDistributionViewDynamicProtocols:
         ``SupportsSampling`` (reverse direction of the sampling-only test)."""
         import jax.numpy as jnp
         from probpipe.core._numeric_record_distribution import (
-            FlattenedDistributionView, NumericRecordDistribution,
+            FlattenedDistributionView,
+            NumericRecordDistribution,
         )
         from probpipe.core.record import EventTemplate
 
@@ -383,6 +403,7 @@ class TestSampleReturnTypeConvention:
 
     def test_numeric_distribution_returns_array(self):
         import jax.numpy as jnp
+
         dist = Normal(loc=0.0, scale=1.0, name="x")
         k = jax.random.PRNGKey(0)
         assert isinstance(dist._sample(k, ()), jnp.ndarray)
@@ -392,6 +413,7 @@ class TestSampleReturnTypeConvention:
     def test_product_distribution_return_types(self):
         from probpipe import NumericRecord, Record
         from probpipe.core._record_array import NumericRecordArray
+
         dist = ProductDistribution(
             x=Normal(loc=0.0, scale=1.0, name="x"),
             y=Normal(loc=0.0, scale=1.0, name="y"),
@@ -426,6 +448,7 @@ class TestSampleReturnTypeConvention:
         import numpy as np
         from probpipe import Record
         from probpipe.core._record_array import NumericRecordArray
+
         # Build a small JointEmpirical from stored per-component samples
         je = JointEmpirical(
             x=np.asarray([[1.0], [2.0], [3.0]]),
@@ -439,8 +462,10 @@ class TestSampleReturnTypeConvention:
     def test_joint_gaussian_return_types(self):
         from probpipe import Record
         from probpipe.core._record_array import NumericRecordArray
+
         jg = JointGaussian(
-            x=1, y=1,
+            x=1,
+            y=1,
             mean=jnp.zeros(2),
             cov=jnp.eye(2),
         )
@@ -460,6 +485,7 @@ class TestMixtureSamplingDispatch:
     def test_array_components_stacked(self):
         import jax.numpy as jnp
         from probpipe.core._broadcast_distributions import _make_mixture_marginal
+
         comps = [Normal(loc=0.0, scale=1.0, name=f"c{i}") for i in range(3)]
         mix = _make_mixture_marginal(comps)
         s = mix._sample(jax.random.PRNGKey(0), (4,))
@@ -470,6 +496,7 @@ class TestMixtureSamplingDispatch:
         from probpipe.core._broadcast_distributions import _make_mixture_marginal
         from probpipe.core._record_array import RecordArray, NumericRecordArray
         from probpipe import Record
+
         comps = [
             ProductDistribution(
                 a=Normal(loc=float(i), scale=1.0, name="a"),
@@ -498,6 +525,7 @@ class TestTransformedDistributionDynamicProtocols:
     def test_over_full_tfp_base_has_all_protocols(self):
         from probpipe import Normal, TransformedDistribution
         import tensorflow_probability.substrates.jax.bijectors as tfb
+
         td = TransformedDistribution(Normal(loc=0.0, scale=1.0, name="x"), tfb.Exp())
         assert isinstance(td, SupportsSampling)
         assert isinstance(td, SupportsLogProb)
@@ -526,6 +554,7 @@ class TestTransformedDistributionDynamicProtocols:
             @property
             def support(self):
                 from probpipe.core.constraints import real
+
                 return real
 
             def _log_prob(self, x):
@@ -571,6 +600,7 @@ class TestJointEmpiricalDispatch:
 
     def test_numeric_dispatch(self):
         from probpipe import JointEmpirical, NumericJointEmpirical
+
         je = JointEmpirical(x=jnp.zeros((5, 2)), y=jnp.zeros(5))
         assert type(je) is NumericJointEmpirical
         # Empirical distributions deliberately do not claim
@@ -583,6 +613,7 @@ class TestJointEmpiricalDispatch:
     def test_numeric_rejects_non_numeric(self):
         from probpipe import NumericJointEmpirical
         import numpy as np
+
         with pytest.raises(TypeError, match="numeric"):
             NumericJointEmpirical(
                 labels=np.array(["a", "b", "c"], dtype=object),
@@ -594,6 +625,7 @@ class TestJointEmpiricalDispatch:
         generic base class and must not claim the numeric protocols."""
         import numpy as np
         from probpipe import JointEmpirical, NumericJointEmpirical
+
         je = JointEmpirical(
             labels=np.array(["a", "b", "c"], dtype=object),
             ids=np.array([0, 1, 2]),
@@ -619,6 +651,7 @@ class TestSimpleGenerativeModelSampling:
         class _L:
             def generate_data(self, params, num_observations, *, key):
                 import jax
+
                 k = key if key is not None else jax.random.PRNGKey(0)
                 return jax.random.normal(k, (num_observations, 3))
 
@@ -641,22 +674,26 @@ class TestProtocolsSupportedByAll:
 
     def test_all_leaves_support_all_candidates(self):
         from probpipe.core.protocols import protocols_supported_by_all
+
         leaves = [
             Normal(loc=0.0, scale=1.0, name="a"),
             Normal(loc=0.0, scale=1.0, name="b"),
         ]
         result = protocols_supported_by_all(
-            leaves, (SupportsLogProb, SupportsMean, SupportsVariance),
+            leaves,
+            (SupportsLogProb, SupportsMean, SupportsVariance),
         )
         assert result == (SupportsLogProb, SupportsMean, SupportsVariance)
 
     def test_partial_support_filters_to_intersection(self):
         """A leaf missing one protocol removes that protocol from the result."""
         from probpipe.core.protocols import protocols_supported_by_all
+
         boot = BootstrapDistribution(jnp.array([1.0, 2.0, 3.0]), name="b")
         leaves = [Normal(loc=0.0, scale=1.0, name="n"), boot]
         result = protocols_supported_by_all(
-            leaves, (SupportsLogProb, SupportsMean, SupportsVariance),
+            leaves,
+            (SupportsLogProb, SupportsMean, SupportsVariance),
         )
         # Bootstrap has mean+variance but not log_prob.
         assert SupportsLogProb not in result
@@ -672,22 +709,26 @@ class TestProtocolsSupportedByAll:
 
         leaves = [_Stub(), _Stub()]
         result = protocols_supported_by_all(
-            leaves, (SupportsLogProb, SupportsMean),
+            leaves,
+            (SupportsLogProb, SupportsMean),
         )
         assert result == ()
 
     def test_preserves_candidate_order(self):
         """Result preserves the order of ``candidates``."""
         from probpipe.core.protocols import protocols_supported_by_all
+
         leaves = [Normal(loc=0.0, scale=1.0, name="n")]
         result = protocols_supported_by_all(
-            leaves, (SupportsVariance, SupportsLogProb, SupportsMean),
+            leaves,
+            (SupportsVariance, SupportsLogProb, SupportsMean),
         )
         assert result == (SupportsVariance, SupportsLogProb, SupportsMean)
 
     def test_empty_leaves_list(self):
         """Empty leaves: ``all([])`` is True, so every candidate passes."""
         from probpipe.core.protocols import protocols_supported_by_all
+
         result = protocols_supported_by_all([], (SupportsLogProb, SupportsMean))
         assert result == (SupportsLogProb, SupportsMean)
 

--- a/tests/core/test_provenance.py
+++ b/tests/core/test_provenance.py
@@ -29,8 +29,8 @@ from probpipe.core.provenance import ParentInfo
 # 1. Provenance basics (dataclass, with_source, write-once)
 # ===========================================================================
 
-class TestProvenanceBasics:
 
+class TestProvenanceBasics:
     def test_provenance_fields(self):
         p = Provenance("test_op", metadata={"key": "val"})
         assert p.operation == "test_op"
@@ -65,6 +65,7 @@ class TestProvenanceBasics:
     def test_with_source_none_is_noop_record(self):
         """with_source(None) leaves a Record unchanged."""
         from probpipe import Record
+
         r = Record({"x": jnp.array(1.0)})
         result = r.with_source(None)
         assert result is r
@@ -75,8 +76,8 @@ class TestProvenanceBasics:
 # 2. ParentInfo hash and equality
 # ===========================================================================
 
-class TestParentInfoHashEq:
 
+class TestParentInfoHashEq:
     def test_hashable_without_source(self):
         """Root ParentInfo (source=None) is hashable."""
         p = ParentInfo(type_name="Normal", name="prior")
@@ -134,8 +135,8 @@ class TestParentInfoHashEq:
 # 3. from_distribution provenance
 # ===========================================================================
 
-class TestFromDistributionProvenance:
 
+class TestFromDistributionProvenance:
     def test_normal_from_distribution(self):
         src = Beta(alpha=2.0, beta=5.0, name="beta_src")
         converted = from_distribution(src, Normal)
@@ -159,8 +160,8 @@ class TestFromDistributionProvenance:
 # 3. TransformedDistribution provenance
 # ===========================================================================
 
-class TestTransformedDistributionProvenance:
 
+class TestTransformedDistributionProvenance:
     def test_transform_provenance_attached(self):
         base = Normal(loc=0.0, scale=1.0, name="base")
         td = TransformedDistribution(base, tfb.Exp())
@@ -191,8 +192,8 @@ class TestTransformedDistributionProvenance:
 # 4. Conditioning provenance
 # ===========================================================================
 
-class TestConditioningProvenance:
 
+class TestConditioningProvenance:
     def test_product_condition_on(self):
         joint = ProductDistribution(
             x=Normal(loc=0.0, scale=1.0, name="x"),
@@ -217,7 +218,10 @@ class TestConditioningProvenance:
 
     def test_gaussian_condition_on(self):
         jg = JointGaussian(
-            mean=jnp.zeros(2), cov=jnp.eye(2), x=1, y=1,
+            mean=jnp.zeros(2),
+            cov=jnp.eye(2),
+            x=1,
+            y=1,
         )
         cond = condition_on(jg, x=jnp.array([0.0]))
         assert cond.source.operation == "condition_on"
@@ -228,16 +232,15 @@ class TestConditioningProvenance:
 # 5. Broadcasting provenance
 # ===========================================================================
 
-class TestBroadcastingProvenance:
 
+class TestBroadcastingProvenance:
     def test_broadcast_loop_provenance(self, full_provenance_mode):
         n = Normal(loc=0.0, scale=1.0, name="input_normal")
 
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, dispatch="sequential",
-                      n_broadcast_samples=20, seed=42)
+        wf = WorkflowFunction(func=identity, dispatch="sequential", n_broadcast_samples=20, seed=42)
         result = wf(x=n)
         assert hasattr(result, "samples")
         assert result.source is not None
@@ -256,8 +259,7 @@ class TestBroadcastingProvenance:
         def double(x: float) -> float:
             return 2.0 * x
 
-        wf = WorkflowFunction(func=double, dispatch="jax",
-                      n_broadcast_samples=20, seed=42)
+        wf = WorkflowFunction(func=double, dispatch="jax", n_broadcast_samples=20, seed=42)
         result = wf(x=n)
         assert hasattr(result, "samples")
         assert result.source is not None
@@ -271,8 +273,7 @@ class TestBroadcastingProvenance:
         def add(x: float, y: float) -> float:
             return x + y
 
-        wf = WorkflowFunction(func=add, dispatch="sequential",
-                      n_broadcast_samples=20, seed=42)
+        wf = WorkflowFunction(func=add, dispatch="sequential", n_broadcast_samples=20, seed=42)
         result = wf(x=a, y=b)
         assert result.source is not None
         assert len(result.source.parents) == 2
@@ -285,8 +286,7 @@ class TestBroadcastingProvenance:
         def add(a: float, b: float) -> float:
             return a + b
 
-        wf = WorkflowFunction(func=add, dispatch="sequential",
-                      n_broadcast_samples=20, seed=42)
+        wf = WorkflowFunction(func=add, dispatch="sequential", n_broadcast_samples=20, seed=42)
         result = wf(a=ed, b=n)
         assert hasattr(result, "samples")
         assert result.source is not None
@@ -297,8 +297,8 @@ class TestBroadcastingProvenance:
 # 6. Provenance chains (multi-step lineage)
 # ===========================================================================
 
-class TestProvenanceChains:
 
+class TestProvenanceChains:
     def test_two_step_chain(self):
         """from_distribution → condition_on creates a 2-step chain."""
         src = Beta(alpha=2.0, beta=5.0, name="prior")
@@ -323,8 +323,7 @@ class TestProvenanceChains:
         def log_val(x: float) -> float:
             return jnp.log(x)
 
-        wf = WorkflowFunction(func=log_val, dispatch="sequential",
-                      n_broadcast_samples=20, seed=42)
+        wf = WorkflowFunction(func=log_val, dispatch="sequential", n_broadcast_samples=20, seed=42)
         result = wf(x=td)
         # result → broadcast → td → transform → base
         assert result.source.operation == "broadcast"
@@ -340,8 +339,8 @@ class TestProvenanceChains:
 # 7. Serialization
 # ===========================================================================
 
-class TestSerialization:
 
+class TestSerialization:
     def test_to_dict_basic(self):
         p = Provenance("test_op", metadata={"key": "val"})
         d = p.to_dict()
@@ -418,8 +417,8 @@ class TestSerialization:
 # 8. provenance_ancestors
 # ===========================================================================
 
-class TestProvenanceAncestors:
 
+class TestProvenanceAncestors:
     def test_no_provenance_returns_empty(self):
         n = Normal(loc=0.0, scale=1.0, name="n")
         assert provenance_ancestors(n) == []
@@ -440,8 +439,7 @@ class TestProvenanceAncestors:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, dispatch="sequential",
-                      n_broadcast_samples=10, seed=42)
+        wf = WorkflowFunction(func=identity, dispatch="sequential", n_broadcast_samples=10, seed=42)
         result = wf(x=td)
         ancestors = provenance_ancestors(result)
         # result → td → base; both steps now produce ParentInfo in FULL mode.
@@ -458,8 +456,7 @@ class TestProvenanceAncestors:
         def add(x: float, y: float) -> float:
             return x + y
 
-        wf = WorkflowFunction(func=add, dispatch="sequential",
-                      n_broadcast_samples=10, seed=42)
+        wf = WorkflowFunction(func=add, dispatch="sequential", n_broadcast_samples=10, seed=42)
         result = wf(x=n, y=n)
         ancestors = provenance_ancestors(result)
         # n appears as both args but dedup keeps only one ParentInfo for it
@@ -498,6 +495,7 @@ class TestProvenanceAncestors:
 # 9. provenance_dag
 # ===========================================================================
 
+
 def _count_dag_entries(dot) -> tuple[int, int]:
     """Count (nodes, edges) in a graphviz Digraph via its body list."""
     nodes = sum(1 for line in dot.body if "->" not in line and " [" in line)
@@ -506,7 +504,6 @@ def _count_dag_entries(dot) -> tuple[int, int]:
 
 
 class TestProvenanceDag:
-
     @pytest.fixture(autouse=True)
     def _require_graphviz(self):
         # provenance_dag() builds a graphviz.Digraph; skip this class's
@@ -543,8 +540,7 @@ class TestProvenanceDag:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, dispatch="sequential",
-                      n_broadcast_samples=10, seed=42)
+        wf = WorkflowFunction(func=identity, dispatch="sequential", n_broadcast_samples=10, seed=42)
         result = wf(x=td)
         dag = provenance_dag(result)
         # result <- td <- base : 3 nodes, 2 edges.
@@ -587,8 +583,8 @@ class TestProvenanceDag:
 # 10. ProvenanceMode behaviour
 # ===========================================================================
 
-class TestProvenanceModes:
 
+class TestProvenanceModes:
     def test_lightweight_is_default(self):
         assert probpipe.provenance_config.mode is ProvenanceMode.LIGHTWEIGHT
 
@@ -599,8 +595,7 @@ class TestProvenanceModes:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, dispatch="sequential",
-                      n_broadcast_samples=10, seed=42)
+        wf = WorkflowFunction(func=identity, dispatch="sequential", n_broadcast_samples=10, seed=42)
         result = wf(x=n)
         assert result.source is not None
         assert len(result.source.parents) == 1
@@ -616,8 +611,7 @@ class TestProvenanceModes:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, dispatch="sequential",
-                      n_broadcast_samples=10, seed=42)
+        wf = WorkflowFunction(func=identity, dispatch="sequential", n_broadcast_samples=10, seed=42)
         result = wf(x=n)
         parent = result.source.parents[0]
         assert parent is not n
@@ -633,8 +627,7 @@ class TestProvenanceModes:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, dispatch="sequential",
-                      n_broadcast_samples=10, seed=42)
+        wf = WorkflowFunction(func=identity, dispatch="sequential", n_broadcast_samples=10, seed=42)
         result = wf(x=n)
         ancestors = provenance_ancestors(result)
         assert len(ancestors) == 1
@@ -653,8 +646,7 @@ class TestProvenanceModes:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, dispatch="sequential",
-                      n_broadcast_samples=10, seed=42)
+        wf = WorkflowFunction(func=identity, dispatch="sequential", n_broadcast_samples=10, seed=42)
         result = wf(x=n)
         dag = provenance_dag(result)
         num_nodes, num_edges = _count_dag_entries(dag)
@@ -669,8 +661,7 @@ class TestProvenanceModes:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, dispatch="sequential",
-                      n_broadcast_samples=10, seed=42)
+        wf = WorkflowFunction(func=identity, dispatch="sequential", n_broadcast_samples=10, seed=42)
         result = wf(x=n)
         assert result.source is None
 
@@ -696,9 +687,7 @@ class TestProvenanceModes:
         del parent
         gc.collect()
 
-        assert ref() is None, (
-            "LIGHTWEIGHT provenance should not hold a strong ref to the parent"
-        )
+        assert ref() is None, "LIGHTWEIGHT provenance should not hold a strong ref to the parent"
 
     def test_full_mode_parent_is_retained(self, full_provenance_mode):
         """FULL mode keeps the parent alive via ParentInfo.obj."""
@@ -713,9 +702,7 @@ class TestProvenanceModes:
         del parent
         gc.collect()
 
-        assert ref() is not None, (
-            "FULL mode should retain the parent via ParentInfo.obj"
-        )
+        assert ref() is not None, "FULL mode should retain the parent via ParentInfo.obj"
 
     def test_off_mode_ancestors_empty(self):
         """In OFF mode provenance_ancestors returns an empty list."""
@@ -725,8 +712,7 @@ class TestProvenanceModes:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, dispatch="sequential",
-                      n_broadcast_samples=10, seed=42)
+        wf = WorkflowFunction(func=identity, dispatch="sequential", n_broadcast_samples=10, seed=42)
         result = wf(x=n)
         assert provenance_ancestors(result) == []
 
@@ -739,8 +725,7 @@ class TestProvenanceModes:
         def identity(x: float) -> float:
             return x
 
-        wf = WorkflowFunction(func=identity, dispatch="sequential",
-                      n_broadcast_samples=10, seed=42)
+        wf = WorkflowFunction(func=identity, dispatch="sequential", n_broadcast_samples=10, seed=42)
         result = wf(x=n)
         dag = provenance_dag(result)
         num_nodes, num_edges = _count_dag_entries(dag)

--- a/tests/core/test_random_function.py
+++ b/tests/core/test_random_function.py
@@ -15,6 +15,7 @@ from probpipe import (
     ArrayRandomFunction,
 )
 from probpipe import log_prob, sample
+
 # Test fixtures construct ``Normal`` from batched arrays; the rejection
 # in ``TFPDistribution.__init__`` (PR-C.2) makes that a user-facing
 # error. Internal infra opts into the bypass — the fixtures here mock
@@ -26,6 +27,7 @@ from probpipe.distributions._tfp_base import _allow_batched_tfp_init
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def key():
@@ -220,4 +222,3 @@ class TestArrayRandomFunction:
         extra_batch, n = rf._parse_X(X)
         assert extra_batch == (2, 4)
         assert n == 10
-

--- a/tests/core/test_random_measure.py
+++ b/tests/core/test_random_measure.py
@@ -131,7 +131,9 @@ class _DiracRandomMeasure(
 
     def _mean(self):
         return _make_mixture_marginal(
-            self._components, weights=self._w, name=f"{self.name}_expected",
+            self._components,
+            weights=self._w,
+            name=f"{self.name}_expected",
         )
 
     def _random_log_prob(self):
@@ -251,9 +253,7 @@ class TestMean:
         ``mean(_)`` collapses that to its array-valued mean.
         """
         locs = [0.0, 2.0, 5.0]
-        comps = [
-            Normal(loc=loc, scale=1.0, name=f"n{i}") for i, loc in enumerate(locs)
-        ]
+        comps = [Normal(loc=loc, scale=1.0, name=f"n{i}") for i, loc in enumerate(locs)]
         weights = jnp.array([0.2, 0.3, 0.5])
         rm = _DiracRandomMeasure(comps, weights=weights)
         m = mean(mean(rm))

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -213,16 +213,19 @@ class TestImmutability:
 
     def test_replace_preserves_numeric_record(self):
         from probpipe import NumericRecord
+
         nr = NumericRecord(a=1.0, b=2.0)
         assert type(nr.replace(a=3.0)) is NumericRecord
 
     def test_merge_preserves_numeric_record(self):
         from probpipe import NumericRecord
+
         nr = NumericRecord(a=1.0)
         assert type(nr.merge(NumericRecord(b=2.0))) is NumericRecord
 
     def test_without_preserves_numeric_record(self):
         from probpipe import NumericRecord
+
         nr = NumericRecord(a=1.0, b=2.0)
         assert type(nr.without("a")) is NumericRecord
 
@@ -410,6 +413,7 @@ class TestConversion:
 
     def test_to_numeric_returns_numeric_record(self):
         from probpipe import NumericRecord
+
         v = Record(a=1.0, b=jnp.array([2.0, 3.0]))
         nr = v.to_numeric()
         assert isinstance(nr, NumericRecord)
@@ -423,7 +427,9 @@ class TestConversion:
         """
         xr = pytest.importorskip("xarray")
         da = xr.DataArray(
-            [1.0, 2.0, 3.0], dims=["time"], coords={"time": [10, 20, 30]},
+            [1.0, 2.0, 3.0],
+            dims=["time"],
+            coords={"time": [10, 20, 30]},
             attrs={"units": "m"},
         )
         back = Record(y=da).to_numeric().to_native()
@@ -436,6 +442,7 @@ class TestConversion:
         recurse into nested non-NumericRecord children (regression for
         the divergence flagged in PR-A review)."""
         from probpipe import NumericRecord
+
         outer = Record(inner=Record(a=1.0), z=2.0)
         nr = outer.to_numeric()
         assert isinstance(nr, NumericRecord)
@@ -483,7 +490,7 @@ class TestEnsure:
 class TestLeafOps:
     def test_map(self):
         v = Record(a=2.0, b=3.0)
-        v2 = v.map(lambda x: x ** 2)
+        v2 = v.map(lambda x: x**2)
         assert v2["a"] == 4.0
         assert v2["b"] == 9.0
 
@@ -496,6 +503,7 @@ class TestLeafOps:
         """``map`` on a NumericRecord returns a NumericRecord as long as
         the mapped values remain numeric (validated by ``__init__``)."""
         from probpipe import NumericRecord
+
         nr = NumericRecord(a=1.0, b=2.0)
         out = nr.map(lambda x: x * 2)
         assert type(out) is NumericRecord
@@ -504,6 +512,7 @@ class TestLeafOps:
         """A map that returns a string violates the NumericRecord
         invariant and must fail loudly at reconstruction."""
         from probpipe import NumericRecord
+
         nr = NumericRecord(a=1.0, b=2.0)
         with pytest.raises(TypeError, match="numeric"):
             nr.map(lambda x: "not numeric")
@@ -582,6 +591,7 @@ class TestReprAndEquality:
     def test_eq_type_strict(self):
         """Record == NumericRecord is False even with identical fields."""
         from probpipe import NumericRecord
+
         r = Record(a=1.0, b=2.0)
         nr = NumericRecord(a=1.0, b=2.0)
         assert r != nr
@@ -708,21 +718,15 @@ class TestProvenance:
 
     def test_provenance_ancestors_walks_through_distribution(self):
         prior = Normal(loc=0.0, scale=1.0, name="prior")
-        r = Record(theta=1.0).with_source(
-            Provenance("draw", parents=(prior,))
-        )
+        r = Record(theta=1.0).with_source(Provenance("draw", parents=(prior,)))
         ancestors = provenance_ancestors(r)
         assert len(ancestors) == 1
         assert ancestors[0] is prior
 
     def test_provenance_ancestors_walks_nested_records(self):
         prior = Normal(loc=0.0, scale=1.0, name="prior")
-        middle = Record(theta=1.0).with_source(
-            Provenance("draw", parents=(prior,))
-        )
-        outer = Record(result=2.0).with_source(
-            Provenance("transform", parents=(middle,))
-        )
+        middle = Record(theta=1.0).with_source(Provenance("draw", parents=(prior,)))
+        outer = Record(result=2.0).with_source(Provenance("transform", parents=(middle,)))
         ancestors = provenance_ancestors(outer)
         names = [getattr(a, "name", None) for a in ancestors]
         assert names == [middle.name, "prior"]
@@ -734,6 +738,7 @@ class TestEventTemplatePack:
 
     def test_pack_builds_record_in_field_order(self):
         from probpipe.core.record import EventTemplate
+
         tpl = EventTemplate(a=(), b=(3,))
         # kwargs out of order — pack keys the Record in template field order
         rec = tpl.pack(b=jnp.ones(3), a=jnp.array(0.5))
@@ -744,10 +749,12 @@ class TestEventTemplatePack:
 
     def test_pack_missing_field_raises(self):
         from probpipe.core.record import EventTemplate
+
         with pytest.raises(TypeError, match="missing"):
             EventTemplate(a=(), b=()).pack(a=0.5)
 
     def test_pack_unexpected_field_raises(self):
         from probpipe.core.record import EventTemplate
+
         with pytest.raises(TypeError, match="unexpected"):
             EventTemplate(a=(), b=()).pack(a=0.5, b=0.4, c=1.0)

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -126,7 +126,8 @@ class TestRecordArrayAccess:
         tpl = EventTemplate(x=(3,))
         ra = RecordArray(
             x=jnp.arange(30.0).reshape(10, 3),
-            batch_shape=(10,), template=tpl,
+            batch_shape=(10,),
+            template=tpl,
         )
         assert type(ra[0]) is Record
 
@@ -135,11 +136,13 @@ class TestRecordArrayAccess:
         the numeric invariant survives slicing (fix for PR #123 review
         comment #4)."""
         from probpipe import NumericRecord
+
         tpl = EventTemplate(x=(3,), y=())
         nra = NumericRecordArray(
             x=jnp.arange(30.0).reshape(10, 3),
             y=jnp.arange(10.0),
-            batch_shape=(10,), template=tpl,
+            batch_shape=(10,),
+            template=tpl,
         )
         elem = nra[0]
         assert type(elem) is NumericRecord
@@ -283,9 +286,7 @@ class TestNumericRecordArrayFlatten:
     def test_unflatten_explicit_batch(self):
         tpl = EventTemplate(a=(), b=(2,))
         flat = jnp.zeros((4, 5, 3))
-        nra = NumericRecordArray.unflatten(
-            flat, template=tpl, batch_shape=(4, 5)
-        )
+        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(4, 5))
         assert nra.batch_shape == (4, 5)
         assert nra["a"].shape == (4, 5)
         assert nra["b"].shape == (4, 5, 2)
@@ -333,7 +334,8 @@ class TestNumericRecordArrayNested:
         inner = Record(a=jnp.arange(5.0), b=jnp.arange(5.0) + 10)
         nra = NumericRecordArray(
             {"outer": inner, "m": jnp.arange(5.0) + 100},
-            batch_shape=(5,), template=tpl,
+            batch_shape=(5,),
+            template=tpl,
         )
         flat = nra.flatten()
         assert flat.shape == (5, 3)
@@ -347,8 +349,7 @@ class TestNumericRecordArrayNested:
         np.testing.assert_allclose(elem["outer"]["b"], inner["b"][2])
 
     def test_flatten_nested_depth2_roundtrip(self):
-        tpl = EventTemplate(
-            outer=EventTemplate(deep=EventTemplate(g=(), h=()), a=()), m=())
+        tpl = EventTemplate(outer=EventTemplate(deep=EventTemplate(g=(), h=()), a=()), m=())
         flat = jnp.arange(20.0).reshape(5, 4)  # outer/deep/g, outer/deep/h, outer/a, m
         nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(5,))
         np.testing.assert_allclose(nra.flatten(), flat)
@@ -369,21 +370,23 @@ class TestNumericRecordArrayNested:
     def test_getitem_slash_path(self):
         tpl = self._nested_tpl()
         nra = NumericRecordArray.unflatten(
-            jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,))
+            jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,)
+        )
         np.testing.assert_allclose(nra["outer/a"], nra["outer"]["a"])
         with pytest.raises(KeyError):
-            nra["outer/missing"]    # leaf missing inside the sub-record
+            nra["outer/missing"]  # leaf missing inside the sub-record
         with pytest.raises(KeyError):
-            nra["nope/a"]           # head field not in the store
+            nra["nope/a"]  # head field not in the store
         with pytest.raises(KeyError):
-            nra["m/x"]              # slash descends into a (scalar) leaf
+            nra["m/x"]  # slash descends into a (scalar) leaf
 
     def test_getitem_int_nested_element(self):
         # Integer indexing of a nested record array descends into the nested
         # field, returning a (nested) record element — not an indexing error.
         tpl = self._nested_tpl()
         nra = NumericRecordArray.unflatten(
-            jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,))
+            jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,)
+        )
         elem = nra[2]
         assert isinstance(elem, Record)
         np.testing.assert_allclose(elem["outer"]["a"], nra["outer"]["a"][2])
@@ -392,10 +395,10 @@ class TestNumericRecordArrayNested:
     def test_getitem_int_nested_multidim_batch(self):
         tpl = self._nested_tpl()
         nra = NumericRecordArray.unflatten(
-            jnp.arange(24.0).reshape(2, 4, 3), template=tpl, batch_shape=(2, 4))
+            jnp.arange(24.0).reshape(2, 4, 3), template=tpl, batch_shape=(2, 4)
+        )
         elem = nra[5]  # flat index into the (2, 4) batch
-        np.testing.assert_allclose(
-            elem["outer"]["a"], np.asarray(nra["outer"]["a"]).reshape(-1)[5])
+        np.testing.assert_allclose(elem["outer"]["a"], np.asarray(nra["outer"]["a"]).reshape(-1)[5])
 
 
 # ---------------------------------------------------------------------------
@@ -519,18 +522,14 @@ class TestRecordArrayPyTree:
 class TestRepr:
     def test_record_array_repr(self):
         tpl = EventTemplate(x=(3,))
-        ra = RecordArray(
-            x=jnp.zeros((5, 3)), batch_shape=(5,), template=tpl
-        )
+        ra = RecordArray(x=jnp.zeros((5, 3)), batch_shape=(5,), template=tpl)
         r = repr(ra)
         assert "RecordArray" in r
         assert "batch_shape=(5,)" in r
 
     def test_numeric_record_array_repr(self):
         tpl = EventTemplate(x=())
-        nra = NumericRecordArray(
-            x=jnp.zeros(5), batch_shape=(5,), template=tpl
-        )
+        nra = NumericRecordArray(x=jnp.zeros(5), batch_shape=(5,), template=tpl)
         r = repr(nra)
         assert "NumericRecordArray" in r
 
@@ -560,10 +559,8 @@ class TestEquality:
         assert a != b
 
     def test_unequal_template(self):
-        a = RecordArray(x=jnp.zeros(3), batch_shape=(3,),
-                        template=EventTemplate(x=()))
-        b = RecordArray(x=jnp.zeros((3, 2)), batch_shape=(3,),
-                        template=EventTemplate(x=(2,)))
+        a = RecordArray(x=jnp.zeros(3), batch_shape=(3,), template=EventTemplate(x=()))
+        b = RecordArray(x=jnp.zeros((3, 2)), batch_shape=(3,), template=EventTemplate(x=(2,)))
         assert a != b
 
     def test_recordarray_not_equal_to_numeric_recordarray(self):
@@ -582,7 +579,8 @@ class TestEquality:
         tpl = EventTemplate(x=())
         ra = RecordArray(
             x=jnp.array([jnp.nan, 1.0, jnp.nan]),
-            batch_shape=(3,), template=tpl,
+            batch_shape=(3,),
+            template=tpl,
         )
         assert ra == ra
 
@@ -635,7 +633,9 @@ class TestNumericRecordArrayValidation:
         tpl = EventTemplate(x=(2,))
         with pytest.raises(TypeError, match="numeric"):
             NumericRecordArray(
-                {"x": ["a", "b"]}, batch_shape=(), template=tpl,
+                {"x": ["a", "b"]},
+                batch_shape=(),
+                template=tpl,
             )
 
     def test_rejects_object_dtype_array(self):
@@ -650,7 +650,8 @@ class TestNumericRecordArrayValidation:
         with pytest.raises(ValueError, match="shape"):
             NumericRecordArray(
                 {"x": jnp.zeros((5, 2))},  # expected (5, 3)
-                batch_shape=(5,), template=tpl,
+                batch_shape=(5,),
+                template=tpl,
             )
 
     def test_tree_map_to_string_rejected(self):
@@ -658,7 +659,9 @@ class TestNumericRecordArrayValidation:
         unflatten time rather than produce a corrupt NumericRecordArray."""
         tpl = EventTemplate(x=())
         nra = NumericRecordArray(
-            x=jnp.arange(3.0), batch_shape=(3,), template=tpl,
+            x=jnp.arange(3.0),
+            batch_shape=(3,),
+            template=tpl,
         )
         with pytest.raises(TypeError, match="numeric"):
             jax.tree.map(lambda x: "hi", nra)
@@ -666,7 +669,9 @@ class TestNumericRecordArrayValidation:
     def test_accepts_numpy_leaf_and_coerces_to_jnp(self):
         tpl = EventTemplate(x=())
         nra = NumericRecordArray(
-            x=np.arange(3.0), batch_shape=(3,), template=tpl,
+            x=np.arange(3.0),
+            batch_shape=(3,),
+            template=tpl,
         )
         assert isinstance(nra["x"], jnp.ndarray)
 
@@ -679,7 +684,8 @@ class TestNumericRecordArrayValidation:
         with pytest.raises(TypeError, match="non-numeric dtype"):
             NumericRecordArray(
                 {"x": np.array([{"a": 1}, {"b": 2}], dtype=object)},
-                batch_shape=(2,), template=tpl,
+                batch_shape=(2,),
+                template=tpl,
             )
 
     def test_rejects_numpy_string_dtype_batch(self):
@@ -687,7 +693,8 @@ class TestNumericRecordArrayValidation:
         with pytest.raises(TypeError, match="non-numeric dtype"):
             NumericRecordArray(
                 {"x": np.array(["a", "b"])},  # dtype='<U1'
-                batch_shape=(2,), template=tpl,
+                batch_shape=(2,),
+                template=tpl,
             )
 
     def test_nested_template_field_allowed(self):
@@ -696,6 +703,7 @@ class TestNumericRecordArrayValidation:
         the numeric-dtype check. This is how nested ProductDistributions
         materialise samples."""
         from probpipe import Record
+
         inner_tpl = EventTemplate(x=(), y=())
         outer_tpl = EventTemplate(physics=inner_tpl, obs=(3,))
         inner = Record(x=1.0, y=2.0)
@@ -720,9 +728,7 @@ class TestProvenance:
 
     @pytest.fixture
     def ra(self):
-        return NumericRecordArray.stack(
-            [NumericRecord(x=float(i), y=2.0 * i) for i in range(3)]
-        )
+        return NumericRecordArray.stack([NumericRecord(x=float(i), y=2.0 * i) for i in range(3)])
 
     def test_initial_source_is_none(self, ra):
         assert ra.source is None
@@ -738,9 +744,7 @@ class TestProvenance:
             ra.with_source(Provenance("second", parents=()))
 
     def test_eq_ignores_source(self, ra):
-        ra2 = NumericRecordArray.stack(
-            [NumericRecord(x=float(i), y=2.0 * i) for i in range(3)]
-        )
+        ra2 = NumericRecordArray.stack([NumericRecord(x=float(i), y=2.0 * i) for i in range(3)])
         ra.with_source(Provenance("a", parents=()))
         ra2.with_source(Provenance("b", parents=()))
         assert ra == ra2
@@ -792,8 +796,7 @@ class TestHierarchy:
         validation — must still ``isinstance`` as a ``Record``."""
         tpl = EventTemplate(label=None, value=())
         ra = RecordArray(
-            {"label": np.asarray(["a", "b", "c"], dtype=object),
-             "value": jnp.arange(3.0)},
+            {"label": np.asarray(["a", "b", "c"], dtype=object), "value": jnp.arange(3.0)},
             batch_shape=(3,),
             template=tpl,
         )
@@ -803,9 +806,7 @@ class TestHierarchy:
     def test_numericrecordarray_is_record(self):
         """The ``NumericRecordArray`` subclass inherits through the
         chain NumericRecordArray → RecordArray → Record."""
-        ra = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(3)]
-        )
+        ra = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(3)])
         assert isinstance(ra, NumericRecordArray)
         assert isinstance(ra, RecordArray)
         assert isinstance(ra, Record)
@@ -828,9 +829,7 @@ class TestHierarchy:
         assert mro.index("Record") < mro.index("object")
 
     def test_source_slot_inherited_from_record(self):
-        ra = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(2)]
-        )
+        ra = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(2)])
         # Record defines the ``_source`` slot; RecordArray should
         # *not* redeclare it (that would raise a layout conflict on
         # construction). Confirm the attribute works end-to-end.
@@ -842,15 +841,14 @@ class TestHierarchy:
         """RecordArray uses Record's ``_name`` slot for its stored name,
         not a separate property on RecordArray. The default name is
         derived from the class name + fields at construction time."""
-        ra = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(2)]
-        )
+        ra = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(2)])
         assert "numericrecordarray" in ra.name.lower()
 
     def test_custom_name_kwarg_honored(self):
         """RecordArray accepts a ``name=`` kwarg at construction,
         matching Record's API."""
         from probpipe.core.record import EventTemplate
+
         tpl = EventTemplate(x=())
         ra = NumericRecordArray(
             {"x": jnp.arange(3.0)},
@@ -873,16 +871,12 @@ class TestSingleFieldCoercion:
     """
 
     def test_np_asarray_single_field(self):
-        nra = NumericRecordArray.stack(
-            [NumericRecord(result=float(i)) for i in range(4)]
-        )
+        nra = NumericRecordArray.stack([NumericRecord(result=float(i)) for i in range(4)])
         arr = np.asarray(nra)
         np.testing.assert_allclose(arr, [0.0, 1.0, 2.0, 3.0])
 
     def test_jnp_asarray_single_field(self):
-        nra = NumericRecordArray.stack(
-            [NumericRecord(result=float(i)) for i in range(4)]
-        )
+        nra = NumericRecordArray.stack([NumericRecord(result=float(i)) for i in range(4)])
         arr = jnp.asarray(nra)
         assert isinstance(arr, jnp.ndarray)
         np.testing.assert_allclose(arr, [0.0, 1.0, 2.0, 3.0])
@@ -897,8 +891,6 @@ class TestSingleFieldCoercion:
     # ``float()`` / ``int()`` / ``bool()`` are deliberately not exposed
     # on NumericRecordArray — the value isn't scalar.
     def test_float_not_supported(self):
-        nra = NumericRecordArray.stack(
-            [NumericRecord(result=float(i)) for i in range(4)]
-        )
+        nra = NumericRecordArray.stack([NumericRecord(result=float(i)) for i in range(4)])
         with pytest.raises(TypeError):
             float(nra)

--- a/tests/core/test_record_array_view.py
+++ b/tests/core/test_record_array_view.py
@@ -48,9 +48,7 @@ from probpipe.core.record import EventTemplate
 @pytest.fixture
 def numeric_ra():
     """A NumericRecordArray with two numeric fields, batch_shape=(4,)."""
-    return NumericRecordArray.stack(
-        [NumericRecord(x=float(i), y=float(i * 2)) for i in range(4)]
-    )
+    return NumericRecordArray.stack([NumericRecord(x=float(i), y=float(i * 2)) for i in range(4)])
 
 
 @pytest.fixture
@@ -192,7 +190,7 @@ class TestViewForwarding:
         explicit-conversion policy."""
         v = numeric_ra.view("x")
         with pytest.raises(TypeError):
-            v + 1           # no __add__ on view
+            v + 1  # no __add__ on view
         np.testing.assert_allclose(
             np.asarray(jnp.asarray(v) + 1),
             [1.0, 2.0, 3.0, 4.0],
@@ -229,12 +227,8 @@ class TestSweepGroupingByParent:
     def test_two_views_different_parents_product(self):
         """Views from two different ``RecordArray``s carry different
         parent ids → distinct groups → cartesian product."""
-        ra_a = NumericRecordArray.stack(
-            [NumericRecord(a=float(i)) for i in range(3)]
-        )
-        ra_b = NumericRecordArray.stack(
-            [NumericRecord(b=float(j * 10)) for j in range(2)]
-        )
+        ra_a = NumericRecordArray.stack([NumericRecord(a=float(i)) for i in range(3)])
+        ra_b = NumericRecordArray.stack([NumericRecord(b=float(j * 10)) for j in range(2)])
 
         @workflow_function
         def f(a, b):
@@ -242,14 +236,12 @@ class TestSweepGroupingByParent:
 
         out = f(a=ra_a.view("a"), b=ra_b.view("b"))
         assert isinstance(out, NumericRecordArray)
-        assert out.batch_shape == (3, 2)   # cartesian product
+        assert out.batch_shape == (3, 2)  # cartesian product
 
     def test_view_plus_plain_ra_products(self, numeric_ra):
         """A view and an independent ``RecordArray`` are in different
         groups (the view's parent ≠ the independent RA) → product."""
-        other = NumericRecordArray.stack(
-            [NumericRecord(z=float(k * 100)) for k in range(2)]
-        )
+        other = NumericRecordArray.stack([NumericRecord(z=float(k * 100)) for k in range(2)])
 
         @workflow_function
         def f(x, p):
@@ -263,8 +255,7 @@ class TestSweepGroupingByParent:
         """A 3-field NumericRecordArray with three sibling views
         collapses to one (n,) axis, not (n, n, n)."""
         ra = NumericRecordArray.stack(
-            [NumericRecord(a=float(i), b=float(i * 2), c=float(i * 10))
-             for i in range(5)]
+            [NumericRecord(a=float(i), b=float(i * 2), c=float(i * 10)) for i in range(5)]
         )
 
         @workflow_function
@@ -312,16 +303,17 @@ class TestPatternParity:
     def test_parity_on_mixed_fields(self):
         """Works with mixed numeric/categorical marginals too."""
         ff = FullFactorialDesign(
-            method=["nutpie", "pymc"], scale=[0.5, 1.0],
+            method=["nutpie", "pymc"],
+            scale=[0.5, 1.0],
         )
 
         @workflow_function
         def label_a(p: Record):
-            return f'{p["method"]}-{float(p["scale"]):.1f}'
+            return f"{p['method']}-{float(p['scale']):.1f}"
 
         @workflow_function
         def label_b(method, scale):
-            return f'{method}-{float(scale):.1f}'
+            return f"{method}-{float(scale):.1f}"
 
         out_a = label_a(p=ff)
         out_b = label_b(**ff.select_all())

--- a/tests/core/test_record_distribution.py
+++ b/tests/core/test_record_distribution.py
@@ -89,7 +89,8 @@ class TestSingleFieldShapeShim:
             _ = multi_field_dist.ndim
 
     def test_error_message_mentions_event_shapes_not_dtypes(
-        self, multi_field_dist,
+        self,
+        multi_field_dist,
     ):
         """The error message points users at ``.event_shapes`` only.
         ``.dtypes`` is only defined on ``NumericRecordDistribution``

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -34,6 +34,7 @@ from probpipe.core.record import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def roundtrip(obj):
     return pickle.loads(pickle.dumps(obj))
 
@@ -73,6 +74,7 @@ def test_record_immutability_after_unpickle():
 
 def test_record_provenance_preserved():
     from probpipe.core.provenance import Provenance
+
     r = Record(x=jnp.array(1.0))
     r.with_source(Provenance(operation="test_op", metadata={"k": "v"}))
     assert r._source is not None

--- a/tests/core/test_recordarray_broadcasting.py
+++ b/tests/core/test_recordarray_broadcasting.py
@@ -42,9 +42,7 @@ class TestRecordArrayDetection:
         def f(p: NumericRecord) -> float:
             return p["x"]
 
-        ra = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(4)]
-        )
+        ra = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(4)])
         out = f(p=ra)
         assert out.batch_shape == (4,)
 
@@ -56,9 +54,7 @@ class TestRecordArrayDetection:
         def f(ra: NumericRecordArray):
             return ra["x"].sum()
 
-        ra = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(4)]
-        )
+        ra = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(4)])
         out = f(ra=ra)
         # Single inner call - output is the unwrapped float result.
         assert float(out) == 6.0
@@ -73,8 +69,7 @@ class TestRecordArrayDetection:
             return p["x"]
 
         tpl = EventTemplate(x=())
-        scalar_ra = NumericRecordArray({"x": jnp.asarray(7.0)},
-                                       batch_shape=(), template=tpl)
+        scalar_ra = NumericRecordArray({"x": jnp.asarray(7.0)}, batch_shape=(), template=tpl)
         # No broadcasting - one call with the batch_shape=() RecordArray
         # passed through.
         out = f(p=scalar_ra)
@@ -89,12 +84,8 @@ class TestRecordArrayDetection:
         def f(a: NumericRecord, b: NumericRecord) -> float:
             return a["x"] + b["y"]
 
-        a = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(3)]
-        )
-        b = NumericRecordArray.stack(
-            [NumericRecord(y=float(i)) for i in range(5)]
-        )
+        a = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(3)])
+        b = NumericRecordArray.stack([NumericRecord(y=float(i)) for i in range(5)])
         out = f(a=a, b=b)
         assert isinstance(out, NumericRecordArray)
         assert out.batch_shape == (3, 5)
@@ -184,10 +175,12 @@ class TestDistributionOnlyPath:
             return x * 2
 
         from probpipe.core._broadcast_distributions import _RecordMarginal
+
         out = f(x=Normal(loc=2.0, scale=0.1, name="x"))
         assert isinstance(out, _RecordMarginal)
         # Mean of 2 * N(2, 0.1) is ~4.
         from probpipe import mean as pmean
+
         assert abs(float(pmean(out)) - 4.0) < 0.1
 
 
@@ -204,9 +197,7 @@ class TestNestedSweepPlusDistribution:
 
     @pytest.fixture
     def sweep(self):
-        return NumericRecordArray.stack(
-            [NumericRecord(bias=float(i)) for i in range(3)]
-        )
+        return NumericRecordArray.stack([NumericRecord(bias=float(i)) for i in range(3)])
 
     def test_scalar_inner_gives_distribution_array(self, sweep):
         @workflow_function(n_broadcast_samples=50, dispatch="sequential")
@@ -218,6 +209,7 @@ class TestNestedSweepPlusDistribution:
         assert out.batch_shape == (3,)
         # Per-row mean ≈ bias + 0
         from probpipe import mean as pmean
+
         means = pmean(out)
         np.testing.assert_allclose(means, [0.0, 1.0, 2.0], atol=0.2)
 
@@ -270,12 +262,8 @@ class TestDispatch:
         def f(a: NumericRecord, b: NumericRecord) -> float:
             return a["x"] + b["y"]
 
-        a = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(3)]
-        )
-        b = NumericRecordArray.stack(
-            [NumericRecord(y=float(i)) for i in range(5)]
-        )
+        a = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(3)])
+        b = NumericRecordArray.stack([NumericRecord(y=float(i)) for i in range(5)])
 
         with pytest.raises(ValueError, match="single plain RecordArray sweep"):
             f(a=a, b=b)
@@ -292,9 +280,7 @@ class TestProvenanceChain:
         def f(p: NumericRecord) -> float:
             return p["x"]
 
-        sweep = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(3)]
-        )
+        sweep = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(3)])
         out = f(p=sweep)
         assert out.source is not None
         assert out.source.operation == "workflow.stack"
@@ -308,9 +294,7 @@ class TestProvenanceChain:
         def f(p: NumericRecord, noise: float) -> float:
             return p["x"] + noise
 
-        sweep = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(3)]
-        )
+        sweep = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(3)])
         noise_dist = Normal(loc=0.0, scale=1.0, name="noise")
         out = f(p=sweep, noise=noise_dist)
         assert out.source.operation == "workflow.nested"
@@ -322,22 +306,19 @@ class TestProvenanceChain:
         """Default LIGHTWEIGHT: the sweep output keeps a traversable source — a
         ``ParentInfo`` with ``obj=None`` (so the parent array is GC-eligible) and
         the lineage preserved via ``.source``."""
+
         @workflow_function
         def f(p: NumericRecord) -> float:
             return p["x"]
 
-        sweep = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(3)]
-        )
+        sweep = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(3)])
         out = f(p=sweep)
         assert out.source is not None
         assert out.source.operation == "workflow.stack"
         parent = out.source.parents[0]
         assert parent.obj is None  # live ref dropped in LIGHTWEIGHT
         assert parent.type_name == "NumericRecordArray"
-        assert any(
-            a.type_name == "NumericRecordArray" for a in provenance_ancestors(out)
-        )
+        assert any(a.type_name == "NumericRecordArray" for a in provenance_ancestors(out))
 
     def test_pure_sweep_provenance_off(self):
         """OFF: the sweep output carries no provenance."""
@@ -347,9 +328,7 @@ class TestProvenanceChain:
         def f(p: NumericRecord) -> float:
             return p["x"]
 
-        sweep = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(3)]
-        )
+        sweep = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(3)])
         out = f(p=sweep)
         assert out.source is None
 
@@ -380,12 +359,9 @@ class TestMultiDimensionalBatch:
     def sweep_2d(self):
         """3 x 2 sweep over (r, k)."""
         from probpipe.core.record import EventTemplate
-        r_values = jnp.array([[1.0, 1.0],
-                              [2.0, 2.0],
-                              [3.0, 3.0]])
-        k_values = jnp.array([[10.0, 20.0],
-                              [10.0, 20.0],
-                              [10.0, 20.0]])
+
+        r_values = jnp.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+        k_values = jnp.array([[10.0, 20.0], [10.0, 20.0], [10.0, 20.0]])
         tpl = EventTemplate(r=(), k=())
         return NumericRecordArray(
             {"r": r_values, "k": k_values},
@@ -403,9 +379,7 @@ class TestMultiDimensionalBatch:
         assert out.batch_shape == (3, 2)
         np.testing.assert_allclose(
             out["f"],
-            [[10.0, 20.0],
-             [20.0, 40.0],
-             [30.0, 60.0]],
+            [[10.0, 20.0], [20.0, 40.0], [30.0, 60.0]],
         )
 
     def test_2d_sweep_record_output(self, sweep_2d):
@@ -438,6 +412,7 @@ class TestMultiDimensionalBatch:
         """Nested regime: each sweep cell marginalises over the MC
         draws; output is a DistributionArray matching the sweep's
         batch_shape."""
+
         @workflow_function(n_broadcast_samples=10, dispatch="sequential")
         def f(p: NumericRecord, noise: float) -> float:
             return p["r"] * p["k"] + noise
@@ -455,7 +430,9 @@ class TestMultiDimensionalBatch:
         vals = jnp.arange(24.0).reshape(shape)
         tpl = EventTemplate(v=())
         sweep = NumericRecordArray(
-            {"v": vals}, batch_shape=shape, template=tpl,
+            {"v": vals},
+            batch_shape=shape,
+            template=tpl,
         )
 
         @workflow_function
@@ -479,8 +456,6 @@ class TestAutoWrapFieldName:
         def my_scalar_fn(p: NumericRecord) -> float:
             return p["x"] * 2
 
-        sweep = NumericRecordArray.stack(
-            [NumericRecord(x=float(i)) for i in range(3)]
-        )
+        sweep = NumericRecordArray.stack([NumericRecord(x=float(i)) for i in range(3)])
         out = my_scalar_fn(p=sweep)
         assert out.fields == ("my_scalar_fn",)

--- a/tests/core/test_transition.py
+++ b/tests/core/test_transition.py
@@ -43,9 +43,7 @@ def provenance_step(dist, value):
     field = dist.samples.fields[0]
     samples = dist.samples[field] + value
     new_dist = EmpiricalDistribution(samples, name=field)
-    new_dist.with_source(
-        Provenance("custom_step", parents=(dist,), metadata={"value": value})
-    )
+    new_dist.with_source(Provenance("custom_step", parents=(dist,), metadata={"value": value}))
     return new_dist
 
 
@@ -65,6 +63,7 @@ class TestIterate:
         still work.
         """
         from probpipe import DistributionArray
+
         dists = iterate(step_fn=shift_step, initial=initial, inputs=[1.0, 2.0])
         assert isinstance(dists, DistributionArray)
         assert len(dists) == 3  # initial + 2 steps
@@ -116,12 +115,15 @@ class TestIterate:
 
     def test_callback_early_stop(self, initial):
         """Callback returning False truncates iteration."""
+
         def stop_after_one(i, dist):
             if i >= 1:
                 return False
 
         dists = iterate(
-            step_fn=shift_step, initial=initial, inputs=[1.0, 2.0, 3.0, 4.0],
+            step_fn=shift_step,
+            initial=initial,
+            inputs=[1.0, 2.0, 3.0, 4.0],
             callback=stop_after_one,
         )
         # initial + steps 0 and 1 (stops after callback for step 1)
@@ -135,6 +137,7 @@ class TestIterate:
 
     def test_bad_return_type(self, initial):
         """Non-Distribution return raises TypeError."""
+
         def bad_step(dist, inp):
             return "not a distribution"
 
@@ -304,7 +307,9 @@ class TestIncrementalConditioner:
         """update() conditions on a single data batch, updates state."""
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2) * 10.0, name="prior")
         conditioner = IncrementalConditioner(
-            prior, _SimpleLikelihood(), condition_fn=_mock_condition_fn,
+            prior,
+            _SimpleLikelihood(),
+            condition_fn=_mock_condition_fn,
         )
         assert conditioner.curr_posterior is prior
 
@@ -318,7 +323,9 @@ class TestIncrementalConditioner:
         """Successive update() calls chain posteriors."""
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2) * 10.0, name="prior")
         conditioner = IncrementalConditioner(
-            prior, _SimpleLikelihood(), condition_fn=_mock_condition_fn,
+            prior,
+            _SimpleLikelihood(),
+            condition_fn=_mock_condition_fn,
         )
         post1 = conditioner.update(data=jnp.ones((10, 2)))
         post2 = conditioner.update(data=jnp.ones((10, 2)) * 2.0)
@@ -329,9 +336,12 @@ class TestIncrementalConditioner:
         """update_all() iterates over batches, returns DistributionArray,
         updates state."""
         from probpipe import DistributionArray
+
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2) * 10.0, name="prior")
         conditioner = IncrementalConditioner(
-            prior, _SimpleLikelihood(), condition_fn=_mock_condition_fn,
+            prior,
+            _SimpleLikelihood(),
+            condition_fn=_mock_condition_fn,
         )
         batches = [jnp.ones((10, 2)) * i for i in [1.0, 2.0, 3.0]]
         dists = conditioner.update_all(data_batches=batches)
@@ -345,7 +355,9 @@ class TestIncrementalConditioner:
         """step property exposes the step function for use with iterate."""
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2) * 10.0, name="prior")
         conditioner = IncrementalConditioner(
-            prior, _SimpleLikelihood(), condition_fn=_mock_condition_fn,
+            prior,
+            _SimpleLikelihood(),
+            condition_fn=_mock_condition_fn,
         )
         assert isinstance(conditioner.step, WorkflowFunction)
 
@@ -364,10 +376,12 @@ class TestIncrementalConditioner:
 class TestNestability:
     def test_nested_iterate(self, initial):
         """A step function can call iterate internally."""
+
         def inner_step(dist, value):
             field = dist.samples.fields[0]
             return EmpiricalDistribution(
-                dist.samples[field] + value, name=field,
+                dist.samples[field] + value,
+                name=field,
             )
 
         def outer_step(dist, batch):

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -61,10 +61,7 @@ class TestExecuteDistributionBroadcast:
 
         def fake_execute_many(request):
             seen["request"] = request
-            return [
-                request.func(**call_values)
-                for call_values in request.call_value_list
-            ]
+            return [request.func(**call_values) for call_values in request.call_value_list]
 
         monkeypatch.setattr(
             _workflow_distribution_broadcast._workflow_execution,
@@ -94,8 +91,7 @@ class TestExecuteDistributionBroadcast:
         assert len(request.call_value_list) == 5
         assert all(call_values["offset"] == 2.0 for call_values in request.call_value_list)
         assert all(
-            not isinstance(call_values["x"], Normal)
-            for call_values in request.call_value_list
+            not isinstance(call_values["x"], Normal) for call_values in request.call_value_list
         )
         assert result.source.metadata == {
             "dispatch": "thread",

--- a/tests/core/test_workflow_options_namespace.py
+++ b/tests/core/test_workflow_options_namespace.py
@@ -145,9 +145,13 @@ def test_var_keyword_receives_workflow_control_names():
     )
 
     assert result.num_atoms == 5
-    assert seen == [
-        {"seed": 42, "n_broadcast_samples": 99, "include_inputs": True},
-    ] * 5
+    assert (
+        seen
+        == [
+            {"seed": 42, "n_broadcast_samples": 99, "include_inputs": True},
+        ]
+        * 5
+    )
 
 
 def test_unbindable_call_time_control_name_is_rejected():

--- a/tests/core/test_workflow_plan.py
+++ b/tests/core/test_workflow_plan.py
@@ -17,9 +17,7 @@ from probpipe.core.protocols import SupportsSampling
 
 
 def _numeric_record_array(field: str, values: range) -> NumericRecordArray:
-    return NumericRecordArray.stack(
-        [NumericRecord(**{field: float(value)}) for value in values]
-    )
+    return NumericRecordArray.stack([NumericRecord(**{field: float(value)}) for value in values])
 
 
 class TestBroadcastRegime:
@@ -115,12 +113,7 @@ class TestHintClassification:
 
 class TestArrayGrouping:
     def test_sibling_views_zip_into_one_group(self):
-        ra = NumericRecordArray.stack(
-            [
-                NumericRecord(x=float(i), y=float(2 * i))
-                for i in range(4)
-            ]
-        )
+        ra = NumericRecordArray.stack([NumericRecord(x=float(i), y=float(2 * i)) for i in range(4)])
 
         plan = build_broadcast_plan(
             values={"x": ra.view("x"), "y": ra.view("y")},

--- a/tests/core/test_workflow_sweep.py
+++ b/tests/core/test_workflow_sweep.py
@@ -19,9 +19,7 @@ from probpipe.core._workflow_plan import build_broadcast_plan
 
 
 def _numeric_record_array(field: str, values: range) -> NumericRecordArray:
-    return NumericRecordArray.stack(
-        [NumericRecord(**{field: float(value)}) for value in values]
-    )
+    return NumericRecordArray.stack([NumericRecord(**{field: float(value)}) for value in values])
 
 
 def _unexpected_distribution_broadcast(*args, **kwargs):
@@ -35,10 +33,7 @@ def _require_not_called(*args, **kwargs):
 class TestSliceSweepValues:
     def test_views_from_same_parent_zip(self):
         parent = NumericRecordArray.stack(
-            [
-                NumericRecord(x=float(i), y=float(10 + i))
-                for i in range(3)
-            ]
+            [NumericRecord(x=float(i), y=float(10 + i)) for i in range(3)]
         )
         values = {"x": parent.view("x"), "y": parent.view("y")}
         plan = build_broadcast_plan(values=values, hints={})
@@ -52,10 +47,11 @@ class TestSliceSweepValues:
             for i in range(plan.n_sweep)
         ]
 
-        assert [
-            (float(row["x"]), float(row["y"]))
-            for row in observed
-        ] == [(0.0, 10.0), (1.0, 11.0), (2.0, 12.0)]
+        assert [(float(row["x"]), float(row["y"])) for row in observed] == [
+            (0.0, 10.0),
+            (1.0, 11.0),
+            (2.0, 12.0),
+        ]
 
     def test_arrays_from_different_parents_use_row_major_product(self):
         values = {
@@ -73,10 +69,7 @@ class TestSliceSweepValues:
             for i in range(plan.n_sweep)
         ]
 
-        assert [
-            (float(row["a"]["a"]), float(row["b"]["b"]))
-            for row in observed
-        ] == [
+        assert [(float(row["a"]["a"]), float(row["b"]["b"])) for row in observed] == [
             (0.0, 0.0),
             (0.0, 1.0),
             (0.0, 2.0),
@@ -132,10 +125,7 @@ class TestExecuteSweep:
 
         def fake_execute_many(request):
             seen["request"] = request
-            return [
-                request.func(**call_values)
-                for call_values in request.call_value_list
-            ]
+            return [request.func(**call_values) for call_values in request.call_value_list]
 
         monkeypatch.setattr(
             _workflow_sweep._workflow_execution,
@@ -219,9 +209,7 @@ class TestExecuteSweep:
             return BroadcastDistribution(
                 input_samples={"noise": jnp.asarray([0.0])},
                 output_samples=jnp.asarray([loc]),
-                output_distributions=[
-                    Normal(loc=loc, scale=1.0, name=f"row_{int(loc)}")
-                ],
+                output_distributions=[Normal(loc=loc, scale=1.0, name=f"row_{int(loc)}")],
                 weights=None,
                 broadcast_args=["noise"],
             )

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -200,9 +200,9 @@ class TestNormalDist:
 _SCIPY_EQUIVALENTS = {
     "Normal": _scipy.norm(loc=0.0, scale=1.0),
     "Beta": _scipy.beta(a=2.0, b=5.0),
-    "Gamma": _scipy.gamma(a=3.0, scale=1.0),        # scipy scale = 1 / rate
+    "Gamma": _scipy.gamma(a=3.0, scale=1.0),  # scipy scale = 1 / rate
     "InverseGamma": _scipy.invgamma(a=3.0, scale=1.0),
-    "Exponential": _scipy.expon(scale=0.5),         # scipy scale = 1 / rate
+    "Exponential": _scipy.expon(scale=0.5),  # scipy scale = 1 / rate
     "LogNormal": _scipy.lognorm(s=1.0, scale=1.0),  # s = sigma, scale = exp(loc)
     "StudentT": _scipy.t(df=5.0, loc=0.0, scale=1.0),
     "Uniform": _scipy.uniform(loc=0.0, scale=1.0),  # scipy scale = high - low
@@ -221,8 +221,10 @@ class TestContinuousMoments:
         cls, kwargs = _CONTINUOUS_DISTS[name]
         scipy_dist = _SCIPY_EQUIVALENTS[name]
         np.testing.assert_allclose(
-            float(mean(cls(**kwargs))), float(scipy_dist.mean()),
-            rtol=1e-5, atol=1e-6,
+            float(mean(cls(**kwargs))),
+            float(scipy_dist.mean()),
+            rtol=1e-5,
+            atol=1e-6,
         )
 
     @pytest.mark.parametrize("name", list(_SCIPY_EQUIVALENTS))
@@ -230,8 +232,10 @@ class TestContinuousMoments:
         cls, kwargs = _CONTINUOUS_DISTS[name]
         scipy_dist = _SCIPY_EQUIVALENTS[name]
         np.testing.assert_allclose(
-            float(variance(cls(**kwargs))), float(scipy_dist.var()),
-            rtol=1e-5, atol=1e-6,
+            float(variance(cls(**kwargs))),
+            float(scipy_dist.var()),
+            rtol=1e-5,
+            atol=1e-6,
         )
 
     @pytest.mark.parametrize("name", list(_SCIPY_EQUIVALENTS))
@@ -277,6 +281,7 @@ class TestProb:
     def test_prob_equals_exp_logprob(self, key):
         """prob(dist, x) must equal exp(log_prob(dist, x))."""
         from probpipe import log_prob as log_prob_op
+
         d = Normal(loc=0.0, scale=1.0, name="x")
         xs = jnp.array([-1.0, 0.5, 1.2])
         np.testing.assert_allclose(

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -29,13 +29,9 @@ def key():
 @pytest.fixture(
     params=[
         pytest.param(lambda: Bernoulli(probs=0.7, name="x"), id="Bernoulli"),
-        pytest.param(
-            lambda: Binomial(total_count=10, probs=0.3, name="x"), id="Binomial"
-        ),
+        pytest.param(lambda: Binomial(total_count=10, probs=0.3, name="x"), id="Binomial"),
         pytest.param(lambda: Poisson(rate=5.0, name="x"), id="Poisson"),
-        pytest.param(
-            lambda: Categorical(probs=[0.2, 0.3, 0.5], name="x"), id="Categorical"
-        ),
+        pytest.param(lambda: Categorical(probs=[0.2, 0.3, 0.5], name="x"), id="Categorical"),
         pytest.param(
             lambda: NegativeBinomial(total_count=5, probs=0.4, name="x"),
             id="NegativeBinomial",
@@ -82,9 +78,7 @@ _NAMED_DISTS = {
     "Binomial": lambda name: Binomial(total_count=10, probs=0.3, name=name),
     "Poisson": lambda name: Poisson(rate=5.0, name=name),
     "Categorical": lambda name: Categorical(probs=[0.2, 0.3, 0.5], name=name),
-    "NegativeBinomial": lambda name: NegativeBinomial(
-        total_count=5, probs=0.4, name=name
-    ),
+    "NegativeBinomial": lambda name: NegativeBinomial(total_count=5, probs=0.4, name=name),
 }
 
 

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -20,6 +20,7 @@ from probpipe import cov, from_distribution, log_prob, mean, prob, sample, varia
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def key():
     return jax.random.PRNGKey(42)
@@ -120,35 +121,34 @@ class TestMultivariateNormal:
     def test_log_prob_matches_scipy(self, gaussian, loc, cov_matrix, key):
         """log_prob and prob must match scipy.stats.multivariate_normal."""
         import scipy.stats
+
         scipy_mvn = scipy.stats.multivariate_normal(
             mean=np.asarray(loc), cov=np.asarray(cov_matrix)
         )
         s = sample(gaussian, key=key, sample_shape=(5,))
         s_np = np.asarray(s)
-        np.testing.assert_allclose(
-            log_prob(gaussian, s), scipy_mvn.logpdf(s_np), rtol=1e-5
-        )
-        np.testing.assert_allclose(
-            prob(gaussian, s), scipy_mvn.pdf(s_np), rtol=1e-5
-        )
+        np.testing.assert_allclose(log_prob(gaussian, s), scipy_mvn.logpdf(s_np), rtol=1e-5)
+        np.testing.assert_allclose(prob(gaussian, s), scipy_mvn.pdf(s_np), rtol=1e-5)
 
     def test_mean_and_cov(self, gaussian, loc, cov_matrix, key):
         """Sample mean and cov from 50k draws must match analytical values."""
         import scipy.stats
+
         draws = np.asarray(sample(gaussian, key=key, sample_shape=(50_000,)))
         np.testing.assert_allclose(draws.mean(0), np.asarray(loc), atol=0.02)
         np.testing.assert_allclose(
-            np.cov(draws, rowvar=False), np.asarray(cov_matrix), atol=0.05,
+            np.cov(draws, rowvar=False),
+            np.asarray(cov_matrix),
+            atol=0.05,
         )
 
     def test_marginal_ks(self, gaussian, loc, cov_matrix, key):
         """Each MVN marginal X_i ~ N(loc_i, cov_ii): KS test on 50k samples."""
         import scipy.stats
+
         draws = np.asarray(sample(gaussian, key=key, sample_shape=(50_000,)))
         for i in range(draws.shape[1]):
-            marginal = scipy.stats.norm(
-                loc=float(loc[i]), scale=float(jnp.sqrt(cov_matrix[i, i]))
-            )
+            marginal = scipy.stats.norm(loc=float(loc[i]), scale=float(jnp.sqrt(cov_matrix[i, i])))
             _, p = scipy.stats.kstest(draws[:, i], marginal.cdf)
             assert p > 0.001, f"KS failed for marginal {i}: p={p:.4e}"
 
@@ -172,9 +172,7 @@ class TestMultivariateNormal:
         assert gaussian.dtype == loc.dtype
 
     def test_from_distribution_empirical(self, gaussian, key):
-        ed = from_distribution(
-            gaussian, RecordEmpiricalDistribution, key=key, num_samples=2000
-        )
+        ed = from_distribution(gaussian, RecordEmpiricalDistribution, key=key, num_samples=2000)
         g2 = from_distribution(ed, MultivariateNormal, name="fitted")
         np.testing.assert_allclose(g2.loc, gaussian.loc, atol=0.2)
         assert g2.name == "fitted"
@@ -203,9 +201,7 @@ class TestEmpiricalDistribution:
         ed = RecordEmpiricalDistribution(simple_samples, simple_weights, name="x")
         np.testing.assert_allclose(ed.weights.sum(), 1.0)
         expected_mean = jnp.sum(simple_samples.ravel() * ed.weights)
-        np.testing.assert_allclose(
-            jnp.asarray(mean(ed)).ravel(), expected_mean, atol=1e-6
-        )
+        np.testing.assert_allclose(jnp.asarray(mean(ed)).ravel(), expected_mean, atol=1e-6)
 
     def test_weights_normalized(self):
         """Unnormalized weights should be normalized internally."""
@@ -261,17 +257,13 @@ class TestEmpiricalDistribution:
     def test_mean(self, simple_samples, simple_weights):
         ed = RecordEmpiricalDistribution(simple_samples, simple_weights, name="x")
         expected = jnp.sum(simple_samples.ravel() * ed.weights)
-        np.testing.assert_allclose(
-            jnp.asarray(mean(ed)).ravel(), expected, atol=1e-6
-        )
+        np.testing.assert_allclose(jnp.asarray(mean(ed)).ravel(), expected, atol=1e-6)
 
     def test_variance(self, simple_samples, simple_weights):
         ed = RecordEmpiricalDistribution(simple_samples, simple_weights, name="x")
         mu = jnp.asarray(mean(ed))
         expected = jnp.sum(ed.weights * (simple_samples.ravel() - mu.ravel()) ** 2)
-        np.testing.assert_allclose(
-            jnp.asarray(variance(ed)).ravel(), expected, atol=1e-6
-        )
+        np.testing.assert_allclose(jnp.asarray(variance(ed)).ravel(), expected, atol=1e-6)
 
     def test_cov_matrix(self):
         samples = jnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
@@ -293,9 +285,7 @@ class TestEmpiricalDistribution:
         assert ed.name == "emp"
 
     def test_from_distribution(self, gaussian, key):
-        ed = from_distribution(
-            gaussian, RecordEmpiricalDistribution, key=key, num_samples=50
-        )
+        ed = from_distribution(gaussian, RecordEmpiricalDistribution, key=key, num_samples=50)
         assert ed.num_atoms == 50
         assert ed.event_shape == gaussian.event_shape
         assert ed.source is not None
@@ -325,6 +315,7 @@ class TestEmpiricalValidationMessages:
     def test_zero_dim_first_field_reports_shape(self):
         """First field is 0-D → message names the field and shape."""
         from probpipe import Record
+
         rec = Record(x=jnp.array(1.0))
         with pytest.raises(ValueError) as exc:
             RecordEmpiricalDistribution(rec)
@@ -336,6 +327,7 @@ class TestEmpiricalValidationMessages:
         """A later field is 0-D → message names that field, its shape,
         and the reference field."""
         from probpipe import Record
+
         rec = Record(x=jnp.zeros(5), y=jnp.array(2.0))
         with pytest.raises(ValueError) as exc:
             RecordEmpiricalDistribution(rec)
@@ -349,6 +341,7 @@ class TestEmpiricalValidationMessages:
         """A later field has a different sample-axis length → message
         names the field, its full shape, and the reference field."""
         from probpipe import Record
+
         rec = Record(x=jnp.zeros(5), y=jnp.zeros(7))
         with pytest.raises(ValueError) as exc:
             RecordEmpiricalDistribution(rec)
@@ -376,7 +369,8 @@ class TestFlatSamples:
         ed = EmpiricalDistribution(jnp.arange(10.0), name="x")
         assert ed.flat_samples.shape == (10, 1)
         np.testing.assert_array_equal(
-            ed.flat_samples, jnp.arange(10.0).reshape(10, 1),
+            ed.flat_samples,
+            jnp.arange(10.0).reshape(10, 1),
         )
 
     def test_single_field_1d_event(self):
@@ -392,12 +386,14 @@ class TestFlatSamples:
         ed = EmpiricalDistribution(samples, name="W")
         assert ed.flat_samples.shape == (4, 6)
         np.testing.assert_array_equal(
-            ed.flat_samples, samples.reshape(4, 6),
+            ed.flat_samples,
+            samples.reshape(4, 6),
         )
 
     def test_multi_field_1d_events(self):
         # Multi-field record → column-stack in insertion order.
         from probpipe import Record
+
         rec = Record(
             mu=jnp.arange(8.0),
             log_sigma=jnp.arange(8.0) + 100.0,
@@ -407,12 +403,14 @@ class TestFlatSamples:
         # First column is mu, second is log_sigma — insertion order.
         np.testing.assert_array_equal(ed.flat_samples[:, 0], jnp.arange(8.0))
         np.testing.assert_array_equal(
-            ed.flat_samples[:, 1], jnp.arange(8.0) + 100.0,
+            ed.flat_samples[:, 1],
+            jnp.arange(8.0) + 100.0,
         )
 
     def test_multi_field_mixed_event_shapes(self):
         # mu: (10,), beta: (10, 3) → flat_samples (10, 1+3) = (10, 4).
         from probpipe import Record
+
         rec = Record(
             mu=jnp.arange(10.0),
             beta=jnp.arange(30.0).reshape(10, 3),
@@ -421,12 +419,14 @@ class TestFlatSamples:
         assert ed.flat_samples.shape == (10, 4)
         np.testing.assert_array_equal(ed.flat_samples[:, 0], jnp.arange(10.0))
         np.testing.assert_array_equal(
-            ed.flat_samples[:, 1:], jnp.arange(30.0).reshape(10, 3),
+            ed.flat_samples[:, 1:],
+            jnp.arange(30.0).reshape(10, 3),
         )
 
     def test_field_order_matches_insertion(self):
         # Insertion-order rule: flat_samples columns follow `dist.fields`.
         from probpipe import Record
+
         rec1 = Record(z=jnp.zeros(5), a=jnp.ones(5))
         rec2 = Record(a=jnp.ones(5), z=jnp.zeros(5))
         ed1 = RecordEmpiricalDistribution(rec1)
@@ -451,6 +451,7 @@ class TestFlatSamples:
         # cleanly alongside non-empty fields. Pins that the
         # reshape-then-concat pipeline doesn't choke on prod([0]) == 0.
         from probpipe import Record
+
         rec = Record(
             empty=jnp.zeros((10, 0)),
             real=jnp.arange(30.0).reshape(10, 3),
@@ -458,7 +459,8 @@ class TestFlatSamples:
         ed = RecordEmpiricalDistribution(rec)
         assert ed.flat_samples.shape == (10, 3)
         np.testing.assert_array_equal(
-            ed.flat_samples, jnp.arange(30.0).reshape(10, 3),
+            ed.flat_samples,
+            jnp.arange(30.0).reshape(10, 3),
         )
 
 
@@ -491,9 +493,8 @@ class TestEmpiricalLogWeights:
         samples = jnp.array([[1.0], [2.0]])
         with pytest.raises(ValueError, match="not both"):
             EmpiricalDistribution(
-                samples,
-                weights=jnp.array([0.5, 0.5]),
-                log_weights=jnp.array([0.0, 0.0]), name="x")
+                samples, weights=jnp.array([0.5, 0.5]), log_weights=jnp.array([0.0, 0.0]), name="x"
+            )
 
     def test_log_weights_wrong_length_raises(self):
         samples = jnp.array([[1.0], [2.0], [3.0]])
@@ -630,13 +631,19 @@ class TestDistributionABC:
         class MinimalDist(NumericRecordDistribution, SupportsSampling, SupportsExpectation):
             _sampling_cost = "low"
             _preferred_orchestration = None
+
             @property
             def event_shape(self):
                 return (1,)
+
             def _sample(self, key, sample_shape=()):
                 return jnp.zeros(sample_shape + (1,))
+
             def _expectation(self, f, *, key=None, num_evaluations=None, return_dist=None):
-                return _mc_expectation(self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist)
+                return _mc_expectation(
+                    self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist
+                )
+
         d = MinimalDist(name="minimal")
         with pytest.raises(TypeError, match="does not support mean"):
             mean(d)
@@ -649,13 +656,19 @@ class TestDistributionABC:
         class MinimalDist(NumericRecordDistribution, SupportsSampling, SupportsExpectation):
             _sampling_cost = "low"
             _preferred_orchestration = None
+
             @property
             def event_shape(self):
                 return (1,)
+
             def _sample(self, key, sample_shape=()):
                 return jnp.zeros(sample_shape + (1,))
+
             def _expectation(self, f, *, key=None, num_evaluations=None, return_dist=None):
-                return _mc_expectation(self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist)
+                return _mc_expectation(
+                    self, f, key=key, num_evaluations=num_evaluations, return_dist=return_dist
+                )
+
         d = MinimalDist(name="minimal")
         with pytest.raises(TypeError, match="does not support variance"):
             variance(d)
@@ -702,9 +715,7 @@ class TestTFPDistribution:
         np.testing.assert_allclose(mean(gaussian), loc, atol=1e-6)
 
     def test_variance_delegates(self, gaussian, cov_matrix):
-        np.testing.assert_allclose(
-            variance(gaussian), jnp.diag(cov_matrix), atol=1e-5
-        )
+        np.testing.assert_allclose(variance(gaussian), jnp.diag(cov_matrix), atol=1e-5)
 
 
 # ---------------------------------------------------------------------------
@@ -750,6 +761,7 @@ class TestDistributionCoverageGaps:
         boilerplate. ``dtypes`` is canonical (subclass must override);
         ``dtype`` derives from it.
         """
+
         class Scalar(NumericRecordDistribution):
             @property
             def event_shape(self):
@@ -772,6 +784,7 @@ class TestDistributionCoverageGaps:
         than returning a silent default-float for every field (which
         would lie for integer-valued distributions like ``Bernoulli``).
         """
+
         class Scalar(NumericRecordDistribution):
             @property
             def event_shape(self):
@@ -784,6 +797,7 @@ class TestDistributionCoverageGaps:
     def test_dtype_uniform_with_template(self):
         """NumericRecordDistribution.dtype is the common dtype when all fields match."""
         from probpipe import Normal
+
         n = Normal(loc=0.0, scale=1.0, name="x")
         assert n.dtype == n._tfp_dist.dtype
 

--- a/tests/distributions/test_gaussian_random_function.py
+++ b/tests/distributions/test_gaussian_random_function.py
@@ -79,14 +79,13 @@ def _assert_da_of(dist, cls):
     assert isinstance(dist, DistributionArray)
     for i in range(dist.size):
         cell = dist._flat_component(i)
-        assert isinstance(cell, cls), (
-            f"cell {i} is {type(cell).__name__}, expected {cls.__name__}"
-        )
+        assert isinstance(cell, cls), f"cell {i} is {type(cell).__name__}, expected {cls.__name__}"
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def key():
@@ -101,7 +100,7 @@ def key():
 def _rbf_kernel(X1, X2, lengthscale=1.0, variance=1.0):
     """Simple RBF kernel for mock GP."""
     sq_dist = jnp.sum((X1[:, None, :] - X2[None, :, :]) ** 2, axis=-1)
-    return variance * jnp.exp(-0.5 * sq_dist / lengthscale ** 2)
+    return variance * jnp.exp(-0.5 * sq_dist / lengthscale**2)
 
 
 class _ScalarGP(GaussianRandomFunction):
@@ -350,6 +349,7 @@ class TestLinearBasisFunction:
     def test_marginal_mean_value(self, scalar_lbf):
         """Check mean matches manual computation."""
         from probpipe import mean as mean_op
+
         X = jnp.array([[0.0], [1.0]])
         dist = scalar_lbf(X)
         # ``scalar_lbf(X)`` returns a ``DistributionArray`` of cells;
@@ -408,9 +408,7 @@ class TestLinearBasisFunction:
 
     def test_covariance_full_joint_multi(self, multi_output_lbf):
         X = jnp.linspace(-1, 1, 5).reshape(-1, 1)
-        cov = multi_output_lbf.predict_covariance(
-            X, joint_inputs=True, joint_outputs=True
-        )
+        cov = multi_output_lbf.predict_covariance(X, joint_inputs=True, joint_outputs=True)
         assert cov.shape == (10, 10)  # 5*2 x 5*2
 
     # -- Function sampling --------------------------------------------------
@@ -585,9 +583,7 @@ class TestLinearMap:
         assert cov_per_out.shape == (2, 3, 3)
 
         # Get via full joint and extract
-        cov_full = h.predict_covariance(
-            X, joint_inputs=True, joint_outputs=True
-        )
+        cov_full = h.predict_covariance(X, joint_inputs=True, joint_outputs=True)
         assert cov_full.shape == (6, 6)
 
         # The per-output covariance for output 0 should match the
@@ -754,8 +750,10 @@ class TestIndependentSum:
         X = jnp.stack([jnp.linspace(-1, 1, 5), jnp.zeros(5)], axis=-1)  # (5, 2)
         np.testing.assert_allclose(
             h.predict_covariance(X, joint_inputs=True),
-            (gp1.predict_covariance(X, joint_inputs=True)
-             + gp2.predict_covariance(X, joint_inputs=True)),
+            (
+                gp1.predict_covariance(X, joint_inputs=True)
+                + gp2.predict_covariance(X, joint_inputs=True)
+            ),
             atol=1e-5,
         )
 
@@ -853,6 +851,7 @@ class TestAlgebraComposition:
 
 # ---------- shared fixtures for correctness tests ----------
 
+
 @pytest.fixture
 def correctness_X():
     """4 test input points for correctness checks."""
@@ -881,11 +880,14 @@ def _simple_multi_output_features(X):
     """
     x = X[..., 0]  # (n,)
     ones = jnp.ones_like(x)
-    return jnp.stack([
-        jnp.stack([ones, x], axis=-1),       # output 0: [1, x]
-        jnp.stack([x, x ** 2], axis=-1),     # output 1: [x, x^2]
-        jnp.stack([ones, -x], axis=-1),      # output 2: [1, -x]
-    ], axis=-2)  # (n, 3, 2)
+    return jnp.stack(
+        [
+            jnp.stack([ones, x], axis=-1),  # output 0: [1, x]
+            jnp.stack([x, x**2], axis=-1),  # output 1: [x, x^2]
+            jnp.stack([ones, -x], axis=-1),  # output 2: [1, -x]
+        ],
+        axis=-2,
+    )  # (n, 3, 2)
 
 
 @pytest.fixture
@@ -907,18 +909,20 @@ def correlated_lbf(correctness_w_mean, correctness_w_cov):
 def _simple_scalar_features(X):
     """Feature map: scalar input → [1, x, x^2]."""
     x = X[..., 0]
-    return jnp.stack([jnp.ones_like(x), x, x ** 2], axis=-1)  # (n, 3)
+    return jnp.stack([jnp.ones_like(x), x, x**2], axis=-1)  # (n, 3)
 
 
 @pytest.fixture
 def scalar_correctness_lbf():
     """Scalar LBF with non-trivial weight covariance."""
     w_mean = jnp.array([1.0, -0.5, 0.2])
-    w_cov = jnp.array([
-        [1.0, 0.2, -0.1],
-        [0.2, 0.8, 0.05],
-        [-0.1, 0.05, 0.3],
-    ])
+    w_cov = jnp.array(
+        [
+            [1.0, 0.2, -0.1],
+            [0.2, 0.8, 0.05],
+            [-0.1, 0.05, 0.3],
+        ]
+    )
     weights = MultivariateNormal(name="weights", loc=w_mean, cov=w_cov)
     return LinearBasisFunction(
         feature_map=_simple_scalar_features,
@@ -932,12 +936,10 @@ class TestLinearBasisFunctionCorrectness:
 
     def test_mean_scalar(self, scalar_correctness_lbf, correctness_X):
         X = correctness_X
-        phi = np.array(_simple_scalar_features(X))   # (4, 3)
+        phi = np.array(_simple_scalar_features(X))  # (4, 3)
         m = np.array([1.0, -0.5, 0.2])
         expected = phi @ m
-        np.testing.assert_allclose(
-            scalar_correctness_lbf.predict_mean(X), expected, atol=1e-5
-        )
+        np.testing.assert_allclose(scalar_correctness_lbf.predict_mean(X), expected, atol=1e-5)
 
     def test_variance_equals_cov_diag_scalar(self, scalar_correctness_lbf, correctness_X):
         X = correctness_X
@@ -947,12 +949,14 @@ class TestLinearBasisFunctionCorrectness:
 
     def test_joint_cov_scalar(self, scalar_correctness_lbf, correctness_X):
         X = correctness_X
-        phi = np.array(_simple_scalar_features(X))   # (4, 3)
-        C = np.array([
-            [1.0, 0.2, -0.1],
-            [0.2, 0.8, 0.05],
-            [-0.1, 0.05, 0.3],
-        ])
+        phi = np.array(_simple_scalar_features(X))  # (4, 3)
+        C = np.array(
+            [
+                [1.0, 0.2, -0.1],
+                [0.2, 0.8, 0.05],
+                [-0.1, 0.05, 0.3],
+            ]
+        )
         expected = phi @ C @ phi.T  # (4, 4)
         cov = scalar_correctness_lbf.predict_covariance(X, joint_inputs=True)
         np.testing.assert_allclose(cov, expected, atol=1e-5)
@@ -962,20 +966,14 @@ class TestLinearBasisFunctionCorrectness:
         phi = np.array(_simple_multi_output_features(X))  # (4, 3, 2)
         m = np.array(correctness_w_mean)
         expected = np.einsum("now,w->no", phi, m)  # (4, 3)
-        np.testing.assert_allclose(
-            correlated_lbf.predict_mean(X), expected, atol=1e-5
-        )
+        np.testing.assert_allclose(correlated_lbf.predict_mean(X), expected, atol=1e-5)
 
-    def test_full_joint_cov_multi_output(
-        self, correlated_lbf, correctness_X, correctness_w_cov
-    ):
+    def test_full_joint_cov_multi_output(self, correlated_lbf, correctness_X, correctness_w_cov):
         X = correctness_X
         phi = np.array(_simple_multi_output_features(X))  # (4, 3, 2)
         C = np.array(correctness_w_cov)
         expected = _dense_lbf_full_joint_cov(phi, C)  # (12, 12)
-        cov = correlated_lbf.predict_covariance(
-            X, joint_inputs=True, joint_outputs=True
-        )
+        cov = correlated_lbf.predict_covariance(X, joint_inputs=True, joint_outputs=True)
         np.testing.assert_allclose(cov, expected, atol=1e-5)
 
     def test_variance_equals_diag_of_per_point_cov(
@@ -983,25 +981,17 @@ class TestLinearBasisFunctionCorrectness:
     ):
         """predict_variance should equal diag of joint_outputs cov at each point."""
         X = correctness_X
-        var = correlated_lbf.predict_variance(X)      # (4, 3)
-        per_pt = correlated_lbf.predict_covariance(
-            X, joint_outputs=True
-        )                                               # (4, 3, 3)
+        var = correlated_lbf.predict_variance(X)  # (4, 3)
+        per_pt = correlated_lbf.predict_covariance(X, joint_outputs=True)  # (4, 3, 3)
         for i in range(4):
-            np.testing.assert_allclose(
-                var[i], np.diag(np.array(per_pt[i])), atol=1e-5
-            )
+            np.testing.assert_allclose(var[i], np.diag(np.array(per_pt[i])), atol=1e-5)
 
-    def test_per_output_cov_matches_full_joint_blocks(
-        self, correlated_lbf, correctness_X
-    ):
+    def test_per_output_cov_matches_full_joint_blocks(self, correlated_lbf, correctness_X):
         """joint_inputs per-output cov should match blocks of full joint."""
         X = correctness_X
         n = 4
         d_out = 3
-        per_out = correlated_lbf.predict_covariance(
-            X, joint_inputs=True
-        )  # (3, 4, 4)
+        per_out = correlated_lbf.predict_covariance(X, joint_inputs=True)  # (3, 4, 4)
         full = correlated_lbf.predict_covariance(
             X, joint_inputs=True, joint_outputs=True
         )  # (12, 12)
@@ -1018,9 +1008,7 @@ class TestLinearMapCorrectness:
     Effective feature map: Φ_h(x) = (A @ Φ_g(x)^T)^T, then standard formulas.
     """
 
-    def test_mean_ground_truth(
-        self, correlated_lbf, correctness_X, correctness_w_mean
-    ):
+    def test_mean_ground_truth(self, correlated_lbf, correctness_X, correctness_w_mean):
         A = jnp.array([[1.0, 0.0, -1.0], [0.5, 0.5, 0.0]])  # (2, 3)
         h = A @ correlated_lbf
         X = correctness_X
@@ -1032,9 +1020,7 @@ class TestLinearMapCorrectness:
         expected = np.einsum("oh,...h->...o", np.array(A), g_mean)  # (4, 2)
         np.testing.assert_allclose(h.predict_mean(X), expected, atol=1e-5)
 
-    def test_per_point_cov_ground_truth(
-        self, correlated_lbf, correctness_X, correctness_w_cov
-    ):
+    def test_per_point_cov_ground_truth(self, correlated_lbf, correctness_X, correctness_w_cov):
         """Per-point output covariance: A @ Φ(x) @ C @ Φ(x)^T @ A^T."""
         A_np = np.array([[1.0, 0.0, -1.0], [0.5, 0.5, 0.0]])
         A = jnp.array(A_np)
@@ -1047,13 +1033,11 @@ class TestLinearMapCorrectness:
         cov_jo = h.predict_covariance(X, joint_outputs=True)  # (4, 2, 2)
         for i in range(4):
             # Effective features for h at point i: A @ phi_g[i]
-            phi_h_i = A_np @ phi_g[i]   # (2, 2)
+            phi_h_i = A_np @ phi_g[i]  # (2, 2)
             expected_i = phi_h_i @ C @ phi_h_i.T  # (2, 2)
             np.testing.assert_allclose(cov_jo[i], expected_i, atol=1e-5)
 
-    def test_variance_is_diag_of_per_point_cov(
-        self, correlated_lbf, correctness_X
-    ):
+    def test_variance_is_diag_of_per_point_cov(self, correlated_lbf, correctness_X):
         A = jnp.array([[1.0, 0.0, -1.0], [0.5, 0.5, 0.0]])
         h = A @ correlated_lbf
         X = correctness_X
@@ -1061,13 +1045,9 @@ class TestLinearMapCorrectness:
         var = h.predict_variance(X)  # (4, 2)
         cov_jo = h.predict_covariance(X, joint_outputs=True)  # (4, 2, 2)
         for i in range(4):
-            np.testing.assert_allclose(
-                var[i], np.diag(np.array(cov_jo[i])), atol=1e-6
-            )
+            np.testing.assert_allclose(var[i], np.diag(np.array(cov_jo[i])), atol=1e-6)
 
-    def test_full_joint_cov_ground_truth(
-        self, correlated_lbf, correctness_X, correctness_w_cov
-    ):
+    def test_full_joint_cov_ground_truth(self, correlated_lbf, correctness_X, correctness_w_cov):
         """Full joint covariance against dense computation."""
         A_np = np.array([[1.0, 0.0, -1.0], [0.5, 0.5, 0.0]])
         A = jnp.array(A_np)
@@ -1081,14 +1061,10 @@ class TestLinearMapCorrectness:
         phi_h = np.einsum("oh,nhw->now", A_np, phi_g)  # (4, 2, 2)
         expected = _dense_lbf_full_joint_cov(phi_h, C)  # (8, 8)
 
-        cov = h.predict_covariance(
-            X, joint_inputs=True, joint_outputs=True
-        )  # (8, 8)
+        cov = h.predict_covariance(X, joint_inputs=True, joint_outputs=True)  # (8, 8)
         np.testing.assert_allclose(cov, expected, atol=1e-5)
 
-    def test_per_output_cov_ground_truth(
-        self, correlated_lbf, correctness_X, correctness_w_cov
-    ):
+    def test_per_output_cov_ground_truth(self, correlated_lbf, correctness_X, correctness_w_cov):
         """Per-output cross-input cov: key test for the covariance fix.
 
         This is the path that was buggy before (used phi**2 instead of
@@ -1104,7 +1080,7 @@ class TestLinearMapCorrectness:
         phi_g = np.array(_simple_multi_output_features(X))  # (4, 3, 2)
         C = np.array(correctness_w_cov)
         phi_h = np.einsum("oh,nhw->now", A_np, phi_g)  # (4, 2, 2)
-        full = _dense_lbf_full_joint_cov(phi_h, C)       # (8, 8)
+        full = _dense_lbf_full_joint_cov(phi_h, C)  # (8, 8)
 
         n, d_out = 4, 2
         per_out = h.predict_covariance(X, joint_inputs=True)  # (2, 4, 4)
@@ -1114,13 +1090,13 @@ class TestLinearMapCorrectness:
             idx = np.arange(n) * d_out + o
             expected_block = full[np.ix_(idx, idx)]
             np.testing.assert_allclose(
-                per_out[o], expected_block, atol=1e-5,
-                err_msg=f"Per-output cov mismatch for output {o}"
+                per_out[o],
+                expected_block,
+                atol=1e-5,
+                err_msg=f"Per-output cov mismatch for output {o}",
             )
 
-    def test_per_output_cov_cross_output_matters(
-        self, correctness_w_cov
-    ):
+    def test_per_output_cov_cross_output_matters(self, correctness_w_cov):
         """Demonstrate that ignoring cross-output correlations gives
         wrong answers, and our code gets it right.
 
@@ -1155,16 +1131,15 @@ class TestLinearMapCorrectness:
         # Wrong: the old phi**2 formula (ignores cross-output correlations)
         # Per-output base cov (joint_inputs, not joint_outputs):
         #   base_cov_w[i, j] for each output w independently
-        base_per_out = np.array(
-            base.predict_covariance(X, joint_inputs=True)
-        )  # (3, 2, 2)
-        wrong_cov = np.einsum(
-            "ow,...wij->...oij", A_np ** 2, base_per_out
-        )[0]  # squeeze the single output dim → (2, 2)
+        base_per_out = np.array(base.predict_covariance(X, joint_inputs=True))  # (3, 2, 2)
+        wrong_cov = np.einsum("ow,...wij->...oij", A_np**2, base_per_out)[
+            0
+        ]  # squeeze the single output dim → (2, 2)
 
         # These should differ
-        assert not np.allclose(correct_cov, wrong_cov, atol=1e-3), \
+        assert not np.allclose(correct_cov, wrong_cov, atol=1e-3), (
             "Test is degenerate: correct and wrong formulas agree"
+        )
 
         # Our implementation should match the correct formula
         h_cov = h.predict_covariance(X, joint_inputs=True)  # (1, 2, 2)
@@ -1174,41 +1149,37 @@ class TestLinearMapCorrectness:
 class TestScaleCorrectness:
     """Verify scalar scaling moments against ground truth."""
 
-    def test_variance_ground_truth(
-        self, scalar_correctness_lbf, correctness_X
-    ):
+    def test_variance_ground_truth(self, scalar_correctness_lbf, correctness_X):
         alpha = 3.0
         h = alpha * scalar_correctness_lbf
         X = correctness_X
 
         phi = np.array(_simple_scalar_features(X))
-        C = np.array([
-            [1.0, 0.2, -0.1],
-            [0.2, 0.8, 0.05],
-            [-0.1, 0.05, 0.3],
-        ])
-        base_var = np.diag(phi @ C @ phi.T)
-        np.testing.assert_allclose(
-            h.predict_variance(X), alpha ** 2 * base_var, atol=1e-5
+        C = np.array(
+            [
+                [1.0, 0.2, -0.1],
+                [0.2, 0.8, 0.05],
+                [-0.1, 0.05, 0.3],
+            ]
         )
+        base_var = np.diag(phi @ C @ phi.T)
+        np.testing.assert_allclose(h.predict_variance(X), alpha**2 * base_var, atol=1e-5)
 
-    def test_full_joint_cov_ground_truth(
-        self, scalar_correctness_lbf, correctness_X
-    ):
+    def test_full_joint_cov_ground_truth(self, scalar_correctness_lbf, correctness_X):
         alpha = -2.5
         h = alpha * scalar_correctness_lbf
         X = correctness_X
 
         phi = np.array(_simple_scalar_features(X))
-        C = np.array([
-            [1.0, 0.2, -0.1],
-            [0.2, 0.8, 0.05],
-            [-0.1, 0.05, 0.3],
-        ])
-        expected = alpha ** 2 * (phi @ C @ phi.T)
-        np.testing.assert_allclose(
-            h.predict_covariance(X, joint_inputs=True), expected, atol=1e-5
+        C = np.array(
+            [
+                [1.0, 0.2, -0.1],
+                [0.2, 0.8, 0.05],
+                [-0.1, 0.05, 0.3],
+            ]
         )
+        expected = alpha**2 * (phi @ C @ phi.T)
+        np.testing.assert_allclose(h.predict_covariance(X, joint_inputs=True), expected, atol=1e-5)
 
 
 class TestShiftCorrectness:
@@ -1224,22 +1195,20 @@ class TestShiftCorrectness:
         expected = phi @ m + b
         np.testing.assert_allclose(h.predict_mean(X), expected, atol=1e-5)
 
-    def test_cov_unchanged_ground_truth(
-        self, scalar_correctness_lbf, correctness_X
-    ):
+    def test_cov_unchanged_ground_truth(self, scalar_correctness_lbf, correctness_X):
         h = scalar_correctness_lbf + 999.0
         X = correctness_X
 
         phi = np.array(_simple_scalar_features(X))
-        C = np.array([
-            [1.0, 0.2, -0.1],
-            [0.2, 0.8, 0.05],
-            [-0.1, 0.05, 0.3],
-        ])
-        expected = phi @ C @ phi.T
-        np.testing.assert_allclose(
-            h.predict_covariance(X, joint_inputs=True), expected, atol=1e-5
+        C = np.array(
+            [
+                [1.0, 0.2, -0.1],
+                [0.2, 0.8, 0.05],
+                [-0.1, 0.05, 0.3],
+            ]
         )
+        expected = phi @ C @ phi.T
+        np.testing.assert_allclose(h.predict_covariance(X, joint_inputs=True), expected, atol=1e-5)
 
 
 class TestIndependentSumCorrectness:
@@ -1278,52 +1247,66 @@ class TestIndependentSumCorrectness:
 
     def test_variance_ground_truth(self, correctness_X):
         """Sum variance = sum of individual variances."""
-        C1 = np.array([
-            [1.0, 0.2, 0.0],
-            [0.2, 0.5, 0.0],
-            [0.0, 0.0, 0.3],
-        ])
-        C2 = np.array([
-            [0.5, 0.0, 0.1],
-            [0.0, 0.8, 0.0],
-            [0.1, 0.0, 0.2],
-        ])
+        C1 = np.array(
+            [
+                [1.0, 0.2, 0.0],
+                [0.2, 0.5, 0.0],
+                [0.0, 0.0, 0.3],
+            ]
+        )
+        C2 = np.array(
+            [
+                [0.5, 0.0, 0.1],
+                [0.0, 0.8, 0.0],
+                [0.1, 0.0, 0.2],
+            ]
+        )
         w1 = MultivariateNormal(name="w1", loc=jnp.zeros(3), cov=jnp.array(C1))
         w2 = MultivariateNormal(name="w2", loc=jnp.zeros(3), cov=jnp.array(C2))
         lbf1 = LinearBasisFunction(
-            feature_map=_simple_scalar_features, weights=w1, input_shape=(1,),
+            feature_map=_simple_scalar_features,
+            weights=w1,
+            input_shape=(1,),
         )
         lbf2 = LinearBasisFunction(
-            feature_map=_simple_scalar_features, weights=w2, input_shape=(1,),
+            feature_map=_simple_scalar_features,
+            weights=w2,
+            input_shape=(1,),
         )
         h = lbf1 + lbf2
         X = correctness_X
 
         phi = np.array(_simple_scalar_features(X))
         expected_var = np.diag(phi @ C1 @ phi.T) + np.diag(phi @ C2 @ phi.T)
-        np.testing.assert_allclose(
-            h.predict_variance(X), expected_var, atol=1e-5
-        )
+        np.testing.assert_allclose(h.predict_variance(X), expected_var, atol=1e-5)
 
     def test_covariance_ground_truth(self, correctness_X):
         """Sum covariance = sum of individual covariances."""
-        C1 = np.array([
-            [1.0, 0.2, 0.0],
-            [0.2, 0.5, 0.0],
-            [0.0, 0.0, 0.3],
-        ])
-        C2 = np.array([
-            [0.5, 0.0, 0.1],
-            [0.0, 0.8, 0.0],
-            [0.1, 0.0, 0.2],
-        ])
+        C1 = np.array(
+            [
+                [1.0, 0.2, 0.0],
+                [0.2, 0.5, 0.0],
+                [0.0, 0.0, 0.3],
+            ]
+        )
+        C2 = np.array(
+            [
+                [0.5, 0.0, 0.1],
+                [0.0, 0.8, 0.0],
+                [0.1, 0.0, 0.2],
+            ]
+        )
         w1 = MultivariateNormal(name="w1", loc=jnp.zeros(3), cov=jnp.array(C1))
         w2 = MultivariateNormal(name="w2", loc=jnp.zeros(3), cov=jnp.array(C2))
         lbf1 = LinearBasisFunction(
-            feature_map=_simple_scalar_features, weights=w1, input_shape=(1,),
+            feature_map=_simple_scalar_features,
+            weights=w1,
+            input_shape=(1,),
         )
         lbf2 = LinearBasisFunction(
-            feature_map=_simple_scalar_features, weights=w2, input_shape=(1,),
+            feature_map=_simple_scalar_features,
+            weights=w2,
+            input_shape=(1,),
         )
         h = lbf1 + lbf2
         X = correctness_X
@@ -1377,7 +1360,7 @@ class TestCompositionCorrectness:
         phi_g = np.array(_simple_multi_output_features(X))
         C = np.array(correctness_w_cov)
         phi_h = np.einsum("oh,nhw->now", A_np, phi_g)
-        expected_cov = alpha ** 2 * _dense_lbf_full_joint_cov(phi_h, C)
+        expected_cov = alpha**2 * _dense_lbf_full_joint_cov(phi_h, C)
         np.testing.assert_allclose(
             h.predict_covariance(X, joint_inputs=True, joint_outputs=True),
             expected_cov,
@@ -1395,7 +1378,7 @@ class TestMonteCarlo:
 
     N_SAMPLES = 20_000
     MC_ATOL_MEAN = 0.05
-    MC_ATOL_VAR = 0.25     # variance/covariance estimation has higher MC noise
+    MC_ATOL_VAR = 0.25  # variance/covariance estimation has higher MC noise
 
     def _sample_outputs(self, lbf, X, key, n_samples):
         """Draw n_samples function realizations and evaluate at X."""
@@ -1406,14 +1389,10 @@ class TestMonteCarlo:
         """LBF sample moments should match predicted moments."""
         X = correctness_X
         key = jax.random.PRNGKey(123)
-        Y = self._sample_outputs(
-            scalar_correctness_lbf, X, key, self.N_SAMPLES
-        )  # (N, 4)
+        Y = self._sample_outputs(scalar_correctness_lbf, X, key, self.N_SAMPLES)  # (N, 4)
 
         pred_mean = np.array(scalar_correctness_lbf.predict_mean(X))
-        pred_cov = np.array(
-            scalar_correctness_lbf.predict_covariance(X, joint_inputs=True)
-        )
+        pred_cov = np.array(scalar_correctness_lbf.predict_covariance(X, joint_inputs=True))
 
         emp_mean = Y.mean(axis=0)
         emp_cov = np.cov(Y, rowvar=False)
@@ -1430,9 +1409,7 @@ class TestMonteCarlo:
         key = jax.random.PRNGKey(456)
 
         # Sample base, apply A in sample space
-        Y_base = self._sample_outputs(
-            correlated_lbf, X, key, self.N_SAMPLES
-        )  # (N, 4, 3)
+        Y_base = self._sample_outputs(correlated_lbf, X, key, self.N_SAMPLES)  # (N, 4, 3)
         Y_h = np.einsum("oh,...h->...o", A_np, Y_base)  # (N, 4, 2)
 
         pred_mean = np.array(h.predict_mean(X))  # (4, 2)
@@ -1452,16 +1429,12 @@ class TestMonteCarlo:
         X = correctness_X
         key = jax.random.PRNGKey(789)
 
-        Y_base = self._sample_outputs(
-            correlated_lbf, X, key, self.N_SAMPLES
-        )
+        Y_base = self._sample_outputs(correlated_lbf, X, key, self.N_SAMPLES)
         Y_h = np.einsum("oh,...h->...o", A_np, Y_base)  # (N, 4, 2)
         # Flatten to (N, 8) for covariance estimation
         Y_flat = Y_h.reshape(self.N_SAMPLES, -1)
 
-        pred_cov = np.array(
-            h.predict_covariance(X, joint_inputs=True, joint_outputs=True)
-        )
+        pred_cov = np.array(h.predict_covariance(X, joint_inputs=True, joint_outputs=True))
         emp_cov = np.cov(Y_flat, rowvar=False)
 
         np.testing.assert_allclose(emp_cov, pred_cov, atol=self.MC_ATOL_VAR)
@@ -1473,20 +1446,14 @@ class TestMonteCarlo:
         X = correctness_X
         key = jax.random.PRNGKey(101)
 
-        Y_base = self._sample_outputs(
-            scalar_correctness_lbf, X, key, self.N_SAMPLES
-        )
+        Y_base = self._sample_outputs(scalar_correctness_lbf, X, key, self.N_SAMPLES)
         Y_h = alpha * Y_base
 
         pred_mean = np.array(h.predict_mean(X))
         pred_var = np.array(h.predict_variance(X))
 
-        np.testing.assert_allclose(
-            Y_h.mean(axis=0), pred_mean, atol=self.MC_ATOL_MEAN
-        )
-        np.testing.assert_allclose(
-            Y_h.var(axis=0), pred_var, atol=self.MC_ATOL_VAR
-        )
+        np.testing.assert_allclose(Y_h.mean(axis=0), pred_mean, atol=self.MC_ATOL_MEAN)
+        np.testing.assert_allclose(Y_h.var(axis=0), pred_var, atol=self.MC_ATOL_VAR)
 
     def test_shift_moments(self, scalar_correctness_lbf, correctness_X):
         """grf + b: sample base, shift, check moments."""
@@ -1495,20 +1462,14 @@ class TestMonteCarlo:
         X = correctness_X
         key = jax.random.PRNGKey(202)
 
-        Y_base = self._sample_outputs(
-            scalar_correctness_lbf, X, key, self.N_SAMPLES
-        )
+        Y_base = self._sample_outputs(scalar_correctness_lbf, X, key, self.N_SAMPLES)
         Y_h = Y_base + b
 
         pred_mean = np.array(h.predict_mean(X))
         pred_var = np.array(h.predict_variance(X))
 
-        np.testing.assert_allclose(
-            Y_h.mean(axis=0), pred_mean, atol=self.MC_ATOL_MEAN
-        )
-        np.testing.assert_allclose(
-            Y_h.var(axis=0), pred_var, atol=self.MC_ATOL_VAR
-        )
+        np.testing.assert_allclose(Y_h.mean(axis=0), pred_mean, atol=self.MC_ATOL_MEAN)
+        np.testing.assert_allclose(Y_h.var(axis=0), pred_var, atol=self.MC_ATOL_VAR)
 
     def test_independent_sum_moments(self, correctness_X):
         """grf1 + grf2: sample both independently, add, check moments."""
@@ -1523,10 +1484,14 @@ class TestMonteCarlo:
             cov=0.3 * jnp.eye(3),
         )
         lbf1 = LinearBasisFunction(
-            feature_map=_simple_scalar_features, weights=w1, input_shape=(1,),
+            feature_map=_simple_scalar_features,
+            weights=w1,
+            input_shape=(1,),
         )
         lbf2 = LinearBasisFunction(
-            feature_map=_simple_scalar_features, weights=w2, input_shape=(1,),
+            feature_map=_simple_scalar_features,
+            weights=w2,
+            input_shape=(1,),
         )
         h = lbf1 + lbf2
         X = correctness_X
@@ -1540,9 +1505,7 @@ class TestMonteCarlo:
         pred_cov = np.array(h.predict_covariance(X, joint_inputs=True))
         emp_cov = np.cov(Y_h, rowvar=False)
 
-        np.testing.assert_allclose(
-            Y_h.mean(axis=0), pred_mean, atol=self.MC_ATOL_MEAN
-        )
+        np.testing.assert_allclose(Y_h.mean(axis=0), pred_mean, atol=self.MC_ATOL_MEAN)
         np.testing.assert_allclose(emp_cov, pred_cov, atol=self.MC_ATOL_VAR)
 
 
@@ -1560,6 +1523,7 @@ class TestRBFKernelBaseline:
 
     def test_rbf_matches_scipy_unit(self):
         from scipy.spatial.distance import cdist
+
         rng = np.random.default_rng(0)
         X = rng.standard_normal((7, 2)).astype(np.float32)
         K = np.asarray(_rbf_kernel(jnp.asarray(X), jnp.asarray(X)))
@@ -1569,14 +1533,14 @@ class TestRBFKernelBaseline:
 
     def test_rbf_matches_scipy_with_hyperparams(self):
         from scipy.spatial.distance import cdist
+
         rng = np.random.default_rng(1)
         X = rng.standard_normal((5, 3)).astype(np.float32)
         ls = 2.0
         var = 3.5
-        K = np.asarray(_rbf_kernel(jnp.asarray(X), jnp.asarray(X),
-                                   lengthscale=ls, variance=var))
+        K = np.asarray(_rbf_kernel(jnp.asarray(X), jnp.asarray(X), lengthscale=ls, variance=var))
         sq_dist = cdist(X, X, "sqeuclidean")
-        expected = var * np.exp(-0.5 * sq_dist / ls ** 2)
+        expected = var * np.exp(-0.5 * sq_dist / ls**2)
         np.testing.assert_allclose(K, expected, atol=1e-5)
 
     def test_rbf_diagonal_equals_variance(self):

--- a/tests/distributions/test_joint_empirical.py
+++ b/tests/distributions/test_joint_empirical.py
@@ -26,8 +26,8 @@ from probpipe.core.node import WorkflowFunction
 # Construction
 # ---------------------------------------------------------------------------
 
-class TestConstruction:
 
+class TestConstruction:
     def test_basic_construction(self):
         je = JointEmpirical(
             x=jnp.array([1.0, 2.0, 3.0]),
@@ -110,8 +110,8 @@ class TestConstruction:
 # Sampling
 # ---------------------------------------------------------------------------
 
-class TestSampling:
 
+class TestSampling:
     def test_sample_returns_values(self):
         je = JointEmpirical(
             x=jnp.array([1.0, 2.0, 3.0]),
@@ -167,7 +167,9 @@ class TestSampling:
         s = sample(je, key=key, sample_shape=(50_000,))
         # MC std ~ sqrt(0.01*0.99*100^2) / sqrt(50_000) ~ 0.044
         np.testing.assert_allclose(
-            float(jnp.mean(s["x"])), 99.0, atol=0.15,
+            float(jnp.mean(s["x"])),
+            99.0,
+            atol=0.15,
         )
 
 
@@ -175,8 +177,8 @@ class TestSampling:
 # Views
 # ---------------------------------------------------------------------------
 
-class TestViews:
 
+class TestViews:
     def test_getitem_returns_view(self):
         je = JointEmpirical(
             x=jnp.array([1.0, 2.0]),
@@ -208,8 +210,8 @@ class TestViews:
 # Moments
 # ---------------------------------------------------------------------------
 
-class TestMoments:
 
+class TestMoments:
     def test_mean_uniform(self):
         je = JointEmpirical(
             x=jnp.array([1.0, 3.0]),
@@ -238,10 +240,10 @@ class TestMoments:
         np.testing.assert_allclose(v["x"], 1.0, atol=1e-5)
 
 
-
 # ---------------------------------------------------------------------------
 # LogProb
 # ---------------------------------------------------------------------------
+
 
 class TestLogProb:
     """Empirical distributions deliberately do **not** implement
@@ -252,13 +254,12 @@ class TestLogProb:
 
     def test_does_not_claim_log_prob(self):
         from probpipe import SupportsLogProb
-        je = JointEmpirical(x=jnp.array([1.0, 2.0, 3.0]),
-                            y=jnp.array([4.0, 5.0, 6.0]))
+
+        je = JointEmpirical(x=jnp.array([1.0, 2.0, 3.0]), y=jnp.array([4.0, 5.0, 6.0]))
         assert not isinstance(je, SupportsLogProb)
 
     def test_log_prob_op_raises(self):
-        je = JointEmpirical(x=jnp.array([1.0, 2.0, 3.0]),
-                            y=jnp.array([4.0, 5.0, 6.0]))
+        je = JointEmpirical(x=jnp.array([1.0, 2.0, 3.0]), y=jnp.array([4.0, 5.0, 6.0]))
         s = sample(je, key=jax.random.PRNGKey(0))
         with pytest.raises(TypeError, match="log_prob"):
             log_prob(je, s)
@@ -268,8 +269,8 @@ class TestLogProb:
 # Flatten / Unflatten
 # ---------------------------------------------------------------------------
 
-class TestFlattenUnflatten:
 
+class TestFlattenUnflatten:
     def test_flatten_roundtrip(self):
         je = JointEmpirical(
             a=jnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
@@ -288,8 +289,8 @@ class TestFlattenUnflatten:
 # Conditioning
 # ---------------------------------------------------------------------------
 
-class TestConditionOn:
 
+class TestConditionOn:
     def test_condition_on_removes_component(self):
         """Conditioning removes the specified component."""
         je = JointEmpirical(
@@ -315,7 +316,7 @@ class TestConditionOn:
         """Row-wise correlation is preserved after conditioning."""
         x = jnp.array([10.0, 20.0, 30.0])
         y = jnp.array([100.0, 200.0, 300.0])  # y = 10 * x
-        z = jnp.array([1.0, 2.0, 3.0])        # z = x / 10
+        z = jnp.array([1.0, 2.0, 3.0])  # z = x / 10
         je = JointEmpirical(x=x, y=y, z=z)
         cond = condition_on(je, x=jnp.array(0.0))  # remove x
         s = sample(cond, key=jax.random.PRNGKey(1), sample_shape=(100,))
@@ -382,8 +383,8 @@ class TestConditionOn:
 # Broadcasting
 # ---------------------------------------------------------------------------
 
-class TestBroadcasting:
 
+class TestBroadcasting:
     def test_views_in_workflow(self):
         je = JointEmpirical(
             x=jnp.array([1.0, 2.0, 3.0]),

--- a/tests/distributions/test_joint_gaussian.py
+++ b/tests/distributions/test_joint_gaussian.py
@@ -25,8 +25,8 @@ from probpipe.core.node import WorkflowFunction
 # Construction
 # ---------------------------------------------------------------------------
 
-class TestConstruction:
 
+class TestConstruction:
     def test_basic_construction(self):
         jg = JointGaussian(
             mean=jnp.array([0.0, 1.0]),
@@ -107,13 +107,14 @@ class TestConstruction:
 # Sampling
 # ---------------------------------------------------------------------------
 
-class TestSampling:
 
+class TestSampling:
     def test_sample_returns_values(self):
         jg = JointGaussian(
             mean=jnp.array([0.0, 1.0]),
             cov=jnp.eye(2),
-            x=1, y=1,
+            x=1,
+            y=1,
         )
         key = jax.random.PRNGKey(0)
         s = sample(jg, key=key)
@@ -126,7 +127,8 @@ class TestSampling:
         jg = JointGaussian(
             mean=jnp.array([0.0, 1.0]),
             cov=jnp.eye(2),
-            x=1, y=1,
+            x=1,
+            y=1,
         )
         key = jax.random.PRNGKey(1)
         s = sample(jg, key=key, sample_shape=(10,))
@@ -158,13 +160,14 @@ class TestSampling:
 # log_prob
 # ---------------------------------------------------------------------------
 
-class TestLogProb:
 
+class TestLogProb:
     def test_log_prob_shape(self):
         jg = JointGaussian(
             mean=jnp.array([0.0, 1.0]),
             cov=jnp.eye(2),
-            x=1, y=1,
+            x=1,
+            y=1,
         )
         key = jax.random.PRNGKey(10)
         s = sample(jg, key=key, sample_shape=(5,))
@@ -174,9 +177,7 @@ class TestLogProb:
     def test_log_prob_matches_mvn(self):
         """log_prob should match a full MultivariateNormal."""
         m = jnp.array([1.0, 2.0, 3.0])
-        c = jnp.array([[2.0, 0.5, 0.1],
-                        [0.5, 1.0, 0.3],
-                        [0.1, 0.3, 1.5]])
+        c = jnp.array([[2.0, 0.5, 0.1], [0.5, 1.0, 0.3], [0.1, 0.3, 1.5]])
         jg = JointGaussian(mean=m, cov=c, a=1, b=2)
         mvn = MultivariateNormal(loc=m, cov=c, name="z")
 
@@ -193,8 +194,8 @@ class TestLogProb:
 # Moments
 # ---------------------------------------------------------------------------
 
-class TestMoments:
 
+class TestMoments:
     def test_mean(self):
         m = jnp.array([1.0, 2.0, 3.0])
         jg = JointGaussian(mean=m, cov=jnp.eye(3), a=1, b=2)
@@ -216,13 +217,14 @@ class TestMoments:
 # Views
 # ---------------------------------------------------------------------------
 
-class TestViews:
 
+class TestViews:
     def test_marginal_is_mvn(self):
         jg = JointGaussian(
             mean=jnp.array([0.0, 1.0, 2.0]),
             cov=jnp.eye(3),
-            a=1, bc=2,
+            a=1,
+            bc=2,
         )
         assert isinstance(jg.components["a"], MultivariateNormal)
         assert isinstance(jg.components["bc"], MultivariateNormal)
@@ -231,27 +233,21 @@ class TestViews:
         jg = JointGaussian(
             mean=jnp.array([5.0, 10.0, 15.0]),
             cov=jnp.eye(3),
-            x=1, yz=2,
+            x=1,
+            yz=2,
         )
-        np.testing.assert_allclose(
-            mean(jg.components["x"]), jnp.array([5.0]), atol=1e-6
-        )
-        np.testing.assert_allclose(
-            mean(jg.components["yz"]), jnp.array([10.0, 15.0]), atol=1e-6
-        )
+        np.testing.assert_allclose(mean(jg.components["x"]), jnp.array([5.0]), atol=1e-6)
+        np.testing.assert_allclose(mean(jg.components["yz"]), jnp.array([10.0, 15.0]), atol=1e-6)
 
     def test_marginal_cov_correct(self):
-        cov = jnp.array([[2.0, 0.5, 0.1],
-                          [0.5, 1.0, 0.3],
-                          [0.1, 0.3, 1.5]])
+        cov = jnp.array([[2.0, 0.5, 0.1], [0.5, 1.0, 0.3], [0.1, 0.3, 1.5]])
         jg = JointGaussian(
             mean=jnp.zeros(3),
             cov=cov,
-            x=1, yz=2,
+            x=1,
+            yz=2,
         )
-        np.testing.assert_allclose(
-            jg.components["x"].cov, jnp.array([[2.0]]), atol=1e-5
-        )
+        np.testing.assert_allclose(jg.components["x"].cov, jnp.array([[2.0]]), atol=1e-5)
         np.testing.assert_allclose(
             jg.components["yz"].cov, jnp.array([[1.0, 0.3], [0.3, 1.5]]), atol=1e-5
         )
@@ -261,8 +257,8 @@ class TestViews:
 # condition_on
 # ---------------------------------------------------------------------------
 
-class TestConditionOn:
 
+class TestConditionOn:
     def test_basic_conditioning(self):
         """Condition x=1 → should get a JointGaussian with only y."""
         cov = jnp.array([[1.0, 0.5], [0.5, 1.0]])
@@ -321,14 +317,15 @@ class TestConditionOn:
         mu = np.array([0.0, 1.0, -1.0])
         # 3x3 positive-definite covariance with nontrivial cross terms
         cov_np = np.array(
-            [[1.00, 0.30, 0.20],
-             [0.30, 2.00, 0.50],
-             [0.20, 0.50, 1.50]],
+            [[1.00, 0.30, 0.20], [0.30, 2.00, 0.50], [0.20, 0.50, 1.50]],
             dtype=np.float32,
         )
         jg = JointGaussian(
-            mean=jnp.asarray(mu), cov=jnp.asarray(cov_np),
-            a=1, b=1, c=1,
+            mean=jnp.asarray(mu),
+            cov=jnp.asarray(cov_np),
+            a=1,
+            b=1,
+            c=1,
         )
 
         # Condition on c = 0.5.
@@ -343,10 +340,14 @@ class TestConditionOn:
         # ProbPipe stores per-component marginal variance, so compare diagonals.
         cond_var = variance(cond)
         np.testing.assert_allclose(
-            float(cond_var["a"][0]), expected_cond_cov[0, 0], atol=1e-5,
+            float(cond_var["a"][0]),
+            expected_cond_cov[0, 0],
+            atol=1e-5,
         )
         np.testing.assert_allclose(
-            float(cond_var["b"][0]), expected_cond_cov[1, 1], atol=1e-5,
+            float(cond_var["b"][0]),
+            expected_cond_cov[1, 1],
+            atol=1e-5,
         )
 
     def test_conditional_mean_vs_scipy(self):
@@ -354,14 +355,15 @@ class TestConditionOn:
         reasoning via the Gaussian formula computed with numpy."""
         mu = np.array([0.5, -0.3, 1.2])
         cov_np = np.array(
-            [[1.0, 0.2, 0.1],
-             [0.2, 1.5, 0.4],
-             [0.1, 0.4, 0.8]],
+            [[1.0, 0.2, 0.1], [0.2, 1.5, 0.4], [0.1, 0.4, 0.8]],
             dtype=np.float32,
         )
         jg = JointGaussian(
-            mean=jnp.asarray(mu), cov=jnp.asarray(cov_np),
-            x=1, y=1, z=1,
+            mean=jnp.asarray(mu),
+            cov=jnp.asarray(cov_np),
+            x=1,
+            y=1,
+            z=1,
         )
         # Condition on y = 2.0
         y_obs = 2.0
@@ -384,7 +386,9 @@ class TestConditionOn:
         jg = JointGaussian(
             mean=jnp.array([0.0, 1.0, 2.0, 3.0]),
             cov=jnp.eye(4),
-            a=1, b=1, c=2,
+            a=1,
+            b=1,
+            c=2,
         )
         cond = condition_on(jg, a=jnp.array([0.0]))
         assert cond.event_shapes == {"b": (1,), "c": (2,)}
@@ -395,7 +399,9 @@ class TestConditionOn:
         jg = JointGaussian(
             mean=jnp.array([0.0, 1.0, 2.0, 3.0]),
             cov=jnp.eye(4),
-            a=1, b=1, c=2,
+            a=1,
+            b=1,
+            c=2,
         )
         cond = condition_on(jg, a=jnp.array([0.0]), c=jnp.array([2.0, 3.0]))
         assert cond.event_shapes == {"b": (1,)}
@@ -442,13 +448,14 @@ class TestConditionOn:
 # Flatten / Unflatten
 # ---------------------------------------------------------------------------
 
-class TestFlattenUnflatten:
 
+class TestFlattenUnflatten:
     def test_flatten_roundtrip(self):
         jg = JointGaussian(
             mean=jnp.array([0.0, 1.0, 2.0]),
             cov=jnp.eye(3),
-            a=1, bc=2,
+            a=1,
+            bc=2,
         )
         key = jax.random.PRNGKey(30)
         s = sample(jg, key=key, sample_shape=(5,))
@@ -463,8 +470,8 @@ class TestFlattenUnflatten:
 # Broadcasting
 # ---------------------------------------------------------------------------
 
-class TestBroadcasting:
 
+class TestBroadcasting:
     def test_views_in_workflow(self):
         cov = jnp.array([[1.0, 0.9], [0.9, 1.0]])
         jg = JointGaussian(mean=jnp.zeros(2), cov=cov, x=1, y=1)
@@ -488,13 +495,14 @@ class TestBroadcasting:
 # Repr
 # ---------------------------------------------------------------------------
 
-class TestRepr:
 
+class TestRepr:
     def test_repr(self):
         jg = JointGaussian(
             mean=jnp.zeros(3),
             cov=jnp.eye(3),
-            x=1, yz=2,
+            x=1,
+            yz=2,
             name="my_gauss",
         )
         r = repr(jg)

--- a/tests/distributions/test_kde.py
+++ b/tests/distributions/test_kde.py
@@ -29,6 +29,7 @@ from probpipe.distributions.kde import KDEDistribution
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def two_field_template():
     return EventTemplate(intercept=(), slope=())
@@ -44,10 +45,13 @@ def flat_samples():
 # Constructor + validation
 # ---------------------------------------------------------------------------
 
+
 class TestEventTemplateConstructor:
     def test_multi_field_template_preserved(self, two_field_template, flat_samples):
         kde = KDEDistribution(
-            flat_samples, event_template=two_field_template, name="post",
+            flat_samples,
+            event_template=two_field_template,
+            name="post",
         )
         assert kde.event_template is two_field_template
         assert kde.event_template.fields == ("intercept", "slope")
@@ -62,7 +66,9 @@ class TestEventTemplateConstructor:
         (the existing single-field behaviour is the baseline)."""
         single = EventTemplate(theta=(2,))
         kde = KDEDistribution(
-            flat_samples, event_template=single, name="post",
+            flat_samples,
+            event_template=single,
+            name="post",
         )
         # Single-field template still gets stored — but the special-case
         # multi-field path isn't taken.
@@ -79,10 +85,13 @@ class TestEventTemplateConstructor:
 # _sample round-trip
 # ---------------------------------------------------------------------------
 
+
 class TestSampleRoundTrip:
     def test_sample_scalar_returns_numeric_record(self, two_field_template, flat_samples):
         kde = KDEDistribution(
-            flat_samples, event_template=two_field_template, name="post",
+            flat_samples,
+            event_template=two_field_template,
+            name="post",
         )
         s = kde._sample(jax.random.PRNGKey(0), ())
         assert isinstance(s, _NumericRecord)
@@ -90,7 +99,9 @@ class TestSampleRoundTrip:
 
     def test_sample_batched_returns_record_array(self, two_field_template, flat_samples):
         kde = KDEDistribution(
-            flat_samples, event_template=two_field_template, name="post",
+            flat_samples,
+            event_template=two_field_template,
+            name="post",
         )
         s = kde._sample(jax.random.PRNGKey(1), (8,))
         assert isinstance(s, NumericRecordArray)
@@ -110,10 +121,13 @@ class TestSampleRoundTrip:
 # _log_prob dual input
 # ---------------------------------------------------------------------------
 
+
 class TestLogProbDualInput:
     def test_structured_and_flat_inputs_agree(self, two_field_template, flat_samples):
         kde = KDEDistribution(
-            flat_samples, event_template=two_field_template, name="post",
+            flat_samples,
+            event_template=two_field_template,
+            name="post",
         )
         nr = NumericRecord(intercept=jnp.array(0.5), slope=jnp.array(-0.3))
         lp_struct = kde._log_prob(nr)
@@ -123,7 +137,9 @@ class TestLogProbDualInput:
     def test_record_accepted(self, two_field_template, flat_samples):
         """Plain Record (not NumericRecord) also accepted."""
         kde = KDEDistribution(
-            flat_samples, event_template=two_field_template, name="post",
+            flat_samples,
+            event_template=two_field_template,
+            name="post",
         )
         rec = Record(intercept=jnp.array(0.5), slope=jnp.array(-0.3))
         lp = kde._log_prob(rec)
@@ -133,29 +149,35 @@ class TestLogProbDualInput:
         """A NumericRecordArray input is flattened to (batch, d) and the
         TFP mixture log-prob returns a (batch,) array."""
         kde = KDEDistribution(
-            flat_samples, event_template=two_field_template, name="post",
+            flat_samples,
+            event_template=two_field_template,
+            name="post",
         )
         # Build a 3-row NumericRecordArray
         nra = NumericRecordArray(
-            {"intercept": jnp.array([0.5, 0.6, 0.7]),
-             "slope": jnp.array([-0.3, -0.4, -0.5])},
+            {"intercept": jnp.array([0.5, 0.6, 0.7]), "slope": jnp.array([-0.3, -0.4, -0.5])},
             batch_shape=(3,),
             template=NumericEventTemplate(intercept=(), slope=()),
         )
         lp = kde._log_prob(nra)
         assert lp.shape == (3,)
         # Matches the flat form
-        lp_flat = kde._log_prob(jnp.stack([
-            jnp.array([0.5, -0.3]),
-            jnp.array([0.6, -0.4]),
-            jnp.array([0.7, -0.5]),
-        ]))
+        lp_flat = kde._log_prob(
+            jnp.stack(
+                [
+                    jnp.array([0.5, -0.3]),
+                    jnp.array([0.6, -0.4]),
+                    jnp.array([0.7, -0.5]),
+                ]
+            )
+        )
         assert jnp.allclose(lp, lp_flat)
 
 
 # ---------------------------------------------------------------------------
 # from_empirical factory
 # ---------------------------------------------------------------------------
+
 
 class TestFromEmpirical:
     def test_multi_field_record_empirical(self, two_field_template):
@@ -187,7 +209,8 @@ class TestFromEmpirical:
     def test_rejects_non_record_empirical(self):
         """Generic (object-array) EmpiricalDistribution is rejected."""
         emp_generic = EmpiricalDistribution(
-            np.array([{"a": 1}, {"a": 2}], dtype=object), name="x",
+            np.array([{"a": 1}, {"a": 2}], dtype=object),
+            name="x",
         )
         with pytest.raises(TypeError, match="RecordEmpiricalDistribution"):
             KDEDistribution.from_empirical(emp_generic)

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -41,9 +41,7 @@ def key():
             id="Wishart",
         ),
         pytest.param(
-            lambda: VonMisesFisher(
-                mean_direction=[1.0, 0.0, 0.0], concentration=5.0, name="v"
-            ),
+            lambda: VonMisesFisher(mean_direction=[1.0, 0.0, 0.0], concentration=5.0, name="v"),
             id="VonMisesFisher",
         ),
     ]
@@ -109,9 +107,7 @@ class TestGeneric:
         w = Wishart(df=5.0, scale_tril=jnp.eye(3), name="sigma")
         assert w.name == "sigma"
 
-        v = VonMisesFisher(
-            mean_direction=[1.0, 0.0, 0.0], concentration=5.0, name="dir"
-        )
+        v = VonMisesFisher(mean_direction=[1.0, 0.0, 0.0], concentration=5.0, name="dir")
         assert v.name == "dir"
 
 
@@ -218,7 +214,7 @@ class TestMultivariateMoments:
         alpha = np.array([1.0, 2.0, 3.0])
         alpha_0 = alpha.sum()
         d = Dirichlet(concentration=alpha, name="d")
-        expected = alpha * (alpha_0 - alpha) / (alpha_0 ** 2 * (alpha_0 + 1))
+        expected = alpha * (alpha_0 - alpha) / (alpha_0**2 * (alpha_0 + 1))
         np.testing.assert_allclose(variance(d), expected, rtol=1e-6)
 
     def test_dirichlet_cov_matches_scipy(self):

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -31,6 +31,7 @@ from probpipe.core.record import Record
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def normal_x():
     return Normal(loc=0.0, scale=1.0, name="x")
@@ -62,8 +63,8 @@ def joint_xz(normal_x, mvn_z):
 # 1. TestProductDistribution
 # ===========================================================================
 
-class TestProductDistribution:
 
+class TestProductDistribution:
     def test_construction_normal_components(self, normal_x, normal_y):
         joint = ProductDistribution(x=normal_x, y=normal_y)
         assert isinstance(joint, ProductDistribution)
@@ -125,9 +126,7 @@ class TestProductDistribution:
         key = jax.random.PRNGKey(4)
         s = sample(joint_xy, key=key)
         lp_joint = log_prob(joint_xy, s)
-        lp_sum = jnp.asarray(log_prob(normal_x, s["x"])) + jnp.asarray(
-            log_prob(normal_y, s["y"])
-        )
+        lp_sum = jnp.asarray(log_prob(normal_x, s["x"])) + jnp.asarray(log_prob(normal_y, s["y"]))
         np.testing.assert_allclose(float(lp_joint), float(lp_sum), atol=1e-5)
 
     def test_log_prob_batch(self, joint_xy):
@@ -184,8 +183,7 @@ class TestProductDistribution:
     def test_supports_per_field(self):
         """``supports`` maps each field to its component's support constraint
         (heterogeneous constraints preserved per field)."""
-        joint = ProductDistribution(Gamma(2.0, 1.0, name="g"),
-                                    Normal(loc=0.0, scale=1.0, name="x"))
+        joint = ProductDistribution(Gamma(2.0, 1.0, name="g"), Normal(loc=0.0, scale=1.0, name="x"))
         sup = joint.supports
         assert set(sup.keys()) == {"g", "x"}
         assert sup["g"] == joint.components["g"].support
@@ -198,20 +196,23 @@ class TestProductDistribution:
         ``leaf_shapes`` -- so every value is a leaf Constraint."""
         joint = ProductDistribution(
             name="joint",
-            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
-                   "deep": {"g": Gamma(2.0, 1.0, name="g")}},
+            outer={
+                "a": Normal(loc=0.0, scale=1.0, name="a"),
+                "deep": {"g": Gamma(2.0, 1.0, name="g")},
+            },
             m=Normal(loc=0.0, scale=1.0, name="m"),
         )
         sup = joint.supports
         assert set(sup.keys()) == set(joint.event_template.leaf_shapes.keys())
         assert "outer/deep/g" in sup
         assert sup["outer/deep/g"] != sup["outer/a"]  # positive vs real
-        assert sup["outer/a"] == sup["m"]             # both real
+        assert sup["outer/a"] == sup["m"]  # both real
 
 
 # ===========================================================================
 # 2. TestFlattenUnflatten
 # ===========================================================================
+
 
 class TestFlattenUnflatten:
     """Test flatten_value / unflatten_value (inherited from RecordDistribution)."""
@@ -235,7 +236,8 @@ class TestFlattenUnflatten:
         flat = joint_xy.flatten_value(s)
         assert flat.shape == (2,)
         recovered = joint_xy.unflatten_value(
-            flat, template=joint_xy.event_template,
+            flat,
+            template=joint_xy.event_template,
         )
         assert isinstance(recovered, Record)
         np.testing.assert_allclose(recovered["x"], s["x"], atol=1e-6)
@@ -248,7 +250,8 @@ class TestFlattenUnflatten:
         flat = joint_xz.flatten_value(s)
         assert flat.shape == (4,)
         recovered = joint_xz.unflatten_value(
-            flat, template=joint_xz.event_template,
+            flat,
+            template=joint_xz.event_template,
         )
         assert isinstance(recovered, Record)
         np.testing.assert_allclose(recovered["x"], s["x"], atol=1e-6)
@@ -261,17 +264,18 @@ class TestFlattenUnflatten:
         flat = joint_xy.flatten_value(s)
         assert flat.shape == (2,)
         recovered = joint_xy.unflatten_value(
-            flat, template=joint_xy.event_template,
+            flat,
+            template=joint_xy.event_template,
         )
         assert isinstance(recovered, Record)
         np.testing.assert_allclose(recovered["x"], s["x"], atol=1e-6)
         np.testing.assert_allclose(recovered["y"], s["y"], atol=1e-6)
 
 
-
 # ===========================================================================
 # 3b. TestNestedSampleFlatten (issue #262)
 # ===========================================================================
+
 
 class TestNestedSampleFlatten:
     """A batched draw from a nested ProductDistribution is a canonical, nested
@@ -282,13 +286,16 @@ class TestNestedSampleFlatten:
     def nested(self):
         return ProductDistribution(
             name="joint",
-            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
-                   "b": Normal(loc=2.0, scale=0.5, name="b")},
+            outer={
+                "a": Normal(loc=0.0, scale=1.0, name="a"),
+                "b": Normal(loc=2.0, scale=0.5, name="b"),
+            },
             m=Normal(loc=-1.0, scale=1.0, name="m"),
         )
 
     def test_batched_nested_field_is_record_array(self, nested):
         from probpipe.core._record_array import NumericRecordArray
+
         s = sample(nested, key=jax.random.PRNGKey(0), sample_shape=(6,))
         assert isinstance(s, NumericRecordArray)
         assert isinstance(s["outer"], NumericRecordArray)  # not a plain Record
@@ -300,6 +307,7 @@ class TestNestedSampleFlatten:
 
     def test_batched_nested_flatten_roundtrip(self, nested):
         from probpipe.core._record_array import NumericRecordArray
+
         s = sample(nested, key=jax.random.PRNGKey(1), sample_shape=(6,))
         leaves = list(nested.event_template.numeric_leaf_shapes)
         flat = s.flatten()
@@ -311,8 +319,7 @@ class TestNestedSampleFlatten:
         for i, leaf in enumerate(leaves):
             np.testing.assert_allclose(flat[:, i], s[leaf], atol=1e-6)
         # Secondary: the columns round-trip back to the same leaves via unflatten.
-        rec = NumericRecordArray.unflatten(
-            flat, template=nested.event_template, batch_shape=(6,))
+        rec = NumericRecordArray.unflatten(flat, template=nested.event_template, batch_shape=(6,))
         for leaf in leaves:
             np.testing.assert_allclose(rec[leaf], s[leaf], atol=1e-6)
 
@@ -322,14 +329,18 @@ class TestNestedSampleFlatten:
         # (the else branch of _sample_nested); such a field is not flattenable.
         from probpipe import JointEmpirical
         from probpipe.core._record_array import NumericRecordArray, RecordArray
+
         je = JointEmpirical(
             labels=np.array(["a", "b", "c"], dtype=object),
-            ids=np.array([0, 1, 2]), name="je",
+            ids=np.array([0, 1, 2]),
+            name="je",
         )
         joint = ProductDistribution(
             name="joint",
-            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
-                   "b": Normal(loc=2.0, scale=0.5, name="b")},
+            outer={
+                "a": Normal(loc=0.0, scale=1.0, name="a"),
+                "b": Normal(loc=2.0, scale=0.5, name="b"),
+            },
             je=je,
         )
         assert not isinstance(joint, NumericRecordDistribution)
@@ -343,8 +354,8 @@ class TestNestedSampleFlatten:
 # 4. TestDistributionView (RecordDistributionView for ProductDistribution)
 # ===========================================================================
 
-class TestDistributionView:
 
+class TestDistributionView:
     def test_view_type(self, joint_xy):
         view = joint_xy["x"]
         assert isinstance(view, _RecordDistributionView)
@@ -391,14 +402,12 @@ class TestDistributionView:
         assert "'x'" in r
 
 
-
-
 # ===========================================================================
 # 7. TestConditionOn
 # ===========================================================================
 
-class TestConditionOn:
 
+class TestConditionOn:
     def test_condition_on_removes_conditioned_component(self, joint_xy):
         cond = condition_on(joint_xy, x=jnp.array(2.0))
         assert "x" not in cond.components
@@ -447,12 +456,14 @@ class TestConditionOn:
 # 10. TestBroadcastingReconnection
 # ===========================================================================
 
+
 class TestBroadcastingReconnection:
     """Test that _RecordDistributionViews from the same parent are sampled jointly."""
 
     @staticmethod
     def _make_add_workflow(backend="sequential"):
         """Create a workflow that adds two arrays."""
+
         def add(a: float, b: float) -> float:
             return a + b
 
@@ -512,9 +523,7 @@ class TestBroadcastingReconnection:
         result = wf(a=view_x, b=view_x)
         assert hasattr(result, "samples")
         # a and b are the same samples, so a - b = 0 for every sample
-        np.testing.assert_allclose(
-            np.array(result.samples), 0.0, atol=1e-5
-        )
+        np.testing.assert_allclose(np.array(result.samples), 0.0, atol=1e-5)
 
     def test_mix_of_view_and_independent(self):
         """Mix of _RecordDistributionView and independent Normal both work."""
@@ -579,17 +588,15 @@ class TestBroadcastingReconnection:
         )
         result = wf(a=view_x, b=view_x)
         assert hasattr(result, "samples")
-        np.testing.assert_allclose(
-            np.array(result.samples), 0.0, atol=1e-5
-        )
+        np.testing.assert_allclose(np.array(result.samples), 0.0, atol=1e-5)
 
 
 # ===========================================================================
 # 11. TestPytreeRegistration
 # ===========================================================================
 
-class TestPytreeRegistration:
 
+class TestPytreeRegistration:
     def test_tree_flatten_unflatten_roundtrip(self, normal_x, normal_y):
         joint = ProductDistribution(x=normal_x, y=normal_y, name="rt")
         children, aux = jax.tree_util.tree_flatten(joint)
@@ -627,18 +634,21 @@ class TestPytreeRegistration:
 # 11. Dynamic protocol support
 # ===========================================================================
 
+
 class TestProductProtocolDuckTyping:
     """ProductDistribution dynamically includes protocols based on components."""
 
     def test_all_log_prob_components(self):
         """All Normal components → isinstance SupportsLogProb True."""
         from probpipe import SupportsLogProb
+
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(1, 2, name="y"))
         assert isinstance(joint, SupportsLogProb)
 
     def test_all_mean_variance_components(self):
         """All Normal components → isinstance SupportsMean/SupportsVariance True."""
         from probpipe import SupportsMean, SupportsVariance
+
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(1, 2, name="y"))
         assert isinstance(joint, SupportsMean)
         assert isinstance(joint, SupportsVariance)
@@ -646,6 +656,7 @@ class TestProductProtocolDuckTyping:
     def test_mixed_no_log_prob(self):
         """Component lacking SupportsLogProb → product lacks it too."""
         from probpipe import BootstrapDistribution, SupportsLogProb
+
         boot = BootstrapDistribution(jnp.array([1.0, 2.0, 3.0]), name="y")
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=boot)
         assert not isinstance(joint, SupportsLogProb)
@@ -653,12 +664,14 @@ class TestProductProtocolDuckTyping:
     def test_always_supports_sampling(self):
         """ProductDistribution always supports SupportsSampling."""
         from probpipe import SupportsSampling
+
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(1, 2, name="y"))
         assert isinstance(joint, SupportsSampling)
 
     def test_always_supports_conditioning(self):
         """ProductDistribution always supports SupportsConditioning."""
         from probpipe import SupportsConditioning
+
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(1, 2, name="y"))
         assert isinstance(joint, SupportsConditioning)
 
@@ -676,7 +689,8 @@ class TestProductProtocolDuckTyping:
         exposes the numeric API.
         """
         joint = ProductDistribution(
-            x=Normal(0, 1, name="x"), y=Normal(1, 2, name="y"),
+            x=Normal(0, 1, name="x"),
+            y=Normal(1, 2, name="y"),
         )
         assert isinstance(joint, NumericRecordDistribution)
         # Numeric API is available.
@@ -742,6 +756,7 @@ class TestProductProtocolDuckTyping:
 # 12. Additional coverage
 # ===========================================================================
 
+
 class TestSingleComponent:
     """ProductDistribution with one component."""
 
@@ -786,11 +801,15 @@ class TestSingleComponent:
 
         # 1-D vector (canonical RWMH / NUTS shape: flat parameter vector).
         np.testing.assert_allclose(
-            float(joint._log_prob(jnp.array([0.5]))), lp_ref, atol=1e-6,
+            float(joint._log_prob(jnp.array([0.5]))),
+            lp_ref,
+            atol=1e-6,
         )
         # Scalar (defensive — some kernels pass a 0-d array).
         np.testing.assert_allclose(
-            float(joint._log_prob(jnp.array(0.5))), lp_ref, atol=1e-6,
+            float(joint._log_prob(jnp.array(0.5))),
+            lp_ref,
+            atol=1e-6,
         )
         # Batched: (B, event_size). Each row's log-prob matches the
         # reference at the corresponding scalar.
@@ -815,7 +834,6 @@ class TestLogProbBatchValues:
 
 
 class TestEmptyComponentsValidation:
-
     def test_raises_on_empty(self):
         with pytest.raises(ValueError, match="at least one"):
             ProductDistribution()
@@ -933,12 +951,12 @@ class TestPositionalAndAutoRename:
         key = jax.random.PRNGKey(123)
         s_orig = original._sample(key, (5000,))
         s_renamed = renamed._sample(key, (5000,))
-        np.testing.assert_allclose(np.asarray(s_orig), np.asarray(s_renamed),
-                                   atol=1e-6)
+        np.testing.assert_allclose(np.asarray(s_orig), np.asarray(s_renamed), atol=1e-6)
 
     def test_rename_traversable_via_provenance_ancestors(self, full_provenance_mode):
         """The original distribution is in the renamed component's ancestors."""
         from probpipe.core.provenance import provenance_ancestors
+
         original = Normal(loc=0.0, scale=1.0, name="x")
         joint = ProductDistribution(renamed_x=original)
         renamed = joint.components["renamed_x"]
@@ -946,7 +964,6 @@ class TestPositionalAndAutoRename:
 
 
 class TestDistributionViewFromDistribution:
-
     def test_from_distribution_raises(self, joint_xy):
         with pytest.raises(TypeError):
             from_distribution(Normal(loc=0.0, scale=1.0, name="x"), _RecordDistributionView)
@@ -985,6 +1002,7 @@ class TestEnumerateWithDistributionViews:
 # 8. TestNestedProductDistribution
 # ===========================================================================
 
+
 class TestNestedProductDistribution:
     """Tests for ProductDistribution with nested dict components.
 
@@ -1002,8 +1020,10 @@ class TestNestedProductDistribution:
     @pytest.fixture
     def nested_joint(self):
         return ProductDistribution(
-            physics={"force": Normal(loc=0.0, scale=1.0, name="force"),
-                     "mass": Gamma(concentration=2.0, rate=1.0, name="mass")},
+            physics={
+                "force": Normal(loc=0.0, scale=1.0, name="force"),
+                "mass": Gamma(concentration=2.0, rate=1.0, name="mass"),
+            },
             observation=Normal(loc=0.0, scale=0.1, name="observation"),
         )
 
@@ -1109,7 +1129,8 @@ class TestNestedProductDistribution:
         flat = nested_joint.flatten_value(s)
         assert flat.shape == (3,)
         recovered = nested_joint.unflatten_value(
-            flat, template=nested_joint.event_template,
+            flat,
+            template=nested_joint.event_template,
         )
         assert isinstance(recovered, Record)
         # Check all leaves match
@@ -1159,18 +1180,14 @@ class TestNestedProductDistribution:
 
     def test_condition_on_all_leaves_in_group(self, nested_joint):
         """Conditioning on all components under a dict removes it."""
-        cond = condition_on(nested_joint,
-            physics={"force": jnp.array(1.0), "mass": jnp.array(2.0)}
-        )
+        cond = condition_on(nested_joint, physics={"force": jnp.array(1.0), "mass": jnp.array(2.0)})
         assert "physics" not in cond._components
         assert "observation" in cond._components
         assert cond.event_size == 1
 
     def test_condition_on_single_nested_leaf(self, nested_joint):
         """Condition on one component, keeping the sibling."""
-        cond = condition_on(nested_joint,
-            physics={"force": jnp.array(1.0)}
-        )
+        cond = condition_on(nested_joint, physics={"force": jnp.array(1.0)})
         # physics dict still exists but only contains mass
         assert "physics" in cond._components
         assert isinstance(cond._components["physics"], dict)
@@ -1181,9 +1198,7 @@ class TestNestedProductDistribution:
 
     def test_condition_on_nested_leaf_sample(self, nested_joint):
         """Samples from conditioned nested joint should exclude conditioned leaf."""
-        cond = condition_on(nested_joint,
-            physics={"force": jnp.array(1.0)}
-        )
+        cond = condition_on(nested_joint, physics={"force": jnp.array(1.0)})
         key = jax.random.PRNGKey(50)
         s = sample(cond, key=key, sample_shape=(5,))
         assert isinstance(s, (Record, RecordArray))
@@ -1197,9 +1212,7 @@ class TestNestedProductDistribution:
 
     def test_condition_on_nested_leaf_log_prob(self, nested_joint):
         """Log-prob should work on conditioned nested joint."""
-        cond = condition_on(nested_joint,
-            physics={"force": jnp.array(1.0)}
-        )
+        cond = condition_on(nested_joint, physics={"force": jnp.array(1.0)})
         key = jax.random.PRNGKey(51)
         s = sample(cond, key=key)
         lp = log_prob(cond, s)
@@ -1207,7 +1220,8 @@ class TestNestedProductDistribution:
 
     def test_condition_on_multiple_leaves_across_groups(self, nested_joint):
         """Condition on leaves from different groups simultaneously."""
-        cond = condition_on(nested_joint,
+        cond = condition_on(
+            nested_joint,
             physics={"force": jnp.array(1.0)},
             observation=jnp.array(0.5),
         )
@@ -1219,9 +1233,7 @@ class TestNestedProductDistribution:
 
     def test_condition_on_positional_dict(self, nested_joint):
         """Condition using a positional dict instead of kwargs."""
-        cond = condition_on(nested_joint,
-            {"physics": {"force": jnp.array(1.0)}}
-        )
+        cond = condition_on(nested_joint, {"physics": {"force": jnp.array(1.0)}})
         assert "physics" in cond._components
         assert "mass" in cond._components["physics"]
         assert "force" not in cond._components["physics"]
@@ -1229,7 +1241,8 @@ class TestNestedProductDistribution:
     def test_condition_on_positional_and_kwargs_exclusive(self, nested_joint):
         """Cannot mix positional dict and kwargs."""
         with pytest.raises(TypeError, match="either a positional dict or keyword"):
-            condition_on(nested_joint,
+            condition_on(
+                nested_joint,
                 {"physics": {"force": jnp.array(1.0)}},
                 observation=jnp.array(0.5),
             )
@@ -1242,30 +1255,25 @@ class TestNestedProductDistribution:
     def test_condition_on_leaf_with_dict_raises(self, nested_joint):
         """Passing a dict for a component distribution should raise TypeError."""
         with pytest.raises(TypeError, match="component distribution"):
-            condition_on(nested_joint,
-                observation={"sub": jnp.array(1.0)}
-            )
+            condition_on(nested_joint, observation={"sub": jnp.array(1.0)})
 
     def test_condition_on_unknown_nested_key_raises(self, nested_joint):
         """Unknown key inside a nested dict should raise KeyError."""
         with pytest.raises(KeyError, match="not found"):
-            condition_on(nested_joint,
-                physics={"nonexistent": jnp.array(1.0)}
-            )
+            condition_on(nested_joint, physics={"nonexistent": jnp.array(1.0)})
 
     def test_condition_on_all_raises(self, nested_joint):
         """Conditioning on all leaves should raise ValueError."""
         with pytest.raises(ValueError, match="Cannot condition on all"):
-            condition_on(nested_joint,
+            condition_on(
+                nested_joint,
                 physics={"force": jnp.array(1.0), "mass": jnp.array(2.0)},
                 observation=jnp.array(0.5),
             )
 
     def test_condition_on_provenance(self, nested_joint):
         """Conditioned distribution should have provenance."""
-        cond = condition_on(nested_joint,
-            physics={"force": jnp.array(1.0)}
-        )
+        cond = condition_on(nested_joint, physics={"force": jnp.array(1.0)})
         assert cond.source is not None
         assert cond.source.operation == "condition_on"
 
@@ -1331,15 +1339,17 @@ class TestNestedProductDistribution:
 # 9. TestNestedWithMVN
 # ===========================================================================
 
+
 class TestNestedWithMVN:
     """Nested dicts where some leaves are multivariate (non-scalar event)."""
 
     @pytest.fixture
     def nested_mvn(self):
         return ProductDistribution(
-            group={"position": MultivariateNormal(
-                        loc=jnp.zeros(2), cov=jnp.eye(2), name="position"),
-                   "scale": Normal(loc=1.0, scale=0.1, name="scale")},
+            group={
+                "position": MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="position"),
+                "scale": Normal(loc=1.0, scale=0.1, name="scale"),
+            },
             label=Normal(loc=0.0, scale=1.0, name="label"),
         )
 
@@ -1369,7 +1379,8 @@ class TestNestedWithMVN:
         assert flat.shape == (4,)
 
         recovered = nested_mvn.unflatten_value(
-            flat, template=nested_mvn.event_template,
+            flat,
+            template=nested_mvn.event_template,
         )
         assert isinstance(recovered, Record)
         np.testing.assert_allclose(

--- a/tests/distributions/test_sequential_joint.py
+++ b/tests/distributions/test_sequential_joint.py
@@ -26,8 +26,8 @@ from probpipe.core.node import WorkflowFunction
 # Construction
 # ---------------------------------------------------------------------------
 
-class TestConstruction:
 
+class TestConstruction:
     def test_basic_construction(self):
         joint = SequentialJointDistribution(
             z=Normal(loc=0.0, scale=1.0, name="z"),
@@ -94,8 +94,8 @@ class TestConstruction:
 # Sampling
 # ---------------------------------------------------------------------------
 
-class TestSampling:
 
+class TestSampling:
     def test_sample_returns_values(self):
         joint = SequentialJointDistribution(
             z=Normal(loc=0.0, scale=1.0, name="z"),
@@ -146,8 +146,8 @@ class TestSampling:
 # log_prob
 # ---------------------------------------------------------------------------
 
-class TestLogProb:
 
+class TestLogProb:
     def test_log_prob_shape(self):
         joint = SequentialJointDistribution(
             z=Normal(loc=0.0, scale=1.0, name="z"),
@@ -180,10 +180,9 @@ class TestLogProb:
         lp = log_prob(joint, value)
 
         # Independent baseline: scipy.stats.norm.logpdf
-        expected = (
-            scipy.stats.norm.logpdf(float(z_val), loc=0.0, scale=1.0)
-            + scipy.stats.norm.logpdf(float(x_val), loc=float(z_val), scale=0.5)
-        )
+        expected = scipy.stats.norm.logpdf(
+            float(z_val), loc=0.0, scale=1.0
+        ) + scipy.stats.norm.logpdf(float(x_val), loc=float(z_val), scale=0.5)
         np.testing.assert_allclose(float(lp), expected, atol=1e-5)
 
     def test_log_prob_three_components(self):
@@ -209,8 +208,8 @@ class TestLogProb:
 # DistributionView
 # ---------------------------------------------------------------------------
 
-class TestDistributionView:
 
+class TestDistributionView:
     def test_getitem_returns_view(self):
         joint = SequentialJointDistribution(
             z=Normal(loc=0.0, scale=1.0, name="z"),
@@ -242,8 +241,8 @@ class TestDistributionView:
 # Conditioning
 # ---------------------------------------------------------------------------
 
-class TestConditionOn:
 
+class TestConditionOn:
     def test_condition_on_removes_conditioned_component(self):
         joint = SequentialJointDistribution(
             z=Normal(loc=0.0, scale=1.0, name="z"),
@@ -375,9 +374,8 @@ class TestConditionOn:
         lp = unnormalized_log_prob(cond, value)
         assert jnp.isfinite(lp)
         # Should be log p(z=0) + log p(x=1|z=0) (unnormalized conditional)
-        expected = (
-            scipy.stats.norm.logpdf(0.0, loc=0.0, scale=1.0)
-            + scipy.stats.norm.logpdf(1.0, loc=0.0, scale=0.5)
+        expected = scipy.stats.norm.logpdf(0.0, loc=0.0, scale=1.0) + scipy.stats.norm.logpdf(
+            1.0, loc=0.0, scale=0.5
         )
         np.testing.assert_allclose(float(lp), expected, atol=1e-5)
 
@@ -423,8 +421,8 @@ class TestConditionOn:
 # Flatten / Unflatten
 # ---------------------------------------------------------------------------
 
-class TestFlattenUnflatten:
 
+class TestFlattenUnflatten:
     def test_flatten_roundtrip(self):
         joint = SequentialJointDistribution(
             z=Normal(loc=0.0, scale=1.0, name="z"),
@@ -443,8 +441,8 @@ class TestFlattenUnflatten:
 # Broadcasting reconnection
 # ---------------------------------------------------------------------------
 
-class TestBroadcastingReconnection:
 
+class TestBroadcastingReconnection:
     def test_views_from_sequential_joint_loop(self):
         joint = SequentialJointDistribution(
             z=Normal(loc=0.0, scale=1.0, name="z"),
@@ -463,9 +461,7 @@ class TestBroadcastingReconnection:
         result = wf(a=joint["z"], b=joint["x"])
         assert hasattr(result, "samples")
         # z and x are jointly sampled, x ≈ z, so a - b ≈ 0
-        np.testing.assert_allclose(
-            np.array(result.samples), 0.0, atol=0.15
-        )
+        np.testing.assert_allclose(np.array(result.samples), 0.0, atol=0.15)
 
     def test_views_from_sequential_joint_reject_jax(self):
         """Explicit ``dispatch="jax"`` is rejected for sequential-joint views.
@@ -520,17 +516,15 @@ class TestBroadcastingReconnection:
         )
         result = wf(a=joint["z"], b=joint["x"])
         assert hasattr(result, "samples")
-        np.testing.assert_allclose(
-            np.array(result.samples), 0.0, atol=0.15
-        )
+        np.testing.assert_allclose(np.array(result.samples), 0.0, atol=0.15)
 
 
 # ---------------------------------------------------------------------------
 # Repr
 # ---------------------------------------------------------------------------
 
-class TestRepr:
 
+class TestRepr:
     def test_repr_includes_callable(self):
         joint = SequentialJointDistribution(
             z=Normal(loc=0.0, scale=1.0, name="z"),

--- a/tests/distributions/test_support_and_conversion.py
+++ b/tests/distributions/test_support_and_conversion.py
@@ -5,21 +5,51 @@ import jax.numpy as jnp
 import pytest
 from probpipe import from_distribution
 from probpipe import (
-    NumericRecordDistribution, RecordEmpiricalDistribution, EmpiricalDistribution,
+    NumericRecordDistribution,
+    RecordEmpiricalDistribution,
+    EmpiricalDistribution,
     Provenance,
 )
 from probpipe.distributions import (
     MultivariateNormal,
-    Normal, Beta, Gamma, InverseGamma, Exponential, LogNormal,
-    StudentT, Uniform, Cauchy, Laplace, HalfNormal, HalfCauchy,
-    Pareto, TruncatedNormal,
-    Bernoulli, Binomial, Poisson, Categorical, NegativeBinomial,
-    Dirichlet, Multinomial, Wishart, VonMisesFisher,
+    Normal,
+    Beta,
+    Gamma,
+    InverseGamma,
+    Exponential,
+    LogNormal,
+    StudentT,
+    Uniform,
+    Cauchy,
+    Laplace,
+    HalfNormal,
+    HalfCauchy,
+    Pareto,
+    TruncatedNormal,
+    Bernoulli,
+    Binomial,
+    Poisson,
+    Categorical,
+    NegativeBinomial,
+    Dirichlet,
+    Multinomial,
+    Wishart,
+    VonMisesFisher,
 )
 from probpipe.core.constraints import (
-    Constraint, real, positive, non_negative, non_negative_integer,
-    boolean, unit_interval, simplex, positive_definite, sphere,
-    interval, greater_than, integer_interval,
+    Constraint,
+    real,
+    positive,
+    non_negative,
+    non_negative_integer,
+    boolean,
+    unit_interval,
+    simplex,
+    positive_definite,
+    sphere,
+    interval,
+    greater_than,
+    integer_interval,
     _supports_compatible,
 )
 
@@ -286,7 +316,9 @@ class TestFromDistribution:
 
     def test_binomial_from_poisson(self, key):
         p = Poisson(rate=3.0, name="p")
-        b = from_distribution(p, Binomial, key=key, check_support=False, total_count=10, num_samples=5000)
+        b = from_distribution(
+            p, Binomial, key=key, check_support=False, total_count=10, num_samples=5000
+        )
         # mean ~ 3, so probs ~ 0.3
         assert b.probs is not None
 

--- a/tests/distributions/test_tfp_array_backend.py
+++ b/tests/distributions/test_tfp_array_backend.py
@@ -78,15 +78,22 @@ class TestMakeArrayBackendConstruction:
 
     def test_required_minimum_surface(self):
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(2,), loc=jnp.zeros(2), scale=1.0,
+            name="x",
+            batch_shape=(2,),
+            loc=jnp.zeros(2),
+            scale=1.0,
         )
         for attr in (
-            "batch_shape", "event_shape", "cell",
-            "_sample", "_log_prob", "_mean", "_variance", "_cov",
+            "batch_shape",
+            "event_shape",
+            "cell",
+            "_sample",
+            "_log_prob",
+            "_mean",
+            "_variance",
+            "_cov",
         ):
-            assert hasattr(backend, attr), (
-                f"_TFPArrayBackend missing required attr {attr!r}"
-            )
+            assert hasattr(backend, attr), f"_TFPArrayBackend missing required attr {attr!r}"
 
     def test_mismatched_batch_shape_rejected(self):
         """Declaring ``batch_shape=(5,)`` with params that broadcast to
@@ -109,7 +116,10 @@ class TestCellMaterialisation:
     def test_cell_returns_fresh_scalar_normal(self):
         loc = jnp.array([0.0, 1.0, 2.0, 3.0, 4.0])
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(5,), loc=loc, scale=1.0,
+            name="x",
+            batch_shape=(5,),
+            loc=loc,
+            scale=1.0,
         )
         cell0 = backend.cell(0)
         cell2 = backend.cell(2)
@@ -133,7 +143,10 @@ class TestCellMaterialisation:
         """
         loc = jnp.array([10.0, 20.0, 30.0])
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(3,), loc=loc, scale=1.0,
+            name="x",
+            batch_shape=(3,),
+            loc=loc,
+            scale=1.0,
         )
         a = backend.cell(0)
         b = backend.cell(2)
@@ -144,8 +157,10 @@ class TestCellMaterialisation:
 
     def test_cell_name_auto_suffixes(self):
         backend = Normal._make_array_backend(
-            name="weights", batch_shape=(3,),
-            loc=jnp.zeros(3), scale=jnp.ones(3),
+            name="weights",
+            batch_shape=(3,),
+            loc=jnp.zeros(3),
+            scale=jnp.ones(3),
         )
         for i in range(3):
             assert backend.cell(i).name == f"weights_{i}"
@@ -154,8 +169,10 @@ class TestCellMaterialisation:
         """Cells materialise as scalar distributions
         (``tfd batch_shape == ()``)."""
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(4,),
-            loc=jnp.arange(4.0), scale=jnp.ones(4),
+            name="x",
+            batch_shape=(4,),
+            loc=jnp.arange(4.0),
+            scale=jnp.ones(4),
         )
         for i in range(4):
             cell = backend.cell(i)
@@ -163,7 +180,10 @@ class TestCellMaterialisation:
 
     def test_cell_negative_index_rejected(self):
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(3,), loc=jnp.zeros(3), scale=1.0,
+            name="x",
+            batch_shape=(3,),
+            loc=jnp.zeros(3),
+            scale=1.0,
         )
         with pytest.raises(IndexError):
             backend.cell(-1)
@@ -175,7 +195,10 @@ class TestCellMaterialisation:
         loc = jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         scale_tril = jnp.broadcast_to(jnp.eye(d), (2, d, d))
         backend = MultivariateNormal._make_array_backend(
-            name="z", batch_shape=(2,), loc=loc, scale_tril=scale_tril,
+            name="z",
+            batch_shape=(2,),
+            loc=loc,
+            scale_tril=scale_tril,
         )
         cell0 = backend.cell(0)
         cell1 = backend.cell(1)
@@ -193,10 +216,12 @@ class TestCellMaterialisation:
 class TestMultiDimensionalBatch:
     def test_int_index_maps_to_row_major_position(self):
         """Flat ``int`` indices unravel row-major over ``batch_shape``."""
-        loc = jnp.array([[10.0, 11.0, 12.0],
-                         [20.0, 21.0, 22.0]])
+        loc = jnp.array([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]])
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(2, 3), loc=loc, scale=1.0,
+            name="x",
+            batch_shape=(2, 3),
+            loc=loc,
+            scale=1.0,
         )
         # Row-major: index 0 -> (0, 0), index 4 -> (1, 1), index 5 -> (1, 2).
         assert float(backend.cell(0).loc) == 10.0
@@ -204,10 +229,12 @@ class TestMultiDimensionalBatch:
         assert float(backend.cell(5).loc) == 22.0
 
     def test_tuple_index_axis_aligned(self):
-        loc = jnp.array([[10.0, 11.0, 12.0],
-                         [20.0, 21.0, 22.0]])
+        loc = jnp.array([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]])
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(2, 3), loc=loc, scale=1.0,
+            name="x",
+            batch_shape=(2, 3),
+            loc=loc,
+            scale=1.0,
         )
         assert float(backend.cell((0, 0)).loc) == 10.0
         assert float(backend.cell((1, 2)).loc) == 22.0
@@ -215,7 +242,10 @@ class TestMultiDimensionalBatch:
     def test_int_and_tuple_indices_match(self):
         loc = jnp.arange(12.0).reshape(3, 4)
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(3, 4), loc=loc, scale=1.0,
+            name="x",
+            batch_shape=(3, 4),
+            loc=loc,
+            scale=1.0,
         )
         for flat in range(12):
             multi = np.unravel_index(flat, (3, 4))
@@ -225,8 +255,10 @@ class TestMultiDimensionalBatch:
 
     def test_tuple_wrong_rank_rejected(self):
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(2, 3),
-            loc=jnp.zeros((2, 3)), scale=1.0,
+            name="x",
+            batch_shape=(2, 3),
+            loc=jnp.zeros((2, 3)),
+            scale=1.0,
         )
         with pytest.raises(IndexError):
             backend.cell((0,))
@@ -241,14 +273,16 @@ class TestBatchedOpsMatchTFPNative:
     def _make_pair(self, loc, scale):
         backend = Normal._make_array_backend(
             name="x",
-            batch_shape=tuple(jnp.broadcast_shapes(
-                jnp.asarray(loc).shape, jnp.asarray(scale).shape,
-            )),
+            batch_shape=tuple(
+                jnp.broadcast_shapes(
+                    jnp.asarray(loc).shape,
+                    jnp.asarray(scale).shape,
+                )
+            ),
             loc=loc,
             scale=scale,
         )
-        tfp_native = tfd.Normal(loc=jnp.asarray(loc),
-                                scale=jnp.asarray(scale))
+        tfp_native = tfd.Normal(loc=jnp.asarray(loc), scale=jnp.asarray(scale))
         return backend, tfp_native
 
     def test_sample_shape_matches_native(self):
@@ -275,19 +309,23 @@ class TestBatchedOpsMatchTFPNative:
         )
 
     def test_mean_variance_match_native(self):
-        backend, native = self._make_pair(jnp.array([1.0, 2.0, 3.0]),
-                                          jnp.array([0.1, 0.2, 0.3]))
+        backend, native = self._make_pair(jnp.array([1.0, 2.0, 3.0]), jnp.array([0.1, 0.2, 0.3]))
         np.testing.assert_allclose(
-            np.asarray(backend._mean()), np.asarray(native.mean()),
+            np.asarray(backend._mean()),
+            np.asarray(native.mean()),
         )
         np.testing.assert_allclose(
-            np.asarray(backend._variance()), np.asarray(native.variance()),
+            np.asarray(backend._variance()),
+            np.asarray(native.variance()),
         )
 
     def test_multi_d_batch_sample_shape(self):
         loc = jnp.zeros((2, 3))
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(2, 3), loc=loc, scale=1.0,
+            name="x",
+            batch_shape=(2, 3),
+            loc=loc,
+            scale=1.0,
         )
         samples = backend._sample(jax.random.PRNGKey(0))
         assert samples.shape == (2, 3)
@@ -340,8 +378,10 @@ class TestPytreeRegistration:
 
     def _backend(self):
         return Normal._make_array_backend(
-            name="x", batch_shape=(5,),
-            loc=jnp.arange(5.0), scale=1.0,
+            name="x",
+            batch_shape=(5,),
+            loc=jnp.arange(5.0),
+            scale=1.0,
         )
 
     def test_flatten_yields_batched_params_in_insertion_order(self):
@@ -362,24 +402,21 @@ class TestPytreeRegistration:
         assert isinstance(rebuilt, _TFPArrayBackend)
         assert rebuilt.batch_shape == backend.batch_shape
         # Behavioural equivalence: same mean, same per-cell scalar.
-        np.testing.assert_allclose(
-            np.asarray(rebuilt._mean()), np.asarray(backend._mean())
-        )
+        np.testing.assert_allclose(np.asarray(rebuilt._mean()), np.asarray(backend._mean()))
         assert float(rebuilt.cell(2).loc) == float(backend.cell(2).loc)
 
     def test_jit_through_backend(self):
         """A ``jit``-compiled function that consumes the backend
         traces cleanly: the backend is a valid pytree node, so JAX
         threads its leaves through the compilation."""
+
         @jax.jit
         def fn(b):
             return b._mean()
 
         backend = self._backend()
         out = fn(backend)
-        np.testing.assert_allclose(
-            np.asarray(out), np.arange(5.0)
-        )
+        np.testing.assert_allclose(np.asarray(out), np.arange(5.0))
 
     def test_tree_map_replaces_leaves(self):
         """``tree_map`` over the backend rebuilds it with transformed
@@ -389,16 +426,16 @@ class TestPytreeRegistration:
         assert isinstance(scaled, _TFPArrayBackend)
         assert scaled.batch_shape == backend.batch_shape
         # ``loc`` doubled, ``scale`` doubled; per-cell mean = 2 * loc.
-        np.testing.assert_allclose(
-            np.asarray(scaled._mean()), 2.0 * np.arange(5.0)
-        )
+        np.testing.assert_allclose(np.asarray(scaled._mean()), 2.0 * np.arange(5.0))
 
     def test_vmap_over_leading_batch(self):
         """vmap-able through ``tree_map`` lifting a fresh axis on each
         leaf, then calling the backend's vectorised op under the lift."""
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(3,),
-            loc=jnp.zeros(3), scale=jnp.ones(3),
+            name="x",
+            batch_shape=(3,),
+            loc=jnp.zeros(3),
+            scale=jnp.ones(3),
         )
         # Stack two backends along a new leading axis via tree_map.
         stacked = jax.tree_util.tree_map(
@@ -429,7 +466,10 @@ class TestScalarParamBroadcasting:
         """All-scalar params + ``batch_shape=(5,)`` produces five
         identical Normals."""
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(5,), loc=0.0, scale=1.0,
+            name="x",
+            batch_shape=(5,),
+            loc=0.0,
+            scale=1.0,
         )
         assert backend.batch_shape == (5,)
         for i in range(5):
@@ -441,8 +481,10 @@ class TestScalarParamBroadcasting:
         """``loc`` scalar + ``scale`` array broadcasts ``loc`` to
         match the batch axis."""
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(3,),
-            loc=0.0, scale=jnp.array([0.1, 0.2, 0.3]),
+            name="x",
+            batch_shape=(3,),
+            loc=0.0,
+            scale=jnp.array([0.1, 0.2, 0.3]),
         )
         for i in range(3):
             cell = backend.cell(i)
@@ -450,7 +492,10 @@ class TestScalarParamBroadcasting:
 
     def test_multi_d_batch_with_scalar_params(self):
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(2, 3), loc=0.0, scale=1.0,
+            name="x",
+            batch_shape=(2, 3),
+            loc=0.0,
+            scale=1.0,
         )
         assert backend.batch_shape == (2, 3)
         for i in range(6):
@@ -474,8 +519,12 @@ class TestBackendApproximate:
         ``is_approximate`` attribute, so the ``DistributionArray``
         defaults to exact (``False``)."""
         from probpipe import DistributionArray
+
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(3,), loc=jnp.zeros(3), scale=1.0,
+            name="x",
+            batch_shape=(3,),
+            loc=jnp.zeros(3),
+            scale=1.0,
         )
         da = DistributionArray._from_backend(backend, name="x")
         assert da.is_approximate is False
@@ -512,9 +561,12 @@ class TestFlatComponentNegativeRejection:
 
     def test_backed_path_rejects_negative(self):
         from probpipe import DistributionArray
+
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(3,),
-            loc=jnp.zeros(3), scale=1.0,
+            name="x",
+            batch_shape=(3,),
+            loc=jnp.zeros(3),
+            scale=1.0,
         )
         da = DistributionArray._from_backend(backend, name="x")
         with pytest.raises(IndexError):
@@ -524,8 +576,8 @@ class TestFlatComponentNegativeRejection:
         """The literal path used to silently allow Python tuple
         wraparound; align with the backed path."""
         from probpipe import DistributionArray
-        comps = [Normal(loc=float(i), scale=1.0, name=f"c_{i}")
-                 for i in range(3)]
+
+        comps = [Normal(loc=float(i), scale=1.0, name=f"c_{i}") for i in range(3)]
         da = DistributionArray(comps, name="x")
         with pytest.raises(IndexError):
             da._flat_component(-1)
@@ -533,9 +585,12 @@ class TestFlatComponentNegativeRejection:
     def test_user_facing_da_minus_one_still_works(self):
         """``da[-1]`` continues to work via ``__getitem__`` wrap."""
         from probpipe import DistributionArray
+
         backend = Normal._make_array_backend(
-            name="x", batch_shape=(3,),
-            loc=jnp.array([10.0, 20.0, 30.0]), scale=1.0,
+            name="x",
+            batch_shape=(3,),
+            loc=jnp.array([10.0, 20.0, 30.0]),
+            scale=1.0,
         )
         da = DistributionArray._from_backend(backend, name="x")
         assert float(da[-1].loc) == 30.0

--- a/tests/distributions/test_tfp_batch_rejection.py
+++ b/tests/distributions/test_tfp_batch_rejection.py
@@ -58,14 +58,11 @@ class TestRejectionAcrossClasses:
 
     def test_beta_batched_rejected(self):
         with pytest.raises(ValueError, match=r"batch_shape"):
-            Beta(alpha=jnp.array([1.0, 2.0]),
-                 beta=jnp.array([1.0, 1.0]),
-                 name="b")
+            Beta(alpha=jnp.array([1.0, 2.0]), beta=jnp.array([1.0, 1.0]), name="b")
 
     def test_gamma_batched_rejected(self):
         with pytest.raises(ValueError, match=r"batch_shape"):
-            Gamma(concentration=jnp.array([1.0, 2.0, 3.0]),
-                  rate=1.0, name="g")
+            Gamma(concentration=jnp.array([1.0, 2.0, 3.0]), rate=1.0, name="g")
 
     def test_mvn_batched_rejected(self):
         # MVN with batched loc: loc.shape=(2, d) implies batch_shape=(2,).
@@ -149,14 +146,19 @@ class TestScalarConstructionUnchanged:
 class TestMigrationPath:
     def test_universal_factory_works_in_place_of_legacy_form(self):
         da = DistributionArray.from_batched_params(
-            Normal, loc=jnp.zeros(5), scale=1.0, name="x",
+            Normal,
+            loc=jnp.zeros(5),
+            scale=1.0,
+            name="x",
         )
         assert da.batch_shape == (5,)
         assert da[0].name == "x_0"
 
     def test_per_class_alias_works(self):
         da = Normal.from_batched_params(
-            loc=jnp.zeros(5), scale=1.0, name="x",
+            loc=jnp.zeros(5),
+            scale=1.0,
+            name="x",
         )
         assert da.batch_shape == (5,)
 

--- a/tests/distributions/test_transformed.py
+++ b/tests/distributions/test_transformed.py
@@ -82,9 +82,7 @@ class TestTFPBase:
         assert jnp.all(samples > 0)
 
     def test_multivariate_exp(self, key):
-        base = MultivariateNormal(
-            loc=jnp.zeros(3), cov=jnp.eye(3), name="z"
-        )
+        base = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
         td = TransformedDistribution(base, tfb.Exp())
         samples = jnp.asarray(sample(td, key=key, sample_shape=(10,)))
         assert samples.shape == (10, 3)
@@ -218,18 +216,21 @@ class TestTransformedProtocolDuckTyping:
     def test_isinstance_log_prob_from_tfp_base(self):
         """TFP base supports SupportsLogProb → transformed does too."""
         from probpipe import SupportsLogProb
+
         td = TransformedDistribution(Normal(0, 1, name="x"), tfb.Exp())
         assert isinstance(td, SupportsLogProb)
 
     def test_isinstance_mean_from_tfp_base(self):
         """TFP base supports SupportsMean → transformed does too."""
         from probpipe import SupportsMean
+
         td = TransformedDistribution(Normal(0, 1, name="x"), tfb.Exp())
         assert isinstance(td, SupportsMean)
 
     def test_empirical_base_has_mean(self):
         """RecordEmpiricalDistribution supports SupportsMean → transformed does too."""
         from probpipe import SupportsMean
+
         emp = EmpiricalDistribution(jnp.array([1.0, 2.0, 3.0]), name="x")
         td = TransformedDistribution(emp, tfb.Exp())
         assert isinstance(td, SupportsMean)
@@ -237,6 +238,7 @@ class TestTransformedProtocolDuckTyping:
     def test_empirical_base_no_log_prob(self):
         """RecordEmpiricalDistribution lacks SupportsLogProb → transformed lacks it."""
         from probpipe import SupportsLogProb
+
         emp = EmpiricalDistribution(jnp.array([1.0, 2.0, 3.0]), name="x")
         td = TransformedDistribution(emp, tfb.Exp())
         assert not isinstance(td, SupportsLogProb)
@@ -253,6 +255,7 @@ class TestBijectorCorrectness:
     def test_identity_preserves_moments(self, key):
         """Identity bijector: moments and log_prob are unchanged."""
         import numpy as np
+
         base = Normal(loc=2.0, scale=0.5, name="x")
         td = TransformedDistribution(base, tfb.Identity())
         # Moments
@@ -277,6 +280,7 @@ class TestBijectorCorrectness:
         """
         import numpy as np
         import tensorflow_probability.substrates.jax.distributions as tfd
+
         base = Normal(loc=0.0, scale=1.0, name="x")
         bijector = tfb.Exp()
         td = TransformedDistribution(base, bijector)
@@ -285,5 +289,6 @@ class TestBijectorCorrectness:
         np.testing.assert_allclose(
             np.asarray(log_prob(td, ys)),
             np.asarray(tfp_ref.log_prob(ys)),
-            rtol=1e-5, atol=1e-6,
+            rtol=1e-5,
+            atol=1e-6,
         )

--- a/tests/inference/test_arviz_regression.py
+++ b/tests/inference/test_arviz_regression.py
@@ -30,10 +30,12 @@ def frozen_idata():
     mu = rng.normal(0.0, 1.0, (nchain, ndraw)) + 0.05 * np.arange(nchain)[:, None]
     sigma = np.abs(rng.normal(1.0, 0.2, (nchain, ndraw)))
     loglik = {"y": rng.normal(-2.0, 0.5, (nchain, ndraw, nobs))}
-    return azb.from_dict({
-        "posterior": {"mu": mu, "sigma": sigma},
-        "log_likelihood": loglik,
-    })
+    return azb.from_dict(
+        {
+            "posterior": {"mu": mu, "sigma": sigma},
+            "log_likelihood": loglik,
+        }
+    )
 
 
 # -- The load-bearing default-drift tripwire ----------------------------------

--- a/tests/inference/test_bayesflow_likelihoods.py
+++ b/tests/inference/test_bayesflow_likelihoods.py
@@ -68,8 +68,10 @@ def _nested_prior():
     ``_analytic_posterior`` applies per leaf (``flatten`` order ``[a, b, m]``)."""
     return ProductDistribution(
         name="joint",
-        outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
-               "b": Normal(loc=0.0, scale=1.0, name="b")},
+        outer={
+            "a": Normal(loc=0.0, scale=1.0, name="a"),
+            "b": Normal(loc=0.0, scale=1.0, name="b"),
+        },
         m=Normal(loc=0.0, scale=1.0, name="m"),
     )
 
@@ -86,8 +88,13 @@ def _analytic_posterior(y_rows: np.ndarray) -> tuple[np.ndarray, float]:
 def nle():
     """A briefly-trained NLE, shared across the NLE tests."""
     return learn_amortized_likelihood(
-        _prior(), _SIM, num_simulations=4000, epochs=25,
-        batch_size=256, random_seed=0, verbose=0,
+        _prior(),
+        _SIM,
+        num_simulations=4000,
+        epochs=25,
+        batch_size=256,
+        random_seed=0,
+        verbose=0,
     )
 
 
@@ -95,8 +102,13 @@ def nle():
 def nre():
     """A briefly-trained NRE-C ratio, shared across the NRE tests."""
     return learn_amortized_ratio(
-        _prior(), _SIM, num_simulations=8000, epochs=40,
-        batch_size=256, random_seed=0, verbose=0,
+        _prior(),
+        _SIM,
+        num_simulations=8000,
+        epochs=40,
+        batch_size=256,
+        random_seed=0,
+        verbose=0,
     )
 
 
@@ -108,9 +120,11 @@ class TestSurrogateContract:
         y_row = np.array([[0.6, -0.1]], dtype="float32")
         ours = float(nle.log_likelihood(theta, y_row))
         keys = _adapter_field_keys(("a", "b"))
-        data = {keys[0]: np.array([[0.4]], "float32"),
-                keys[1]: np.array([[-0.3]], "float32"),
-                "observation": y_row}
+        data = {
+            keys[0]: np.array([[0.4]], "float32"),
+            keys[1]: np.array([[-0.3]], "float32"),
+            "observation": y_row,
+        }
         public = float(np.asarray(nle.approximator.log_prob(data=data)).reshape(-1)[0])
         # The bypass is the same op sequence on the same float32 buffers --
         # observed diff is exactly 0.0; the bound is float32 headroom.
@@ -122,9 +136,11 @@ class TestSurrogateContract:
         y_row = np.array([[0.6, -0.1]], dtype="float32")
         ours = float(nre.log_likelihood(theta, y_row))
         keys = _adapter_field_keys(("a", "b"))
-        data = {keys[0]: np.array([[0.4]], "float32"),
-                keys[1]: np.array([[-0.3]], "float32"),
-                "observation": y_row}
+        data = {
+            keys[0]: np.array([[0.4]], "float32"),
+            keys[1]: np.array([[-0.3]], "float32"),
+            "observation": y_row,
+        }
         public = float(np.asarray(nre.approximator.log_ratio(data=data)).reshape(-1)[0])
         # Same op sequence as the public path; observed diff exactly 0.0.
         np.testing.assert_allclose(ours, public, atol=1e-5)
@@ -143,10 +159,12 @@ class TestSurrogateContract:
         g = jax.grad(f)(th0)
         assert jnp.isfinite(g).all() and (jnp.abs(g) > 1e-8).any()
         eps = 1e-3
-        fd = np.array([
-            (float(f(th0.at[i].add(eps))) - float(f(th0.at[i].add(-eps)))) / (2 * eps)
-            for i in range(2)
-        ])
+        fd = np.array(
+            [
+                (float(f(th0.at[i].add(eps))) - float(f(th0.at[i].add(-eps)))) / (2 * eps)
+                for i in range(2)
+            ]
+        )
         rel = np.abs(np.asarray(g) - fd) / (np.abs(fd) + 1e-6)
         # Observed max relative error across training seeds and probe points:
         # NLE <= 9.2e-4, NRE <= 6.4e-3 (the classifier is only piecewise-smooth).
@@ -171,11 +189,14 @@ class TestSurrogateContract:
         (the MCMC helper passes flat vectors; predictive paths pass records)."""
         flat = jnp.array([0.4, -0.3])
         record = NumericRecordArray.unflatten(
-            flat, template=_prior().event_template, batch_shape=())
+            flat, template=_prior().event_template, batch_shape=()
+        )
         y_row = jnp.array([0.6, -0.1])
         np.testing.assert_allclose(
             float(nle.log_likelihood(flat, y_row)),
-            float(nle.log_likelihood(record, y_row)), rtol=1e-6)
+            float(nle.log_likelihood(record, y_row)),
+            rtol=1e-6,
+        )
 
     def test_generate_data_passthrough(self, nle):
         """The wrapper delegates generate_data to the training simulator."""
@@ -183,7 +204,8 @@ class TestSurrogateContract:
         key = jax.random.PRNGKey(9)
         np.testing.assert_allclose(
             np.asarray(nle.generate_data(params, 3, key=key)),
-            np.asarray(_SIM.generate_data(params, 3, key=key)))
+            np.asarray(_SIM.generate_data(params, 3, key=key)),
+        )
 
     def test_repr(self, nle, nre):
         assert repr(nle) == "BayesFlowLikelihood(theta_dim=2, data_dim=2)"
@@ -212,18 +234,24 @@ class TestSurrogateContract:
                 a = params.flatten()[0]
                 return a + 0.1 * jax.random.normal(key, (num_observations, 1))
 
-        lik = learn_amortized_ratio(_prior(), _ScalarSim(), num_simulations=256,
-                                    epochs=2, batch_size=64, random_seed=0,
-                                    verbose=0)
+        lik = learn_amortized_ratio(
+            _prior(),
+            _ScalarSim(),
+            num_simulations=256,
+            epochs=2,
+            batch_size=64,
+            random_seed=0,
+            verbose=0,
+        )
         theta = jnp.array([0.3, -0.2])
         y3 = jnp.array([0.1, 0.4, -0.3])
         total = float(lik.log_likelihood(theta, y3))
-        per = sum(float(lik.per_datum_log_likelihood(theta, jnp.array([v])))
-                  for v in [0.1, 0.4, -0.3])
+        per = sum(
+            float(lik.per_datum_log_likelihood(theta, jnp.array([v]))) for v in [0.1, 0.4, -0.3]
+        )
         np.testing.assert_allclose(total, per, rtol=1e-5)
         # A (n, 1) column is the same dataset.
-        np.testing.assert_allclose(
-            total, float(lik.log_likelihood(theta, y3[:, None])), rtol=1e-6)
+        np.testing.assert_allclose(total, float(lik.log_likelihood(theta, y3[:, None])), rtol=1e-6)
 
 
 class TestConditioning:
@@ -237,10 +265,10 @@ class TestConditioning:
     """
 
     def _check_posterior(self, model, y_rows, mean_tol, ratio_band):
-        post = condition_on(model, jnp.asarray(y_rows),
-                            num_results=1500, num_warmup=500, random_seed=0)
-        draws = np.stack([np.asarray(post.draws()[f]).reshape(-1) for f in ("a", "b")],
-                         axis=-1)
+        post = condition_on(
+            model, jnp.asarray(y_rows), num_results=1500, num_warmup=500, random_seed=0
+        )
+        draws = np.stack([np.asarray(post.draws()[f]).reshape(-1) for f in ("a", "b")], axis=-1)
         an_mean, an_std = _analytic_posterior(np.asarray(y_rows))
         mean_err = np.abs(draws.mean(0) - an_mean).max() / an_std
         ratio = draws.std(0) / an_std
@@ -250,8 +278,9 @@ class TestConditioning:
     def test_nle_single_observation(self, nle):
         # Observed across seeds: mean err 0.05-0.10 post-std, ratios 0.99-1.11.
         y = np.array([[0.8, -0.4]], dtype="float32")
-        self._check_posterior(SimpleModel(prior=_prior(), likelihood=nle), y,
-                              mean_tol=0.3, ratio_band=(0.85, 1.25))
+        self._check_posterior(
+            SimpleModel(prior=_prior(), likelihood=nle), y, mean_tol=0.3, ratio_band=(0.85, 1.25)
+        )
 
     def test_nle_multi_observation_sharpens(self, nle):
         """n=8 i.i.d. rows: the posterior matches the analytic n-observation
@@ -263,23 +292,25 @@ class TestConditioning:
         # Observed across seeds: mean err 0.03-0.34 post-std, ratios 0.99-1.10
         # (the per-row score errors accumulate over n rows, hence the wider
         # mean bound than n=1).
-        self._check_posterior(SimpleModel(prior=_prior(), likelihood=nle), y,
-                              mean_tol=0.6, ratio_band=(0.85, 1.25))
+        self._check_posterior(
+            SimpleModel(prior=_prior(), likelihood=nle), y, mean_tol=0.6, ratio_band=(0.85, 1.25)
+        )
 
     def test_nre_single_observation(self, nre):
         # Observed across seeds: mean err 0.02-0.09 post-std, ratios 0.95-1.08.
         y = np.array([[0.8, -0.4]], dtype="float32")
-        self._check_posterior(SimpleModel(prior=_prior(), likelihood=nre), y,
-                              mean_tol=0.3, ratio_band=(0.8, 1.25))
+        self._check_posterior(
+            SimpleModel(prior=_prior(), likelihood=nre), y, mean_tol=0.3, ratio_band=(0.8, 1.25)
+        )
 
     def _check_nested_posterior(self, model, y, mean_tol, ratio_band):
         """Like ``_check_posterior`` but over the three *nested* leaves
         (``outer/a``, ``outer/b``, ``m``) -- in ``flatten`` order, so leaf j of
         the analytic posterior lines up with observation column j."""
-        post = condition_on(model, jnp.asarray(y),
-                            num_results=1500, num_warmup=500, random_seed=0)
-        draws = np.stack([np.asarray(post.draws()[f]).reshape(-1)
-                          for f in ("outer/a", "outer/b", "m")], axis=-1)
+        post = condition_on(model, jnp.asarray(y), num_results=1500, num_warmup=500, random_seed=0)
+        draws = np.stack(
+            [np.asarray(post.draws()[f]).reshape(-1) for f in ("outer/a", "outer/b", "m")], axis=-1
+        )
         an_mean, an_std = _analytic_posterior(np.asarray(y))
         mean_err = np.abs(draws.mean(0) - an_mean).max() / an_std
         ratio = draws.std(0) / an_std
@@ -293,24 +324,36 @@ class TestConditioning:
         nesting is purely the leaf-keyed adapter routing (no bijectors)."""
         prior = _nested_prior()
         nle = learn_amortized_likelihood(
-            prior, _SIM, num_simulations=4000, epochs=25,
-            batch_size=256, random_seed=0, verbose=0,
+            prior,
+            _SIM,
+            num_simulations=4000,
+            epochs=25,
+            batch_size=256,
+            random_seed=0,
+            verbose=0,
         )
         y = np.array([[0.8, -0.4, 0.3]], dtype="float32")
-        self._check_nested_posterior(SimpleModel(prior=prior, likelihood=nle), y,
-                                     mean_tol=0.3, ratio_band=(0.85, 1.25))
+        self._check_nested_posterior(
+            SimpleModel(prior=prior, likelihood=nle), y, mean_tol=0.3, ratio_band=(0.85, 1.25)
+        )
 
     def test_nre_nested_prior_end_to_end(self):
         """NRE lifts a nested prior (issue #262): the same nested conjugate
         recovery as NLE, via the leaf-keyed classifier routing."""
         prior = _nested_prior()
         nre = learn_amortized_ratio(
-            prior, _SIM, num_simulations=8000, epochs=40,
-            batch_size=256, random_seed=0, verbose=0,
+            prior,
+            _SIM,
+            num_simulations=8000,
+            epochs=40,
+            batch_size=256,
+            random_seed=0,
+            verbose=0,
         )
         y = np.array([[0.8, -0.4, 0.3]], dtype="float32")
-        self._check_nested_posterior(SimpleModel(prior=prior, likelihood=nre), y,
-                                     mean_tol=0.3, ratio_band=(0.8, 1.25))
+        self._check_nested_posterior(
+            SimpleModel(prior=prior, likelihood=nre), y, mean_tol=0.3, ratio_band=(0.8, 1.25)
+        )
 
     def test_nle_constrained_prior_matches_true_likelihood(self):
         """A constrained (Gamma) prior end to end, judged against NUTS run with
@@ -325,26 +368,34 @@ class TestConditioning:
                 t = jnp.ravel(jnp.asarray(t))
                 rows = jnp.atleast_2d(jnp.asarray(data))
                 resid = (rows - t[None, :]) / _SIGMA
-                return (-0.5 * jnp.sum(resid**2)
-                        - rows.size * jnp.log(_SIGMA * np.sqrt(2 * np.pi)))
+                return -0.5 * jnp.sum(resid**2) - rows.size * jnp.log(_SIGMA * np.sqrt(2 * np.pi))
 
         def _gamma_prior():
-            return ProductDistribution(pp.Gamma(5.0, 1.0, name="lam"),
-                                       Normal(loc=0.0, scale=1.0, name="m"))
+            return ProductDistribution(
+                pp.Gamma(5.0, 1.0, name="lam"), Normal(loc=0.0, scale=1.0, name="m")
+            )
 
-        y = np.asarray(_SIM.generate_data(jnp.array([5.0, 0.5]), 4,
-                                          key=jax.random.PRNGKey(5)))
+        y = np.asarray(_SIM.generate_data(jnp.array([5.0, 0.5]), 4, key=jax.random.PRNGKey(5)))
 
         def _lam_draws(likelihood):
-            post = condition_on(SimpleModel(prior=_gamma_prior(), likelihood=likelihood),
-                                jnp.asarray(y), num_results=1500, num_warmup=500,
-                                random_seed=0)
+            post = condition_on(
+                SimpleModel(prior=_gamma_prior(), likelihood=likelihood),
+                jnp.asarray(y),
+                num_results=1500,
+                num_warmup=500,
+                random_seed=0,
+            )
             return np.asarray(post.draws()["lam"]).reshape(-1)
 
         ref = _lam_draws(_TrueGaussianLik())
         lik = learn_amortized_likelihood(
-            _gamma_prior(), _SIM, num_simulations=3000, epochs=20,
-            batch_size=256, random_seed=0, verbose=0,
+            _gamma_prior(),
+            _SIM,
+            num_simulations=3000,
+            epochs=20,
+            batch_size=256,
+            random_seed=0,
+            verbose=0,
         )
         lam = _lam_draws(lik)
         assert (lam > 0).all()
@@ -374,18 +425,30 @@ class TestConditioning:
         y_obs = jnp.array([[2.0, 1.0]])
         an_mean, an_std = 5.0 / 4.0, np.sqrt(5.0) / 4.0
         lik = learn_amortized_likelihood(
-            pp.Gamma(2.0, 2.0, name="lam"), _PoissonPairSim(),
-            num_simulations=4000, epochs=25, batch_size=256, random_seed=0,
-            dequantize=True, verbose=0,
+            pp.Gamma(2.0, 2.0, name="lam"),
+            _PoissonPairSim(),
+            num_simulations=4000,
+            epochs=25,
+            batch_size=256,
+            random_seed=0,
+            dequantize=True,
+            verbose=0,
         )
-        twin = BayesFlowLikelihood(lik.approximator, lik.prior, lik.simulator,
-                                   data_dim=2, dequantized=False)
+        twin = BayesFlowLikelihood(
+            lik.approximator, lik.prior, lik.simulator, data_dim=2, dequantized=False
+        )
         np.testing.assert_allclose(
             float(lik.log_likelihood(jnp.array([1.3]), y_obs)),
-            float(twin.log_likelihood(jnp.array([1.3]), y_obs + 0.5)), rtol=1e-6)
+            float(twin.log_likelihood(jnp.array([1.3]), y_obs + 0.5)),
+            rtol=1e-6,
+        )
         post = condition_on(
             SimpleModel(prior=pp.Gamma(2.0, 2.0, name="lam"), likelihood=lik),
-            y_obs, num_results=1500, num_warmup=500, random_seed=0)
+            y_obs,
+            num_results=1500,
+            num_warmup=500,
+            random_seed=0,
+        )
         lam = np.asarray(post.draws()["lam"]).reshape(-1)
         assert (lam > 0).all()
         # Observed across seeds 0-2: mean err 0.03-0.17 posterior-std units,
@@ -399,8 +462,9 @@ class TestValidation:
 
     def test_rejects_unknown_sim_backend(self):
         with pytest.raises(ValueError, match="Unknown sim_backend"):
-            learn_amortized_likelihood(_prior(), _SIM, sim_backend="bogus",
-                                       num_simulations=8, epochs=1)
+            learn_amortized_likelihood(
+                _prior(), _SIM, sim_backend="bogus", num_simulations=8, epochs=1
+            )
 
     @pytest.mark.parametrize("override", [{"epochs": 0}, {"num_simulations": 0}])
     def test_rejects_nonpositive_counts(self, override):
@@ -417,8 +481,7 @@ class TestValidation:
             pass
 
         with pytest.raises(TypeError, match="generate_data"):
-            learn_amortized_likelihood(_prior(), _NoGenerate(),
-                                       num_simulations=8, epochs=1)
+            learn_amortized_likelihood(_prior(), _NoGenerate(), num_simulations=8, epochs=1)
 
     def test_rejects_non_record_prior(self):
         with pytest.raises(TypeError, match="RecordDistribution"):
@@ -437,8 +500,9 @@ class TestValidation:
                 return jnp.full((num_observations, 2), 2.0**23)
 
         with pytest.raises(ValueError, match=r"2\*\*23"):
-            learn_amortized_likelihood(_prior(), _HugeCounts(), num_simulations=8,
-                                       epochs=1, dequantize=True)
+            learn_amortized_likelihood(
+                _prior(), _HugeCounts(), num_simulations=8, epochs=1, dequantize=True
+            )
 
     def test_nle_rejects_one_dimensional_observations(self):
         """The default coupling flow cannot model 1-D densities; the error points
@@ -454,18 +518,24 @@ class TestValidation:
                 return a + 0.1 * jax.random.normal(key, (num_observations, 1))
 
         with pytest.raises(ValueError, match="learn_amortized_ratio"):
-            learn_amortized_likelihood(_prior(), _Scalar(),
-                                       num_simulations=8, epochs=1)
+            learn_amortized_likelihood(_prior(), _Scalar(), num_simulations=8, epochs=1)
 
 
 class TestDeterminism:
     def test_training_deterministic_for_seed(self):
         """Two same-seed NLE trainings produce identical learned scores."""
+
         def _fit():
             return learn_amortized_likelihood(
-                _prior(), _SIM, num_simulations=400, epochs=1,
-                batch_size=256, random_seed=0, verbose=0,
+                _prior(),
+                _SIM,
+                num_simulations=400,
+                epochs=1,
+                batch_size=256,
+                random_seed=0,
+                verbose=0,
             )
+
         theta, y = jnp.array([0.3, -0.1]), jnp.array([0.5, 0.0])
         v1 = float(_fit().log_likelihood(theta, y))
         v2 = float(_fit().log_likelihood(theta, y))

--- a/tests/inference/test_bayesflow_posteriors.py
+++ b/tests/inference/test_bayesflow_posteriors.py
@@ -39,7 +39,7 @@ class _ToyLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = params.flatten()        # structured record (training) or raw array (direct)
+        t = params.flatten()  # structured record (training) or raw array (direct)
         a, b = t[0], t[1]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([a + b, a - b])
@@ -203,8 +203,7 @@ def _nested_prior():
     per-leaf bijector *under* nesting; ``flatten`` order is ``[r, m, c]``."""
     return ProductDistribution(
         name="joint",
-        outer={"r": pp.Gamma(3.0, 1.0, name="r"),
-               "m": Normal(loc=0.0, scale=1.0, name="m")},
+        outer={"r": pp.Gamma(3.0, 1.0, name="r"), "m": Normal(loc=0.0, scale=1.0, name="m")},
         c=Normal(loc=0.0, scale=1.0, name="c"),
     )
 
@@ -230,7 +229,8 @@ def _nested_observe(r, m, c, seed):
     per-draw record via ``unflatten`` (flatten order ``[r, m, c]``) -- the same
     structured object the offline simulator passes the simulator at train time."""
     rec = NumericRecordArray.unflatten(
-        jnp.array([r, m, c]), template=_nested_prior().event_template, batch_shape=())
+        jnp.array([r, m, c]), template=_nested_prior().event_template, batch_shape=()
+    )
     return _NestedLikelihood().generate_data(rec, 1, key=jax.random.PRNGKey(seed))[0]
 
 
@@ -238,9 +238,15 @@ def _nested_observe(r, m, c, seed):
 def npe_model():
     """A briefly-trained NPE estimator, shared across the NPE tests."""
     return learn_amortized_posterior(
-        _prior(), _ToyLikelihood(), method="npe",
-        num_simulations=3000, epochs=6, batch_size=256,
-        num_results=500, random_seed=0, verbose=0,
+        _prior(),
+        _ToyLikelihood(),
+        method="npe",
+        num_simulations=3000,
+        epochs=6,
+        batch_size=256,
+        num_results=500,
+        random_seed=0,
+        verbose=0,
     )
 
 
@@ -261,16 +267,21 @@ class TestBayesFlowNPE:
         """The same trained model conditions on distinct observations, and the
         posterior means land on the correct side of zero (the defining property
         of amortized inference)."""
-        mean_a_hi = float(np.mean(np.asarray(condition_on(npe_model, _observe(1.0, 0.0, 2)).draws()["a"])))
-        mean_a_lo = float(np.mean(np.asarray(condition_on(npe_model, _observe(-1.0, 0.0, 3)).draws()["a"])))
+        mean_a_hi = float(
+            np.mean(np.asarray(condition_on(npe_model, _observe(1.0, 0.0, 2)).draws()["a"]))
+        )
+        mean_a_lo = float(
+            np.mean(np.asarray(condition_on(npe_model, _observe(-1.0, 0.0, 3)).draws()["a"]))
+        )
         assert mean_a_hi > 0 > mean_a_lo
 
     def test_contract(self, npe_model):
         """``condition_on`` honours ``num_results`` (and its model default) and
         ignores the MCMC-only kwargs; the result is a named
         ``ApproximateDistribution``."""
-        post = condition_on(npe_model, _observe(0.0, 0.0, 1),
-                            num_results=300, num_warmup=99, num_chains=4)
+        post = condition_on(
+            npe_model, _observe(0.0, 0.0, 1), num_results=300, num_warmup=99, num_chains=4
+        )
         assert isinstance(post, ApproximateDistribution)
         assert post.algorithm == "bayesflow_npe"
         draws = post.draws()
@@ -327,9 +338,15 @@ class TestBayesFlowMethods:
     def test_methods_smoke(self, method):
         """Each amortized method trains and conditions, returning named draws."""
         model = learn_amortized_posterior(
-            _prior(), _ToyLikelihood(), method=method,
-            num_simulations=1500, epochs=3, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+            _prior(),
+            _ToyLikelihood(),
+            method=method,
+            num_simulations=1500,
+            epochs=3,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
         )
         post = condition_on(model, _observe(0.5, 0.0, 0))
         assert post.algorithm == f"bayesflow_{method}"
@@ -341,12 +358,19 @@ class TestBayesFlowMethods:
         """A vector-valued parameter field round-trips through the per-field
         reshape/concatenate and returns named draws of the right shape."""
         model = learn_amortized_posterior(
-            _vec_prior(), _VecLikelihood(), method="npe",
-            num_simulations=2000, epochs=4, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+            _vec_prior(),
+            _VecLikelihood(),
+            method="npe",
+            num_simulations=2000,
+            epochs=4,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
         )
-        obs = _VecLikelihood().generate_data(jnp.array([0.5, -0.5, 0.2]), 1,
-                                             key=jax.random.PRNGKey(5))[0]
+        obs = _VecLikelihood().generate_data(
+            jnp.array([0.5, -0.5, 0.2]), 1, key=jax.random.PRNGKey(5)
+        )[0]
         draws = condition_on(model, obs).draws()
         m = np.asarray(draws["m"]).reshape(200, -1)
         s = np.asarray(draws["s"]).reshape(200, -1)
@@ -361,9 +385,16 @@ class TestBayesFlowMethods:
 
         net = bf.networks.CouplingFlow()
         model = learn_amortized_posterior(
-            _prior(), _ToyLikelihood(), method="npe", inference_network=net,
-            num_simulations=1500, epochs=3, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+            _prior(),
+            _ToyLikelihood(),
+            method="npe",
+            inference_network=net,
+            num_simulations=1500,
+            epochs=3,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
         )
         # The exact instance passed in is the one used (not a method default).
         assert model._approximator.inference_network is net
@@ -377,12 +408,19 @@ class TestBayesFlowMethods:
 
         prior = pp.MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="theta")
         model = learn_amortized_posterior(
-            prior, _SingleFieldLikelihood(), method="npe",
-            num_simulations=1500, epochs=3, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+            prior,
+            _SingleFieldLikelihood(),
+            method="npe",
+            num_simulations=1500,
+            epochs=3,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
         )
-        obs = _SingleFieldLikelihood().generate_data(jnp.array([0.5, -0.5]), 1,
-                                                     key=jax.random.PRNGKey(4))[0]
+        obs = _SingleFieldLikelihood().generate_data(
+            jnp.array([0.5, -0.5]), 1, key=jax.random.PRNGKey(4)
+        )[0]
         draws = condition_on(model, obs).draws()
         assert np.asarray(draws["theta"]).reshape(200, -1).shape == (200, 2)
         assert np.isfinite(np.asarray(draws["theta"])).all()
@@ -392,9 +430,16 @@ class TestBayesFlowMethods:
         (``sim_backend="sequential"``) and conditions to named draws -- ``vmap``
         would fail on it, so success proves the eager loop ran."""
         model = learn_amortized_posterior(
-            _prior(), _NonJaxLikelihood(), method="npe", sim_backend="sequential",
-            num_simulations=800, epochs=2, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+            _prior(),
+            _NonJaxLikelihood(),
+            method="npe",
+            sim_backend="sequential",
+            num_simulations=800,
+            epochs=2,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
         )
         post = condition_on(model, _observe(0.5, 0.0, 0))
         assert post.algorithm == "bayesflow_npe"
@@ -407,12 +452,17 @@ class TestBayesFlowMethods:
         split handles ``event_shape=()``, and flow matching (unlike NPE's
         coupling flow) has no >= 2-parameter requirement."""
         model = learn_amortized_posterior(
-            Normal(loc=0.0, scale=1.0, name="a"), _ScalarLikelihood(), method="fmpe",
-            num_simulations=1500, epochs=3, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+            Normal(loc=0.0, scale=1.0, name="a"),
+            _ScalarLikelihood(),
+            method="fmpe",
+            num_simulations=1500,
+            epochs=3,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
         )
-        obs = _ScalarLikelihood().generate_data(jnp.array([0.7]), 1,
-                                                key=jax.random.PRNGKey(4))[0]
+        obs = _ScalarLikelihood().generate_data(jnp.array([0.7]), 1, key=jax.random.PRNGKey(4))[0]
         draws = condition_on(model, obs).draws()
         assert np.asarray(draws["a"]).reshape(-1).shape[0] == 200
         assert np.isfinite(np.asarray(draws["a"])).all()
@@ -430,15 +480,22 @@ class TestBayesFlowMethods:
         so a given run is reproducible; the band absorbs that estimator imprecision
         plus cross-platform / library-version drift."""
         import bayesflow as bf
-        prior = Normal(loc=0.0, scale=1.0, name="a")   # event_size 1 -> FlowMatching
+
+        prior = Normal(loc=0.0, scale=1.0, name="a")  # event_size 1 -> FlowMatching
         model = learn_amortized_posterior(
-            prior, _ConjugateGaussianLikelihood(), method="npe",
-            num_simulations=5000, epochs=40, batch_size=256,
-            num_results=2000, random_seed=0, verbose=0,
+            prior,
+            _ConjugateGaussianLikelihood(),
+            method="npe",
+            num_simulations=5000,
+            epochs=40,
+            batch_size=256,
+            num_results=2000,
+            random_seed=0,
+            verbose=0,
         )
         assert isinstance(model._approximator.inference_network, bf.networks.FlowMatching)
         s2 = _CONJ_SIGMA**2
-        post_std = (s2 / (1 + s2)) ** 0.5          # analytic posterior std
+        post_std = (s2 / (1 + s2)) ** 0.5  # analytic posterior std
         sim = _ConjugateGaussianLikelihood()
         mean_errs, std_ratios = [], []
         for i in range(6):
@@ -459,13 +516,18 @@ class TestBayesFlowMethods:
         split, adapter routing, and posterior assembly with multiple mixed-shape
         fields and bigger data, and checks the posterior responds to the data."""
         model = learn_amortized_posterior(
-            _multi_field_prior(), _MultiFieldLikelihood(), method="npe",
-            num_simulations=2500, epochs=5, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+            _multi_field_prior(),
+            _MultiFieldLikelihood(),
+            method="npe",
+            num_simulations=2500,
+            epochs=5,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
         )
         sim = _MultiFieldLikelihood()
-        obs = sim.generate_data(jnp.array([0.5, -0.5, 0.3, -0.2]), 1,
-                                key=jax.random.PRNGKey(6))[0]
+        obs = sim.generate_data(jnp.array([0.5, -0.5, 0.3, -0.2]), 1, key=jax.random.PRNGKey(6))[0]
         assert obs.shape == (8,)  # higher-dimensional observation
         draws = condition_on(model, obs).draws()
         assert np.asarray(draws["a"]).reshape(200, -1).shape == (200, 1)
@@ -474,7 +536,9 @@ class TestBayesFlowMethods:
         assert all(np.isfinite(np.asarray(draws[f])).all() for f in ("a", "b", "c"))
         # Amortized response: the posterior mean of `a` tracks the observation.
         obs_hi = sim.generate_data(jnp.array([1.0, 0.0, 0.0, 0.0]), 1, key=jax.random.PRNGKey(1))[0]
-        obs_lo = sim.generate_data(jnp.array([-1.0, 0.0, 0.0, 0.0]), 1, key=jax.random.PRNGKey(2))[0]
+        obs_lo = sim.generate_data(jnp.array([-1.0, 0.0, 0.0, 0.0]), 1, key=jax.random.PRNGKey(2))[
+            0
+        ]
         mean_a_hi = float(np.mean(np.asarray(condition_on(model, obs_hi).draws()["a"])))
         mean_a_lo = float(np.mean(np.asarray(condition_on(model, obs_lo).draws()["a"])))
         assert mean_a_hi > mean_a_lo
@@ -485,15 +549,22 @@ class TestBayesFlowMethods:
         the analytic mean and its std matches the analytic std (averaged over
         several observations). Trains a bit longer than the smoke tests so the
         estimator is near-converged."""
-        prior = ProductDistribution(Normal(loc=0.0, scale=1.0, name="a"),
-                                    Normal(loc=0.0, scale=1.0, name="b"))
+        prior = ProductDistribution(
+            Normal(loc=0.0, scale=1.0, name="a"), Normal(loc=0.0, scale=1.0, name="b")
+        )
         model = learn_amortized_posterior(
-            prior, _ConjugateGaussianLikelihood(), method="npe",
-            num_simulations=5000, epochs=40, batch_size=256,
-            num_results=4000, random_seed=0, verbose=0,
+            prior,
+            _ConjugateGaussianLikelihood(),
+            method="npe",
+            num_simulations=5000,
+            epochs=40,
+            batch_size=256,
+            num_results=4000,
+            random_seed=0,
+            verbose=0,
         )
         s2 = _CONJ_SIGMA**2
-        post_std = (s2 / (1 + s2)) ** 0.5          # analytic posterior std
+        post_std = (s2 / (1 + s2)) ** 0.5  # analytic posterior std
         sim = _ConjugateGaussianLikelihood()
         mean_errs, std_ratios = [], []
         for i in range(6):
@@ -520,9 +591,15 @@ class TestBayesFlowMethods:
         so every draw lands in the positive support. NPE no longer rejects nested
         priors -- it lifts them via per-leaf bijectors and adapter keying."""
         model = learn_amortized_posterior(
-            _nested_prior(), _NestedLikelihood(), method="npe",
-            num_simulations=3000, epochs=8, batch_size=256,
-            num_results=400, random_seed=0, verbose=0,
+            _nested_prior(),
+            _NestedLikelihood(),
+            method="npe",
+            num_simulations=3000,
+            epochs=8,
+            batch_size=256,
+            num_results=400,
+            random_seed=0,
+            verbose=0,
         )
         draws = condition_on(model, _nested_observe(2.0, -0.5, 0.4, seed=7)).draws()
         r = np.asarray(draws["outer/r"]).reshape(-1)
@@ -530,12 +607,16 @@ class TestBayesFlowMethods:
         c = np.asarray(draws["c"]).reshape(-1)
         assert r.shape == (400,) and m.shape == (400,) and c.shape == (400,)
         assert np.isfinite(r).all() and np.isfinite(m).all() and np.isfinite(c).all()
-        assert (r > 0).all()        # per-leaf forward bijector (Exp) under nesting
+        assert (r > 0).all()  # per-leaf forward bijector (Exp) under nesting
         # Amortized response: the posterior mean of `c` tracks the observation.
-        mean_c_hi = float(np.mean(np.asarray(
-            condition_on(model, _nested_observe(2.0, 0.0, 1.0, 2)).draws()["c"])))
-        mean_c_lo = float(np.mean(np.asarray(
-            condition_on(model, _nested_observe(2.0, 0.0, -1.0, 3)).draws()["c"])))
+        mean_c_hi = float(
+            np.mean(np.asarray(condition_on(model, _nested_observe(2.0, 0.0, 1.0, 2)).draws()["c"]))
+        )
+        mean_c_lo = float(
+            np.mean(
+                np.asarray(condition_on(model, _nested_observe(2.0, 0.0, -1.0, 3)).draws()["c"])
+            )
+        )
         assert mean_c_hi > mean_c_lo
 
     def test_nested_prior_calibration_against_conjugate(self):
@@ -547,14 +628,22 @@ class TestBayesFlowMethods:
         coordinate and fail here."""
         prior = ProductDistribution(
             name="joint",
-            outer={"a": Normal(loc=0.0, scale=1.0, name="a"),
-                   "b": Normal(loc=0.0, scale=1.0, name="b")},
+            outer={
+                "a": Normal(loc=0.0, scale=1.0, name="a"),
+                "b": Normal(loc=0.0, scale=1.0, name="b"),
+            },
             m=Normal(loc=0.0, scale=1.0, name="m"),
         )
         model = learn_amortized_posterior(
-            prior, _ConjugateGaussianLikelihood(), method="npe",
-            num_simulations=5000, epochs=40, batch_size=256,
-            num_results=4000, random_seed=0, verbose=0,
+            prior,
+            _ConjugateGaussianLikelihood(),
+            method="npe",
+            num_simulations=5000,
+            epochs=40,
+            batch_size=256,
+            num_results=4000,
+            random_seed=0,
+            verbose=0,
         )
         s2 = _CONJ_SIGMA**2
         post_std = (s2 / (1 + s2)) ** 0.5
@@ -583,14 +672,22 @@ class TestBayesFlowMethods:
         of test_wishart_matrix_prior_round_trip."""
         prior = ProductDistribution(
             name="joint",
-            outer={"cov": pp.Wishart(df=4.0, scale=jnp.eye(2), name="cov"),
-                   "m": Normal(loc=0.0, scale=1.0, name="m")},
+            outer={
+                "cov": pp.Wishart(df=4.0, scale=jnp.eye(2), name="cov"),
+                "m": Normal(loc=0.0, scale=1.0, name="m"),
+            },
             c=Normal(loc=0.0, scale=1.0, name="c"),
         )
         model = learn_amortized_posterior(
-            prior, _ConjugateGaussianLikelihood(), method="fmpe",
-            num_simulations=600, epochs=2, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+            prior,
+            _ConjugateGaussianLikelihood(),
+            method="fmpe",
+            num_simulations=600,
+            epochs=2,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
         )
         obs = jnp.array([1.5, 0.3, 0.3, 1.2, 0.5, 0.0])  # flat (cov 2x2, m, c)
         cov = np.asarray(condition_on(model, obs).draws()["outer/cov"]).reshape(-1, 2, 2)
@@ -604,9 +701,15 @@ class TestBayesFlowMethods:
         params["a"]/["b"] exclusively, so training succeeds only when the
         structured record is passed."""
         model = learn_amortized_posterior(
-            _prior(), _NamedFieldLikelihood(), method="npe",
-            num_simulations=800, epochs=2, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+            _prior(),
+            _NamedFieldLikelihood(),
+            method="npe",
+            num_simulations=800,
+            epochs=2,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
         )
         draws = condition_on(model, jnp.array([0.8, 0.2])).draws()
         assert np.asarray(draws["a"]).reshape(-1).shape[0] == 200
@@ -616,16 +719,23 @@ class TestBayesFlowMethods:
         """A constrained (positive) prior field is trained in unconstrained space and
         its draws are mapped back through the forward bijector, so they land in the
         support -- here all positive. The accompanying real-valued field is unaffected."""
-        prior = ProductDistribution(pp.Gamma(3.0, 1.0, name="r"),
-                                    Normal(loc=0.0, scale=1.0, name="m"))
+        prior = ProductDistribution(
+            pp.Gamma(3.0, 1.0, name="r"), Normal(loc=0.0, scale=1.0, name="m")
+        )
         model = learn_amortized_posterior(
-            prior, _PositiveLikelihood(), method="npe",
-            num_simulations=1500, epochs=5, batch_size=256,
-            num_results=400, random_seed=0, verbose=0,
+            prior,
+            _PositiveLikelihood(),
+            method="npe",
+            num_simulations=1500,
+            epochs=5,
+            batch_size=256,
+            num_results=400,
+            random_seed=0,
+            verbose=0,
         )
         r = np.asarray(condition_on(model, jnp.array([3.0, 1.0])).draws()["r"]).reshape(-1)
         assert np.isfinite(r).all()
-        assert (r > 0).all()        # forward bijector (Exp) keeps every draw in support
+        assert (r > 0).all()  # forward bijector (Exp) keeps every draw in support
 
     def test_adapter_internal_names_avoid_collisions(self):
         """Theta fields are re-keyed away from BayesFlow adapter internals.
@@ -639,9 +749,15 @@ class TestBayesFlowMethods:
             Normal(loc=0.0, scale=1.0, name="inference_variables"),
         )
         model = learn_amortized_posterior(
-            prior, _ToyLikelihood(), method="npe",
-            num_simulations=800, epochs=2, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+            prior,
+            _ToyLikelihood(),
+            method="npe",
+            num_simulations=800,
+            epochs=2,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
         )
         draws = condition_on(model, jnp.array([0.5, 0.1])).draws()
         for f in ("observation", "inference_variables"):
@@ -653,16 +769,23 @@ class TestBayesFlowMethods:
         """A bounded-interval prior field (Beta, unit-interval support) rounds
         through the Sigmoid bijector: trained unconstrained, every posterior
         draw lands strictly inside (0, 1)."""
-        prior = ProductDistribution(pp.Beta(2.0, 2.0, name="q"),
-                                    Normal(loc=0.0, scale=1.0, name="m"))
+        prior = ProductDistribution(
+            pp.Beta(2.0, 2.0, name="q"), Normal(loc=0.0, scale=1.0, name="m")
+        )
         model = learn_amortized_posterior(
-            prior, _ConjugateGaussianLikelihood(), method="npe",
-            num_simulations=800, epochs=2, batch_size=256,
-            num_results=300, random_seed=0, verbose=0,
+            prior,
+            _ConjugateGaussianLikelihood(),
+            method="npe",
+            num_simulations=800,
+            epochs=2,
+            batch_size=256,
+            num_results=300,
+            random_seed=0,
+            verbose=0,
         )
         q = np.asarray(condition_on(model, jnp.array([0.5, 0.0])).draws()["q"]).reshape(-1)
         assert np.isfinite(q).all()
-        assert ((q > 0) & (q < 1)).all()   # Sigmoid forward keeps draws in (0, 1)
+        assert ((q > 0) & (q < 1)).all()  # Sigmoid forward keeps draws in (0, 1)
 
     def test_wishart_matrix_prior_round_trip(self):
         """A matrix-valued constrained field (Wishart, positive-definite support)
@@ -670,18 +793,25 @@ class TestBayesFlowMethods:
         shape at train time -- a flattened input would crash the
         CholeskyOuterProduct chain -- and the forward map at sample time returns
         draws that are symmetric positive definite."""
-        prior = ProductDistribution(pp.Wishart(df=4.0, scale=jnp.eye(2), name="cov"),
-                                    Normal(loc=0.0, scale=1.0, name="m"))
-        model = learn_amortized_posterior(
-            prior, _ConjugateGaussianLikelihood(), method="fmpe",
-            num_simulations=600, epochs=2, batch_size=256,
-            num_results=200, random_seed=0, verbose=0,
+        prior = ProductDistribution(
+            pp.Wishart(df=4.0, scale=jnp.eye(2), name="cov"), Normal(loc=0.0, scale=1.0, name="m")
         )
-        obs = jnp.array([1.5, 0.3, 0.3, 1.2, 0.5])    # flattened (cov, m) observation
+        model = learn_amortized_posterior(
+            prior,
+            _ConjugateGaussianLikelihood(),
+            method="fmpe",
+            num_simulations=600,
+            epochs=2,
+            batch_size=256,
+            num_results=200,
+            random_seed=0,
+            verbose=0,
+        )
+        obs = jnp.array([1.5, 0.3, 0.3, 1.2, 0.5])  # flattened (cov, m) observation
         cov = np.asarray(condition_on(model, obs).draws()["cov"]).reshape(-1, 2, 2)
         assert np.isfinite(cov).all()
         np.testing.assert_allclose(cov, np.swapaxes(cov, -1, -2), atol=1e-5)  # symmetric
-        assert np.linalg.eigvalsh(cov).min() > 0                              # positive definite
+        assert np.linalg.eigvalsh(cov).min() > 0  # positive definite
 
     def test_dirichlet_simplex_prior_npe(self):
         """A single 2-simplex (Dirichlet) prior under method='npe': the coupling-flow
@@ -689,10 +819,17 @@ class TestBayesFlowMethods:
         event_size of two), so NPE falls back to flow matching instead of building a
         units=0 coupling flow; draws land on the simplex."""
         import bayesflow as bf
+
         model = learn_amortized_posterior(
-            pp.Dirichlet(jnp.ones(2), name="p"), _ConjugateGaussianLikelihood(),
-            method="npe", num_simulations=600, epochs=2, batch_size=256,
-            num_results=300, random_seed=0, verbose=0,
+            pp.Dirichlet(jnp.ones(2), name="p"),
+            _ConjugateGaussianLikelihood(),
+            method="npe",
+            num_simulations=600,
+            epochs=2,
+            batch_size=256,
+            num_results=300,
+            random_seed=0,
+            verbose=0,
         )
         assert isinstance(model._approximator.inference_network, bf.networks.FlowMatching)
         p = np.asarray(condition_on(model, jnp.array([0.7, 0.3])).draws()["p"]).reshape(-1, 2)
@@ -703,12 +840,20 @@ class TestBayesFlowMethods:
         """Two same-seed trainings produce bit-identical models: keras init + fit
         are seeded via ``keras.utils.set_random_seed`` (the calibration tests'
         tolerance rationale relies on this reproducibility)."""
+
         def _fit():
             return learn_amortized_posterior(
-                _prior(), _ToyLikelihood(), method="npe",
-                num_simulations=400, epochs=1, batch_size=256,
-                num_results=100, random_seed=0, verbose=0,
+                _prior(),
+                _ToyLikelihood(),
+                method="npe",
+                num_simulations=400,
+                epochs=1,
+                batch_size=256,
+                num_results=100,
+                random_seed=0,
+                verbose=0,
             )
+
         obs = _observe(0.4, -0.2, 5)
         d1 = np.asarray(condition_on(_fit(), obs).draws()["a"]).reshape(-1)
         d2 = np.asarray(condition_on(_fit(), obs).draws()["a"]).reshape(-1)
@@ -719,6 +864,7 @@ class TestBayesFlowMethods:
         caller's NumPy / Python random state, so a call does not silently make the
         caller's unrelated random streams deterministic."""
         import random as pyrandom
+
         np.random.seed(123)
         pyrandom.seed(7)
         expected_np = np.random.random()
@@ -726,9 +872,15 @@ class TestBayesFlowMethods:
         np.random.seed(123)
         pyrandom.seed(7)
         learn_amortized_posterior(
-            _prior(), _ToyLikelihood(), method="fmpe",
-            num_simulations=256, epochs=1, batch_size=256,
-            num_results=50, random_seed=0, verbose=0,
+            _prior(),
+            _ToyLikelihood(),
+            method="fmpe",
+            num_simulations=256,
+            epochs=1,
+            batch_size=256,
+            num_results=50,
+            random_seed=0,
+            verbose=0,
         )
         assert np.random.random() == expected_np
         assert pyrandom.random() == expected_py
@@ -751,23 +903,32 @@ class TestBayesFlowValidation:
         ``event_template``) is rejected with a clear TypeError."""
         with pytest.raises(TypeError, match="RecordDistribution"):
             learn_amortized_posterior(
-                jnp.zeros(2), _ToyLikelihood(), num_simulations=8, epochs=1,
+                jnp.zeros(2),
+                _ToyLikelihood(),
+                num_simulations=8,
+                epochs=1,
             )
 
     def test_rejects_unknown_method(self):
         """An unsupported amortized method is rejected up front."""
         with pytest.raises(ValueError, match="Unknown amortized SBI method"):
             learn_amortized_posterior(
-                _prior(), _ToyLikelihood(), method="bogus",
-                num_simulations=8, epochs=1,
+                _prior(),
+                _ToyLikelihood(),
+                method="bogus",
+                num_simulations=8,
+                epochs=1,
             )
 
     def test_rejects_unknown_sim_backend(self):
         """An unsupported simulation backend is rejected up front."""
         with pytest.raises(ValueError, match="Unknown sim_backend"):
             learn_amortized_posterior(
-                _prior(), _ToyLikelihood(), sim_backend="bogus",
-                num_simulations=8, epochs=1,
+                _prior(),
+                _ToyLikelihood(),
+                sim_backend="bogus",
+                num_simulations=8,
+                epochs=1,
             )
 
     @pytest.mark.parametrize(
@@ -782,8 +943,7 @@ class TestBayesFlowValidation:
 
     @pytest.mark.parametrize(
         "override",
-        [{"num_simulations": 100.5}, {"batch_size": "64"}, {"epochs": 2.0},
-         {"num_results": None}],
+        [{"num_simulations": 100.5}, {"batch_size": "64"}, {"epochs": 2.0}, {"num_results": None}],
     )
     def test_rejects_non_integer_counts(self, override):
         """Count parameters must be integers -- floats (even integral ones),
@@ -796,8 +956,9 @@ class TestBayesFlowValidation:
     def test_rejects_discrete_prior(self):
         """A discrete prior field has no smooth bijector to R^d and is rejected up
         front with a clear error (here a Poisson count parameter)."""
-        bad_prior = ProductDistribution(pp.Poisson(3.0, name="k"),
-                                        Normal(loc=0.0, scale=1.0, name="m"))
+        bad_prior = ProductDistribution(
+            pp.Poisson(3.0, name="k"), Normal(loc=0.0, scale=1.0, name="m")
+        )
         with pytest.raises(ValueError, match="discrete"):
             learn_amortized_posterior(bad_prior, _ToyLikelihood(), num_simulations=8, epochs=1)
 
@@ -814,5 +975,4 @@ class TestBayesFlowValidation:
                 raise NotImplementedError
 
         with pytest.raises(TypeError, match="per-field"):
-            learn_amortized_posterior(_NoSupports(), _ToyLikelihood(),
-                                      num_simulations=8, epochs=1)
+            learn_amortized_posterior(_NoSupports(), _ToyLikelihood(), num_simulations=8, epochs=1)

--- a/tests/inference/test_blackjax_ess.py
+++ b/tests/inference/test_blackjax_ess.py
@@ -78,9 +78,7 @@ class _ConcatGaussianLik(Likelihood):
 
     def log_likelihood(self, params, data):
         if hasattr(params, "fields"):
-            theta = jnp.concatenate(
-                [jnp.atleast_1d(params[f]) for f in params.fields]
-            )
+            theta = jnp.concatenate([jnp.atleast_1d(params[f]) for f in params.fields])
         else:
             theta = jnp.atleast_1d(jnp.asarray(params))
         return -0.5 / self.obs_var * jnp.sum((jnp.asarray(data) - theta) ** 2)
@@ -145,11 +143,13 @@ class TestGaussianPriorDetection:
         covariance verbatim — the off-diagonal ``a``-``b`` terms must
         survive, in ``event_template.fields`` order ``[a, b]``.
         """
-        cov_in = jnp.array([
-            [2.0, 0.5, 0.1],
-            [0.5, 1.0, 0.0],
-            [0.1, 0.0, 3.0],
-        ])
+        cov_in = jnp.array(
+            [
+                [2.0, 0.5, 0.1],
+                [0.5, 1.0, 0.0],
+                [0.1, 0.0, 3.0],
+            ]
+        )
         mean_in = jnp.array([1.0, -2.0, 3.0])
         prior = JointGaussian(mean=mean_in, cov=cov_in, a=1, b=2)
         params = _gaussian_prior_params(prior)
@@ -188,7 +188,9 @@ class TestGaussianPriorDetection:
         finding noted on ``test_normal_scalar_promoted_to_length_one``).
         """
         da = Normal.from_batched_params(
-            loc=jnp.array([0.0, 1.0]), scale=jnp.array([0.5, 2.0]), name="x",
+            loc=jnp.array([0.0, 1.0]),
+            scale=jnp.array([0.5, 2.0]),
+            name="x",
         )
         assert not isinstance(da, Normal)
         assert _gaussian_prior_params(da) is None
@@ -203,7 +205,9 @@ class TestGaussianPriorDetection:
         mean, cov = params
         np.testing.assert_allclose(np.asarray(mean), [1.0, -2.0])
         np.testing.assert_allclose(
-            np.asarray(cov), [[0.25, 0.0], [0.0, 0.49]], rtol=1e-5,
+            np.asarray(cov),
+            [[0.25, 0.0], [0.0, 0.49]],
+            rtol=1e-5,
         )
 
     def test_product_mixed_normal_and_mvn(self):
@@ -261,15 +265,10 @@ class TestGaussianPriorDetection:
 
 
 class TestRegistration:
-
     def test_method_registered_at_75(self):
         names = inference_method_registry.list_methods()
         assert "blackjax_elliptical_slice" in names
-        assert (
-            inference_method_registry
-            .get_method("blackjax_elliptical_slice").priority
-            == 75
-        )
+        assert inference_method_registry.get_method("blackjax_elliptical_slice").priority == 75
 
 
 class TestFeasibilityCheck:
@@ -334,7 +333,8 @@ class TestFeasibilityCheck:
         prior = JointGaussian(
             mean=jnp.zeros(3),
             cov=jnp.array([[1.0, 0.3, 0.0], [0.3, 1.0, 0.0], [0.0, 0.0, 2.0]]),
-            a=1, b=2,
+            a=1,
+            b=2,
         )
 
         class _Lik(Likelihood):
@@ -357,7 +357,7 @@ class _NonTraceableGaussianLik(Likelihood):
     def log_likelihood(self, params, data):
         mu = params["mu"] if hasattr(params, "fields") else params
         resid = np.asarray(data) - np.asarray(mu)
-        return float(-0.5 * np.sum(resid ** 2))
+        return float(-0.5 * np.sum(resid**2))
 
 
 class TestDeclinesToRWMH:
@@ -387,8 +387,11 @@ class TestDeclinesToRWMH:
         # No method= → registry auto-selects. ESS (75) declines
         # (non-traceable), NUTS/HMC (gradient) decline, so RWMH (55) wins.
         posterior = condition_on(
-            model, np.zeros((5, 2)),
-            num_results=50, num_warmup=20, random_seed=0,
+            model,
+            np.zeros((5, 2)),
+            num_results=50,
+            num_warmup=20,
+            random_seed=0,
         )
         assert posterior.algorithm == "blackjax_rwmh"
 
@@ -414,11 +417,16 @@ class TestPosteriorRecovery:
         model = SimpleModel(prior, _GaussianMeanLik(), name="m")
 
         post = elliptical_slice(
-            model, data, num_results=3000, num_warmup=500,
-            num_chains=2, random_seed=42,
+            model,
+            data,
+            num_results=3000,
+            num_warmup=500,
+            num_chains=2,
+            random_seed=42,
         )
         draws = np.concatenate(
-            [np.asarray(c) for c in post.chains], axis=0,
+            [np.asarray(c) for c in post.chains],
+            axis=0,
         )
         n = data.shape[0]
         y_bar = float(np.asarray(data).mean())
@@ -426,7 +434,9 @@ class TestPosteriorRecovery:
         analytic_sd = float(np.sqrt(1.0 / (n + 1)))
         np.testing.assert_allclose(float(draws.mean()), analytic_mean, atol=0.05)
         np.testing.assert_allclose(
-            float(draws.std(ddof=1)), analytic_sd, atol=0.04,
+            float(draws.std(ddof=1)),
+            analytic_sd,
+            atol=0.04,
         )
 
     def test_multivariate_anisotropic_prior(self):
@@ -463,11 +473,16 @@ class TestPosteriorRecovery:
         model = SimpleModel(prior, _MVNLik(), name="m")
 
         post = elliptical_slice(
-            model, data, num_results=2000, num_warmup=500,
-            num_chains=2, random_seed=42,
+            model,
+            data,
+            num_results=2000,
+            num_warmup=500,
+            num_chains=2,
+            random_seed=42,
         )
         draws = np.concatenate(
-            [np.asarray(c) for c in post.chains], axis=0,
+            [np.asarray(c) for c in post.chains],
+            axis=0,
         )
 
         # Closed-form posterior.
@@ -481,7 +496,8 @@ class TestPosteriorRecovery:
         sample_cov = np.cov(draws, rowvar=False)
         frob = np.linalg.norm(sample_cov - sigma_post, ord="fro")
         np.testing.assert_array_less(
-            frob, 0.15 * np.linalg.norm(sigma_post, ord="fro"),
+            frob,
+            0.15 * np.linalg.norm(sigma_post, ord="fro"),
         )
 
     def test_product_distribution_prior(self):
@@ -503,8 +519,12 @@ class TestPosteriorRecovery:
         model = SimpleModel(prior, _ConcatGaussianLik(obs_var), name="m")
 
         post = elliptical_slice(
-            model, data, num_results=3000, num_warmup=500,
-            num_chains=2, random_seed=7,
+            model,
+            data,
+            num_results=3000,
+            num_warmup=500,
+            num_chains=2,
+            random_seed=7,
         )
         draws = np.concatenate([np.asarray(c) for c in post.chains], axis=0)
 
@@ -516,7 +536,9 @@ class TestPosteriorRecovery:
 
         np.testing.assert_allclose(draws.mean(0), post_mean, atol=0.06)
         np.testing.assert_allclose(
-            draws.std(0, ddof=1), np.sqrt(np.diag(sigma_post)), rtol=0.12,
+            draws.std(0, ddof=1),
+            np.sqrt(np.diag(sigma_post)),
+            rtol=0.12,
         )
         # Independent prior + diagonal likelihood -> posterior is diagonal.
         sample_cov = np.cov(draws, rowvar=False)
@@ -536,7 +558,10 @@ class TestPosteriorRecovery:
         """
         sigma_prior = np.array([[1.0, 0.8], [0.8, 1.0]])
         prior = JointGaussian(
-            mean=jnp.zeros(2), cov=jnp.asarray(sigma_prior), a=1, b=1,
+            mean=jnp.zeros(2),
+            cov=jnp.asarray(sigma_prior),
+            a=1,
+            b=1,
         )
         n, obs_var = 10, 10.0
         rng = np.random.default_rng(2)
@@ -545,8 +570,12 @@ class TestPosteriorRecovery:
         model = SimpleModel(prior, _ConcatGaussianLik(obs_var), name="m")
 
         post = elliptical_slice(
-            model, data, num_results=4000, num_warmup=800,
-            num_chains=2, random_seed=13,
+            model,
+            data,
+            num_results=4000,
+            num_warmup=800,
+            num_chains=2,
+            random_seed=13,
         )
         draws = np.concatenate([np.asarray(c) for c in post.chains], axis=0)
 
@@ -564,7 +593,8 @@ class TestPosteriorRecovery:
         sample_cov = np.cov(draws, rowvar=False)
         frob = np.linalg.norm(sample_cov - sigma_post, ord="fro")
         np.testing.assert_array_less(
-            frob, 0.15 * np.linalg.norm(sigma_post, ord="fro"),
+            frob,
+            0.15 * np.linalg.norm(sigma_post, ord="fro"),
         )
 
 
@@ -574,10 +604,13 @@ class TestPosteriorRecovery:
 
 
 class TestProvenanceAndAuxiliary:
-
     def test_provenance(self, gaussian_model, data):
         post = elliptical_slice(
-            gaussian_model, data, num_results=50, num_warmup=20, random_seed=0,
+            gaussian_model,
+            data,
+            num_results=50,
+            num_warmup=20,
+            random_seed=0,
         )
         assert post.algorithm == "elliptical_slice"
         assert post.source.operation == "elliptical_slice"
@@ -585,8 +618,12 @@ class TestProvenanceAndAuxiliary:
     def test_auxiliary_datatree_has_subiter_stats(self, gaussian_model, data):
         num_chains, num_results = 2, 50
         post = elliptical_slice(
-            gaussian_model, data, num_results=num_results, num_warmup=20,
-            num_chains=num_chains, random_seed=0,
+            gaussian_model,
+            data,
+            num_results=num_results,
+            num_warmup=20,
+            num_chains=num_chains,
+            random_seed=0,
         )
         assert post.inference_data is not None
         assert "posterior" in post.inference_data
@@ -603,8 +640,12 @@ class TestProvenanceAndAuxiliary:
 
     def test_warmup_stored(self, gaussian_model):
         post = elliptical_slice(
-            gaussian_model, jnp.zeros(10), num_results=20, num_warmup=15,
-            num_chains=2, random_seed=0,
+            gaussian_model,
+            jnp.zeros(10),
+            num_results=20,
+            num_warmup=15,
+            num_chains=2,
+            random_seed=0,
         )
         assert post.warmup_samples is not None
         assert post.warmup_samples[0].shape == (15, 1)
@@ -612,7 +653,11 @@ class TestProvenanceAndAuxiliary:
     def test_no_warmup_path(self, gaussian_model, data):
         """``num_warmup=0`` runs and stores no warmup chains."""
         post = elliptical_slice(
-            gaussian_model, data, num_results=30, num_warmup=0, random_seed=0,
+            gaussian_model,
+            data,
+            num_results=30,
+            num_warmup=0,
+            random_seed=0,
         )
         assert isinstance(post, ApproximateDistribution)
         assert post.warmup_samples is None
@@ -621,8 +666,12 @@ class TestProvenanceAndAuxiliary:
     def test_explicit_init_smoke(self, gaussian_model, data):
         """An explicit ``init=`` (matching the 1-D param dim) runs cleanly."""
         post = elliptical_slice(
-            gaussian_model, data, num_results=30, num_warmup=5,
-            init=jnp.array([2.5]), random_seed=0,
+            gaussian_model,
+            data,
+            num_results=30,
+            num_warmup=5,
+            init=jnp.array([2.5]),
+            random_seed=0,
         )
         assert isinstance(post, ApproximateDistribution)
         # 1-D Normal prior → single-parameter chains.
@@ -630,8 +679,12 @@ class TestProvenanceAndAuxiliary:
 
     def test_multi_chain_shape(self, gaussian_model, data):
         post = elliptical_slice(
-            gaussian_model, data, num_results=30, num_warmup=10,
-            num_chains=3, random_seed=0,
+            gaussian_model,
+            data,
+            num_results=30,
+            num_warmup=10,
+            num_chains=3,
+            random_seed=0,
         )
         assert post.num_chains == 3
         assert post.num_draws == 30
@@ -643,12 +696,13 @@ class TestProvenanceAndAuxiliary:
 
 
 class TestErrors:
-
     def test_raises_on_bare_distribution(self):
         with pytest.raises(TypeError, match="SimpleModel"):
             elliptical_slice(
                 Normal(loc=0.0, scale=1.0, name="x"),
-                jnp.zeros(5), num_results=10, num_warmup=5,
+                jnp.zeros(5),
+                num_results=10,
+                num_warmup=5,
             )
 
     def test_raises_on_non_gaussian_prior(self):
@@ -661,11 +715,17 @@ class TestErrors:
         model = SimpleModel(prior, _Lik(), name="m")
         with pytest.raises(TypeError, match="Gaussian"):
             elliptical_slice(
-                model, jnp.zeros(5), num_results=10, num_warmup=5,
+                model,
+                jnp.zeros(5),
+                num_results=10,
+                num_warmup=5,
             )
 
     def test_raises_on_none_data(self, gaussian_model):
         with pytest.raises(TypeError, match="observed data"):
             elliptical_slice(
-                gaussian_model, data=None, num_results=10, num_warmup=5,
+                gaussian_model,
+                data=None,
+                num_results=10,
+                num_warmup=5,
             )

--- a/tests/inference/test_blackjax_mcmc.py
+++ b/tests/inference/test_blackjax_mcmc.py
@@ -79,8 +79,13 @@ class TestBlackJAXNuts:
 
     def test_runs_end_to_end(self, small_model):
         posterior = condition_on(
-            small_model, jnp.zeros((4,)), method="blackjax_nuts",
-            num_results=200, num_warmup=200, num_chains=2, random_seed=0,
+            small_model,
+            jnp.zeros((4,)),
+            method="blackjax_nuts",
+            num_results=200,
+            num_warmup=200,
+            num_chains=2,
+            random_seed=0,
         )
         m = mean(posterior)
         assert m["a"].shape == ()
@@ -89,8 +94,13 @@ class TestBlackJAXNuts:
     def test_collapses_to_prior_under_identity_likelihood(self, small_model):
         # With an identity likelihood, the posterior is the prior.
         posterior = condition_on(
-            small_model, jnp.zeros((4,)), method="blackjax_nuts",
-            num_results=400, num_warmup=400, num_chains=2, random_seed=0,
+            small_model,
+            jnp.zeros((4,)),
+            method="blackjax_nuts",
+            num_results=400,
+            num_warmup=400,
+            num_chains=2,
+            random_seed=0,
         )
         m = mean(posterior)
         np.testing.assert_allclose(float(m["a"].squeeze()), 1.0, atol=0.15)
@@ -111,8 +121,13 @@ class TestBlackJAXNuts:
         y = jnp.asarray([1.0, 2.0, 3.0])
 
         posterior = condition_on(
-            model, y, method="blackjax_nuts",
-            num_results=2000, num_warmup=1000, num_chains=2, random_seed=0,
+            model,
+            y,
+            method="blackjax_nuts",
+            num_results=2000,
+            num_warmup=1000,
+            num_chains=2,
+            random_seed=0,
         )
 
         # Analytic posterior: N(1.5, 0.25). MC std error on the posterior
@@ -138,8 +153,13 @@ class TestBlackJAXNuts:
         overwrite it).
         """
         posterior = condition_on(
-            small_model, jnp.zeros((4,)), method="blackjax_nuts",
-            num_results=50, num_warmup=0, step_size=0.05, random_seed=0,
+            small_model,
+            jnp.zeros((4,)),
+            method="blackjax_nuts",
+            num_results=50,
+            num_warmup=0,
+            step_size=0.05,
+            random_seed=0,
         )
         m = mean(posterior)
         assert jnp.isfinite(m["a"]).all()
@@ -155,9 +175,15 @@ class TestBlackJAXHmc:
 
     def test_runs_end_to_end(self, small_model):
         posterior = condition_on(
-            small_model, jnp.zeros((4,)), method="blackjax_hmc",
-            num_results=200, num_warmup=200, num_chains=1,
-            step_size=0.05, num_integration_steps=10, random_seed=0,
+            small_model,
+            jnp.zeros((4,)),
+            method="blackjax_hmc",
+            num_results=200,
+            num_warmup=200,
+            num_chains=1,
+            step_size=0.05,
+            num_integration_steps=10,
+            random_seed=0,
         )
         m = mean(posterior)
         assert m["a"].shape == ()
@@ -184,9 +210,15 @@ class TestBlackJAXHmc:
         y = jnp.asarray([1.0, 2.0, 3.0])
 
         posterior = condition_on(
-            model, y, method="blackjax_hmc",
-            num_results=4000, num_warmup=2000, num_chains=2,
-            step_size=0.1, num_integration_steps=5, random_seed=0,
+            model,
+            y,
+            method="blackjax_hmc",
+            num_results=4000,
+            num_warmup=2000,
+            num_chains=2,
+            step_size=0.1,
+            num_integration_steps=5,
+            random_seed=0,
         )
 
         post_mean = float(mean(posterior)["mu"].squeeze())
@@ -206,13 +238,17 @@ class TestBlackJAXHmc:
         prior = ProductDistribution(mu=Normal(loc=0.0, scale=1.0, name="mu"))
         model = SimpleModel(prior, _GaussianMeanLikelihood(), name="g")
         posterior = condition_on(
-            model, jnp.asarray([1.0, 2.0, 3.0]), method="blackjax_hmc",
-            num_results=1000, num_warmup=500, num_chains=2,
-            step_size=0.1, num_integration_steps=10, random_seed=0,
+            model,
+            jnp.asarray([1.0, 2.0, 3.0]),
+            method="blackjax_hmc",
+            num_results=1000,
+            num_warmup=500,
+            num_chains=2,
+            step_size=0.1,
+            num_integration_steps=10,
+            random_seed=0,
         )
-        steps = np.asarray(
-            posterior.inference_data["sample_stats"]["num_integration_steps"]
-        )
+        steps = np.asarray(posterior.inference_data["sample_stats"]["num_integration_steps"])
         # Randomized, not a single fixed L.
         assert np.unique(steps).size >= 5
         # Mean trajectory length tracks the configured value.
@@ -233,9 +269,15 @@ class TestBlackJAXHmc:
         prior = ProductDistribution(mu=Normal(loc=0.0, scale=1.0, name="mu"))
         model = SimpleModel(prior, _GaussianMeanLikelihood(), name="g")
         posterior = condition_on(
-            model, jnp.asarray([1.0, 2.0, 3.0]), method="blackjax_hmc",
-            num_results=4000, num_warmup=2000, num_chains=2,
-            step_size=0.1, num_integration_steps=10, random_seed=0,
+            model,
+            jnp.asarray([1.0, 2.0, 3.0]),
+            method="blackjax_hmc",
+            num_results=4000,
+            num_warmup=2000,
+            num_chains=2,
+            step_size=0.1,
+            num_integration_steps=10,
+            random_seed=0,
         )
         post_mean = float(mean(posterior)["mu"].squeeze())
         post_var = float(variance(posterior)["mu"].squeeze())
@@ -271,18 +313,22 @@ class TestBlackJAXHmc:
         prior = ProductDistribution(mu=Normal(loc=0.0, scale=1.0, name="mu"))
         model = SimpleModel(prior, _GaussianMeanLikelihood(), name="g")
         posterior = condition_on(
-            model, jnp.asarray([1.0, 2.0, 3.0]), method="blackjax_hmc",
-            num_results=100, num_warmup=0, num_chains=1,
-            step_size=0.1, num_integration_steps=10, random_seed=0,
+            model,
+            jnp.asarray([1.0, 2.0, 3.0]),
+            method="blackjax_hmc",
+            num_results=100,
+            num_warmup=0,
+            num_chains=1,
+            step_size=0.1,
+            num_integration_steps=10,
+            random_seed=0,
         )
         draws = np.asarray(posterior.draws()["mu"]).reshape(-1)
         assert draws.shape[0] == 100
         assert np.all(np.isfinite(draws))
         # Trajectory length is still randomized (and floored) on the
         # zero-warmup path.
-        steps = np.asarray(
-            posterior.inference_data["sample_stats"]["num_integration_steps"]
-        )
+        steps = np.asarray(posterior.inference_data["sample_stats"]["num_integration_steps"])
         assert steps.min() >= 1
         assert np.unique(steps).size >= 5
 
@@ -299,16 +345,23 @@ class TestSampleStats:
     def test_sample_stats_keys_shapes_and_ranges(self, small_model):
         num_chains, num_results = 2, 200
         posterior = condition_on(
-            small_model, jnp.zeros((4,)), method="blackjax_nuts",
-            num_results=num_results, num_warmup=200,
-            num_chains=num_chains, random_seed=0,
+            small_model,
+            jnp.zeros((4,)),
+            method="blackjax_nuts",
+            num_results=num_results,
+            num_warmup=200,
+            num_chains=num_chains,
+            random_seed=0,
         )
         ds = posterior.inference_data["sample_stats"]
 
         # NUTS plumbs these four info fields plus the injected step_size.
         expected = {
-            "step_size", "acceptance_rate", "is_divergent",
-            "num_integration_steps", "energy",
+            "step_size",
+            "acceptance_rate",
+            "is_divergent",
+            "num_integration_steps",
+            "energy",
         }
         assert expected.issubset(set(ds.data_vars))
 
@@ -337,8 +390,13 @@ class TestSampleStats:
     def test_posterior_has_one_chain_dim_per_chain(self, small_model):
         num_chains = 2
         posterior = condition_on(
-            small_model, jnp.zeros((4,)), method="blackjax_nuts",
-            num_results=100, num_warmup=100, num_chains=num_chains, random_seed=0,
+            small_model,
+            jnp.zeros((4,)),
+            method="blackjax_nuts",
+            num_results=100,
+            num_warmup=100,
+            num_chains=num_chains,
+            random_seed=0,
         )
         post_grp = posterior.inference_data["posterior"]
         assert post_grp.sizes["chain"] == num_chains

--- a/tests/inference/test_blackjax_rwmh.py
+++ b/tests/inference/test_blackjax_rwmh.py
@@ -50,7 +50,9 @@ def iso_gaussian():
 def aniso_gaussian():
     """A 2-D anisotropic ``N(0, diag(1, 4))`` — analytic stds [1, 2]."""
     return MultivariateNormal(
-        loc=jnp.zeros(2), cov=jnp.diag(jnp.array([1.0, 4.0])), name="z",
+        loc=jnp.zeros(2),
+        cov=jnp.diag(jnp.array([1.0, 4.0])),
+        name="z",
     )
 
 
@@ -100,7 +102,7 @@ class TestProductionSigma:
         d = 2
         sigma = np.asarray(_production_sigma(cov, d))
         proposal_cov = sigma @ sigma.T
-        expected = (2.38 ** 2 / d) * np.asarray(cov)
+        expected = (2.38**2 / d) * np.asarray(cov)
         np.testing.assert_allclose(proposal_cov, expected, atol=1e-4)
 
     def test_rgg_scale_value(self):
@@ -140,15 +142,21 @@ class TestAdaptiveWarmup:
         # N(0, diag(1, 4)) — adapt should fit the elongation and produce
         # sample stds close to [1, 2].
         result = rwmh(
-            dist=aniso_gaussian, num_results=4000, num_warmup=1500,
-            num_chains=2, random_seed=7,
+            dist=aniso_gaussian,
+            num_results=4000,
+            num_warmup=1500,
+            num_chains=2,
+            random_seed=7,
         )
         draws = np.concatenate(
-            [np.asarray(c) for c in result.chains], axis=0,
+            [np.asarray(c) for c in result.chains],
+            axis=0,
         )
         np.testing.assert_allclose(draws.mean(0), [0.0, 0.0], atol=0.15)
         np.testing.assert_allclose(
-            draws.std(0, ddof=1), [1.0, 2.0], rtol=0.15,
+            draws.std(0, ddof=1),
+            [1.0, 2.0],
+            rtol=0.15,
         )
 
     def test_accept_rate_in_operating_range(self):
@@ -156,11 +164,16 @@ class TestAdaptiveWarmup:
         # finite-d adaptation (no dual-averaging) lands in roughly
         # [0.10, 0.65] — small enough to mix, large enough not to stick.
         dist = MultivariateNormal(
-            loc=jnp.zeros(5), cov=jnp.eye(5), name="z",
+            loc=jnp.zeros(5),
+            cov=jnp.eye(5),
+            name="z",
         )
         result = rwmh(
-            dist=dist, num_results=2000, num_warmup=1000,
-            num_chains=1, random_seed=3,
+            dist=dist,
+            num_results=2000,
+            num_warmup=1000,
+            num_chains=1,
+            random_seed=3,
         )
         accept_rate = result.source.metadata["accept_rate"]
         assert 0.10 < accept_rate < 0.65, f"unexpected accept_rate {accept_rate}"
@@ -176,8 +189,12 @@ class TestAdaptiveWarmup:
         near one.
         """
         result = rwmh(
-            dist=iso_gaussian, num_results=400, num_warmup=100,
-            step_size=0.01, adapt=False, random_seed=0,
+            dist=iso_gaussian,
+            num_results=400,
+            num_warmup=100,
+            step_size=0.01,
+            adapt=False,
+            random_seed=0,
         )
         assert result.source.metadata["step_size"] == 0.01
         assert result.source.metadata["adapt"] is False
@@ -194,8 +211,11 @@ class TestAdaptiveWarmup:
         """
         tiny_chol = jnp.eye(2) * 1e-2
         result = rwmh(
-            dist=iso_gaussian, num_results=400, num_warmup=50,
-            proposal_cov=tiny_chol, random_seed=0,
+            dist=iso_gaussian,
+            num_results=400,
+            num_warmup=50,
+            proposal_cov=tiny_chol,
+            random_seed=0,
         )
         assert result.num_draws == 400
         assert result.source.metadata["accept_rate"] > 0.9
@@ -205,8 +225,11 @@ class TestAdaptiveWarmup:
         a second proof the supplied cov is actually used."""
         huge_chol = jnp.eye(2) * 50.0
         result = rwmh(
-            dist=iso_gaussian, num_results=400, num_warmup=50,
-            proposal_cov=huge_chol, random_seed=0,
+            dist=iso_gaussian,
+            num_results=400,
+            num_warmup=50,
+            proposal_cov=huge_chol,
+            random_seed=0,
         )
         assert result.source.metadata["accept_rate"] < 0.1
 
@@ -217,8 +240,11 @@ class TestNumWarmupZeroWarning:
     def test_warns_when_adapt_true_and_no_warmup(self, iso_gaussian):
         with pytest.warns(UserWarning, match="num_warmup=0"):
             rwmh(
-                dist=iso_gaussian, num_results=50, num_warmup=0,
-                adapt=True, random_seed=0,
+                dist=iso_gaussian,
+                num_results=50,
+                num_warmup=0,
+                adapt=True,
+                random_seed=0,
             )
 
     def test_no_warning_when_adapt_false(self, iso_gaussian):
@@ -227,8 +253,11 @@ class TestNumWarmupZeroWarning:
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)
             rwmh(
-                dist=iso_gaussian, num_results=50, num_warmup=0,
-                adapt=False, random_seed=0,
+                dist=iso_gaussian,
+                num_results=50,
+                num_warmup=0,
+                adapt=False,
+                random_seed=0,
             )
 
     def test_no_warning_when_proposal_cov_given(self, iso_gaussian):
@@ -237,8 +266,12 @@ class TestNumWarmupZeroWarning:
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)
             rwmh(
-                dist=iso_gaussian, num_results=50, num_warmup=0,
-                adapt=True, proposal_cov=jnp.eye(2) * 0.5, random_seed=0,
+                dist=iso_gaussian,
+                num_results=50,
+                num_warmup=0,
+                adapt=True,
+                proposal_cov=jnp.eye(2) * 0.5,
+                random_seed=0,
             )
 
     def test_bad_proposal_cov_shape_raises_valueerror(self, iso_gaussian):
@@ -249,8 +282,11 @@ class TestNumWarmupZeroWarning:
         """
         with pytest.raises(ValueError, match=r"proposal_cov must be a square"):
             rwmh(
-                dist=iso_gaussian, num_results=50, num_warmup=20,
-                proposal_cov=jnp.eye(3), random_seed=0,
+                dist=iso_gaussian,
+                num_results=50,
+                num_warmup=20,
+                proposal_cov=jnp.eye(3),
+                random_seed=0,
             )
 
 
@@ -259,6 +295,7 @@ class TestWindowSizing:
 
     def test_zero_warmup_returns_empty(self):
         from probpipe.inference._blackjax_rwmh import _window_sizes
+
         assert _window_sizes(0, n_windows=4) == []
 
     def test_short_warmup_collapses_to_single_window(self):
@@ -267,6 +304,7 @@ class TestWindowSizing:
         Avoids degenerate cov fits from too-few-sample windows.
         """
         from probpipe.inference._blackjax_rwmh import _window_sizes
+
         assert _window_sizes(20, n_windows=4) == [20]
         assert _window_sizes(40, n_windows=4) == [40]
 
@@ -274,6 +312,7 @@ class TestWindowSizing:
         """The 50-step threshold (= 2 * _MIN_STEPS_PER_WINDOW): 49 still
         collapses to one window, 50 is the first to split."""
         from probpipe.inference._blackjax_rwmh import _window_sizes
+
         # 49 // 25 == 1 → single window.
         assert _window_sizes(49, n_windows=4) == [49]
         # 50 // 25 == 2 → at least two windows.
@@ -281,6 +320,7 @@ class TestWindowSizing:
 
     def test_moderate_warmup_uses_three_windows(self):
         from probpipe.inference._blackjax_rwmh import _window_sizes
+
         # 80 steps / 25 = 3 max windows, clamped from 4 requested.
         sizes = _window_sizes(80, n_windows=4)
         assert len(sizes) == 3
@@ -290,6 +330,7 @@ class TestWindowSizing:
 
     def test_long_warmup_uses_all_windows(self):
         from probpipe.inference._blackjax_rwmh import _window_sizes
+
         sizes = _window_sizes(1000, n_windows=4)
         assert len(sizes) == 4
         assert sum(sizes) == 1000
@@ -315,17 +356,24 @@ class TestWindowedWarmup:
         # 5-D with a 30x stretch in the last dim.
         true_stds = jnp.array([1.0, 1.0, 1.0, 1.0, 30.0])
         dist = MultivariateNormal(
-            loc=jnp.zeros(5), cov=jnp.diag(true_stds ** 2), name="z",
+            loc=jnp.zeros(5),
+            cov=jnp.diag(true_stds**2),
+            name="z",
         )
         result = rwmh(
-            dist=dist, num_results=4000, num_warmup=3000,
-            num_chains=1, random_seed=11,
+            dist=dist,
+            num_results=4000,
+            num_warmup=3000,
+            num_chains=1,
+            random_seed=11,
         )
         draws = np.concatenate(
-            [np.asarray(c) for c in result.chains], axis=0,
+            [np.asarray(c) for c in result.chains],
+            axis=0,
         )
         np.testing.assert_allclose(
-            draws.std(0, ddof=1), np.asarray(true_stds),
+            draws.std(0, ddof=1),
+            np.asarray(true_stds),
             rtol=0.15,
         )
 
@@ -335,17 +383,24 @@ class TestWindowedWarmup:
         still run end-to-end and recover the moderate ``N(0, diag(1, 4))``
         target's per-dim stds."""
         result = rwmh(
-            dist=aniso_gaussian, num_results=4000, num_warmup=1500,
-            num_chains=2, n_windows=1, random_seed=7,
+            dist=aniso_gaussian,
+            num_results=4000,
+            num_warmup=1500,
+            num_chains=2,
+            n_windows=1,
+            random_seed=7,
         )
         assert result.num_draws == 4000
         assert result.source.metadata["n_windows"] == 1
         draws = np.concatenate(
-            [np.asarray(c) for c in result.chains], axis=0,
+            [np.asarray(c) for c in result.chains],
+            axis=0,
         )
         np.testing.assert_allclose(draws.mean(0), [0.0, 0.0], atol=0.2)
         np.testing.assert_allclose(
-            draws.std(0, ddof=1), [1.0, 2.0], rtol=0.2,
+            draws.std(0, ddof=1),
+            [1.0, 2.0],
+            rtol=0.2,
         )
 
 
@@ -382,7 +437,7 @@ class _NumpyLogProbDist(NumericRecordDistribution, SupportsLogProb):
         if np.any(np.abs(v) > 50):
             return jnp.asarray(-np.inf)
         prec = np.asarray(self.precision)
-        return jnp.asarray(-0.5 * float(np.sum(prec * v ** 2)))
+        return jnp.asarray(-0.5 * float(np.sum(prec * v**2)))
 
     def _prob(self, value):
         return jnp.exp(self._log_prob(value))
@@ -410,22 +465,31 @@ class TestEagerFallback:
     def test_runs_end_to_end(self):
         dist = _NumpyLogProbDist(name="np_dist")
         result = rwmh(
-            dist=dist, num_results=400, num_warmup=200,
-            num_chains=2, random_seed=42,
+            dist=dist,
+            num_results=400,
+            num_warmup=200,
+            num_chains=2,
+            random_seed=42,
         )
         draws = np.concatenate(
-            [np.asarray(c) for c in result.chains], axis=0,
+            [np.asarray(c) for c in result.chains],
+            axis=0,
         )
         # Standard normal target — sample mean ~ 0, sample sd ~ 1.
         np.testing.assert_allclose(draws.mean(0), [0.0, 0.0], atol=0.3)
         np.testing.assert_allclose(
-            draws.std(0, ddof=1), [1.0, 1.0], rtol=0.3,
+            draws.std(0, ddof=1),
+            [1.0, 1.0],
+            rtol=0.3,
         )
 
     def test_accept_rate_positive(self):
         dist = _NumpyLogProbDist(name="np_dist")
         result = rwmh(
-            dist=dist, num_results=400, num_warmup=200, random_seed=42,
+            dist=dist,
+            num_results=400,
+            num_warmup=200,
+            random_seed=42,
         )
         assert result.source.metadata["accept_rate"] > 0.10
 
@@ -455,15 +519,21 @@ class TestFastEagerEquivalence:
     def test_fast_path_recovers_aniso(self, aniso_gaussian):
         # Confirm we are exercising the fast path: the traceable target.
         from probpipe.inference._inference_utils import is_jax_traceable
+
         assert is_jax_traceable(
-            aniso_gaussian._unnormalized_log_prob, jnp.zeros(2),
+            aniso_gaussian._unnormalized_log_prob,
+            jnp.zeros(2),
         )
         result = rwmh(
-            dist=aniso_gaussian, num_results=4000, num_warmup=1500,
-            num_chains=2, random_seed=7,
+            dist=aniso_gaussian,
+            num_results=4000,
+            num_warmup=1500,
+            num_chains=2,
+            random_seed=7,
         )
         draws = np.concatenate(
-            [np.asarray(c) for c in result.chains], axis=0,
+            [np.asarray(c) for c in result.chains],
+            axis=0,
         )
         np.testing.assert_allclose(draws.mean(0), [0.0, 0.0], atol=0.2)
         np.testing.assert_allclose(draws.std(0, ddof=1), _ANISO_STD, rtol=0.15)
@@ -471,6 +541,7 @@ class TestFastEagerEquivalence:
     def test_eager_path_recovers_aniso(self):
         # Confirm we are exercising the eager path: the non-traceable target.
         from probpipe.inference._inference_utils import is_jax_traceable
+
         dist = _NumpyAnisoLogProbDist(name="np_aniso")
         assert not is_jax_traceable(dist._unnormalized_log_prob, jnp.zeros(2))
         # Lighter counts than the fast path: the Python loop is ~100x
@@ -478,11 +549,15 @@ class TestFastEagerEquivalence:
         # std error here is ~10% and the worst-case mean offset ~0.25,
         # so the bands below carry comfortable MC margin.
         result = rwmh(
-            dist=dist, num_results=600, num_warmup=300,
-            num_chains=2, random_seed=7,
+            dist=dist,
+            num_results=600,
+            num_warmup=300,
+            num_chains=2,
+            random_seed=7,
         )
         draws = np.concatenate(
-            [np.asarray(c) for c in result.chains], axis=0,
+            [np.asarray(c) for c in result.chains],
+            axis=0,
         )
         np.testing.assert_allclose(draws.mean(0), [0.0, 0.0], atol=0.4)
         np.testing.assert_allclose(draws.std(0, ddof=1), _ANISO_STD, rtol=0.2)

--- a/tests/inference/test_blackjax_sgmcmc.py
+++ b/tests/inference/test_blackjax_sgmcmc.py
@@ -41,10 +41,9 @@ def logistic_problem():
     true_theta = jnp.array([1.0, -0.5])
     X = jax.random.normal(jax.random.PRNGKey(0), (N, P))
     logits = X @ true_theta
-    y = (
-        jax.random.uniform(jax.random.PRNGKey(1), (N,))
-        < jax.nn.sigmoid(logits)
-    ).astype(jnp.float32)
+    y = (jax.random.uniform(jax.random.PRNGKey(1), (N,)) < jax.nn.sigmoid(logits)).astype(
+        jnp.float32
+    )
 
     prior = MultivariateNormal(loc=jnp.zeros(P), cov=jnp.eye(P), name="theta")
     # No-intercept logistic regression: prior dims pair 1-to-1 with X columns.
@@ -52,8 +51,11 @@ def logistic_problem():
     model = SimpleModel(prior=prior, likelihood=lik)
     data = Record(X=X, y=y)
     return {
-        "model": model, "data": data, "true_theta": true_theta,
-        "N": N, "P": P,
+        "model": model,
+        "data": data,
+        "true_theta": true_theta,
+        "N": N,
+        "P": P,
     }
 
 
@@ -102,7 +104,10 @@ class TestGradEstimatorCorrectness:
         model = logistic_problem["model"]
         data = logistic_problem["data"]
         measure = MinibatchedDistribution(
-            model.prior, model.likelihood, data, batch_size=20,
+            model.prior,
+            model.likelihood,
+            data,
+            batch_size=20,
         )
         grad_estimator = _build_grad_estimator(measure)
         theta = jnp.array([0.13, -0.21])
@@ -121,7 +126,8 @@ class TestGradEstimatorCorrectness:
 
         def manual_log_density(t):
             per_datum = jax.vmap(
-                model.likelihood.per_datum_log_likelihood, in_axes=(None, 0),
+                model.likelihood.per_datum_log_likelihood,
+                in_axes=(None, 0),
             )(t, batch)
             return model.prior._log_prob(t) + rescale_factor * jnp.sum(per_datum)
 
@@ -139,28 +145,42 @@ class TestReproducibility:
 
     def test_same_seed_produces_identical_chain(self, logistic_problem):
         kwargs = dict(
-            batch_size=20, num_results=50, num_warmup=10,
-            step_size=1e-3, random_seed=123,
+            batch_size=20,
+            num_results=50,
+            num_warmup=10,
+            step_size=1e-3,
+            random_seed=123,
         )
         post1 = BlackJAXSGLDMethod().execute(
-            logistic_problem["model"], logistic_problem["data"], **kwargs,
+            logistic_problem["model"],
+            logistic_problem["data"],
+            **kwargs,
         )
         post2 = BlackJAXSGLDMethod().execute(
-            logistic_problem["model"], logistic_problem["data"], **kwargs,
+            logistic_problem["model"],
+            logistic_problem["data"],
+            **kwargs,
         )
         np.testing.assert_array_equal(post1.flat_samples, post2.flat_samples)
 
     def test_different_seeds_produce_different_chains(self, logistic_problem):
         kwargs = dict(
-            batch_size=20, num_results=50, num_warmup=10, step_size=1e-3,
+            batch_size=20,
+            num_results=50,
+            num_warmup=10,
+            step_size=1e-3,
         )
         post1 = BlackJAXSGLDMethod().execute(
-            logistic_problem["model"], logistic_problem["data"],
-            random_seed=1, **kwargs,
+            logistic_problem["model"],
+            logistic_problem["data"],
+            random_seed=1,
+            **kwargs,
         )
         post2 = BlackJAXSGLDMethod().execute(
-            logistic_problem["model"], logistic_problem["data"],
-            random_seed=2, **kwargs,
+            logistic_problem["model"],
+            logistic_problem["data"],
+            random_seed=2,
+            **kwargs,
         )
         # Chains should differ somewhere — not just identical
         assert not jnp.allclose(post1.flat_samples, post2.flat_samples)
@@ -179,6 +199,7 @@ class TestCheck:
 
     def test_rejects_non_factorisable_likelihood(self):
         """SimpleModel + bare Likelihood (no per_datum) is rejected."""
+
         class _BareLikelihood:
             def log_likelihood(self, params, data):
                 return jnp.asarray(0.0)
@@ -192,14 +213,16 @@ class TestCheck:
     def test_requires_batch_size_kwarg(self, logistic_problem):
         """Missing ``batch_size=`` returns ``feasible=False`` with hint."""
         info = BlackJAXSGLDMethod().check(
-            logistic_problem["model"], logistic_problem["data"],
+            logistic_problem["model"],
+            logistic_problem["data"],
         )
         assert not info.feasible
         assert "batch_size" in info.description
 
     def test_feasible_for_well_formed_input(self, logistic_problem):
         info = BlackJAXSGLDMethod().check(
-            logistic_problem["model"], logistic_problem["data"],
+            logistic_problem["model"],
+            logistic_problem["data"],
             batch_size=20,
         )
         assert info.feasible
@@ -220,34 +243,40 @@ class TestConvergence:
 
     def test_sgld_recovers_logistic_coefficients(self, logistic_problem):
         post = BlackJAXSGLDMethod().execute(
-            logistic_problem["model"], logistic_problem["data"],
-            batch_size=40, num_results=5000, num_warmup=1000,
-            step_size=1e-3, random_seed=42,
+            logistic_problem["model"],
+            logistic_problem["data"],
+            batch_size=40,
+            num_results=5000,
+            num_warmup=1000,
+            step_size=1e-3,
+            random_seed=42,
         )
         assert post.flat_samples.shape == (5000, 2)
         assert jnp.all(jnp.isfinite(post.flat_samples))
         # Non-mixing guard: a stuck chain near init would have ~zero std.
         per_coord_std = np.asarray(jnp.std(post.flat_samples, axis=0))
-        assert per_coord_std.min() > 0.05, (
-            f"Chain looks stuck — per-coord std: {per_coord_std}"
-        )
+        assert per_coord_std.min() > 0.05, f"Chain looks stuck — per-coord std: {per_coord_std}"
         sample_mean = np.asarray(jnp.mean(post.flat_samples, axis=0))
         true = np.asarray(logistic_problem["true_theta"])
         np.testing.assert_allclose(sample_mean, true, atol=0.3)
 
     def test_sghmc_recovers_logistic_coefficients(self, logistic_problem):
         post = BlackJAXSGHMCMethod().execute(
-            logistic_problem["model"], logistic_problem["data"],
-            batch_size=40, num_results=5000, num_warmup=1000,
-            step_size=2e-3, num_integration_steps=4,
-            alpha=0.05, beta=0.0, random_seed=42,
+            logistic_problem["model"],
+            logistic_problem["data"],
+            batch_size=40,
+            num_results=5000,
+            num_warmup=1000,
+            step_size=2e-3,
+            num_integration_steps=4,
+            alpha=0.05,
+            beta=0.0,
+            random_seed=42,
         )
         assert post.flat_samples.shape == (5000, 2)
         assert jnp.all(jnp.isfinite(post.flat_samples))
         per_coord_std = np.asarray(jnp.std(post.flat_samples, axis=0))
-        assert per_coord_std.min() > 0.05, (
-            f"Chain looks stuck — per-coord std: {per_coord_std}"
-        )
+        assert per_coord_std.min() > 0.05, f"Chain looks stuck — per-coord std: {per_coord_std}"
         sample_mean = np.asarray(jnp.mean(post.flat_samples, axis=0))
         true = np.asarray(logistic_problem["true_theta"])
         np.testing.assert_allclose(sample_mean, true, atol=0.3)
@@ -259,9 +288,13 @@ class TestConvergence:
 class TestConditionOnDispatch:
     def test_sgld_via_condition_on(self, logistic_problem):
         post = condition_on(
-            logistic_problem["model"], logistic_problem["data"],
-            method="blackjax_sgld", batch_size=40,
-            num_results=1000, num_warmup=200, step_size=1e-3,
+            logistic_problem["model"],
+            logistic_problem["data"],
+            method="blackjax_sgld",
+            batch_size=40,
+            num_results=1000,
+            num_warmup=200,
+            step_size=1e-3,
             random_seed=7,
         )
         assert isinstance(post, ApproximateDistribution)
@@ -270,18 +303,26 @@ class TestConditionOnDispatch:
     def test_chain_shape_is_num_results_by_event_shape(self, logistic_problem):
         """`post.flat_samples` is `(num_results, *event_shape)` for a single chain."""
         post = BlackJAXSGLDMethod().execute(
-            logistic_problem["model"], logistic_problem["data"],
-            batch_size=20, num_results=100, num_warmup=0,
-            step_size=1e-3, random_seed=1,
+            logistic_problem["model"],
+            logistic_problem["data"],
+            batch_size=20,
+            num_results=100,
+            num_warmup=0,
+            step_size=1e-3,
+            random_seed=1,
         )
         assert post.flat_samples.shape == (100, logistic_problem["P"])
 
     def test_warmup_discards_initial_samples(self, logistic_problem):
         """``num_warmup=N`` drops the first N samples; ``num_results`` retained."""
         post = BlackJAXSGLDMethod().execute(
-            logistic_problem["model"], logistic_problem["data"],
-            batch_size=20, num_results=300, num_warmup=700,
-            step_size=1e-3, random_seed=3,
+            logistic_problem["model"],
+            logistic_problem["data"],
+            batch_size=20,
+            num_results=300,
+            num_warmup=700,
+            step_size=1e-3,
+            random_seed=3,
         )
         assert post.flat_samples.shape == (300, 2)
 
@@ -289,9 +330,14 @@ class TestConditionOnDispatch:
         """``init=`` overrides the prior-sampled default."""
         init = jnp.array([2.5, -1.5])
         post = BlackJAXSGLDMethod().execute(
-            logistic_problem["model"], logistic_problem["data"],
-            batch_size=20, num_results=50, num_warmup=0,
-            step_size=1e-4, random_seed=0, init=init,
+            logistic_problem["model"],
+            logistic_problem["data"],
+            batch_size=20,
+            num_results=50,
+            num_warmup=0,
+            step_size=1e-4,
+            random_seed=0,
+            init=init,
         )
         # With a tiny step size, the very first retained sample should
         # sit close to `init` (it's at most one Langevin step away).
@@ -314,10 +360,14 @@ class TestConditionOnDispatch:
         ``MinibatchedDistribution`` tests.
         """
         post = condition_on(
-            logistic_problem["model"], logistic_problem["data"],
+            logistic_problem["model"],
+            logistic_problem["data"],
             method="blackjax_sgld",
-            batch_size=20, num_results=100, num_warmup=0,
-            step_size=1e-3, random_seed=4,
+            batch_size=20,
+            num_results=100,
+            num_warmup=0,
+            step_size=1e-3,
+            random_seed=4,
             with_replacement=True,
         )
         # No exception + finite, correctly-shaped chain == kwarg accepted

--- a/tests/inference/test_cmdstan_method.py
+++ b/tests/inference/test_cmdstan_method.py
@@ -59,7 +59,11 @@ def test_from_cmdstanpy_produces_arviz1x_datatree(tmp_path):
     y = rng.normal(1.0, 2.0, size=30)
     fit = model.sample(
         data={"N": int(y.size), "y": y.tolist()},
-        chains=2, iter_sampling=200, iter_warmup=200, seed=0, show_console=False,
+        chains=2,
+        iter_sampling=200,
+        iter_warmup=200,
+        seed=0,
+        show_console=False,
     )
 
     idata = azb.from_cmdstanpy(fit)

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -51,7 +51,10 @@ class TestApproximateDistribution:
         auxiliary = build_mcmc_datatree(chains, warmup_chains=[warmup1, warmup2])
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="z")
         return make_posterior(
-            chains, parents=(prior,), algorithm="test", auxiliary=auxiliary,
+            chains,
+            parents=(prior,),
+            algorithm="test",
+            auxiliary=auxiliary,
         )
 
     def test_empty_chains_raises(self):
@@ -77,7 +80,9 @@ class TestApproximateDistribution:
     def test_auxiliary_is_inference_data(self, two_chain_dist):
         assert two_chain_dist.auxiliary is not None
         # arviz InferenceData (0.x has .groups(), 1.x DataTree has .children)
-        assert hasattr(two_chain_dist.auxiliary, "groups") or hasattr(two_chain_dist.auxiliary, "children")
+        assert hasattr(two_chain_dist.auxiliary, "groups") or hasattr(
+            two_chain_dist.auxiliary, "children"
+        )
 
     def test_inference_data_alias(self, two_chain_dist):
         assert two_chain_dist.inference_data is two_chain_dist.auxiliary
@@ -138,7 +143,9 @@ class TestApproximateDistributionValuesTemplate:
         chain = jax.random.normal(jax.random.PRNGKey(0), (100, 3))
         prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
         return make_posterior(
-            [chain], parents=(prior,), algorithm="test",
+            [chain],
+            parents=(prior,),
+            algorithm="test",
             event_template=template,
         )
 
@@ -194,13 +201,16 @@ class TestApproximateDistributionValuesTemplate:
         """
         template = EventTemplate(a=(), b=(2,))  # sizes: a=1, b=2
         # Columns laid out in field_order = (b, a): [b0, b1, a0].
-        b_block = jnp.array([[10.0, 11.0], [12.0, 13.0]])      # (2, 2)
-        a_block = jnp.array([[1.0], [2.0]])                    # (2, 1)
-        chain = jnp.concatenate([b_block, a_block], axis=-1)   # (2, 3)
+        b_block = jnp.array([[10.0, 11.0], [12.0, 13.0]])  # (2, 2)
+        a_block = jnp.array([[1.0], [2.0]])  # (2, 1)
+        chain = jnp.concatenate([b_block, a_block], axis=-1)  # (2, 3)
         prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
         post = make_posterior(
-            [chain], parents=(prior,), algorithm="test",
-            event_template=template, field_order=["b", "a"],
+            [chain],
+            parents=(prior,),
+            algorithm="test",
+            event_template=template,
+            field_order=["b", "a"],
         )
         draws = post.draws()
         # a is the trailing column; b is the leading 2-column block.
@@ -213,13 +223,14 @@ class TestApproximateDistributionValuesTemplate:
         chain = jnp.array([[1.0, 10.0, 11.0], [2.0, 12.0, 13.0]])  # a, then b
         prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
         post = make_posterior(
-            [chain], parents=(prior,), algorithm="test", event_template=template,
+            [chain],
+            parents=(prior,),
+            algorithm="test",
+            event_template=template,
         )
         draws = post.draws()
         np.testing.assert_allclose(np.asarray(draws["a"]), [1.0, 2.0])
-        np.testing.assert_allclose(
-            np.asarray(draws["b"]), [[10.0, 11.0], [12.0, 13.0]]
-        )
+        np.testing.assert_allclose(np.asarray(draws["b"]), [[10.0, 11.0], [12.0, 13.0]])
 
     def test_field_order_must_be_permutation(self):
         """A field_order that isn't a permutation of template fields raises."""
@@ -228,34 +239,43 @@ class TestApproximateDistributionValuesTemplate:
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="z")
         with pytest.raises(ValueError, match="not a permutation"):
             make_posterior(
-                [chain], parents=(prior,), algorithm="test",
-                event_template=template, field_order=["a", "c"],
+                [chain],
+                parents=(prior,),
+                algorithm="test",
+                event_template=template,
+                field_order=["a", "c"],
             )
 
     def test_field_order_chain_too_wide_raises(self):
         """With field_order, a chain wider than the template's total flat
         size raises rather than silently dropping the extra columns in the
         permutation gather."""
-        template = EventTemplate(a=(), b=())          # total flat size 2
-        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 3))   # 3 columns
+        template = EventTemplate(a=(), b=())  # total flat size 2
+        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 3))  # 3 columns
         prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
         with pytest.raises(ValueError, match="doesn't match"):
             make_posterior(
-                [chain], parents=(prior,), algorithm="test",
-                event_template=template, field_order=["a", "b"],
+                [chain],
+                parents=(prior,),
+                algorithm="test",
+                event_template=template,
+                field_order=["a", "b"],
             )
 
     def test_field_order_chain_too_narrow_raises(self):
         """With field_order, a chain narrower than the template's total
         flat size raises clearly rather than clamping the out-of-bounds
         gather indices."""
-        template = EventTemplate(a=(), b=(), c=())    # total flat size 3
-        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 2))   # 2 columns
+        template = EventTemplate(a=(), b=(), c=())  # total flat size 3
+        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 2))  # 2 columns
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="z")
         with pytest.raises(ValueError, match="doesn't match"):
             make_posterior(
-                [chain], parents=(prior,), algorithm="test",
-                event_template=template, field_order=["a", "b", "c"],
+                [chain],
+                parents=(prior,),
+                algorithm="test",
+                event_template=template,
+                field_order=["a", "b", "c"],
             )
 
     def test_field_order_without_template_raises(self):
@@ -265,7 +285,9 @@ class TestApproximateDistributionValuesTemplate:
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="z")
         with pytest.raises(ValueError, match="requires an event_template"):
             make_posterior(
-                [chain], parents=(prior,), algorithm="test",
+                [chain],
+                parents=(prior,),
+                algorithm="test",
                 field_order=["a", "b"],
             )
 
@@ -277,20 +299,26 @@ class TestApproximateDistributionValuesTemplate:
         prior = MultivariateNormal(loc=jnp.zeros(1), cov=jnp.eye(1), name="z")
         with pytest.raises(ValueError, match="not a permutation"):
             make_posterior(
-                [chain], parents=(prior,), algorithm="test",
-                event_template=template, field_order=["b"],
+                [chain],
+                parents=(prior,),
+                algorithm="test",
+                event_template=template,
+                field_order=["b"],
             )
 
     def test_field_order_single_field_width_mismatch_raises(self):
         """With field_order, the chain width is validated for a
         single-field template too — not only for multi-field ones."""
-        template = EventTemplate(a=(2,))              # flat size 2
-        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 3))   # 3 columns
+        template = EventTemplate(a=(2,))  # flat size 2
+        chain = jax.random.normal(jax.random.PRNGKey(0), (5, 3))  # 3 columns
         prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
         with pytest.raises(ValueError, match="doesn't match"):
             make_posterior(
-                [chain], parents=(prior,), algorithm="test",
-                event_template=template, field_order=["a"],
+                [chain],
+                parents=(prior,),
+                algorithm="test",
+                event_template=template,
+                field_order=["a"],
             )
 
     def test_array_shaped_fields(self):
@@ -303,7 +331,9 @@ class TestApproximateDistributionValuesTemplate:
         chain = jax.random.normal(jax.random.PRNGKey(0), (20, flat_size))
         prior = MultivariateNormal(loc=jnp.zeros(flat_size), cov=jnp.eye(flat_size), name="z")
         post = make_posterior(
-            [chain], parents=(prior,), algorithm="test",
+            [chain],
+            parents=(prior,),
+            algorithm="test",
             event_template=template,
         )
         draws = post.draws()
@@ -318,8 +348,11 @@ class TestApproximateDistributionValuesTemplate:
         auxiliary = build_mcmc_datatree([chain], warmup_chains=[warmup])
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="z")
         post = make_posterior(
-            [chain], parents=(prior,), algorithm="test",
-            auxiliary=auxiliary, event_template=template,
+            [chain],
+            parents=(prior,),
+            algorithm="test",
+            auxiliary=auxiliary,
+            event_template=template,
         )
         draws = post.draws(include_warmup=True)
         assert isinstance(draws, (Record, RecordArray))
@@ -336,7 +369,9 @@ class TestApproximateDistributionValuesTemplate:
         chain = jax.random.normal(jax.random.PRNGKey(0), (30, flat_size))
         prior = MultivariateNormal(loc=jnp.zeros(flat_size), cov=jnp.eye(flat_size), name="z")
         post = make_posterior(
-            [chain], parents=(prior,), algorithm="test",
+            [chain],
+            parents=(prior,),
+            algorithm="test",
             event_template=template,
         )
         draws = post.draws()
@@ -363,10 +398,14 @@ class TestApproximateDistributionValuesTemplate:
         flat_size = 3  # a + b + scale
         chain = jax.random.normal(jax.random.PRNGKey(0), (40, flat_size))
         prior = MultivariateNormal(
-            loc=jnp.zeros(flat_size), cov=jnp.eye(flat_size), name="z",
+            loc=jnp.zeros(flat_size),
+            cov=jnp.eye(flat_size),
+            name="z",
         )
         post = make_posterior(
-            [chain], parents=(prior,), algorithm="test",
+            [chain],
+            parents=(prior,),
+            algorithm="test",
             event_template=template,
         )
         # Template + ops all keyed by the top-level template fields,
@@ -389,6 +428,7 @@ class TestApproximateDistributionValuesTemplate:
         # auto-wrap leaf.
         from probpipe import mean as op_mean
         from probpipe import variance as op_variance
+
         m = op_mean(post)
         assert m.fields == expected_fields
         assert m["params"].shape == (2,)  # flat per-component means
@@ -423,8 +463,7 @@ class TestApproximateDistributionValuesTemplate:
         chain = jax.random.normal(jax.random.PRNGKey(0), (20, 3))
         auxiliary = build_mcmc_datatree([chain])
         prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
-        post = make_posterior([chain], parents=(prior,), algorithm="test",
-                             auxiliary=auxiliary)
+        post = make_posterior([chain], parents=(prior,), algorithm="test", auxiliary=auxiliary)
         assert "posterior" in post.auxiliary
 
     def test_algorithm_default_without_auxiliary(self):
@@ -525,13 +564,13 @@ class TestRWMH:
             var  = (sigma_p^2 * sigma_y^2) / (sigma_y^2 + n * sigma_p^2)
         """
         sigma_p = np.sqrt(10.0)  # prior std
-        sigma_y = 1.0            # likelihood std
-        prior = MultivariateNormal(loc=jnp.zeros(2), cov=sigma_p ** 2 * jnp.eye(2), name="params")
+        sigma_y = 1.0  # likelihood std
+        prior = MultivariateNormal(loc=jnp.zeros(2), cov=sigma_p**2 * jnp.eye(2), name="params")
         data = jnp.array([[1.0, 2.0], [1.5, 2.5], [0.8, 1.8]])
         n = data.shape[0]
 
         def log_lik(params, data):
-            return -0.5 / sigma_y ** 2 * jnp.sum((data - params) ** 2)
+            return -0.5 / sigma_y**2 * jnp.sum((data - params) ** 2)
 
         result = rwmh(
             dist=prior,
@@ -546,15 +585,13 @@ class TestRWMH:
 
         # Analytical posterior.
         y_bar = np.asarray(jnp.mean(data, axis=0))
-        denom = sigma_y ** 2 + n * sigma_p ** 2
-        analytical_mean = (n * sigma_p ** 2 / denom) * y_bar
-        analytical_var = (sigma_p ** 2 * sigma_y ** 2) / denom
+        denom = sigma_y**2 + n * sigma_p**2
+        analytical_mean = (n * sigma_p**2 / denom) * y_bar
+        analytical_var = (sigma_p**2 * sigma_y**2) / denom
 
         raw_draws = result.draws()
-        if hasattr(raw_draws, 'fields'):
-            raw_draws = jnp.concatenate(
-                [raw_draws[f] for f in raw_draws.fields], axis=-1
-            )
+        if hasattr(raw_draws, "fields"):
+            raw_draws = jnp.concatenate([raw_draws[f] for f in raw_draws.fields], axis=-1)
         draws = np.asarray(raw_draws).reshape(-1, 2)
         # MC standard error: posterior_sd / sqrt(effective_n).
         # ``adapt=True`` (the default) fits the proposal covariance from
@@ -565,7 +602,7 @@ class TestRWMH:
         n_eff = 300
         mc_se_mean = 4.0 * np.sqrt(analytical_var / n_eff)
         np.testing.assert_allclose(draws.mean(0), analytical_mean, atol=mc_se_mean)
-        mc_se_var = 4.0 * np.sqrt(2.0 * analytical_var ** 2 / (n_eff - 1))
+        mc_se_var = 4.0 * np.sqrt(2.0 * analytical_var**2 / (n_eff - 1))
         np.testing.assert_allclose(draws.var(0, ddof=1), [analytical_var] * 2, atol=mc_se_var)
 
     def test_requires_log_prob(self):
@@ -665,7 +702,7 @@ class TestRWMH:
                 return self._per_field_dict(jnp.float32)
 
             def _log_prob(self, value):
-                return -0.5 * jnp.sum(value ** 2)
+                return -0.5 * jnp.sum(value**2)
 
             def _prob(self, value):
                 return jnp.exp(self._log_prob(value))
@@ -701,7 +738,7 @@ class TestRWMH:
                 return self._per_field_dict(jnp.float32)
 
             def _log_prob(self, value):
-                return -0.5 * jnp.sum(value ** 2)
+                return -0.5 * jnp.sum(value**2)
 
             def _prob(self, value):
                 return jnp.exp(self._log_prob(value))
@@ -743,7 +780,9 @@ class TestRecordDistributionView:
         chain = jax.random.normal(jax.random.PRNGKey(0), (100, 3))
         prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
         return make_posterior(
-            [chain], parents=(prior,), algorithm="test",
+            [chain],
+            parents=(prior,),
+            algorithm="test",
             event_template=template,
         )
 
@@ -786,24 +825,19 @@ class TestRecordDistributionView:
         template = EventTemplate(vec=(5,), scalar=())
         chain = jax.random.normal(jax.random.PRNGKey(0), (50, 6))
         prior = MultivariateNormal(loc=jnp.zeros(6), cov=jnp.eye(6), name="z")
-        post = make_posterior([chain], parents=(prior,), algorithm="test",
-                             event_template=template)
+        post = make_posterior([chain], parents=(prior,), algorithm="test", event_template=template)
         assert post["scalar"].event_shape == ()
         assert post["vec"].event_shape == (5,)
 
     def test_view_mean(self, posterior):
         view = posterior["K"]
         draws = posterior.draws()
-        np.testing.assert_allclose(
-            float(view._mean()), float(jnp.mean(draws["K"])), atol=1e-5
-        )
+        np.testing.assert_allclose(float(view._mean()), float(jnp.mean(draws["K"])), atol=1e-5)
 
     def test_view_variance(self, posterior):
         view = posterior["K"]
         draws = posterior.draws()
-        np.testing.assert_allclose(
-            float(view._variance()), float(jnp.var(draws["K"])), atol=1e-5
-        )
+        np.testing.assert_allclose(float(view._variance()), float(jnp.var(draws["K"])), atol=1e-5)
 
     def test_view_sample(self, posterior):
         view = posterior["r"]
@@ -837,8 +871,7 @@ class TestRecordDistributionView:
         template = EventTemplate(a=(), b=())
         chain = jnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="z")
-        post = make_posterior([chain], parents=(prior,), algorithm="test",
-                             event_template=template)
+        post = make_posterior([chain], parents=(prior,), algorithm="test", event_template=template)
         view = post["a"]
         # Mean of column 0 (field "a"): (1+3+5)/3 = 3.0
         np.testing.assert_allclose(float(view._mean()), 3.0, atol=1e-5)
@@ -871,6 +904,7 @@ class TestViewProtocolDuckTyping:
     def test_view_from_product_isinstance_log_prob(self):
         """ProductDistribution supports SupportsLogProb → so does view."""
         from probpipe import ProductDistribution, SupportsLogProb
+
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(3, 2, name="y"))
         view = joint["x"]
         assert isinstance(view, SupportsLogProb)
@@ -878,30 +912,31 @@ class TestViewProtocolDuckTyping:
     def test_view_from_posterior_not_isinstance_log_prob(self):
         """ApproximateDistribution lacks SupportsLogProb → view doesn't have it."""
         from probpipe import SupportsLogProb
+
         template = EventTemplate(a=(), b=())
         chain = jax.random.normal(jax.random.PRNGKey(0), (50, 2))
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="z")
-        post = make_posterior([chain], parents=(prior,), algorithm="test",
-                             event_template=template)
+        post = make_posterior([chain], parents=(prior,), algorithm="test", event_template=template)
         view = post["a"]
         assert not isinstance(view, SupportsLogProb)
 
     def test_view_always_isinstance_sampling(self):
         """Every view is SupportsSampling regardless of parent type."""
         from probpipe import ProductDistribution, SupportsSampling
+
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(3, 2, name="y"))
         assert isinstance(joint["x"], SupportsSampling)
 
         template = EventTemplate(a=())
         chain = jax.random.normal(jax.random.PRNGKey(0), (20, 1))
         prior = Normal(0, 1, name="x")
-        post = make_posterior([chain], parents=(prior,), algorithm="test",
-                             event_template=template)
+        post = make_posterior([chain], parents=(prior,), algorithm="test", event_template=template)
         assert isinstance(post["a"], SupportsSampling)
 
     def test_view_always_isinstance_mean_variance(self):
         """Every view is SupportsMean and SupportsVariance."""
         from probpipe import ProductDistribution, SupportsMean, SupportsVariance
+
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(3, 2, name="y"))
         view = joint["x"]
         assert isinstance(view, SupportsMean)
@@ -912,7 +947,10 @@ class TestViewProtocolDuckTyping:
         import scipy.stats
 
         from probpipe import ProductDistribution
-        joint = ProductDistribution(x=Normal(loc=2.0, scale=0.5, name="x"), y=Normal(0, 1, name="y"))
+
+        joint = ProductDistribution(
+            x=Normal(loc=2.0, scale=0.5, name="x"), y=Normal(0, 1, name="y")
+        )
         view = joint["x"]
         lp = float(view._log_prob(jnp.array(2.0)))
         expected = scipy.stats.norm.logpdf(2.0, loc=2.0, scale=0.5)
@@ -921,6 +959,7 @@ class TestViewProtocolDuckTyping:
     def test_view_no_cov_when_parent_lacks_it(self):
         """View lacks SupportsCovariance when parent doesn't have it."""
         from probpipe import ProductDistribution, SupportsCovariance
+
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(3, 2, name="y"))
         view = joint["x"]
         assert not isinstance(view, SupportsCovariance)
@@ -928,6 +967,7 @@ class TestViewProtocolDuckTyping:
     def test_dynamic_protocol_depends_on_parent(self):
         """Same _RecordDistributionView base, different isinstance results."""
         from probpipe import ProductDistribution, SupportsLogProb
+
         # ProductDistribution parent → isinstance True
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(3, 2, name="y"))
         view_with = joint["x"]
@@ -937,14 +977,14 @@ class TestViewProtocolDuckTyping:
         template = EventTemplate(a=())
         chain = jax.random.normal(jax.random.PRNGKey(0), (20, 1))
         prior = Normal(0, 1, name="x")
-        post = make_posterior([chain], parents=(prior,), algorithm="test",
-                             event_template=template)
+        post = make_posterior([chain], parents=(prior,), algorithm="test", event_template=template)
         view_without = post["a"]
         assert not isinstance(view_without, SupportsLogProb)
 
     def test_view_still_isinstance_base_class(self):
         """Dynamic subclass is still isinstance of _RecordDistributionView."""
         from probpipe import ProductDistribution
+
         joint = ProductDistribution(x=Normal(0, 1, name="x"), y=Normal(3, 2, name="y"))
         view = joint["x"]
         assert isinstance(view, _RecordDistributionView)
@@ -962,7 +1002,9 @@ class TestRecordDistributionProperties:
         chain = jax.random.normal(jax.random.PRNGKey(0), (50, 3))
         prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
         return make_posterior(
-            [chain], parents=(prior,), algorithm="test",
+            [chain],
+            parents=(prior,),
+            algorithm="test",
             event_template=template,
         )
 
@@ -1060,19 +1102,22 @@ class TestEndToEndValuesPipeline:
     @pytest.fixture
     def posterior(self):
         """Run inference once for all end-to-end tests."""
-        prior = MultivariateNormal(
-            loc=jnp.zeros(2), cov=jnp.eye(2) * 10, name="params"
-        )
+        prior = MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2) * 10, name="params")
 
         class _Lik:
             def log_likelihood(self, params, data):
                 return -0.5 * jnp.sum((data - params) ** 2)
 
         from probpipe import SimpleModel, condition_on
+
         model = SimpleModel(prior, _Lik())
         return condition_on(
-            model, jnp.array([1.0, 2.0]),
-            num_results=500, num_warmup=200, step_size=0.3, random_seed=42,
+            model,
+            jnp.array([1.0, 2.0]),
+            num_results=500,
+            num_warmup=200,
+            step_size=0.3,
+            random_seed=42,
         )
 
     def test_template_propagation(self, posterior):
@@ -1171,7 +1216,9 @@ class TestEndToEndValuesPipeline:
         chain = jax.random.normal(jax.random.PRNGKey(0), (200, 3))
         prior = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="z")
         post = make_posterior(
-            [chain], parents=(prior,), algorithm="test",
+            [chain],
+            parents=(prior,),
+            algorithm="test",
             event_template=template,
         )
         draws = post.draws()
@@ -1182,9 +1229,7 @@ class TestEndToEndValuesPipeline:
         # Per-field views
         view_a = post["a"]
         assert isinstance(view_a, _RecordDistributionView)
-        np.testing.assert_allclose(
-            float(view_a._mean()), float(draws["a"].mean()), atol=1e-5
-        )
+        np.testing.assert_allclose(float(view_a._mean()), float(draws["a"].mean()), atol=1e-5)
 
         # Select multiple fields
         sel = post.select("a", "c")

--- a/tests/inference/test_inference_registry.py
+++ b/tests/inference/test_inference_registry.py
@@ -9,8 +9,13 @@ import numpy as np
 import pytest
 
 from probpipe import (
-    MultivariateNormal, Normal, ProductDistribution, SimpleModel, GLMLikelihood,
-    condition_on, mean,
+    MultivariateNormal,
+    Normal,
+    ProductDistribution,
+    SimpleModel,
+    GLMLikelihood,
+    condition_on,
+    mean,
 )
 from probpipe.core._registry import (
     MethodInfo,
@@ -24,6 +29,7 @@ from probpipe.modeling._likelihood import Likelihood
 # ---------------------------------------------------------------------------
 # Shared test helper
 # ---------------------------------------------------------------------------
+
 
 class FakeMethod(UnaryDispatchMethod):
     """Configurable stub for registry tests."""
@@ -56,10 +62,12 @@ class FakeMethod(UnaryDispatchMethod):
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def simple_model():
     """A simple Poisson regression model."""
     import tensorflow_probability.substrates.jax.glm as tfp_glm
+
     X = np.asarray(np.linspace(-1, 1, 20))[:, None].astype(np.float32)
     prior = MultivariateNormal(loc=jnp.zeros(2), cov=5.0 * jnp.eye(2), name="beta")
     return SimpleModel(prior, GLMLikelihood(tfp_glm.Poisson(), X))
@@ -74,8 +82,8 @@ def data():
 # Generic UnaryDispatchRegistry tests
 # ---------------------------------------------------------------------------
 
-class TestUnaryDispatchRegistry:
 
+class TestUnaryDispatchRegistry:
     def test_register_and_list(self):
         reg = UnaryDispatchRegistry()
         reg.register(FakeMethod("low", 10))
@@ -129,8 +137,8 @@ class TestUnaryDispatchRegistry:
 # Inference method registry tests
 # ---------------------------------------------------------------------------
 
-class TestInferenceMethodRegistry:
 
+class TestInferenceMethodRegistry:
     def test_methods_registered(self):
         methods = inference_method_registry.list_methods()
         assert "tfp_nuts" in methods
@@ -161,16 +169,23 @@ class TestInferenceMethodRegistry:
     def test_method_override(self, simple_model, data):
         """method= should override auto-selection."""
         posterior = condition_on(
-            simple_model, data, method="blackjax_rwmh",
-            num_results=50, num_warmup=20, random_seed=0,
+            simple_model,
+            data,
+            method="blackjax_rwmh",
+            num_results=50,
+            num_warmup=20,
+            random_seed=0,
         )
         assert posterior.algorithm == "blackjax_rwmh"
 
     def test_condition_on_default(self, simple_model, data):
         """Default condition_on should work through the registry."""
         posterior = condition_on(
-            simple_model, data,
-            num_results=50, num_warmup=20, random_seed=0,
+            simple_model,
+            data,
+            num_results=50,
+            num_warmup=20,
+            random_seed=0,
         )
         assert mean(posterior).shape == (2,)
 
@@ -181,9 +196,7 @@ class TestInferenceMethodRegistry:
     def test_infeasible_method_raises(self):
         """Requesting a method that can't handle the dist raises TypeError."""
         with pytest.raises(TypeError):
-            inference_method_registry.execute(
-                "not_a_distribution", None, method="tfp_nuts"
-            )
+            inference_method_registry.execute("not_a_distribution", None, method="tfp_nuts")
 
     def test_bare_log_prob_distribution(self):
         """A bare SupportsLogProb distribution can be conditioned via registry.
@@ -195,8 +208,11 @@ class TestInferenceMethodRegistry:
         """
         prior = Normal(loc=0.0, scale=1.0, name="x")
         posterior = condition_on(
-            prior, method="tfp_nuts",
-            num_results=50, num_warmup=20, random_seed=0,
+            prior,
+            method="tfp_nuts",
+            num_results=50,
+            num_warmup=20,
+            random_seed=0,
         )
         assert mean(posterior).ndim <= 1
 
@@ -214,6 +230,7 @@ class TestInferenceMethodRegistry:
 # ---------------------------------------------------------------------------
 # Opt-in-only sentinel (priority == 0)
 # ---------------------------------------------------------------------------
+
 
 class TestOptInOnlyPriority:
     """Priority 0 = opt-in only: skipped during auto-dispatch."""
@@ -233,16 +250,21 @@ class TestOptInOnlyPriority:
 
     def test_default_priority_is_opt_in(self):
         """A UnaryDispatchMethod subclass without a priority override defaults to opt-in."""
+
         class Bare(UnaryDispatchMethod):
             @property
             def name(self):
                 return "bare"
+
             def supported_types(self):
                 return (object,)
+
             def check(self, *a, **kw):
                 return MethodInfo(feasible=True, method_name="bare")
+
             def execute(self, *a, **kw):
                 return "ran"
+
         reg = UnaryDispatchRegistry()
         reg.register(Bare())
         # Auto-dispatch skips it.
@@ -272,8 +294,8 @@ class TestOptInOnlyPriority:
 # set_priorities zero-crossing warning
 # ---------------------------------------------------------------------------
 
-class TestSetPrioritiesZeroCrossingWarning:
 
+class TestSetPrioritiesZeroCrossingWarning:
     def test_warn_when_demoting_to_opt_in(self):
         reg = UnaryDispatchRegistry()
         reg.register(FakeMethod("a", p=50))
@@ -292,8 +314,8 @@ class TestSetPrioritiesZeroCrossingWarning:
         # Crossings of the 50 break are documentary; they should not warn.
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)
-            reg.set_priorities(a=10)   # exact -> inexact
-            reg.set_priorities(a=80)   # inexact -> exact
+            reg.set_priorities(a=10)  # exact -> inexact
+            reg.set_priorities(a=80)  # inexact -> exact
 
     def test_no_warn_when_staying_zero(self):
         reg = UnaryDispatchRegistry()
@@ -306,6 +328,7 @@ class TestSetPrioritiesZeroCrossingWarning:
 # ---------------------------------------------------------------------------
 # Built-in priority anchors (issue #189)
 # ---------------------------------------------------------------------------
+
 
 class TestBuiltInPriorityAnchors:
     """Priority anchors per issue #189, with the BlackJAX MCMC migration.
@@ -344,22 +367,18 @@ class TestBuiltInPriorityAnchors:
         # use ``BaseDispatchRegistry._effective_priority(method)``.
         for name, expected in self.EXPECTED_PRIORITIES.items():
             if name not in inference_method_registry.list_methods():
-                continue   # optional backend not installed
+                continue  # optional backend not installed
             actual = inference_method_registry.get_method(name).priority
-            assert actual == expected, (
-                f"{name} priority is {actual}, expected {expected}"
-            )
+            assert actual == expected, f"{name} priority is {actual}, expected {expected}"
 
     def test_exact_above_inexact(self):
         """Every exact-tier (>50) priority outranks every inexact-tier (<=50)."""
         registered = set(inference_method_registry.list_methods())
         exact_priorities = [
-            p for n, p in self.EXPECTED_PRIORITIES.items()
-            if n in registered and p > 50
+            p for n, p in self.EXPECTED_PRIORITIES.items() if n in registered and p > 50
         ]
         inexact_priorities = [
-            p for n, p in self.EXPECTED_PRIORITIES.items()
-            if n in registered and 0 < p <= 50
+            p for n, p in self.EXPECTED_PRIORITIES.items() if n in registered and 0 < p <= 50
         ]
         if exact_priorities and inexact_priorities:
             assert min(exact_priorities) > max(inexact_priorities)
@@ -381,7 +400,7 @@ class _UnnormalizedTarget:
     def _unnormalized_log_prob(self, value):
         # Standard normal up to an unknown additive constant. The missing
         # log normalizer is irrelevant for accept/reject.
-        return -0.5 * jnp.sum(value ** 2)
+        return -0.5 * jnp.sum(value**2)
 
     def _mean(self):
         return jnp.zeros(2)
@@ -396,7 +415,7 @@ class _NormalizedTarget:
     """
 
     def _log_prob(self, value):
-        return -0.5 * jnp.sum(value ** 2) - jnp.log(2 * jnp.pi)
+        return -0.5 * jnp.sum(value**2) - jnp.log(2 * jnp.pi)
 
     def _mean(self):
         return jnp.zeros(2)
@@ -454,7 +473,10 @@ class TestUnnormalizedLogProbInference:
 
         dist = _make_unnormalized_distribution()
         posterior = condition_on(
-            dist, num_results=200, num_warmup=100, random_seed=0,
+            dist,
+            num_results=200,
+            num_warmup=100,
+            random_seed=0,
         )
         assert isinstance(posterior, ApproximateDistribution)
         # Standard normal: posterior mean ~0, std ~1 (loose tolerance —
@@ -468,8 +490,12 @@ class TestUnnormalizedLogProbInference:
 
         dist = _make_unnormalized_distribution()
         posterior = condition_on(
-            dist, method="blackjax_rwmh",
-            num_results=200, num_warmup=100, step_size=0.5, random_seed=0,
+            dist,
+            method="blackjax_rwmh",
+            num_results=200,
+            num_warmup=100,
+            step_size=0.5,
+            random_seed=0,
         )
         assert isinstance(posterior, ApproximateDistribution)
 
@@ -484,7 +510,10 @@ class TestUnnormalizedLogProbInference:
 
         dist = _make_normalized_distribution()
         posterior = condition_on(
-            dist, num_results=100, num_warmup=50, random_seed=0,
+            dist,
+            num_results=100,
+            num_warmup=50,
+            random_seed=0,
         )
         assert isinstance(posterior, ApproximateDistribution)
 
@@ -493,8 +522,12 @@ class TestUnnormalizedLogProbInference:
 
         dist = _make_normalized_distribution()
         posterior = condition_on(
-            dist, method="blackjax_rwmh",
-            num_results=100, num_warmup=50, step_size=0.5, random_seed=0,
+            dist,
+            method="blackjax_rwmh",
+            num_results=100,
+            num_warmup=50,
+            step_size=0.5,
+            random_seed=0,
         )
         assert isinstance(posterior, ApproximateDistribution)
 

--- a/tests/inference/test_inference_utils.py
+++ b/tests/inference/test_inference_utils.py
@@ -54,8 +54,7 @@ class _GaussianMeanLikelihood(Likelihood):
         mu = jnp.reshape(jnp.asarray(params), ())
         s = self.scale
         return jnp.sum(
-            -0.5 * ((jnp.asarray(data) - mu) / s) ** 2
-            - jnp.log(s) - 0.5 * jnp.log(2 * jnp.pi)
+            -0.5 * ((jnp.asarray(data) - mu) / s) ** 2 - jnp.log(s) - 0.5 * jnp.log(2 * jnp.pi)
         )
 
 
@@ -76,7 +75,8 @@ class TestBuildTargetLogProbFlat:
         observed = jnp.zeros((4,))
         target_record = build_target_log_prob(small_model, observed)
         target_flat, flat_init, template = build_target_log_prob_flat(
-            small_model, observed,
+            small_model,
+            observed,
         )
         # Round-trip: unflatten the flat init back to a Record and confirm
         # the two callables agree.
@@ -84,12 +84,14 @@ class TestBuildTargetLogProbFlat:
         np.testing.assert_allclose(
             float(target_flat(flat_init)),
             float(target_record(record_init)),
-            rtol=0, atol=1e-6,
+            rtol=0,
+            atol=1e-6,
         )
 
     def test_flat_init_dim_matches_template_flat_size(self, small_model):
         _, flat_init, template = build_target_log_prob_flat(
-            small_model, observed=None,
+            small_model,
+            observed=None,
         )
         # Both fields are scalar Normals: flat_size == 2.
         assert flat_init.shape == (template.flat_size,) == (2,)
@@ -109,6 +111,7 @@ class TestBuildTargetLogProbFlat:
         for hand-rolled distributions that don't carry a Record-shaped
         prior.
         """
+
         class _FlatGaussian:
             event_shape = (2,)
 
@@ -116,12 +119,14 @@ class TestBuildTargetLogProbFlat:
                 return -0.5 * jnp.sum(jnp.asarray(x) ** 2)
 
         target_flat, flat_init, template = build_target_log_prob_flat(
-            _FlatGaussian(), observed=None,
+            _FlatGaussian(),
+            observed=None,
         )
         assert template is None
         assert flat_init.shape == (2,)
         np.testing.assert_allclose(
-            float(target_flat(jnp.asarray([1.0, -1.0]))), -1.0,
+            float(target_flat(jnp.asarray([1.0, -1.0]))),
+            -1.0,
         )
 
 
@@ -207,7 +212,10 @@ class TestRunChainScan:
         num_results = 5
         init = _FakeState(jnp.zeros(event_shape))
         positions, infos = run_chain_scan(
-            _FakeSampler(), init, num_results, jax.random.PRNGKey(0),
+            _FakeSampler(),
+            init,
+            num_results,
+            jax.random.PRNGKey(0),
         )
         # Positions: (num_results, *event_shape).
         assert positions.shape == (num_results, *event_shape)
@@ -218,7 +226,10 @@ class TestRunChainScan:
         # Each step adds one, starting from zeros, so row i == i + 1.
         init = _FakeState(jnp.zeros((2,)))
         positions, _ = run_chain_scan(
-            _FakeSampler(), init, 4, jax.random.PRNGKey(0),
+            _FakeSampler(),
+            init,
+            4,
+            jax.random.PRNGKey(0),
         )
         expected = np.arange(1, 5)[:, None] * np.ones((1, 2))
         np.testing.assert_allclose(np.asarray(positions), expected)
@@ -229,7 +240,7 @@ class TestIsJaxTraceable:
 
     def test_traceable_fn(self):
         init = jnp.array([1.0, 2.0])
-        assert is_jax_traceable(lambda x: jnp.sum(x ** 2), init) is True
+        assert is_jax_traceable(lambda x: jnp.sum(x**2), init) is True
 
     def test_non_traceable_fn(self):
         # ``float(np.asarray(x))`` forces concretisation of a traced value,
@@ -254,7 +265,9 @@ class TestBuildLikelihoodFlat:
     def test_returns_scalar_log_likelihood(self, gaussian_model):
         data = jnp.array([1.0, -1.0, 0.5])
         llf = build_likelihood_flat(
-            gaussian_model._prior, gaussian_model._likelihood, data,
+            gaussian_model._prior,
+            gaussian_model._likelihood,
+            data,
         )
         assert callable(llf)
         out = llf(jnp.array([0.3]))
@@ -264,15 +277,19 @@ class TestBuildLikelihoodFlat:
     def test_matches_independent_gaussian(self, gaussian_model):
         data = jnp.array([1.0, -1.0, 0.5])
         llf = build_likelihood_flat(
-            gaussian_model._prior, gaussian_model._likelihood, data,
+            gaussian_model._prior,
+            gaussian_model._likelihood,
+            data,
         )
         mu, scale = 0.3, 2.0
         expected = np.sum(
-            -0.5 * ((np.asarray(data) - mu) / scale) ** 2
-            - np.log(scale) - 0.5 * np.log(2 * np.pi)
+            -0.5 * ((np.asarray(data) - mu) / scale) ** 2 - np.log(scale) - 0.5 * np.log(2 * np.pi)
         )
         np.testing.assert_allclose(
-            float(llf(jnp.array([mu]))), expected, rtol=0, atol=1e-5,
+            float(llf(jnp.array([mu]))),
+            expected,
+            rtol=0,
+            atol=1e-5,
         )
 
 
@@ -331,7 +348,7 @@ class TestGetInitState:
         prior = Normal(loc=0.0, scale=1.0, name="x")
         assert isinstance(prior, SupportsSampling)
         out = get_init_state(prior, init=None, random_seed=0)
-        assert out.shape == (1,)            # scalar Normal -> length-1 vector
+        assert out.shape == (1,)  # scalar Normal -> length-1 vector
         assert bool(jnp.all(jnp.isfinite(out)))
 
     def test_stan_uniform_fallback(self):
@@ -391,6 +408,7 @@ class TestParallelChainMap:
 
         if jax.local_device_count() != 1:
             import pytest as _pytest
+
             _pytest.skip(
                 "test requires the default 1-device CPU; got "
                 f"{jax.local_device_count()} — set XLA_FLAGS in your shell?"
@@ -444,7 +462,10 @@ class TestParallelChainMap:
         env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
         result = subprocess.run(
             [sys.executable, "-c", script],
-            env=env, capture_output=True, text=True, timeout=120,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
         assert result.returncode == 0, (
             f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"

--- a/tests/inference/test_minibatch.py
+++ b/tests/inference/test_minibatch.py
@@ -83,13 +83,16 @@ class TestConstruction:
 
     def test_construction_rejects_non_log_prob_prior(self, likelihood, data_record):
         """Prior must satisfy SupportsLogProb."""
+
         class _BarePrior:
             pass
+
         with pytest.raises(TypeError, match="SupportsLogProb"):
             MinibatchedDistribution(_BarePrior(), likelihood, data_record, batch_size=32)
 
     def test_construction_rejects_non_cil_likelihood(self, prior, data_record):
         """A bare ``Likelihood`` (no ``per_datum_log_likelihood``) is rejected."""
+
         class _BareLikelihood:
             def log_likelihood(self, params, data):
                 return jnp.asarray(0.0)
@@ -122,10 +125,16 @@ class TestAccessors:
     """The convenience properties exposed for inspection / debugging."""
 
     def test_properties_match_constructor_args(
-        self, prior, likelihood, data_record,
+        self,
+        prior,
+        likelihood,
+        data_record,
     ):
         m = MinibatchedDistribution(
-            prior, likelihood, data_record, batch_size=25,
+            prior,
+            likelihood,
+            data_record,
+            batch_size=25,
             with_replacement=True,
             name="custom_name",
         )
@@ -154,6 +163,7 @@ class TestProtocols:
         Use ``_random_unnormalized_log_prob`` to get the stochastic
         log-density callable that SGMCMC kernels consume."""
         from probpipe.core.protocols import SupportsSampling
+
         assert not isinstance(measure, SupportsSampling)
 
     def test_isinstance_supports_random_unnormalized_log_prob(self, measure):
@@ -197,7 +207,8 @@ class TestInnerDraw:
         batch = inner.batch
         prior_lp = prior._log_prob(theta)
         per_datum = jax.vmap(
-            likelihood.per_datum_log_likelihood, in_axes=(None, 0),
+            likelihood.per_datum_log_likelihood,
+            in_axes=(None, 0),
         )(theta, batch)
         expected = prior_lp + measure._rescale_factor * jnp.sum(per_datum)
 
@@ -205,7 +216,10 @@ class TestInnerDraw:
         np.testing.assert_allclose(float(actual), float(expected), rtol=1e-5)
 
     def test_record_and_recordarray_inputs_equivalent(
-        self, prior, likelihood, regression_data,
+        self,
+        prior,
+        likelihood,
+        regression_data,
     ):
         """``Record`` and ``NumericRecordArray`` data inputs produce
         identical log-densities given the same minibatch indices.
@@ -216,6 +230,7 @@ class TestInnerDraw:
         user passes.
         """
         from probpipe import NumericRecordArray, NumericEventTemplate
+
         X, y = regression_data
         n = X.shape[0]
         record_data = Record(X=X, y=y)
@@ -238,7 +253,10 @@ class TestInnerDraw:
     def test_with_replacement_flag(self, prior, likelihood, data_record):
         """``with_replacement=True`` allows repeated indices."""
         m_wr = MinibatchedDistribution(
-            prior, likelihood, data_record, batch_size=5,
+            prior,
+            likelihood,
+            data_record,
+            batch_size=5,
             with_replacement=True,
         )
         # Stress test: with batch_size=5 and replacement, over many draws
@@ -255,7 +273,11 @@ class TestInnerDraw:
         )
 
     def test_batch_size_equals_dataset_size_matches_full(
-        self, prior, likelihood, data_record, regression_data,
+        self,
+        prior,
+        likelihood,
+        data_record,
+        regression_data,
     ):
         """``batch_size == N`` is the degenerate full-batch case.
 
@@ -266,7 +288,11 @@ class TestInnerDraw:
         X, _ = regression_data
         N = X.shape[0]
         m_full = MinibatchedDistribution(
-            prior, likelihood, data_record, batch_size=N, with_replacement=False,
+            prior,
+            likelihood,
+            data_record,
+            batch_size=N,
+            with_replacement=False,
         )
         inner = m_full._draw_one(jax.random.PRNGKey(11))
         assert inner.rescale_factor == 1.0
@@ -274,7 +300,8 @@ class TestInnerDraw:
         theta = jnp.array([0.2, -0.3])
         # Full-data log-density
         per_datum = jax.vmap(
-            likelihood.per_datum_log_likelihood, in_axes=(None, 0),
+            likelihood.per_datum_log_likelihood,
+            in_axes=(None, 0),
         )(theta, data_record)
         full = prior._log_prob(theta) + jnp.sum(per_datum)
 
@@ -305,6 +332,7 @@ class TestBareArrayData:
             Defines ``log_likelihood`` and ``per_datum_log_likelihood``
             so the protocol check (``isinstance(lik, CIL)``) succeeds.
             """
+
             def log_likelihood(self, params, data):
                 return -0.5 * jnp.sum(jnp.asarray(data) ** 2)
 
@@ -312,7 +340,10 @@ class TestBareArrayData:
                 return -0.5 * jnp.asarray(datum) ** 2
 
         m = MinibatchedDistribution(
-            prior, _ResponseOnlyLikelihood(), y, batch_size=20,
+            prior,
+            _ResponseOnlyLikelihood(),
+            y,
+            batch_size=20,
         )
         assert m.dataset_size == N
 
@@ -338,7 +369,8 @@ class TestMathematicalCorrectness:
         theta = jnp.array([0.3, -0.2])
         # Full reference:
         per_datum = jax.vmap(
-            likelihood.per_datum_log_likelihood, in_axes=(None, 0),
+            likelihood.per_datum_log_likelihood,
+            in_axes=(None, 0),
         )(theta, data_record)
         full_lp = float(prior._log_prob(theta) + jnp.sum(per_datum))
 
@@ -361,7 +393,8 @@ class TestMathematicalCorrectness:
 
         def full_log_density(t):
             per_datum = jax.vmap(
-                likelihood.per_datum_log_likelihood, in_axes=(None, 0),
+                likelihood.per_datum_log_likelihood,
+                in_axes=(None, 0),
             )(t, data_record)
             return prior._log_prob(t) + jnp.sum(per_datum)
 

--- a/tests/inference/test_nutpie.py
+++ b/tests/inference/test_nutpie.py
@@ -35,8 +35,7 @@ class TestCompileForNutpie:
         model = MagicMock()
         model._stan_data = {"N": 10, "x": [1, 2, 3]}
         model._bridgestan_model.return_value = "bs_model"
-        with patch.object(nutpie, "compile_stan_model",
-                          return_value="compiled") as compile_stan:
+        with patch.object(nutpie, "compile_stan_model", return_value="compiled") as compile_stan:
             compiled, pymc_build = _compile_for_nutpie(model, data={"y": [4, 5, 6]})
         compile_stan.assert_called_once_with("bs_model")
         # Construction data (N, x) is preserved, not dropped for the observed y.
@@ -72,8 +71,7 @@ class TestCompileForNutpie:
         return the conditioned build for event_template derivation."""
         model = MagicMock(spec=[])
         model._pymc_model = MagicMock(return_value="pm_model")
-        with patch.object(nutpie, "compile_pymc_model",
-                          return_value="compiled") as compile_pymc:
+        with patch.object(nutpie, "compile_pymc_model", return_value="compiled") as compile_pymc:
             compiled, pymc_build = _compile_for_nutpie(model, data={"y": [1, 2]})
         compile_pymc.assert_called_once_with("pm_model")
         model._pymc_model.assert_called_once_with(data={"y": [1, 2]})
@@ -118,9 +116,7 @@ class TestExtractChains:
 
         mock_posterior = MagicMock()
         mock_posterior.data_vars = ["mu", "sigma"]
-        mock_posterior.__getitem__ = (
-            lambda self, k: {"mu": mu_var, "sigma": sigma_var}[k]
-        )
+        mock_posterior.__getitem__ = lambda self, k: {"mu": mu_var, "sigma": sigma_var}[k]
         mock_trace.posterior = mock_posterior
 
         chains, param_names = _extract_chains(mock_trace, num_chains=2)
@@ -170,13 +166,13 @@ class TestExtractChains:
         vz.values = z
         mock_posterior = MagicMock()
         mock_posterior.data_vars = ["alpha", "mu", "zeta"]  # nutpie's sorted order
-        mock_posterior.__getitem__ = (
-            lambda self, k: {"alpha": va, "mu": vm, "zeta": vz}[k]
-        )
+        mock_posterior.__getitem__ = lambda self, k: {"alpha": va, "mu": vm, "zeta": vz}[k]
         mock_trace.posterior = mock_posterior
 
         chains, names = _extract_chains(
-            mock_trace, num_chains=1, keep_names=["zeta", "alpha", "mu"],
+            mock_trace,
+            num_chains=1,
+            keep_names=["zeta", "alpha", "mu"],
         )
         assert names == ["zeta", "alpha", "mu"]
         # Columns concatenated in keep_names order: zeta=3, alpha=1, mu=2.
@@ -193,9 +189,7 @@ class TestExtractChains:
 class TestNutpieStanIntegration:
     """nutpie sampling of a StanModel preserves construction-time data."""
 
-    def test_construction_data_survives_conditioning(
-        self, _stan_toolchain, tmp_path_factory
-    ):
+    def test_construction_data_survives_conditioning(self, _stan_toolchain, tmp_path_factory):
         """A StanModel built with fixed data (N, x) samples via nutpie when
         conditioned on y.  Without merging the construction data, the rebuilt
         BridgeStan model would lack N and x and fail to instantiate — so
@@ -235,8 +229,12 @@ class TestNutpieStanIntegration:
         )
 
         result = condition_on_nutpie._func(
-            model, data={"y": y.tolist()},
-            num_results=200, num_warmup=200, num_chains=2, random_seed=0,
+            model,
+            data={"y": y.tolist()},
+            num_results=200,
+            num_warmup=200,
+            num_chains=2,
+            random_seed=0,
         )
         assert isinstance(result, ApproximateDistribution)
         assert result.num_chains == 2
@@ -280,8 +278,12 @@ class TestNutpieIntegration:
         y_obs = np.array([1.2, 0.8, 1.1, 0.9, 1.0], dtype=float)
         model = PyMCModel(_gaussian_pymc_fn, name="gaussian")
         result = condition_on_nutpie._func(
-            model, data={"y": y_obs},
-            num_results=500, num_warmup=200, num_chains=2, random_seed=42,
+            model,
+            data={"y": y_obs},
+            num_results=500,
+            num_warmup=200,
+            num_chains=2,
+            random_seed=42,
         )
         assert isinstance(result, ApproximateDistribution)
         assert result.num_chains == 2
@@ -309,8 +311,12 @@ class TestNutpieIntegration:
         model = PyMCModel(_gaussian_pymc_fn, name="gaussian")
         y_obs = np.array([0.0, 1.0], dtype=float)
         result = condition_on_nutpie._func(
-            model, data={"y": y_obs},
-            num_results=50, num_warmup=50, num_chains=1, random_seed=0,
+            model,
+            data={"y": y_obs},
+            num_results=50,
+            num_warmup=50,
+            num_chains=1,
+            random_seed=0,
         )
         assert result.inference_data is not None
         # arviz-like trace exposes posterior as an xarray Dataset/DataTree
@@ -326,6 +332,7 @@ class TestNutpieIntegration:
         alphabetical order while the template uses declaration order,
         the means would be assigned to the wrong fields.
         """
+
         def model_fn(y=None):
             with pm.Model() as m:
                 zeta = pm.Normal("zeta", 100.0, 1.0)
@@ -336,8 +343,12 @@ class TestNutpieIntegration:
 
         model = PyMCModel(model_fn, name="ordering")
         result = condition_on_nutpie._func(
-            model, data={"y": np.zeros(4, dtype=float)},
-            num_results=300, num_warmup=300, num_chains=1, random_seed=0,
+            model,
+            data={"y": np.zeros(4, dtype=float)},
+            num_results=300,
+            num_warmup=300,
+            num_chains=1,
+            random_seed=0,
         )
         draws = result.draws()
         assert draws.fields == ("zeta", "alpha", "mu")
@@ -355,6 +366,7 @@ class TestNutpieIntegration:
         the param order is ``(mu, X)``, so distinct priors catch any
         column mislabeling.
         """
+
         def model_fn(X=None, y=None):
             with pm.Model() as m:
                 mu = pm.Normal("mu", 100.0, 0.5)
@@ -364,14 +376,14 @@ class TestNutpieIntegration:
 
         model = PyMCModel(model_fn, name="partial")
         result = condition_on_nutpie._func(
-            model, data={"y": np.zeros(5, dtype=float)},
-            num_results=200, num_warmup=200, num_chains=1, random_seed=0,
+            model,
+            data={"y": np.zeros(5, dtype=float)},
+            num_results=200,
+            num_warmup=200,
+            num_chains=1,
+            random_seed=0,
         )
         draws = result.draws()
         assert set(draws.fields) == {"mu", "X"}
-        np.testing.assert_allclose(
-            float(jnp.mean(jnp.asarray(draws["mu"]))), 100.0, atol=10.0
-        )
-        np.testing.assert_allclose(
-            float(jnp.mean(jnp.asarray(draws["X"]))), -100.0, atol=10.0
-        )
+        np.testing.assert_allclose(float(jnp.mean(jnp.asarray(draws["mu"]))), 100.0, atol=10.0)
+        np.testing.assert_allclose(float(jnp.mean(jnp.asarray(draws["X"]))), -100.0, atol=10.0)

--- a/tests/linalg/test_linop.py
+++ b/tests/linalg/test_linop.py
@@ -19,6 +19,7 @@ from probpipe.linalg.linear_operator import (
 def approx(a, b, tol=1e-5):
     return jnp.allclose(a, b, atol=tol, rtol=0)
 
+
 class TestDenseLinOp:
     @classmethod
     def setup_class(cls):

--- a/tests/linalg/test_operations.py
+++ b/tests/linalg/test_operations.py
@@ -25,6 +25,7 @@ ALL_OPERATIONS = {"logdet", "mah_dist_squared"}
 # Small helpers
 # -----------------------------------------------------------------------------
 
+
 # compare scalars/arrays consistently
 def _compare_results(got, expected, *, rtol=1e-4, atol=1e-4, msg=None):
     got_arr = jnp.atleast_1d(jnp.asarray(got))
@@ -37,6 +38,7 @@ def _compare_results(got, expected, *, rtol=1e-4, atol=1e-4, msg=None):
 # -----------------------------------------------------------------------------
 # Baseline/reference functions to compare against
 # -----------------------------------------------------------------------------
+
 
 def baseline_logdet(A):
     sign, logabsdet = jnp.linalg.slogdet(A)
@@ -67,6 +69,7 @@ def baseline_mah_dist_squared(x, A, y):
 def rng_key():
     return jax.random.PRNGKey(26423)
 
+
 @pytest.fixture(scope="module")
 def linop_resources(rng_key):
     """Core components used to construct various types of linear operators."""
@@ -78,65 +81,74 @@ def linop_resources(rng_key):
     dense_pd = root_pd @ root_pd.T
     lower_chol_pd = jnp.linalg.cholesky(dense_pd)
     upper_chol_pd = lower_chol_pd.T
-    pd = {"dim": dim_pd, "root": root_pd, "dense": dense_pd,
-           "lower_chol": lower_chol_pd, "upper_chol": upper_chol_pd}
+    pd = {
+        "dim": dim_pd,
+        "root": root_pd,
+        "dense": dense_pd,
+        "lower_chol": lower_chol_pd,
+        "upper_chol": upper_chol_pd,
+    }
 
     # Diagonal matrix with positive diagonal (hence positive definite)
     dim_diag_pd = 10
     diagonal_diag_pd = jax.random.uniform(k2, shape=(dim_diag_pd,), minval=1.0, maxval=10.0)
     sqrt_diagonal_diag_pd = jnp.sqrt(diagonal_diag_pd)
-    diag_pd = {"dim": dim_diag_pd,
-               "diagonal": diagonal_diag_pd,
-               "sqrt_diagonal": sqrt_diagonal_diag_pd,
-               "dense": jnp.diag(diagonal_diag_pd),
-               "dense_root": jnp.diag(sqrt_diagonal_diag_pd)}
+    diag_pd = {
+        "dim": dim_diag_pd,
+        "diagonal": diagonal_diag_pd,
+        "sqrt_diagonal": sqrt_diagonal_diag_pd,
+        "dense": jnp.diag(diagonal_diag_pd),
+        "dense_root": jnp.diag(sqrt_diagonal_diag_pd),
+    }
 
     return {"pd": pd, "diag_pd": diag_pd}
 
 
 # Factories of the form lambda linop_resources : (linop, densified linop, supported operations)
 linop_factories = [
-    pytest.param("root_pd",
-                 lambda x: (RootLinOp(x["pd"]["root"]),
-                            x["pd"]["dense"],
-                            ALL_OPERATIONS),
-                 id="root_pd"),
-
-    pytest.param("cholesky_pd",
-                 lambda x: (CholeskyLinOp(TriangularLinOp(x["pd"]["lower_chol"], lower=True)),
-                            x["pd"]["dense"],
-                            ALL_OPERATIONS),
-                 id="cholesky_pd"),
-
-    pytest.param("dense_pd",
-                 lambda x: (DenseLinOp(x["pd"]["dense"]),
-                            x["pd"]["dense"],
-                            ALL_OPERATIONS),
-                 id="dense_pd"),
-
-    pytest.param("diagonal_diag_pd",
-                 lambda x: (DiagonalLinOp(x["diag_pd"]["diagonal"]),
-                            x["diag_pd"]["dense"],
-                            ALL_OPERATIONS),
-                 id="diagonal_diag_pd"),
-
-    pytest.param("root_diag_pd",
-                 lambda x: (RootLinOp(x["diag_pd"]["dense_root"]),
-                            x["diag_pd"]["dense"],
-                            ALL_OPERATIONS),
-                 id="root_diag_pd"),
-
-    pytest.param("cholesky_diag_pd",
-                 lambda x: (CholeskyLinOp(TriangularLinOp(x["diag_pd"]["dense_root"], lower=True)),
-                            x["diag_pd"]["dense"],
-                            ALL_OPERATIONS),
-                 id="cholesky_diag_pd"),
-
-    pytest.param("dense_diag_pd",
-                 lambda x: (DenseLinOp(x["diag_pd"]["dense"]),
-                            x["diag_pd"]["dense"],
-                            ALL_OPERATIONS),
-                 id="dense_diag_pd")
+    pytest.param(
+        "root_pd",
+        lambda x: (RootLinOp(x["pd"]["root"]), x["pd"]["dense"], ALL_OPERATIONS),
+        id="root_pd",
+    ),
+    pytest.param(
+        "cholesky_pd",
+        lambda x: (
+            CholeskyLinOp(TriangularLinOp(x["pd"]["lower_chol"], lower=True)),
+            x["pd"]["dense"],
+            ALL_OPERATIONS,
+        ),
+        id="cholesky_pd",
+    ),
+    pytest.param(
+        "dense_pd",
+        lambda x: (DenseLinOp(x["pd"]["dense"]), x["pd"]["dense"], ALL_OPERATIONS),
+        id="dense_pd",
+    ),
+    pytest.param(
+        "diagonal_diag_pd",
+        lambda x: (DiagonalLinOp(x["diag_pd"]["diagonal"]), x["diag_pd"]["dense"], ALL_OPERATIONS),
+        id="diagonal_diag_pd",
+    ),
+    pytest.param(
+        "root_diag_pd",
+        lambda x: (RootLinOp(x["diag_pd"]["dense_root"]), x["diag_pd"]["dense"], ALL_OPERATIONS),
+        id="root_diag_pd",
+    ),
+    pytest.param(
+        "cholesky_diag_pd",
+        lambda x: (
+            CholeskyLinOp(TriangularLinOp(x["diag_pd"]["dense_root"], lower=True)),
+            x["diag_pd"]["dense"],
+            ALL_OPERATIONS,
+        ),
+        id="cholesky_diag_pd",
+    ),
+    pytest.param(
+        "dense_diag_pd",
+        lambda x: (DenseLinOp(x["diag_pd"]["dense"]), x["diag_pd"]["dense"], ALL_OPERATIONS),
+        id="dense_diag_pd",
+    ),
 ]
 
 
@@ -146,8 +158,9 @@ linop_factories = [
 @pytest.mark.parametrize("factory_id,factory", linop_factories)
 @pytest.mark.parametrize("batch_mode", ["batch", "single"])
 @pytest.mark.parametrize("with_y", [False, True])
-def test_mah_dist_squared_against_baseline(factory_id, factory, batch_mode, with_y,
-                                           linop_resources, rng_key):
+def test_mah_dist_squared_against_baseline(
+    factory_id, factory, batch_mode, with_y, linop_resources, rng_key
+):
     op, dense, supports = factory(linop_resources)
 
     if "mah_dist_squared" not in supports:
@@ -167,7 +180,11 @@ def test_mah_dist_squared_against_baseline(factory_id, factory, batch_mode, with
     expected = baseline_mah_dist_squared(x, dense, y)
     got = mah_dist_squared(x, op, y)
 
-    _compare_results(got, expected, msg=f"Mismatch for operator '{factory_id}', batch_mode={batch_mode}, with_y={with_y}")
+    _compare_results(
+        got,
+        expected,
+        msg=f"Mismatch for operator '{factory_id}', batch_mode={batch_mode}, with_y={with_y}",
+    )
 
 
 def test_mah_dist_squared_broadcast_y(rng_key, linop_resources):
@@ -201,6 +218,7 @@ def test_mah_dist_squared_incorrect_shape_raises(rng_key, linop_resources):
 # -----------------------------------------------------------------------------
 # Test logdet
 # -----------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("factory_id,factory", linop_factories)
 def test_logdet_against_baseline(factory_id, factory, linop_resources):

--- a/tests/modeling/test_conditionally_independent_likelihood.py
+++ b/tests/modeling/test_conditionally_independent_likelihood.py
@@ -32,6 +32,7 @@ class TestProtocol:
 
     def test_runtime_checkable(self):
         """The Protocol is marked @runtime_checkable."""
+
         # If runtime_checkable, isinstance works on a structural match.
         # A bare Likelihood (no per_datum_log_likelihood) should be False.
         class _BareLikelihood:
@@ -40,7 +41,8 @@ class TestProtocol:
 
         assert isinstance(_BareLikelihood(), Likelihood)
         assert not isinstance(
-            _BareLikelihood(), ConditionallyIndependentLikelihood,
+            _BareLikelihood(),
+            ConditionallyIndependentLikelihood,
         )
 
 
@@ -54,37 +56,45 @@ def bernoulli_glm():
     ``GLMLikelihood`` adds the intercept internally (``fit_intercept=True``
     default); ``params`` is ``(intercept, slope_0, slope_1)``.
     """
-    X = jnp.array([
+    X = jnp.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 1.0],
+            [0.5, 0.5],
+        ]
+    )
+    return GLMLikelihood(tfp_glm.Bernoulli(), x=X), X
+
+
+_BERNOULLI_X = jnp.array(
+    [
         [0.0, 0.0],
         [1.0, 0.0],
         [0.0, 1.0],
         [1.0, 1.0],
         [0.5, 0.5],
-    ])
-    return GLMLikelihood(tfp_glm.Bernoulli(), x=X), X
-
-
-_BERNOULLI_X = jnp.array([
-    [0.0, 0.0],
-    [1.0, 0.0],
-    [0.0, 1.0],
-    [1.0, 1.0],
-    [0.5, 0.5],
-])
-_NORMAL_X = jnp.array([
-    [0.5],
-    [-0.5],
-    [1.0],
-])
+    ]
+)
+_NORMAL_X = jnp.array(
+    [
+        [0.5],
+        [-0.5],
+        [1.0],
+    ]
+)
 
 _PER_DATUM_CASES = [
     # (id, family_factory, X, params (intercept, *slopes), y)
-    ("bernoulli", tfp_glm.Bernoulli, _BERNOULLI_X,
-     jnp.array([0.5, -0.5, 0.25]),
-     jnp.array([1.0, 0.0, 1.0, 1.0, 0.0])),
-    ("normal", tfp_glm.Normal, _NORMAL_X,
-     jnp.array([0.0, 1.0]),
-     jnp.array([0.6, -0.4, 1.1])),
+    (
+        "bernoulli",
+        tfp_glm.Bernoulli,
+        _BERNOULLI_X,
+        jnp.array([0.5, -0.5, 0.25]),
+        jnp.array([1.0, 0.0, 1.0, 1.0, 0.0]),
+    ),
+    ("normal", tfp_glm.Normal, _NORMAL_X, jnp.array([0.0, 1.0]), jnp.array([0.6, -0.4, 1.1])),
 ]
 
 
@@ -108,12 +118,15 @@ class TestGLMLikelihood:
         """
         glm = GLMLikelihood(family_factory(), x=X)
         full = glm.log_likelihood(params, y)
-        per_row = jnp.stack([
-            glm.per_datum_log_likelihood(
-                params, Record(X=X[i], y=y[i]),
-            )
-            for i in range(X.shape[0])
-        ])
+        per_row = jnp.stack(
+            [
+                glm.per_datum_log_likelihood(
+                    params,
+                    Record(X=X[i], y=y[i]),
+                )
+                for i in range(X.shape[0])
+            ]
+        )
         np.testing.assert_allclose(float(full), float(jnp.sum(per_row)), rtol=1e-5)
 
     def test_per_datum_requires_record_datum(self, bernoulli_glm):
@@ -133,8 +146,10 @@ class TestDefaultFallback:
         """``_default_per_datum_log_likelihood`` evaluates the full
         likelihood on a length-1 batch around the datum.
         """
+
         class _SumLikelihood:
             """A toy likelihood: log_likelihood is sum of data, ignoring params."""
+
             def log_likelihood(self, params, data):
                 return jnp.sum(jnp.asarray(data))
 
@@ -150,8 +165,10 @@ class TestDefaultFallback:
         """The fallback's ``jax.tree.map(lambda x: x[None, ...], datum)``
         also works on Record-shaped data — each leaf gets a leading axis.
         """
+
         class _RecordLikelihood:
             """Sum across all leaves of the Record."""
+
             def log_likelihood(self, params, data):
                 # data is Record(X=..., y=...) with shape (n, ...) leaves
                 return jnp.sum(jnp.asarray(data["X"])) + jnp.sum(jnp.asarray(data["y"]))
@@ -172,6 +189,7 @@ class TestDefaultFallback:
 class TestNegativeSpace:
     def test_bare_likelihood_rejected_by_protocol_check(self):
         """A class with only ``log_likelihood`` (no per_datum) doesn't satisfy CIL."""
+
         class _BareLikelihood:
             def log_likelihood(self, params, data):
                 return jnp.asarray(0.0)

--- a/tests/modeling/test_glm.py
+++ b/tests/modeling/test_glm.py
@@ -7,7 +7,15 @@ import pytest
 import scipy.stats
 import tensorflow_probability.substrates.jax.glm as tfp_glm
 
-from probpipe import GLMLikelihood, MultivariateNormal, SimpleModel, Record, EventTemplate, condition_on, mean
+from probpipe import (
+    GLMLikelihood,
+    MultivariateNormal,
+    SimpleModel,
+    Record,
+    EventTemplate,
+    condition_on,
+    mean,
+)
 from probpipe.modeling import Likelihood, GenerativeLikelihood
 
 
@@ -28,7 +36,6 @@ def bernoulli_lik():
 
 
 class TestGLMLikelihood:
-
     def test_satisfies_likelihood_protocol(self, poisson_lik):
         assert isinstance(poisson_lik, Likelihood)
 
@@ -45,8 +52,7 @@ class TestGLMLikelihood:
     def test_poisson_log_likelihood_matches_scipy(self, poisson_lik):
         """Poisson GLM log-likelihood must match sum of scipy.stats.poisson.logpmf."""
         params = jnp.array([1.0, 0.5])
-        data = jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1,
-                          0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=float)
+        data = jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1, 0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=float)
         ll = float(poisson_lik.log_likelihood(params, data))
 
         # Independent baseline: Poisson log link →
@@ -116,7 +122,8 @@ class TestGLMLikelihood:
         assert jnp.isfinite(ll)
         # Per-datum path with 1-D covariate.
         p_lp = lik.per_datum_log_likelihood(
-            params, Record(X=jnp.asarray(x[0]), y=jnp.array(1.0)),
+            params,
+            Record(X=jnp.asarray(x[0]), y=jnp.array(1.0)),
         )
         assert jnp.isfinite(p_lp)
 
@@ -131,8 +138,7 @@ class TestGLMLikelihood:
         X = np.asarray(np.linspace(-1, 1, 20))[:, None].astype(float)
         lik = GLMLikelihood(tfp_glm.Poisson(), X, fit_intercept=False)
         params = jnp.array([0.7])  # one slope, no intercept
-        data = jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1,
-                          0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=float)
+        data = jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1, 0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=float)
         ll = float(lik.log_likelihood(params, data))
 
         params_np = np.asarray(params)
@@ -154,8 +160,7 @@ class TestGLMLikelihood:
         """GLMLikelihood works end-to-end with SimpleModel + condition_on."""
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=5.0 * jnp.eye(2), name="beta")
         model = SimpleModel(prior, poisson_lik)
-        data = jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1,
-                           0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=float)
+        data = jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1, 0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=float)
         posterior = condition_on(model, data, num_results=100, num_warmup=50, random_seed=0)
         m = mean(posterior)
         assert m.shape == (2,)
@@ -181,6 +186,7 @@ class TestGLMLikelihoodDataTemplate:
     def test_data_template_integrates_with_simple_model(self, poisson_lik):
         """SimpleModel merges GLM data_template into fields."""
         from probpipe import Normal, ProductDistribution
+
         prior = ProductDistribution(
             intercept=Normal(loc=0.0, scale=2.0, name="intercept"),
             slope=Normal(loc=0.0, scale=2.0, name="slope"),
@@ -230,9 +236,9 @@ class TestGLMLikelihoodWithValues:
     def test_condition_on_with_record_data(self, poisson_lik):
         prior = MultivariateNormal(loc=jnp.zeros(2), cov=5.0 * jnp.eye(2), name="beta")
         model = SimpleModel(prior, poisson_lik)
-        data = Record(y=jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1,
-                                    0, 2, 6, 1, 3, 2, 0, 4, 1, 3],
-                                   dtype=float))
+        data = Record(
+            y=jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1, 0, 2, 6, 1, 3, 2, 0, 4, 1, 3], dtype=float)
+        )
         posterior = condition_on(model, data, num_results=50, num_warmup=25, random_seed=0)
         assert mean(posterior).shape == (2,)
         # Prior has no event_template, so draws are raw arrays.

--- a/tests/modeling/test_modeling.py
+++ b/tests/modeling/test_modeling.py
@@ -24,14 +24,17 @@ class TestLazyImports:
 
     def test_stanmodel_lazy_load(self):
         from probpipe.modeling import StanModel
+
         assert StanModel is not None
 
     def test_pymcmodel_lazy_load(self):
         from probpipe.modeling import PyMCModel
+
         assert PyMCModel is not None
 
     def test_unknown_attr_raises(self):
         import probpipe.modeling as mod
+
         with pytest.raises(AttributeError, match="has no attribute"):
             mod.NonExistent
 
@@ -46,7 +49,7 @@ class MultivariateNormalLikelihood:
 
     def log_likelihood(self, params, data):
         residuals = data - params[None, :]
-        return -0.5 * jnp.sum(residuals ** 2)
+        return -0.5 * jnp.sum(residuals**2)
 
 
 class SimpleGenerativeLikelihood:
@@ -54,7 +57,7 @@ class SimpleGenerativeLikelihood:
 
     def log_likelihood(self, params, data):
         residuals = data - params[None, :]
-        return -0.5 * jnp.sum(residuals ** 2)
+        return -0.5 * jnp.sum(residuals**2)
 
     def generate_data(self, params, num_observations, *, key=None):
         if key is None:
@@ -232,6 +235,5 @@ class TestIncrementalConditioner:
             cond.update(X=X[s:e], y=y[s:e])
             posterior_mean = mean(cond.curr_posterior)
             assert posterior_mean.fields == ("intercept", "slope"), (
-                f"named fields lost after batch ending at {e}: "
-                f"got {posterior_mean.fields}"
+                f"named fields lost after batch ending at {e}: got {posterior_mean.fields}"
             )

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -84,7 +84,7 @@ class TestPyMCModel:
         assert "y" in names
 
     def test_supports_named_components(self, model):
-        assert hasattr(model, 'fields')
+        assert hasattr(model, "fields")
         assert len(model.fields) > 0
 
     def test_repr(self, model):
@@ -180,8 +180,14 @@ class TestPyMCModel:
 
         data = np.random.randn(50)
         result = condition_on(
-            model, {"y": data}, method="pymc_nuts",
-            num_results=50, num_warmup=50, num_chains=2, cores=2, random_seed=0,
+            model,
+            {"y": data},
+            method="pymc_nuts",
+            num_results=50,
+            num_warmup=50,
+            num_chains=2,
+            cores=2,
+            random_seed=0,
         )
         assert isinstance(result, ApproximateDistribution)
         assert result.num_chains == 2
@@ -202,8 +208,13 @@ class TestPyMCModel:
         data = np.random.randn(50)
         with _captured_pm_sample_kwargs() as captured:
             result = condition_on(
-                model, {"y": data}, method="pymc_nuts",
-                num_results=20, num_warmup=10, num_chains=2, cores=2,
+                model,
+                {"y": data},
+                method="pymc_nuts",
+                num_results=20,
+                num_warmup=10,
+                num_chains=2,
+                cores=2,
                 random_seed=0,
             )
 
@@ -230,12 +241,16 @@ class TestPyMCModel:
             _captured_pm_sample_kwargs() as captured,
         ):
             _ = condition_on(
-                model, {"y": data}, method="pymc_nuts",
-                num_results=20, num_warmup=10, random_seed=0,
+                model,
+                {"y": data},
+                method="pymc_nuts",
+                num_results=20,
+                num_warmup=10,
+                random_seed=0,
             )
 
-        assert captured["chains"] == 4               # the documented default
-        assert captured["cores"] == 4                # min(num_chains=4, cpu_count=4)
+        assert captured["chains"] == 4  # the documented default
+        assert captured["cores"] == 4  # min(num_chains=4, cpu_count=4)
         assert captured["mp_ctx"] == "spawn"
 
     def test_single_core_default_skips_spawn(self, model):
@@ -252,8 +267,12 @@ class TestPyMCModel:
             _captured_pm_sample_kwargs() as captured,
         ):
             _ = condition_on(
-                model, {"y": data}, method="pymc_nuts",
-                num_results=20, num_warmup=10, random_seed=0,
+                model,
+                {"y": data},
+                method="pymc_nuts",
+                num_results=20,
+                num_warmup=10,
+                random_seed=0,
             )
 
         assert captured["cores"] == 1
@@ -267,10 +286,11 @@ class TestEventTemplate:
 
     def test_mixed_scalar_and_vector_rvs(self):
         """Each free RV becomes one field with its event shape."""
+
         def model_fn(y=None):
             with pm.Model() as m:
-                pm.Normal("intercept", 0, 1)             # scalar
-                pm.Normal("slope", 0, 1, shape=3)        # shape (3,)
+                pm.Normal("intercept", 0, 1)  # scalar
+                pm.Normal("slope", 0, 1, shape=3)  # shape (3,)
                 pm.Normal("y", 0, 1, observed=y)
             return m
 
@@ -281,6 +301,7 @@ class TestEventTemplate:
 
     def test_observed_rvs_excluded(self):
         """Observed variables are not part of the parameter template."""
+
         def model_fn(y=None):
             with pm.Model() as m:
                 pm.Normal("mu", 0, 1)
@@ -315,10 +336,12 @@ class TestEventTemplate:
         # Template built from a data-conditioned build picks up the real
         # shape — and the instance carries no cached state afterward.
         N = 50
-        conditioned = model._pymc_model(data={
-            "X": np.zeros(N, dtype=np.float32),
-            "y": np.zeros(N, dtype=np.float32),
-        })
+        conditioned = model._pymc_model(
+            data={
+                "X": np.zeros(N, dtype=np.float32),
+                "y": np.zeros(N, dtype=np.float32),
+            }
+        )
         names = model._conditioned_param_names(conditioned)
         tpl_c = model._event_template_for(conditioned, names)
         assert tpl_c.fields == ("intercept", "alpha")
@@ -341,9 +364,13 @@ class TestEventTemplate:
         y = rng.normal(size=N).astype(np.float32)
         model = PyMCModel(per_observation_effect_model_fn)
         result = condition_on(
-            model, {"X": X, "y": y},
+            model,
+            {"X": X, "y": y},
             method="pymc_nuts",
-            num_results=20, num_warmup=10, num_chains=1, random_seed=0,
+            num_results=20,
+            num_warmup=10,
+            num_chains=1,
+            random_seed=0,
         )
         draws = result.draws()
         assert draws.fields == ("intercept", "alpha")
@@ -366,16 +393,19 @@ class TestEventTemplate:
 
         def model_fn(y=None):
             with pm.Model() as m:
-                intercept = pm.Normal("intercept", 0, 1)      # scalar, defined first
-                pm.Normal("alpha", 0, 1, shape=3)             # shape (3,), sorts first
+                intercept = pm.Normal("intercept", 0, 1)  # scalar, defined first
+                pm.Normal("alpha", 0, 1, shape=3)  # shape (3,), sorts first
                 pm.Normal("y", mu=intercept, sigma=1.0, observed=y)
             return m
 
         y = np.zeros(8, dtype=np.float32)
         result = condition_on(
-            PyMCModel(model_fn), {"y": y},
+            PyMCModel(model_fn),
+            {"y": y},
             method="pymc_advi",
-            num_iterations=200, num_results=25, random_seed=0,
+            num_iterations=200,
+            num_results=25,
+            random_seed=0,
         )
         assert result.algorithm == "pymc_advi"
         draws = result.draws()
@@ -392,9 +422,10 @@ class TestEventTemplate:
         data-conditioned build. ProbPipe does not support such dynamic
         random variables; the template builder must refuse cleanly.
         """
+
         def model_fn(y=None):
             with pm.Model() as m:
-                if y is None:                       # no-data build only
+                if y is None:  # no-data build only
                     pm.Normal("ghost", 0, 1)
                 mu = pm.Normal("mu", 0, 1)
                 pm.Normal("y", mu=mu, sigma=1.0, observed=y)
@@ -415,16 +446,17 @@ class TestEventTemplate:
         explicit check it would be omitted from the template and filtered
         out of the chain, silently vanishing from the posterior.
         """
+
         def model_fn(y=None):
             with pm.Model() as m:
                 mu = pm.Normal("mu", 0, 1)
-                if y is not None:                   # conditioned build only
+                if y is not None:  # conditioned build only
                     pm.Normal("extra", 0, 1)
                 pm.Normal("y", mu=mu, sigma=1.0, observed=y)
             return m
 
         model = PyMCModel(model_fn)
-        assert model.parameter_names == ("mu",)     # extra absent at construction
+        assert model.parameter_names == ("mu",)  # extra absent at construction
         conditioned = model._pymc_model(data={"y": np.zeros(5, dtype=np.float32)})
         with pytest.raises(ValueError, match="dynamic random variables"):
             model._conditioned_param_names(conditioned)
@@ -438,6 +470,7 @@ class TestEventTemplate:
         omitted it is a free RV. Conditioning on ``y`` alone must yield a
         posterior over both ``mu`` and ``X``.
         """
+
         def model_fn(X=None, y=None):
             with pm.Model() as m:
                 mu = pm.Normal("mu", 0, 1)
@@ -470,9 +503,13 @@ class TestEventTemplate:
 
         model = PyMCModel(model_fn)
         result = condition_on(
-            model, {"y": np.zeros(5, dtype=np.float32)},
+            model,
+            {"y": np.zeros(5, dtype=np.float32)},
             method="pymc_nuts",
-            num_results=20, num_warmup=10, num_chains=1, random_seed=0,
+            num_results=20,
+            num_warmup=10,
+            num_chains=1,
+            random_seed=0,
         )
         assert set(result.draws().fields) == {"mu", "X"}
 
@@ -497,14 +534,18 @@ class TestEventTemplate:
 
         model = PyMCModel(model_fn)
         result = condition_on(
-            model, {"y": np.zeros(5, dtype=np.float32)},
+            model,
+            {"y": np.zeros(5, dtype=np.float32)},
             method="pymc_nuts",
-            num_results=200, num_warmup=200, num_chains=1, random_seed=0,
+            num_results=200,
+            num_warmup=200,
+            num_chains=1,
+            random_seed=0,
         )
         draws = result.draws()
         assert set(draws.fields) == {"mu", "X"}
-        assert float(jnp.mean(jnp.asarray(draws["mu"]))) > 50.0    # ~ +100
-        assert float(jnp.mean(jnp.asarray(draws["X"]))) < -50.0    # ~ -100
+        assert float(jnp.mean(jnp.asarray(draws["mu"]))) > 50.0  # ~ +100
+        assert float(jnp.mean(jnp.asarray(draws["X"]))) < -50.0  # ~ -100
 
     def test_pymc_nuts_multiparam_field_order_realigned(self):
         """End-to-end check of the name-keyed wiring (issue #233): the
@@ -530,9 +571,13 @@ class TestEventTemplate:
 
         model = PyMCModel(model_fn)
         result = condition_on(
-            model, {"y": np.zeros(5, dtype=np.float32)},
+            model,
+            {"y": np.zeros(5, dtype=np.float32)},
             method="pymc_nuts",
-            num_results=200, num_warmup=200, num_chains=1, random_seed=0,
+            num_results=200,
+            num_warmup=200,
+            num_chains=1,
+            random_seed=0,
         )
         draws = result.draws()
         # Declared order, not nutpie/pymc's alphabetical data_vars order.
@@ -561,9 +606,13 @@ class TestEventTemplate:
         model = PyMCModel(model_fn)
         with pytest.raises(ValueError, match="dynamic random variables"):
             condition_on(
-                model, {"y": np.zeros(5, dtype=np.float32)},
+                model,
+                {"y": np.zeros(5, dtype=np.float32)},
                 method="pymc_nuts",
-                num_results=5, num_warmup=5, num_chains=1, random_seed=0,
+                num_results=5,
+                num_warmup=5,
+                num_chains=1,
+                random_seed=0,
             )
 
     def test_non_concrete_shape_rejected(self):
@@ -629,6 +678,7 @@ class TestRecordDataUnpacking:
     def test_record_input_unpacked_by_field_name(self):
         """A ``Record(X=..., y=...)`` populates both observed slots."""
         from probpipe import Record
+
         rng = np.random.RandomState(0)
         N = 20
         X = np.asarray(rng.randn(N))[:, None].astype(np.float32)
@@ -662,6 +712,7 @@ class TestRecordDataUnpacking:
         user-facing Record API free of NumPy-shaped friction.
         """
         from probpipe import Record
+
         X = jnp.ones((5, 2), dtype=jnp.float32)  # JAX array
         y = jnp.zeros(5, dtype=jnp.float32)
         model = PyMCModel(self._xy_model)

--- a/tests/modeling/test_simple_generative_model.py
+++ b/tests/modeling/test_simple_generative_model.py
@@ -79,6 +79,7 @@ class TestProtocols:
         """SimpleGenerativeModel now advertises SupportsSampling (joint draw:
         sample prior, call likelihood.generate_data)."""
         from probpipe.core.protocols import SupportsSampling
+
         assert isinstance(model, SupportsSampling)
 
     def test_simulator_is_generative_likelihood(self, simulator):

--- a/tests/modeling/test_simple_model.py
+++ b/tests/modeling/test_simple_model.py
@@ -125,7 +125,7 @@ class TestSimpleModel:
         assert model.likelihood is likelihood
 
     def test_supports_named_components(self, model):
-        assert hasattr(model, 'fields')
+        assert hasattr(model, "fields")
 
     def test_getitem_parameters(self, model, prior):
         assert model["parameters"] is prior
@@ -192,14 +192,23 @@ class TestSimpleModelConditioningPaths:
 
     def test_condition_on_hmc(self, model, data):
         result = condition_on(
-            model, data, num_results=30, num_warmup=10, step_size=0.3,
-            random_seed=42, method="tfp_hmc",
+            model,
+            data,
+            num_results=30,
+            num_warmup=10,
+            step_size=0.3,
+            random_seed=42,
+            method="tfp_hmc",
         )
         assert isinstance(result, ApproximateDistribution)
 
     def test_condition_on_zero_warmup(self, model, data):
         result = condition_on(
-            model, data, num_results=30, num_warmup=0, step_size=0.3,
+            model,
+            data,
+            num_results=30,
+            num_warmup=0,
+            step_size=0.3,
             random_seed=42,
         )
         assert isinstance(result, ApproximateDistribution)
@@ -207,12 +216,18 @@ class TestSimpleModelConditioningPaths:
     def test_condition_on_bad_method(self, model, data):
         with pytest.raises(KeyError):
             from probpipe import condition_on
+
             condition_on(model, data, method="nonexistent_method")
 
     def test_condition_on_explicit_init(self, model, data):
         result = condition_on(
-            model, data, num_results=30, num_warmup=10, step_size=0.3,
-            random_seed=42, init=jnp.ones(2),
+            model,
+            data,
+            num_results=30,
+            num_warmup=10,
+            step_size=0.3,
+            random_seed=42,
+            init=jnp.ones(2),
         )
         assert isinstance(result, ApproximateDistribution)
 
@@ -230,7 +245,12 @@ class TestSimpleModelConditioningPaths:
         model = SimpleModel(prior, NonTraceableLikelihood())
         data = jnp.array([[1.0, 2.0], [1.5, 2.5]])
         result = condition_on(
-            model, data, num_results=30, num_warmup=10, step_size=0.3, random_seed=42,
+            model,
+            data,
+            num_results=30,
+            num_warmup=10,
+            step_size=0.3,
+            random_seed=42,
         )
         assert isinstance(result, ApproximateDistribution)
 
@@ -240,7 +260,11 @@ class TestSimpleModelConditioningPaths:
         model = SimpleModel(prior, GaussianLikelihood())
         data = jnp.array([[1.0, 2.0], [1.5, 2.5]])
         result = condition_on(
-            model, data, num_results=30, num_warmup=10, random_seed=42,
+            model,
+            data,
+            num_results=30,
+            num_warmup=10,
+            random_seed=42,
         )
         assert result.inference_data is not None
         assert hasattr(result.inference_data, "posterior")
@@ -304,8 +328,12 @@ class TestSimpleModelWithValues:
         model = SimpleModel(prior_with_template, likelihood)
         data = Record(obs=jnp.array([[1.0, 2.0], [1.5, 2.5]]))
         result = condition_on(
-            model, data, num_results=50, num_warmup=20,
-            step_size=0.3, random_seed=42,
+            model,
+            data,
+            num_results=50,
+            num_warmup=20,
+            step_size=0.3,
+            random_seed=42,
         )
         assert isinstance(result, ApproximateDistribution)
 
@@ -313,8 +341,12 @@ class TestSimpleModelWithValues:
         model = SimpleModel(prior_with_template, likelihood)
         data = jnp.array([[1.0, 2.0], [1.5, 2.5]])
         result = condition_on(
-            model, data, num_results=50, num_warmup=20,
-            step_size=0.3, random_seed=42,
+            model,
+            data,
+            num_results=50,
+            num_warmup=20,
+            step_size=0.3,
+            random_seed=42,
         )
         assert isinstance(result, ApproximateDistribution)
 
@@ -343,6 +375,7 @@ class TestSimpleModelWithValues:
 
     def test_getitem_data_field_returns_likelihood(self, prior_with_template, likelihood):
         """Data field names return the likelihood."""
+
         class _DataTemplateLikelihood(_ValuesAwareLikelihood):
             @property
             def data_template(self):
@@ -354,6 +387,7 @@ class TestSimpleModelWithValues:
 
     def test_condition_on_rejects_positional_and_named_data(self, prior_with_template):
         """Cannot pass both positional observed and named data kwargs."""
+
         class _DataTemplateLikelihood(_ValuesAwareLikelihood):
             @property
             def data_template(self):
@@ -362,7 +396,9 @@ class TestSimpleModelWithValues:
         model = SimpleModel(prior_with_template, _DataTemplateLikelihood())
         with pytest.raises(ValueError, match="Cannot provide both"):
             condition_on(
-                model, jnp.array([1.0, 2.0]),
+                model,
+                jnp.array([1.0, 2.0]),
                 obs=jnp.array([1.0, 2.0]),
-                num_results=50, random_seed=42,
+                num_results=50,
+                random_seed=42,
             )

--- a/tests/modeling/test_stan_model.py
+++ b/tests/modeling/test_stan_model.py
@@ -51,10 +51,12 @@ class TestParamBlocks:
         assert [(b.name, b.shape) for b in blocks] == [("L", (2, 2))]
 
     def test_mixed_blocks(self):
-        names = ["mu", "theta.1", "theta.2", "theta.3",
-                 "L.1.1", "L.2.1", "L.1.2", "L.2.2"]
+        names = ["mu", "theta.1", "theta.2", "theta.3", "L.1.1", "L.2.1", "L.1.2", "L.2.2"]
         assert [(b.name, b.shape) for b in _param_blocks(names)] == [
-            ("mu", ()), ("theta", (3,)), ("L", (2, 2))]
+            ("mu", ()),
+            ("theta", (3,)),
+            ("L", (2, 2)),
+        ]
 
     def test_empty(self):
         assert _param_blocks([]) == ()
@@ -130,8 +132,7 @@ def conjugate_stan_file(_stan_toolchain, tmp_path_factory):
 @pytest.fixture(scope="module")
 def conjugate_model(conjugate_stan_file):
     """The conjugate model instantiated with data and an explicit name."""
-    return StanModel(conjugate_stan_file, data={"N": 3, "y": [1.0, 2.0, 3.0]},
-                     name="normal_mean")
+    return StanModel(conjugate_stan_file, data={"N": 3, "y": [1.0, 2.0, 3.0]}, name="normal_mean")
 
 
 @pytest.fixture(scope="module")
@@ -194,8 +195,7 @@ class TestStanModelSurface:
         assert "num_params=1" in r
 
     def test_as_unconstrained_distribution(self, conjugate_model):
-        assert isinstance(conjugate_model.as_unconstrained_distribution(),
-                          _UnconstrainedStanView)
+        assert isinstance(conjugate_model.as_unconstrained_distribution(), _UnconstrainedStanView)
 
     def test_name_defaults_to_class_name(self, conjugate_stan_file):
         # Without an explicit name, StanModel falls back to the class name to
@@ -232,13 +232,15 @@ class TestStanModelDensity:
         x = jnp.asarray([0.5])
         np.testing.assert_allclose(
             float(conjugate_model._unnormalized_log_prob(x)),
-            float(conjugate_model._log_prob(x)), atol=1e-6)
+            float(conjugate_model._log_prob(x)),
+            atol=1e-6,
+        )
 
     def test_prob_is_exp_log_prob(self, conjugate_model):
         x = jnp.asarray([0.5])
         np.testing.assert_allclose(
-            float(conjugate_model._prob(x)),
-            float(jnp.exp(conjugate_model._log_prob(x))), rtol=1e-6)
+            float(conjugate_model._prob(x)), float(jnp.exp(conjugate_model._log_prob(x))), rtol=1e-6
+        )
 
     def test_unnormalized_prob_positive(self, conjugate_model):
         up = conjugate_model._unnormalized_prob(jnp.asarray([0.5]))
@@ -260,17 +262,18 @@ class TestStanModelTransforms:
     def test_param_constrain_identity_for_real(self, conjugate_model):
         x = jnp.asarray([1.23])
         np.testing.assert_allclose(
-            np.asarray(conjugate_model.param_constrain(x)), [1.23], atol=1e-6)
+            np.asarray(conjugate_model.param_constrain(x)), [1.23], atol=1e-6
+        )
 
     def test_param_unconstrain_identity_for_real(self, conjugate_model):
         x = jnp.asarray([1.23])
         np.testing.assert_allclose(
-            np.asarray(conjugate_model.param_unconstrain(x)), [1.23], atol=1e-6)
+            np.asarray(conjugate_model.param_unconstrain(x)), [1.23], atol=1e-6
+        )
 
     def test_constrain_unconstrain_round_trip(self, conjugate_model):
         x = jnp.asarray([1.23])
-        round_trip = conjugate_model.param_constrain(
-            conjugate_model.param_unconstrain(x))
+        round_trip = conjugate_model.param_constrain(conjugate_model.param_unconstrain(x))
         np.testing.assert_allclose(np.asarray(round_trip), [1.23], atol=1e-6)
 
     def test_constrain_yields_valid_simplex(self, structured_model):
@@ -286,12 +289,11 @@ class TestStanModelTransforms:
         # constrain o unconstrain is the identity on a valid constrained point.
         # The simplex must sum to 1 exactly in float (0.25 + 0.25 + 0.5) for
         # BridgeStan's strict simplex_free to accept it.
-        constrained = jnp.array([0.5, 0.1, 0.2, 0.3, 1.0, 2.0, 3.0, 4.0,
-                                 0.25, 0.25, 0.5])
+        constrained = jnp.array([0.5, 0.1, 0.2, 0.3, 1.0, 2.0, 3.0, 4.0, 0.25, 0.25, 0.5])
         round_trip = structured_model.param_constrain(
-            structured_model.param_unconstrain(constrained))
-        np.testing.assert_allclose(np.asarray(round_trip),
-                                   np.asarray(constrained), atol=1e-5)
+            structured_model.param_unconstrain(constrained)
+        )
+        np.testing.assert_allclose(np.asarray(round_trip), np.asarray(constrained), atol=1e-5)
 
 
 class TestBridgestanModel:
@@ -321,12 +323,26 @@ class TestStanModelParameters:
 
     def test_parameter_names_stay_per_scalar(self, structured_model):
         assert structured_model.parameter_names == (
-            "mu", "theta.1", "theta.2", "theta.3",
-            "L.1.1", "L.2.1", "L.1.2", "L.2.2", "p.1", "p.2", "p.3")
+            "mu",
+            "theta.1",
+            "theta.2",
+            "theta.3",
+            "L.1.1",
+            "L.2.1",
+            "L.1.2",
+            "L.2.2",
+            "p.1",
+            "p.2",
+            "p.3",
+        )
 
     def test_event_template_shapes(self, structured_model):
         assert structured_model.event_template.event_shapes == {
-            "mu": (), "theta": (3,), "L": (2, 2), "p": (3,)}
+            "mu": (),
+            "theta": (3,),
+            "L": (2, 2),
+            "p": (3,),
+        }
 
     def test_param_blocks_match_real_names(self, structured_model):
         # The pure name-parser, fed BridgeStan's real param_names(), recovers
@@ -334,7 +350,11 @@ class TestStanModelParameters:
         # flattening convention out from under _param_blocks.
         blocks = _param_blocks(structured_model._bs_model.param_names())
         assert [(b.name, b.shape) for b in blocks] == [
-            ("mu", ()), ("theta", (3,)), ("L", (2, 2)), ("p", (3,))]
+            ("mu", ()),
+            ("theta", (3,)),
+            ("L", (2, 2)),
+            ("p", (3,)),
+        ]
 
     def test_getitem_uses_block_fields(self, structured_model):
         assert structured_model["theta"] == "theta"
@@ -343,30 +363,40 @@ class TestStanModelParameters:
 
     def test_pack_value_assembles_column_major(self, structured_model):
         flat = structured_model._pack_value(
-            mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
+            mu=0.5,
+            theta=jnp.array([1.0, 2.0, 3.0]),
             L=jnp.array([[10.0, 30.0], [20.0, 40.0]]),
-            p=jnp.array([0.2, 0.3, 0.5]))
+            p=jnp.array([0.2, 0.3, 0.5]),
+        )
         # L is packed column-major to match BridgeStan: [10, 20, 30, 40].
-        assert jnp.allclose(flat, jnp.array(
-            [0.5, 1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0, 0.2, 0.3, 0.5]))
+        assert jnp.allclose(
+            flat, jnp.array([0.5, 1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0, 0.2, 0.3, 0.5])
+        )
 
     def test_pack_value_missing_block_raises(self, structured_model):
         with pytest.raises(TypeError, match="missing"):
-            structured_model._pack_value(mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
-                                         L=jnp.zeros((2, 2)))  # no p
+            structured_model._pack_value(
+                mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]), L=jnp.zeros((2, 2))
+            )  # no p
 
     def test_pack_value_unexpected_block_raises(self, structured_model):
         with pytest.raises(TypeError, match="unexpected"):
             structured_model._pack_value(
-                mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]), L=jnp.zeros((2, 2)),
-                p=jnp.array([0.2, 0.3, 0.5]), zzz=1.0)
+                mu=0.5,
+                theta=jnp.array([1.0, 2.0, 3.0]),
+                L=jnp.zeros((2, 2)),
+                p=jnp.array([0.2, 0.3, 0.5]),
+                zzz=1.0,
+            )
 
     def test_pack_value_wrong_shape_raises(self, structured_model):
         with pytest.raises(TypeError, match=r"shape \(2, 2\)"):
             structured_model._pack_value(
-                mu=0.5, theta=jnp.array([1.0, 2.0, 3.0]),
+                mu=0.5,
+                theta=jnp.array([1.0, 2.0, 3.0]),
                 L=jnp.array([1.0, 2.0, 3.0, 4.0]),  # flat, not (2, 2)
-                p=jnp.array([0.2, 0.3, 0.5]))
+                p=jnp.array([0.2, 0.3, 0.5]),
+            )
 
     def test_keyword_form_equals_positional(self, structured_model):
         # Both forms route through the same _pack_value, so this guards the
@@ -374,12 +404,14 @@ class TestStanModelParameters:
         # is validated by test_pack_value_assembles_column_major and
         # test_param_blocks_match_real_names. 0.25/0.25/0.5 are exact in float32,
         # so the simplex sums to 1 and BridgeStan's param_unconstrain accepts it.
-        kw = dict(mu=0.5, theta=jnp.array([0.1, 0.2, 0.3]),
-                  L=jnp.array([[1.0, 2.0], [3.0, 4.0]]),
-                  p=jnp.array([0.25, 0.25, 0.5]))
+        kw = dict(
+            mu=0.5,
+            theta=jnp.array([0.1, 0.2, 0.3]),
+            L=jnp.array([[1.0, 2.0], [3.0, 4.0]]),
+            p=jnp.array([0.25, 0.25, 0.5]),
+        )
         lp_kw = float(jnp.asarray(log_prob(structured_model, **kw)))
-        lp_pos = float(jnp.asarray(
-            log_prob(structured_model, structured_model._pack_value(**kw))))
+        lp_pos = float(jnp.asarray(log_prob(structured_model, structured_model._pack_value(**kw))))
         np.testing.assert_allclose(lp_kw, lp_pos, atol=1e-6)
 
 
@@ -388,8 +420,7 @@ class TestUnconstrainedStanView:
     simplex appears with one fewer dimension than in the constrained model."""
 
     def test_name_with_base(self, structured_model):
-        assert structured_model.as_unconstrained_distribution().name == \
-            "structured_unconstrained"
+        assert structured_model.as_unconstrained_distribution().name == "structured_unconstrained"
 
     def test_name_without_base(self, conjugate_stan_file):
         model = StanModel(conjugate_stan_file, data={"N": 3, "y": [1.0, 2.0, 3.0]})
@@ -414,8 +445,7 @@ class TestUnconstrainedStanView:
         x = jnp.zeros(view.event_shape)
         lp = view._log_prob(x)
         assert jnp.isfinite(lp)
-        np.testing.assert_allclose(
-            float(view._unnormalized_log_prob(x)), float(lp), atol=1e-6)
+        np.testing.assert_allclose(float(view._unnormalized_log_prob(x)), float(lp), atol=1e-6)
 
     def test_log_prob_finite_difference_in_mu(self, structured_model):
         # Exact value check: shifting the unconstrained mu coordinate by m moves
@@ -424,15 +454,15 @@ class TestUnconstrainedStanView:
         view = structured_model.as_unconstrained_distribution()
         x0 = jnp.zeros(view.event_shape)
         for m in (0.5, 1.0):
-            delta = (float(view._log_prob(x0.at[0].set(m)))
-                     - float(view._log_prob(x0)))
+            delta = float(view._log_prob(x0.at[0].set(m))) - float(view._log_prob(x0))
             np.testing.assert_allclose(delta, -0.5 * m**2, atol=1e-5)
 
     def test_prob_is_exp_log_prob(self, structured_model):
         view = structured_model.as_unconstrained_distribution()
         x = jnp.zeros(view.event_shape)
         np.testing.assert_allclose(
-            float(view._prob(x)), float(jnp.exp(view._log_prob(x))), rtol=1e-6)
+            float(view._prob(x)), float(jnp.exp(view._log_prob(x))), rtol=1e-6
+        )
 
     def test_repr(self, structured_model):
         r = repr(structured_model.as_unconstrained_distribution())
@@ -446,9 +476,7 @@ class TestStanModelConditionOn:
         (the registry is patched, so no actual MCMC runs)."""
         from probpipe import condition_on
 
-        with patch(
-            "probpipe.inference._registry.inference_method_registry.execute"
-        ) as mock_exec:
+        with patch("probpipe.inference._registry.inference_method_registry.execute") as mock_exec:
             mock_exec.return_value = MagicMock()
             condition_on(conjugate_model, {"y": [1, 2, 3]}, num_results=10)
             mock_exec.assert_called_once()

--- a/tests/record/test_design.py
+++ b/tests/record/test_design.py
@@ -53,10 +53,12 @@ class TestFullFactorial:
         """
         ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
         np.testing.assert_allclose(
-            np.asarray(ff["r"]), [1.5, 1.5, 1.8, 1.8, 2.0, 2.0],
+            np.asarray(ff["r"]),
+            [1.5, 1.5, 1.8, 1.8, 2.0, 2.0],
         )
         np.testing.assert_allclose(
-            np.asarray(ff["K"]), [60., 80., 60., 80., 60., 80.],
+            np.asarray(ff["K"]),
+            [60.0, 80.0, 60.0, 80.0, 60.0, 80.0],
         )
 
     def test_single_marginal_edge_case(self):
@@ -71,7 +73,8 @@ class TestFullFactorial:
         """String marginals produce ``dtype=object`` columns; the
         design falls back to the permissive ``RecordArray`` base."""
         ff = FullFactorialDesign(
-            method=["nutpie", "pymc"], scale=[0.5, 1.0],
+            method=["nutpie", "pymc"],
+            scale=[0.5, 1.0],
         )
         assert isinstance(ff, RecordArray)
         assert not isinstance(ff, NumericRecordArray)
@@ -79,12 +82,15 @@ class TestFullFactorial:
         # Insertion order: method outer, scale inner.
         assert list(ff["method"]) == ["nutpie", "nutpie", "pymc", "pymc"]
         np.testing.assert_allclose(
-            np.asarray(ff["scale"]), [0.5, 1.0, 0.5, 1.0],
+            np.asarray(ff["scale"]),
+            [0.5, 1.0, 0.5, 1.0],
         )
 
     def test_three_axes_shape_and_count(self):
         ff = FullFactorialDesign(
-            a=[1, 2, 3], b=[10, 20], c=[100, 200, 300, 400],
+            a=[1, 2, 3],
+            b=[10, 20],
+            c=[100, 200, 300, 400],
         )
         assert ff.batch_shape == (3 * 2 * 4,)
 
@@ -216,16 +222,20 @@ class TestDesignAsSweep:
 
         @workflow_function
         def label(p: Record):
-            return f'{p["method"]}-{float(p["scale"]):.1f}'
+            return f"{p['method']}-{float(p['scale']):.1f}"
 
         ff = FullFactorialDesign(
-            method=["nutpie", "pymc"], scale=[0.5, 1.0],
+            method=["nutpie", "pymc"],
+            scale=[0.5, 1.0],
         )
         out = label(p=ff)
         assert isinstance(out, RecordArray)
         assert out.batch_shape == (4,)
         assert list(out["label"]) == [
-            "nutpie-0.5", "nutpie-1.0", "pymc-0.5", "pymc-1.0",
+            "nutpie-0.5",
+            "nutpie-1.0",
+            "pymc-0.5",
+            "pymc-1.0",
         ]
 
 
@@ -241,6 +251,7 @@ class TestSelectAll:
         ``WorkflowFunction`` zip rather than cartesian-product — the
         mechanism behind ``f(**design.select_all()) ≡ f(p=design)``."""
         from probpipe.core._record_array import _RecordArrayView
+
         ff = FullFactorialDesign(r=[1.5, 1.8], K=[60.0, 80.0])
         cols = ff.select_all()
         assert set(cols) == {"r", "K"}

--- a/tests/test_binary_registry.py
+++ b/tests/test_binary_registry.py
@@ -27,14 +27,18 @@ from probpipe.core._registry import (
 # Synthetic type hierarchy for dispatch tests
 # ---------------------------------------------------------------------------
 
+
 class Left:
     pass
+
 
 class LeftSub(Left):
     pass
 
+
 class Right:
     pass
+
 
 class RightSub(Right):
     pass
@@ -43,6 +47,7 @@ class RightSub(Right):
 # ---------------------------------------------------------------------------
 # Stub binary method
 # ---------------------------------------------------------------------------
+
 
 class FakeBinaryMethod(BinaryDispatchMethod):
     """Configurable stub for binary-registry tests."""
@@ -85,8 +90,8 @@ class FakeBinaryMethod(BinaryDispatchMethod):
 # Class hierarchy
 # ---------------------------------------------------------------------------
 
-class TestPublicAPI:
 
+class TestPublicAPI:
     def test_unary_is_subclass_of_base_method(self):
         assert issubclass(UnaryDispatchMethod, BaseDispatchMethod)
 
@@ -101,12 +106,20 @@ class TestPublicAPI:
 
     def test_default_priority_is_opt_in_only(self):
         """BaseDispatchMethod.priority defaults to OPT_IN_ONLY_PRIORITY."""
+
         class Bare(BinaryDispatchMethod):
             @property
-            def name(self): return "bare"
-            def supported_types(self): return ((object,), (object,))
-            def check(self, *a, **kw): return MethodInfo(feasible=True)
-            def execute(self, *a, **kw): return "ran"
+            def name(self):
+                return "bare"
+
+            def supported_types(self):
+                return ((object,), (object,))
+
+            def check(self, *a, **kw):
+                return MethodInfo(feasible=True)
+
+            def execute(self, *a, **kw):
+                return "ran"
 
         assert Bare().priority == OPT_IN_ONLY_PRIORITY
 
@@ -115,8 +128,8 @@ class TestPublicAPI:
 # BinaryDispatchRegistry — basic registration and dispatch
 # ---------------------------------------------------------------------------
 
-class TestBinaryDispatchRegistry:
 
+class TestBinaryDispatchRegistry:
     def test_register_and_list(self):
         reg = BinaryDispatchRegistry()
         reg.register(FakeBinaryMethod("low", priority=10))
@@ -143,9 +156,11 @@ class TestBinaryDispatchRegistry:
 
     def test_execute_dispatches_on_joint_types(self):
         reg = BinaryDispatchRegistry()
-        reg.register(FakeBinaryMethod(
-            "lr", left_types=(Left,), right_types=(Right,), priority=10, result="lr"
-        ))
+        reg.register(
+            FakeBinaryMethod(
+                "lr", left_types=(Left,), right_types=(Right,), priority=10, result="lr"
+            )
+        )
         assert reg.execute(Left(), Right()) == "lr"
 
     def test_execute_by_name_override(self):
@@ -171,9 +186,7 @@ class TestBinaryDispatchRegistry:
 
     def test_check_returns_feasible_for_matching_types(self):
         reg = BinaryDispatchRegistry()
-        reg.register(FakeBinaryMethod(
-            "m", left_types=(Left,), right_types=(Right,), priority=10
-        ))
+        reg.register(FakeBinaryMethod("m", left_types=(Left,), right_types=(Right,), priority=10))
         info = reg.check(Left(), Right())
         assert info.feasible
 
@@ -193,37 +206,37 @@ class TestBinaryDispatchRegistry:
 # Type pre-filter: subclass matching and both-slot requirement
 # ---------------------------------------------------------------------------
 
-class TestTypePreFilter:
 
+class TestTypePreFilter:
     def test_subclass_matches_left(self):
         """A method supporting Left also fires for LeftSub (subclass of Left)."""
         reg = BinaryDispatchRegistry()
-        reg.register(FakeBinaryMethod(
-            "m", left_types=(Left,), right_types=(Right,), priority=10, result="ok"
-        ))
+        reg.register(
+            FakeBinaryMethod(
+                "m", left_types=(Left,), right_types=(Right,), priority=10, result="ok"
+            )
+        )
         assert reg.execute(LeftSub(), Right()) == "ok"
 
     def test_subclass_matches_right(self):
         reg = BinaryDispatchRegistry()
-        reg.register(FakeBinaryMethod(
-            "m", left_types=(Left,), right_types=(Right,), priority=10, result="ok"
-        ))
+        reg.register(
+            FakeBinaryMethod(
+                "m", left_types=(Left,), right_types=(Right,), priority=10, result="ok"
+            )
+        )
         assert reg.execute(Left(), RightSub()) == "ok"
 
     def test_wrong_left_type_excluded(self):
         """A method does not fire when the left arg type does not match."""
         reg = BinaryDispatchRegistry()
-        reg.register(FakeBinaryMethod(
-            "m", left_types=(Left,), right_types=(Right,), priority=10
-        ))
+        reg.register(FakeBinaryMethod("m", left_types=(Left,), right_types=(Right,), priority=10))
         with pytest.raises(TypeError):
             reg.execute(Right(), Right())  # Right is not a subclass of Left
 
     def test_wrong_right_type_excluded(self):
         reg = BinaryDispatchRegistry()
-        reg.register(FakeBinaryMethod(
-            "m", left_types=(Left,), right_types=(Right,), priority=10
-        ))
+        reg.register(FakeBinaryMethod("m", left_types=(Left,), right_types=(Right,), priority=10))
         with pytest.raises(TypeError):
             reg.execute(Left(), Left())  # Left is not a subclass of Right
 
@@ -245,6 +258,7 @@ class TestTypePreFilter:
 # ---------------------------------------------------------------------------
 # Opt-in-only priority (OPT_IN_ONLY_PRIORITY = 0)
 # ---------------------------------------------------------------------------
+
 
 class TestOptInOnlyPriority:
     """Priority 0 = opt-in only: skipped during auto-dispatch."""
@@ -287,8 +301,8 @@ class TestOptInOnlyPriority:
 # set_priorities
 # ---------------------------------------------------------------------------
 
-class TestSetPriorities:
 
+class TestSetPriorities:
     def test_reorders_methods(self):
         reg = BinaryDispatchRegistry()
         reg.register(FakeBinaryMethod("a", priority=10))
@@ -334,8 +348,8 @@ class TestSetPriorities:
 # Cache invalidation
 # ---------------------------------------------------------------------------
 
-class TestCacheInvalidation:
 
+class TestCacheInvalidation:
     def test_cache_invalidated_on_register(self):
         """A method registered after a dispatch call is still found."""
         reg = BinaryDispatchRegistry()
@@ -361,6 +375,7 @@ class TestCacheInvalidation:
 # ---------------------------------------------------------------------------
 # Argument-count guards on check / execute
 # ---------------------------------------------------------------------------
+
 
 class TestArgumentCountGuards:
     """No-arg and single-arg dispatch must fail with a clear error."""
@@ -393,8 +408,8 @@ class TestArgumentCountGuards:
 # Registration guards
 # ---------------------------------------------------------------------------
 
-class TestRegistrationGuards:
 
+class TestRegistrationGuards:
     def test_empty_name_rejected(self):
         reg = BinaryDispatchRegistry()
         with pytest.raises(ValueError, match="non-empty"):

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -353,7 +353,10 @@ class TestCovarianceRequiresProtocol:
 
             def _expectation(self, f, *, key=None, num_evaluations=None, return_dist=None):
                 return _mc_expectation(
-                    self, f, key=key, num_evaluations=num_evaluations,
+                    self,
+                    f,
+                    key=key,
+                    num_evaluations=num_evaluations,
                     return_dist=return_dist,
                 )
 

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -45,8 +45,7 @@ def _run_x64(snippet: str) -> str:
     )
     if result.returncode != 0:
         raise AssertionError(
-            f"x64 subprocess failed:\nSTDOUT:\n{result.stdout}\n"
-            f"STDERR:\n{result.stderr}"
+            f"x64 subprocess failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
     return result.stdout.strip()
 

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -23,6 +23,7 @@ from probpipe._weights import (
 # _validate_to_log_weights
 # ---------------------------------------------------------------------------
 
+
 class TestValidation:
     def test_uniform(self):
         log_w, is_uniform = _validate_to_log_weights(5)
@@ -30,16 +31,12 @@ class TestValidation:
         assert is_uniform is True
 
     def test_from_weights(self):
-        log_w, is_uniform = _validate_to_log_weights(
-            3, weights=jnp.array([1.0, 2.0, 1.0])
-        )
+        log_w, is_uniform = _validate_to_log_weights(3, weights=jnp.array([1.0, 2.0, 1.0]))
         assert is_uniform is False
         assert log_w.shape == (3,)
 
     def test_from_log_weights(self):
-        log_w, is_uniform = _validate_to_log_weights(
-            3, log_weights=jnp.array([-1.0, 0.0, -1.0])
-        )
+        log_w, is_uniform = _validate_to_log_weights(3, log_weights=jnp.array([-1.0, 0.0, -1.0]))
         assert is_uniform is False
         npt.assert_allclose(log_w, jnp.array([-1.0, 0.0, -1.0]))
 
@@ -64,38 +61,29 @@ class TestValidation:
 
     def test_negative_weights(self):
         with pytest.raises(ValueError, match="non-negative"):
-            _validate_to_log_weights(
-                3, weights=jnp.array([1.0, -1.0, 1.0])
-            )
+            _validate_to_log_weights(3, weights=jnp.array([1.0, -1.0, 1.0]))
 
     def test_zero_sum_weights(self):
         with pytest.raises(ValueError, match="positive"):
-            _validate_to_log_weights(
-                3, weights=jnp.zeros(3)
-            )
+            _validate_to_log_weights(3, weights=jnp.zeros(3))
 
     def test_log_weights_shape_mismatch(self):
         with pytest.raises(ValueError, match="shape"):
-            _validate_to_log_weights(
-                3, log_weights=jnp.zeros(5)
-            )
+            _validate_to_log_weights(3, log_weights=jnp.zeros(5))
 
     def test_log_weights_all_negative_infinity_rejected(self):
         with pytest.raises(ValueError, match="positive finite"):
-            _validate_to_log_weights(
-                3, log_weights=jnp.full(3, -jnp.inf)
-            )
+            _validate_to_log_weights(3, log_weights=jnp.full(3, -jnp.inf))
 
     def test_log_weights_nan_rejected(self):
         with pytest.raises(ValueError, match="NaN"):
-            _validate_to_log_weights(
-                3, log_weights=jnp.array([0.0, jnp.nan, -1.0])
-            )
+            _validate_to_log_weights(3, log_weights=jnp.array([0.0, jnp.nan, -1.0]))
 
 
 # ---------------------------------------------------------------------------
 # Utility functions
 # ---------------------------------------------------------------------------
+
 
 class TestUtilities:
     def test_normalize_weights(self):
@@ -185,6 +173,7 @@ class TestWeightedChoice:
 # Weights class
 # ---------------------------------------------------------------------------
 
+
 class TestWeightsConstruction:
     def test_uniform_via_n(self):
         w = Weights(n=5)
@@ -266,9 +255,7 @@ class TestWeightsProperties:
     def test_log_normalized(self):
         w = Weights(log_weights=jnp.array([-1.0, 0.0, -1.0]))
         log_n = w.log_normalized
-        npt.assert_allclose(
-            jax.scipy.special.logsumexp(log_n), 0.0, atol=1e-6
-        )
+        npt.assert_allclose(jax.scipy.special.logsumexp(log_n), 0.0, atol=1e-6)
 
     def test_ess_uniform(self):
         w = Weights(n=10)
@@ -497,30 +484,36 @@ class TestWeightsEquality:
 # Factory dispatch tests
 # ---------------------------------------------------------------------------
 
+
 class TestFactoryDispatch:
     def test_empirical_numeric_returns_array_variant(self):
         from probpipe import EmpiricalDistribution, RecordEmpiricalDistribution
+
         dist = EmpiricalDistribution(jnp.array([1.0, 2.0, 3.0]), name="x")
         assert isinstance(dist, RecordEmpiricalDistribution)
 
     def test_empirical_numpy_numeric_returns_array_variant(self):
         from probpipe import EmpiricalDistribution, RecordEmpiricalDistribution
+
         dist = EmpiricalDistribution(np.array([1.0, 2.0, 3.0]), name="x")
         assert isinstance(dist, RecordEmpiricalDistribution)
 
     def test_empirical_object_stays_generic(self):
         from probpipe import EmpiricalDistribution, RecordEmpiricalDistribution
+
         dist = EmpiricalDistribution(["hello", "world"], name="x")
         assert not isinstance(dist, RecordEmpiricalDistribution)
         assert isinstance(dist, EmpiricalDistribution)
 
     def test_empirical_numpy_object_stays_generic(self):
         from probpipe import EmpiricalDistribution, RecordEmpiricalDistribution
+
         dist = EmpiricalDistribution(np.array(["a", "b"], dtype=object), name="x")
         assert not isinstance(dist, RecordEmpiricalDistribution)
 
     def test_bootstrap_numeric_returns_array_variant(self):
         from probpipe import BootstrapReplicateDistribution, RecordBootstrapReplicateDistribution
+
         dist = BootstrapReplicateDistribution(jnp.ones((5, 2)), name="x")
         assert isinstance(dist, RecordBootstrapReplicateDistribution)
 
@@ -530,17 +523,20 @@ class TestFactoryDispatch:
             BootstrapReplicateDistribution,
             RecordBootstrapReplicateDistribution,
         )
+
         emp = EmpiricalDistribution(jnp.ones((5, 2)), name="x")
         dist = BootstrapReplicateDistribution(emp, name="x")
         assert isinstance(dist, RecordBootstrapReplicateDistribution)
 
     def test_bootstrap_object_stays_generic(self):
         from probpipe import BootstrapReplicateDistribution, RecordBootstrapReplicateDistribution
+
         dist = BootstrapReplicateDistribution(["a", "b", "c"], name="x")
         assert not isinstance(dist, RecordBootstrapReplicateDistribution)
 
     def test_subclass_not_redirected(self):
         from probpipe import RecordEmpiricalDistribution
+
         dist = RecordEmpiricalDistribution(jnp.array([1.0, 2.0, 3.0]), name="x")
         assert type(dist) is RecordEmpiricalDistribution
 
@@ -549,9 +545,11 @@ class TestFactoryDispatch:
 # sample_shape tests
 # ---------------------------------------------------------------------------
 
+
 class TestSampleShape:
     def test_default_single_axis(self):
         from probpipe import RecordEmpiricalDistribution
+
         samples = jnp.ones((100, 3))
         dist = RecordEmpiricalDistribution(samples, name="x")
         assert dist.num_atoms == 100
@@ -559,6 +557,7 @@ class TestSampleShape:
 
     def test_explicit_1d_sample_shape(self):
         from probpipe import RecordEmpiricalDistribution
+
         samples = jnp.ones((100, 3))
         dist = RecordEmpiricalDistribution(samples, sample_shape=(100,), name="x")
         assert dist.num_atoms == 100
@@ -566,6 +565,7 @@ class TestSampleShape:
 
     def test_2d_sample_shape(self):
         from probpipe import RecordEmpiricalDistribution
+
         samples = jnp.ones((10, 5, 3))
         dist = RecordEmpiricalDistribution(samples, sample_shape=(10, 5), name="x")
         assert dist.num_atoms == 50
@@ -573,12 +573,14 @@ class TestSampleShape:
 
     def test_sample_shape_mismatch_raises(self):
         from probpipe import RecordEmpiricalDistribution
+
         samples = jnp.ones((10, 3))
         with pytest.raises(ValueError, match="do not match"):
             RecordEmpiricalDistribution(samples, sample_shape=(20,), name="x")
 
     def test_moments_with_sample_shape(self):
         from probpipe import RecordEmpiricalDistribution, mean, variance
+
         key = jax.random.PRNGKey(0)
         samples = jax.random.normal(key, (10, 5, 2))
         dist = RecordEmpiricalDistribution(samples, sample_shape=(10, 5), name="x")

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -20,6 +20,7 @@ from probpipe.validation._predictive_check import (
 # Helper: JAX-based generative likelihood
 # ---------------------------------------------------------------------------
 
+
 class PoissonLikelihood:
     """Poisson regression: y_i ~ Poisson(exp(beta_0 + beta_1 * x_i))."""
 
@@ -41,6 +42,7 @@ class PoissonLikelihood:
 # Helper: non-JAX generative likelihood (plain numpy/Python)
 # ---------------------------------------------------------------------------
 
+
 class NumpyGaussianLikelihood:
     """Gaussian likelihood using only numpy — no JAX dependency in data gen."""
 
@@ -59,6 +61,7 @@ class NumpyGaussianLikelihood:
 # ---------------------------------------------------------------------------
 # Helper: non-numeric generative likelihood (lists of strings)
 # ---------------------------------------------------------------------------
+
 
 class CategoricalLikelihood:
     """Generative likelihood that produces lists of category labels."""
@@ -83,6 +86,7 @@ class CategoricalLikelihood:
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def prior():
     return MultivariateNormal(loc=jnp.zeros(2), cov=jnp.eye(2), name="beta")
@@ -96,32 +100,35 @@ def likelihood():
 
 @pytest.fixture
 def observed_data():
-    return jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1,
-                       0, 2, 6, 1, 3, 2, 0, 4, 1, 3])
+    return jnp.array([2, 1, 3, 0, 5, 1, 2, 4, 3, 1, 0, 2, 6, 1, 3, 2, 0, 4, 1, 3])
 
 
 # ---------------------------------------------------------------------------
 # Tests — JAX-based (existing)
 # ---------------------------------------------------------------------------
 
+
 class TestPredictiveCheck:
     """Tests for the predictive_check WorkflowFunction."""
 
     def test_prior_check_returns_replicated_statistics(self, prior, likelihood):
         result = predictive_check(
-            prior, likelihood, test_fn=lambda d: float(jnp.mean(d)),
-            num_observations=20, num_replications=50, key=jax.random.PRNGKey(0),
+            prior,
+            likelihood,
+            test_fn=lambda d: float(jnp.mean(d)),
+            num_observations=20,
+            num_replications=50,
+            key=jax.random.PRNGKey(0),
         )
         assert "replicated_statistics" in result
         assert result["replicated_statistics"].num_atoms == 50
         assert "observed_statistic" not in result
         assert "p_value" not in result
 
-    def test_posterior_check_returns_p_value(
-        self, prior, likelihood, observed_data
-    ):
+    def test_posterior_check_returns_p_value(self, prior, likelihood, observed_data):
         result = predictive_check(
-            prior, likelihood,
+            prior,
+            likelihood,
             test_fn=lambda d: float(jnp.mean(d)),
             observed_data=observed_data,
             num_replications=100,
@@ -133,12 +140,11 @@ class TestPredictiveCheck:
         assert 0.0 <= result["p_value"] <= 1.0
         assert result["replicated_statistics"].num_atoms == 100
 
-    def test_num_observations_inferred_from_observed(
-        self, prior, likelihood, observed_data
-    ):
+    def test_num_observations_inferred_from_observed(self, prior, likelihood, observed_data):
         """When observed_data is provided, num_observations defaults to len(observed_data)."""
         result = predictive_check(
-            prior, likelihood,
+            prior,
+            likelihood,
             test_fn=lambda d: float(jnp.var(d)),
             observed_data=observed_data,
             num_replications=20,
@@ -149,17 +155,20 @@ class TestPredictiveCheck:
     def test_num_observations_required_without_observed(self, prior, likelihood):
         with pytest.raises(ValueError, match="num_observations is required"):
             predictive_check(
-                prior, likelihood,
+                prior,
+                likelihood,
                 test_fn=lambda d: float(jnp.mean(d)),
                 num_replications=10,
             )
 
     def test_is_workflow_function(self):
         from probpipe.core.node import WorkflowFunction
+
         assert isinstance(predictive_check, WorkflowFunction)
 
     def test_importable_from_top_level(self):
         from probpipe import predictive_check as pc
+
         assert callable(pc)
 
     def test_importable_from_subpackage(self):
@@ -171,9 +180,11 @@ class TestPredictiveCheck:
         assert prior.auxiliary is None or "predictive_check" not in prior.auxiliary
 
         predictive_check(
-            prior, likelihood,
+            prior,
+            likelihood,
             test_fn=lambda d: float(jnp.mean(d)),
-            num_observations=20, num_replications=10,
+            num_observations=20,
+            num_replications=10,
             key=jax.random.PRNGKey(10),
         )
         group = prior.auxiliary["predictive_check"]
@@ -183,23 +194,30 @@ class TestPredictiveCheck:
         assert check_ds.attrs["test_fn_name"]
 
     def test_multiple_checks_accumulate_in_auxiliary(
-        self, prior, likelihood, observed_data,
+        self,
+        prior,
+        likelihood,
+        observed_data,
     ):
         """Multiple predictive_check calls accumulate as ``check_N`` siblings."""
-        group = prior.auxiliary["predictive_check"] if (
-            prior.auxiliary is not None and "predictive_check" in prior.auxiliary
-        ) else None
+        group = (
+            prior.auxiliary["predictive_check"]
+            if (prior.auxiliary is not None and "predictive_check" in prior.auxiliary)
+            else None
+        )
         n_before = len(list(group.children)) if group is not None else 0
 
         predictive_check(
-            prior, likelihood,
+            prior,
+            likelihood,
             test_fn=lambda d: float(jnp.mean(d)),
             observed_data=observed_data,
             num_replications=10,
             key=jax.random.PRNGKey(20),
         )
         predictive_check(
-            prior, likelihood,
+            prior,
+            likelihood,
             test_fn=lambda d: float(jnp.var(d)),
             observed_data=observed_data,
             num_replications=10,
@@ -215,9 +233,11 @@ class TestPredictiveCheck:
             return float(jnp.max(data))
 
         predictive_check(
-            prior, likelihood,
+            prior,
+            likelihood,
             test_fn=my_custom_stat,
-            num_observations=20, num_replications=10,
+            num_observations=20,
+            num_replications=10,
             key=jax.random.PRNGKey(30),
         )
         group = prior.auxiliary["predictive_check"]
@@ -226,7 +246,9 @@ class TestPredictiveCheck:
         assert last.attrs["test_fn_name"] == "my_custom_stat"
 
     def test_frozen_distribution_skips_attachment_silently(
-        self, prior, likelihood,
+        self,
+        prior,
+        likelihood,
     ):
         """Distributions that disallow post-construction attribute
         writes (e.g., a custom subclass with ``__slots__`` that
@@ -295,6 +317,7 @@ class TestPredictiveCheck:
 # Tests — non-JAX data types
 # ---------------------------------------------------------------------------
 
+
 class TestPredictiveCheckNonJax:
     """predictive_check should work with non-JAX data types."""
 
@@ -305,7 +328,8 @@ class TestPredictiveCheckNonJax:
         observed = np.array([1.2, 0.8, 1.5, 0.3, 1.1])
 
         result = predictive_check(
-            prior, lik,
+            prior,
+            lik,
             test_fn=lambda d: float(np.mean(d)),
             observed_data=observed,
             num_replications=100,
@@ -322,7 +346,8 @@ class TestPredictiveCheckNonJax:
         lik = NumpyGaussianLikelihood(rng_seed=7)
 
         result = predictive_check(
-            prior, lik,
+            prior,
+            lik,
             test_fn=lambda d: float(np.std(d)),
             num_observations=50,
             num_replications=30,
@@ -339,14 +364,14 @@ class TestPredictiveCheckNonJax:
             name="logits",
         )
         lik = CategoricalLikelihood(rng_seed=99)
-        observed = ["cat", "dog", "cat", "fish", "cat",
-                     "dog", "cat", "cat", "fish", "cat"]
+        observed = ["cat", "dog", "cat", "fish", "cat", "dog", "cat", "cat", "fish", "cat"]
 
         def cat_fraction(data):
             return sum(1 for x in data if x == "cat") / len(data)
 
         result = predictive_check(
-            prior, lik,
+            prior,
+            lik,
             test_fn=cat_fraction,
             observed_data=observed,
             num_replications=50,
@@ -363,7 +388,8 @@ class TestPredictiveCheckNonJax:
         lik = NumpyGaussianLikelihood(rng_seed=11)
 
         result = predictive_check(
-            dist, lik,
+            dist,
+            lik,
             test_fn=lambda d: float(np.mean(d)),
             num_observations=10,
             num_replications=20,
@@ -375,6 +401,7 @@ class TestPredictiveCheckNonJax:
 # ---------------------------------------------------------------------------
 # Tests — batched fast path
 # ---------------------------------------------------------------------------
+
 
 class TestPredictiveCheckBatched:
     """Tests for the vectorized (batched) predictive check path."""
@@ -399,7 +426,8 @@ class TestPredictiveCheckBatched:
         """GLMLikelihood triggers the batched path and produces correct results."""
         prior, lik = glm_setup
         result = predictive_check(
-            prior, lik,
+            prior,
+            lik,
             test_fn=lambda d: jnp.mean(d),
             num_observations=20,
             num_replications=50,
@@ -412,7 +440,8 @@ class TestPredictiveCheckBatched:
         prior, lik = glm_setup
         observed = jnp.ones(20, dtype=jnp.float32) * 2
         result = predictive_check(
-            prior, lik,
+            prior,
+            lik,
             test_fn=lambda d: jnp.mean(d),
             observed_data=observed,
             num_replications=100,
@@ -433,7 +462,8 @@ class TestPredictiveCheckBatched:
             return -val
 
         result = predictive_check(
-            prior, lik,
+            prior,
+            lik,
             test_fn=non_vmapable,
             num_observations=20,
             num_replications=30,
@@ -444,7 +474,8 @@ class TestPredictiveCheckBatched:
     def test_loop_path_for_plain_likelihood(self, prior, likelihood):
         """PoissonLikelihood (no key arg) uses the loop path."""
         result = predictive_check(
-            prior, likelihood,
+            prior,
+            likelihood,
             test_fn=lambda d: float(jnp.mean(d)),
             num_observations=20,
             num_replications=30,


### PR DESCRIPTION
## Summary

Adopt **`ruff format`** (Black-style) as the code formatter, replacing the
manual horizontal-packing conventions. Formatting is now enforced rather than
hand-maintained.

## Two commits

1. **`9946d1e` — the mechanical sweep.** Configure `[tool.ruff.format]` and run
   `ruff format .` across the tree (**153 files**). Pure formatting, no behavior
   change; recorded in `.git-blame-ignore-revs` so `git blame` skips it. Review
   the *second* commit closely and spot-check this one.
2. **policy wiring** — blocking CI check + pre-commit hook + docs.

## What changed

- **Config** (`[tool.ruff.format]`): double quotes; line length 100 (unchanged);
  **notebooks excluded** so the docs' tutorial cells keep their compact,
  hand-curated layout (they are still linted).
- **CI**: a **blocking** `ruff format --check` step in the lint job (renamed
  "lint & format"). `ruff check` (lint) stays advisory as before.
- **pre-commit**: a `ruff-format` hook (reformats on commit).
- **Docs**: rewrote CONTRIBUTING § Code formatting (now "run `ruff format`; don't
  hand-format") and flipped the "`ruff format` is not used" notes (CONTRIBUTING +
  the pre-commit comment). CHANGELOG entry under Changed.

## Behavior note

ruff/Black keep code on one line when it fits within 100 chars and explode
imports / call arguments **one-item-per-line** when it doesn't — the inverse of
the old hand-packed wrapping. That trade is the point of adopting an autoformatter.

## Test plan

- `ruff format --check .` is clean across the reformatted tree.
- `import probpipe` works; the sweep is formatting-only (no semantic change). CI
  runs the full suite.
- The pre-commit config validates; CI runs the new blocking format check.

(The maintainer's global formatting guidance was also updated to defer to an
autoformatter when a project uses one — a personal-config change outside this repo.)
