### PR TITLE
style: apply safe ruff check --fix autofixes (lint backlog 588 → 263)

### DIFF
--- a/example_scripts/run_prefect_demo.py
+++ b/example_scripts/run_prefect_demo.py
@@ -36,27 +36,25 @@ import numpy as np
 import pandas as pd
 import tensorflow_probability.substrates.jax.glm as tfp_glm
 
+# ---------------------------------------------------------------------------
+# 1. Configure Prefect globally
+# ---------------------------------------------------------------------------
+from prefect.task_runners import ThreadPoolTaskRunner
+
 import probpipe
 from probpipe import (
-    Record,
+    BootstrapReplicateDistribution,
+    EmpiricalDistribution,
+    GLMLikelihood,
     Normal,
     ProductDistribution,
-    EmpiricalDistribution,
-    BootstrapReplicateDistribution,
-    GLMLikelihood,
+    Record,
     SimpleModel,
     WorkflowKind,
     condition_on,
     mean,
     workflow_function,
 )
-
-
-# ---------------------------------------------------------------------------
-# 1. Configure Prefect globally
-# ---------------------------------------------------------------------------
-
-from prefect.task_runners import ThreadPoolTaskRunner
 
 probpipe.prefect_config.workflow_kind = WorkflowKind.TASK
 probpipe.prefect_config.task_runner = ThreadPoolTaskRunner()

--- a/example_scripts/run_ray_demo.py
+++ b/example_scripts/run_ray_demo.py
@@ -67,27 +67,25 @@ import numpy as np
 import pandas as pd
 import tensorflow_probability.substrates.jax.glm as tfp_glm
 
+# ---------------------------------------------------------------------------
+# 1. Configure Prefect to use RayTaskRunner
+# ---------------------------------------------------------------------------
+from prefect_ray import RayTaskRunner
+
 import probpipe
 from probpipe import (
-    Record,
+    BootstrapReplicateDistribution,
+    EmpiricalDistribution,
+    GLMLikelihood,
     Normal,
     ProductDistribution,
-    EmpiricalDistribution,
-    BootstrapReplicateDistribution,
-    GLMLikelihood,
+    Record,
     SimpleModel,
     WorkflowKind,
     condition_on,
     mean,
     workflow_function,
 )
-
-
-# ---------------------------------------------------------------------------
-# 1. Configure Prefect to use RayTaskRunner
-# ---------------------------------------------------------------------------
-
-from prefect_ray import RayTaskRunner
 
 # ``address="auto"`` attaches to the persistent Ray head you launched with
 # ``ray start --head`` (see Usage above). Without that head, each flow would

--- a/probpipe/_array_utils.py
+++ b/probpipe/_array_utils.py
@@ -8,8 +8,9 @@ always returns a new array.
 
 from __future__ import annotations
 
-import jax.numpy as jnp
 from typing import Any
+
+import jax.numpy as jnp
 
 from .custom_types import Array, ArrayLike
 
@@ -25,7 +26,7 @@ def _as_array(x: Any) -> Array:
         raise TypeError(
             f"Could not convert input to array.\n"
             f"Input type: {type(x).__name__}\n"
-            f"Input value: {repr(x)}\n"
+            f"Input value: {x!r}\n"
             f"Original error: {e}"
         ) from e
 

--- a/probpipe/_weights.py
+++ b/probpipe/_weights.py
@@ -18,10 +18,10 @@ from .custom_types import Array, ArrayLike, PRNGKey
 
 __all__ = [
     "Weights",
+    "weighted_choice",
+    "weighted_covariance",
     "weighted_mean",
     "weighted_variance",
-    "weighted_covariance",
-    "weighted_choice",
 ]
 
 
@@ -330,7 +330,7 @@ class Weights:
     that ``-inf`` values may be present.
     """
 
-    __slots__ = ("_n", "_log_weights", "_is_uniform", "_cache")
+    __slots__ = ("_cache", "_is_uniform", "_log_weights", "_n")
 
     def __init__(
         self,

--- a/probpipe/converters/__init__.py
+++ b/probpipe/converters/__init__.py
@@ -7,17 +7,15 @@ conversion** – passing a ``@runtime_checkable`` protocol (e.g.,
 ``SupportsLogProb``) as the target to ``converter_registry.convert()``.
 """
 
+# -- register built-in converters -------------------------------------------
+from ._probpipe import ProbPipeConverter
 from ._registry import (
-    Converter,
-    ConverterRegistry,
     ConversionInfo,
     ConversionMethod,
+    Converter,
+    ConverterRegistry,
     converter_registry,
 )
-
-# -- register built-in converters -------------------------------------------
-
-from ._probpipe import ProbPipeConverter
 from ._tfp import TFPConverter
 
 converter_registry.register(ProbPipeConverter())
@@ -25,7 +23,7 @@ converter_registry.register(TFPConverter())
 
 # Optionally register scipy converter
 try:
-    from ._scipy import ScipyConverter, _HAS_SCIPY
+    from ._scipy import _HAS_SCIPY, ScipyConverter
 
     if _HAS_SCIPY:
         converter_registry.register(ScipyConverter())
@@ -34,18 +32,18 @@ except ImportError:
 
 # -- register protocol converter with built-in resolvers --------------------
 
-from ._protocol import ProtocolConverter, _resolve_target_for_log_prob
 from ..core.protocols import SupportsLogProb
+from ._protocol import ProtocolConverter, _resolve_target_for_log_prob
 
 _protocol_converter = ProtocolConverter(converter_registry)
 _protocol_converter.register_protocol_target(SupportsLogProb, _resolve_target_for_log_prob)
 converter_registry.register(_protocol_converter)
 
 __all__ = [
-    "ConverterRegistry",
     "ConversionInfo",
     "ConversionMethod",
     "Converter",
+    "ConverterRegistry",
     "ProtocolConverter",
     "converter_registry",
 ]

--- a/probpipe/converters/_probpipe.py
+++ b/probpipe/converters/_probpipe.py
@@ -14,12 +14,10 @@ Registered at priority 100 so it is always tried first for ProbPipe types.
 
 from __future__ import annotations
 
-import math
 from typing import Any
 
 import jax.numpy as jnp
 
-from ..custom_types import PRNGKey
 from .._utils import _auto_key
 from ..core.distribution import (
     Distribution,
@@ -61,8 +59,8 @@ def _point_estimate(x):
     or a single-field NumericRecord (the auto-wrap form returned by
     ``RecordEmpiricalDistribution._mean`` — numeric arrays auto-wrap
     as a single-field Record)."""
-    from ..core.distribution import BootstrapDistribution
     from ..core._numeric_record import NumericRecord
+    from ..core.distribution import BootstrapDistribution
 
     if isinstance(x, BootstrapDistribution):
         x = x._mean()

--- a/probpipe/converters/_protocol.py
+++ b/probpipe/converters/_protocol.py
@@ -12,7 +12,6 @@ from typing import Any
 
 from ._registry import ConversionInfo, ConversionMethod, Converter
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/probpipe/converters/_scipy.py
+++ b/probpipe/converters/_scipy.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import jax.numpy as jnp
 
-from .._utils import _auto_key
 from ..core.distribution import (
     NumericRecordDistribution,
     RecordEmpiricalDistribution,
@@ -31,14 +30,14 @@ except ImportError:
 def _build_scipy_to_probpipe() -> dict[type, tuple[str, callable]]:
     """Build scipy.stats type → (ProbPipe class, kwargs extractor)."""
     from ..distributions.continuous import (
-        Normal,
         Beta,
-        Gamma,
-        Exponential,
-        LogNormal,
-        Uniform,
         Cauchy,
+        Exponential,
+        Gamma,
         Laplace,
+        LogNormal,
+        Normal,
+        Uniform,
     )
 
     if not _HAS_SCIPY:

--- a/probpipe/converters/_tfp.py
+++ b/probpipe/converters/_tfp.py
@@ -11,7 +11,6 @@ from typing import Any
 import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
-from ..custom_types import PRNGKey
 from .._utils import _auto_key
 from ..core.distribution import (
     NumericRecordDistribution,
@@ -19,7 +18,6 @@ from ..core.distribution import (
 )
 from ..core.provenance import Provenance
 from ._registry import ConversionInfo, ConversionMethod, Converter
-
 
 # ---------------------------------------------------------------------------
 # TFP → ProbPipe mapping: (ProbPipe class, parameter extractor)
@@ -29,30 +27,28 @@ from ._registry import ConversionInfo, ConversionMethod, Converter
 def _build_tfp_to_probpipe() -> dict[type, tuple[str, callable]]:
     """Build mapping lazily to avoid circular imports."""
     from ..distributions.continuous import (
-        Normal,
         Beta,
-        Gamma,
-        InverseGamma,
+        Cauchy,
         Exponential,
+        Gamma,
+        HalfCauchy,
+        HalfNormal,
+        InverseGamma,
+        Laplace,
         LogNormal,
+        Normal,
+        Pareto,
         StudentT,
         Uniform,
-        Cauchy,
-        Laplace,
-        HalfNormal,
-        HalfCauchy,
-        Pareto,
     )
     from ..distributions.discrete import (
         Bernoulli,
-        Binomial,
-        Poisson,
         Categorical,
-        NegativeBinomial,
+        Poisson,
     )
     from ..distributions.multivariate import (
-        MultivariateNormal,
         Dirichlet,
+        MultivariateNormal,
     )
 
     return {

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -44,8 +44,8 @@ import numpy as np
 
 __all__ = [
     "AuxHooks",
-    "register_aux",
     "aux_for",
+    "register_aux",
 ]
 
 
@@ -146,7 +146,7 @@ def _register_xarray() -> None:
     except ImportError:
         return
 
-    def _capture(leaf: "xr.DataArray") -> dict[str, Any]:
+    def _capture(leaf: xr.DataArray) -> dict[str, Any]:
         # Capture each coord's full ``(dims, values, attrs)`` triple so
         # multi-dim coords and per-coord attrs survive the round-trip
         # — not just the values aligned with the coord's own name.
@@ -165,7 +165,7 @@ def _register_xarray() -> None:
             "name": leaf.name,
         }
 
-    def _restore(arr: jax.Array, aux: dict[str, Any]) -> "xr.DataArray":
+    def _restore(arr: jax.Array, aux: dict[str, Any]) -> xr.DataArray:
         # Rebuild each coord as a ``DataArray(values, dims=…, attrs=…)``
         # so xarray sees the original dims and attrs.
         coords = {
@@ -206,14 +206,14 @@ def _register_pandas() -> None:
     except ImportError:
         return
 
-    def _series_capture(leaf: "pd.Series") -> dict[str, Any]:
+    def _series_capture(leaf: pd.Series) -> dict[str, Any]:
         return {
             "index": leaf.index,
             "name": leaf.name,
             "dtype": leaf.dtype,
         }
 
-    def _series_restore(arr: jax.Array, aux: dict[str, Any]) -> "pd.Series":
+    def _series_restore(arr: jax.Array, aux: dict[str, Any]) -> pd.Series:
         return pd.Series(
             np.asarray(arr),
             index=aux["index"],
@@ -221,14 +221,14 @@ def _register_pandas() -> None:
             dtype=aux["dtype"],
         )
 
-    def _frame_capture(leaf: "pd.DataFrame") -> dict[str, Any]:
+    def _frame_capture(leaf: pd.DataFrame) -> dict[str, Any]:
         return {
             "index": leaf.index,
             "columns": leaf.columns,
             "dtypes": leaf.dtypes.to_dict(),
         }
 
-    def _frame_restore(arr: jax.Array, aux: dict[str, Any]) -> "pd.DataFrame":
+    def _frame_restore(arr: jax.Array, aux: dict[str, Any]) -> pd.DataFrame:
         df = pd.DataFrame(
             np.asarray(arr),
             index=aux["index"],

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -26,14 +26,13 @@ from ._empirical import (
     RecordEmpiricalDistribution,
 )
 from ._record_array import RecordArray
-from ._record_distribution import RecordDistribution
 from .protocols import (
     SupportsLogProb,
     SupportsMean,
     SupportsSampling,
     SupportsVariance,
 )
-from .record import Record, EventTemplate
+from .record import EventTemplate, Record
 
 # ---------------------------------------------------------------------------
 # MarginalizedBroadcastDistribution — output marginal of a broadcast
@@ -445,7 +444,7 @@ def _make_stack(
         aggregate types. The error lists the observed types.
     """
     from ._distribution_array import _make_distribution_array
-    from .record import Record, EventTemplate
+    from .record import Record
 
     # Resolve batch_shape vs. n. Exactly one must be provided.
     if batch_shape is None and n is None:

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -125,8 +125,8 @@ class DistributionArray[T](Distribution[T]):
     # lazily; the literal-array constructor sets it directly.
     # ``_backend`` is ``None`` for the literal path and set by
     # :meth:`_from_backend`.
-    _components: "tuple[Distribution, ...] | None"
-    _backend: "_DistributionArrayBackend | None"
+    _components: tuple[Distribution, ...] | None
+    _backend: _DistributionArrayBackend | None
 
     def __init__(
         self,
@@ -188,7 +188,7 @@ class DistributionArray[T](Distribution[T]):
         name: str,
         batch_shape: tuple[int, ...] | None = None,
         **batched_params,
-    ) -> "DistributionArray":
+    ) -> DistributionArray:
         """Construct a ``DistributionArray`` of homogeneous components.
 
         The recommended way to build a ``DistributionArray`` whose
@@ -285,7 +285,7 @@ class DistributionArray[T](Distribution[T]):
         name: str,
         batch_shape: tuple[int, ...],
         batched_params: dict,
-    ) -> "DistributionArray":
+    ) -> DistributionArray:
         """Build by constructing one ``dist_cls`` instance per cell.
 
         Used by :meth:`from_batched_params` for any ``dist_cls`` that
@@ -309,10 +309,10 @@ class DistributionArray[T](Distribution[T]):
     @classmethod
     def _from_backend(
         cls,
-        backend: "_DistributionArrayBackend",
+        backend: _DistributionArrayBackend,
         *,
         name: str | None = None,
-    ) -> "DistributionArray":
+    ) -> DistributionArray:
         """Construct a backend-delegated ``DistributionArray``.
 
         Storage refactor entry point: when a homogeneous batched form

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -9,7 +9,7 @@ Provides:
 from __future__ import annotations
 
 import copy as _copy
-from abc import ABC, abstractmethod
+from abc import ABC
 
 # ``_ProtocolMeta`` is technically private (leading underscore in
 # ``typing``), but it's the only way to compose a custom metaclass with
@@ -18,18 +18,14 @@ from abc import ABC, abstractmethod
 # ecosystem (Pydantic, attrs, etc.). If a future Python release renames
 # it, the metaclass would need to switch to whatever new base ``typing``
 # exposes; the conflict-avoidance constraint itself doesn't change.
-from typing import TYPE_CHECKING, Any, _ProtocolMeta  # noqa: PLC2701
+from typing import TYPE_CHECKING, Any, _ProtocolMeta
 
 if TYPE_CHECKING:
     from xarray import DataTree
 
     from ._distribution_array import DistributionArray
-    from .record import EventTemplate
 
-import jax
-import jax.numpy as jnp
 
-from ..custom_types import PRNGKey
 from .provenance import Provenance
 
 # ---------------------------------------------------------------------------
@@ -250,7 +246,7 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
         name: str,
         batch_shape: tuple[int, ...] | None = None,
         **batched_params,
-    ) -> "DistributionArray":
+    ) -> DistributionArray:
         """Class-method alias for :meth:`DistributionArray.from_batched_params`.
 
         Lets users write the ergonomic per-class form::

--- a/probpipe/core/_empirical.py
+++ b/probpipe/core/_empirical.py
@@ -64,7 +64,7 @@ from .protocols import (
     SupportsSampling,
     SupportsVariance,
 )
-from .record import Record, EventTemplate
+from .record import EventTemplate, Record
 
 # ---------------------------------------------------------------------------
 # Shared helpers

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -33,7 +33,7 @@ from ..custom_types import ArrayLike
 from ._array_backend import aux_for
 from .record import ArraySpec, EventTemplate, Record, _record_flatten, _spec_size
 
-__all__ = ["NumericRecord", "_is_numeric_leaf", "_NUMERIC_DTYPE_KINDS"]
+__all__ = ["_NUMERIC_DTYPE_KINDS", "NumericRecord", "_is_numeric_leaf"]
 
 
 # Scalar types accepted as numeric leaves. ``bool`` is intentionally
@@ -110,7 +110,7 @@ class NumericRecord(Record):
     ``__slots__`` + ``__setattr__`` guard on the base class.
     """
 
-    __slots__ = ("_flat_size", "_aux")
+    __slots__ = ("_aux", "_flat_size")
 
     def __init__(
         self,

--- a/probpipe/core/_numeric_record_distribution.py
+++ b/probpipe/core/_numeric_record_distribution.py
@@ -39,8 +39,9 @@ express a vectorized batch of structured random variables.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from math import prod
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .record import NumericEventTemplate
@@ -50,7 +51,7 @@ import jax.numpy as jnp
 
 from .._dtype import _as_float_array
 from .._utils import _auto_key
-from .._weights import Weights, weighted_mean, weighted_variance
+from .._weights import Weights
 from ..custom_types import Array, ArrayLike, PRNGKey
 from . import _distribution_base as _base
 from ._distribution_base import Distribution
@@ -75,7 +76,7 @@ from .protocols import (
 
 
 def _vmap_sample(
-    dist: "NumericRecordDistribution",
+    dist: NumericRecordDistribution,
     key: PRNGKey,
     sample_shape: tuple[int, ...] = (),
 ) -> Any:
@@ -112,7 +113,7 @@ def _vmap_sample(
 
 
 def _mc_expectation(
-    dist: "NumericRecordDistribution",
+    dist: NumericRecordDistribution,
     f: Callable[[Any], Any],
     *,
     key: PRNGKey | None = None,
@@ -264,7 +265,7 @@ class NumericRecordDistribution(RecordDistribution):
         object.__setattr__(self, "_event_template", tpl)
         return tpl
 
-    def renamed(self, new_name: str) -> "NumericRecordDistribution":
+    def renamed(self, new_name: str) -> NumericRecordDistribution:
         """Return a renamed copy, regenerating an auto-built template.
 
         Extends :meth:`Distribution.renamed`. When the cached template
@@ -345,7 +346,7 @@ class NumericRecordDistribution(RecordDistribution):
 
     def _check_support_compatible(
         self,
-        source: "NumericRecordDistribution",
+        source: NumericRecordDistribution,
     ) -> None:
         """Raise ``ValueError`` if *source*'s per-field supports are
         incompatible with *self*'s (the target's) per-field supports.

--- a/probpipe/core/_random_functions.py
+++ b/probpipe/core/_random_functions.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 
 import jax.numpy as jnp
 
-from ..custom_types import Array, ArrayLike, PRNGKey
+from ..custom_types import Array, ArrayLike
 from ._distribution_base import Distribution
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/_random_measures.py
+++ b/probpipe/core/_random_measures.py
@@ -85,9 +85,8 @@ from __future__ import annotations
 from abc import abstractmethod
 
 from ..custom_types import Array
-from .constraints import Constraint
 from ._distribution_base import Distribution
-
+from .constraints import Constraint
 
 # ---------------------------------------------------------------------------
 # RandomMeasure[T]

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -18,12 +18,11 @@ import numpy as np
 
 from ..custom_types import Array
 from ._numeric_record import _NUMERIC_DTYPE_KINDS, NumericRecord
-from .provenance import Provenance
 from .record import _PATH_SEP, ArraySpec, EventTemplate, Record, _spec_size
 
 __all__ = [
-    "RecordArray",
     "NumericRecordArray",
+    "RecordArray",
     "_RecordArrayView",
 ]
 
@@ -94,9 +93,7 @@ class RecordArray(Record):
             )
         # Reorder to match the template so iteration order is canonical
         # regardless of kwarg order.
-        store: "OrderedDict[str, Any]" = OrderedDict(
-            (name, fields[name]) for name in template.fields
-        )
+        store: OrderedDict[str, Any] = OrderedDict((name, fields[name]) for name in template.fields)
         # Subclass validation hook. Runs after sort / name-check so
         # subclasses (e.g. NumericRecordArray) see a canonicalised view
         # of the leaves. Raises from ``_validate_fields`` propagate.
@@ -116,10 +113,10 @@ class RecordArray(Record):
     @classmethod
     def _validate_fields(
         cls,
-        store: "OrderedDict[str, Any]",
+        store: OrderedDict[str, Any],
         batch_shape: tuple[int, ...],
         template: EventTemplate,
-    ) -> "OrderedDict[str, Any]":
+    ) -> OrderedDict[str, Any]:
         """Hook for subclasses to validate / coerce leaves at construction.
 
         The base implementation is a no-op — ``RecordArray`` accepts any
@@ -179,7 +176,7 @@ class RecordArray(Record):
             return self._get_record(int(key))
         raise TypeError(f"key must be str or int, got {type(key).__name__}")
 
-    def view(self, field: str) -> "_RecordArrayView":
+    def view(self, field: str) -> _RecordArrayView:
         """Return a single-field view carrying parent identity.
 
         Unlike ``ra[field]`` (which returns the raw column), a view
@@ -386,10 +383,10 @@ class NumericRecordArray(RecordArray):
     @classmethod
     def _validate_fields(
         cls,
-        store: "OrderedDict[str, Any]",
+        store: OrderedDict[str, Any],
         batch_shape: tuple[int, ...],
         template: EventTemplate,
-    ) -> "OrderedDict[str, Any]":
+    ) -> OrderedDict[str, Any]:
         """Require numeric dtype and matching event shape on every leaf.
 
         Raises ``TypeError`` if a leaf is non-numeric, ``ValueError`` if
@@ -399,7 +396,7 @@ class NumericRecordArray(RecordArray):
         element is allowed to be a ``Record`` / ``NumericRecord`` /
         ``RecordArray`` and is validated at its own construction site.
         """
-        out: "OrderedDict[str, Any]" = OrderedDict()
+        out: OrderedDict[str, Any] = OrderedDict()
         for name, raw in store.items():
             spec = template[name]
             # Nested structure: skip numeric validation, let the nested
@@ -643,7 +640,7 @@ class _RecordArrayView(RecordArray):
         Name of the field to view. Must be present in ``parent``.
     """
 
-    __slots__ = ("_parent", "_field")
+    __slots__ = ("_field", "_parent")
 
     def __init__(self, parent: RecordArray, field: str):
         if field not in parent._store:
@@ -685,7 +682,7 @@ class _RecordArrayView(RecordArray):
         return tuple(getattr(self._store[self._field], "shape", ()))
 
     @property
-    def dtype(self) -> "jnp.dtype | None":
+    def dtype(self) -> jnp.dtype | None:
         return getattr(self._store[self._field], "dtype", None)
 
     @property

--- a/probpipe/core/_record_distribution.py
+++ b/probpipe/core/_record_distribution.py
@@ -31,7 +31,7 @@ from .protocols import (
 from .record import ArraySpec, EventTemplate, Record
 
 if TYPE_CHECKING:
-    from ._numeric_record_distribution import FlattenedDistributionView
+    pass
 
 
 __all__ = ["RecordDistribution", "_RecordDistributionView"]
@@ -174,11 +174,11 @@ class _RecordDistributionView(Distribution):
     _sampling_cost = "low"
     _preferred_orchestration = None
 
-    def __new__(cls, parent: "RecordDistribution", key: str) -> "_RecordDistributionView":
+    def __new__(cls, parent: RecordDistribution, key: str) -> _RecordDistributionView:
         actual_cls = _view_class_for_parent(parent)
         return object.__new__(actual_cls)
 
-    def __init__(self, parent: "RecordDistribution", key: str) -> None:
+    def __init__(self, parent: RecordDistribution, key: str) -> None:
         # ``parent.event_template`` is contractually non-``None``
         # (metaclass-enforced on every ``RecordDistribution`` instance).
         template = parent.event_template
@@ -229,7 +229,7 @@ class _RecordDistributionView(Distribution):
         return self.event_shape
 
     @property
-    def dtype(self) -> "jnp.dtype | None":
+    def dtype(self) -> jnp.dtype | None:
         """Dtype of a single draw, if the parent exposes ``dtypes``."""
         dtypes = getattr(self._parent, "dtypes", None)
         if isinstance(dtypes, dict):

--- a/probpipe/core/_registry.py
+++ b/probpipe/core/_registry.py
@@ -35,14 +35,14 @@ from dataclasses import dataclass
 from typing import Any
 
 __all__ = [
+    "OPT_IN_ONLY_PRIORITY",
     "BaseDispatchMethod",
-    "UnaryDispatchMethod",
-    "BinaryDispatchMethod",
     "BaseDispatchRegistry",
-    "UnaryDispatchRegistry",
+    "BinaryDispatchMethod",
     "BinaryDispatchRegistry",
     "MethodInfo",
-    "OPT_IN_ONLY_PRIORITY",
+    "UnaryDispatchMethod",
+    "UnaryDispatchRegistry",
 ]
 
 # Priority value for methods that should not auto-dispatch. The registry

--- a/probpipe/core/config.py
+++ b/probpipe/core/config.py
@@ -20,16 +20,15 @@ from __future__ import annotations
 import os
 
 __all__ = [
-    "WorkflowKind",
     "PrefectConfig",
-    "prefect_config",
-    "ProvenanceMode",
     "ProvenanceConfig",
+    "ProvenanceMode",
+    "WorkflowKind",
+    "prefect_config",
     "provenance_config",
 ]
 from enum import Enum
 from typing import Any
-
 
 # ---------------------------------------------------------------------------
 # WorkflowKind enum

--- a/probpipe/core/constraints.py
+++ b/probpipe/core/constraints.py
@@ -8,18 +8,18 @@ from ..custom_types import Array, ArrayLike
 
 __all__ = [
     "Constraint",
-    "real",
-    "positive",
-    "non_negative",
-    "non_negative_integer",
     "boolean",
-    "unit_interval",
-    "simplex",
-    "positive_definite",
-    "sphere",
-    "interval",
     "greater_than",
     "integer_interval",
+    "interval",
+    "non_negative",
+    "non_negative_integer",
+    "positive",
+    "positive_definite",
+    "real",
+    "simplex",
+    "sphere",
+    "unit_interval",
 ]
 
 

--- a/probpipe/core/distribution.py
+++ b/probpipe/core/distribution.py
@@ -22,7 +22,6 @@ from ._distribution_base import (
     set_return_approx_dist,
 )
 
-
 # Mutable globals: delegate attribute access to _distribution_base so that
 # mutations via set_default_num_evaluations / set_return_approx_dist are
 # visible through this facade module.
@@ -36,51 +35,50 @@ def __getattr__(name: str):
 
 
 # -- _record_distribution ---------------------------------------------------
-from ._record_distribution import (
-    RecordDistribution,
-    _RecordDistributionView,
+# -- _broadcast_distributions -----------------------------------------------
+from ._broadcast_distributions import (
+    BroadcastDistribution,
+    MarginalizedBroadcastDistribution,
+    _ListMarginal,
+    _make_marginal,
+    _make_mixture_marginal,
+    _MixtureMarginal,
+    _RecordMarginal,
+)
+
+# -- _empirical -------------------------------------------------------------
+from ._empirical import (
+    BootstrapReplicateDistribution,
+    EmpiricalDistribution,
+    RecordBootstrapReplicateDistribution,
+    RecordEmpiricalDistribution,
 )
 
 # -- _numeric_record_distribution ---------------------------------------------------
 from ._numeric_record_distribution import (
-    NumericRecordDistribution,
-    FlatNumericRecordDistribution,
     BootstrapDistribution,
+    FlatNumericRecordDistribution,
     FlattenedDistributionView,
+    NumericRecordDistribution,
     NumericRecordDistributionView,
     _mc_expectation,
     _vmap_sample,
 )
 
-# -- _empirical -------------------------------------------------------------
-from ._empirical import (
-    EmpiricalDistribution,
-    RecordEmpiricalDistribution,
-    BootstrapReplicateDistribution,
-    RecordBootstrapReplicateDistribution,
-)
-
-# -- _broadcast_distributions -----------------------------------------------
-from ._broadcast_distributions import (
-    BroadcastDistribution,
-    MarginalizedBroadcastDistribution,
-    _RecordMarginal,
-    _ListMarginal,
-    _MixtureMarginal,
-    _make_marginal,
-    _make_mixture_marginal,
-)
-
 # -- _random_functions ------------------------------------------------------
 from ._random_functions import (
-    RandomFunction,
     ArrayRandomFunction,
+    RandomFunction,
 )
 
 # -- _random_measures -------------------------------------------------------
 from ._random_measures import (
-    RandomMeasure,
     NumericRandomMeasure,
+    RandomMeasure,
+)
+from ._record_distribution import (
+    RecordDistribution,
+    _RecordDistributionView,
 )
 
 __all__ = [

--- a/probpipe/core/protocols.py
+++ b/probpipe/core/protocols.py
@@ -53,13 +53,10 @@ import functools
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     ClassVar,
     Protocol,
     runtime_checkable,
 )
-
-import jax.numpy as jnp
 
 from ..custom_types import Array, ArrayLike, PRNGKey
 
@@ -376,7 +373,7 @@ class _DistributionArrayBackend(Protocol):
     @property
     def event_shape(self) -> tuple[int, ...]: ...
 
-    def cell(self, index: int | tuple[int, ...]) -> "Distribution":
+    def cell(self, index: int | tuple[int, ...]) -> Distribution:
         """Fabricate a scalar ``Distribution`` for the cell at ``index``."""
         ...
 
@@ -598,20 +595,20 @@ class GenerativeLikelihood[P, D](Protocol):
 
 
 __all__ = [
-    "compute_expectation",
-    "SupportsExpectation",
-    "SupportsSampling",
-    "SupportsUnnormalizedLogProb",
-    "SupportsLogProb",
-    "SupportsMean",
-    "SupportsVariance",
-    "SupportsCovariance",
-    "SupportsRandomLogProb",
-    "SupportsRandomUnnormalizedLogProb",
-    "SupportsConditioning",
-    "SupportsArrayBackend",
-    "Likelihood",
     "ConditionallyIndependentLikelihood",
     "GenerativeLikelihood",
+    "Likelihood",
+    "SupportsArrayBackend",
+    "SupportsConditioning",
+    "SupportsCovariance",
+    "SupportsExpectation",
+    "SupportsLogProb",
+    "SupportsMean",
+    "SupportsRandomLogProb",
+    "SupportsRandomUnnormalizedLogProb",
+    "SupportsSampling",
+    "SupportsUnnormalizedLogProb",
+    "SupportsVariance",
+    "compute_expectation",
     "protocols_supported_by_all",
 ]

--- a/probpipe/core/provenance.py
+++ b/probpipe/core/provenance.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
     ProvenanceNode = Distribution | Record | RecordArray
 
-from .config import ProvenanceMode, provenance_config  # noqa: E402
+from .config import ProvenanceMode, provenance_config
 
 __all__ = [
     "ParentInfo",
@@ -196,7 +196,7 @@ def _parent_key(p: Any) -> Any:
     return id(p)
 
 
-def provenance_ancestors(node: "ProvenanceNode") -> list[Any]:
+def provenance_ancestors(node: ProvenanceNode) -> list[Any]:
     """Return all ancestor nodes reachable via provenance chains.
 
     Traverses ``node.source.parents`` recursively (breadth-first) and
@@ -232,7 +232,7 @@ def provenance_ancestors(node: "ProvenanceNode") -> list[Any]:
     return ancestors
 
 
-def provenance_dag(dist: "Distribution"):
+def provenance_dag(dist: Distribution):
     """Build a Graphviz ``Digraph`` of the provenance chain rooted at *dist*.
 
     Each node is labelled with its type and name.  Edges point from parent
@@ -276,7 +276,7 @@ def provenance_dag(dist: "Distribution"):
                     _visit_parent(pp, nid, p.source.operation)
         dot.edge(nid, child_nid, label=operation)
 
-    def _visit_dist(d: "Distribution") -> str:
+    def _visit_dist(d: Distribution) -> str:
         nid = str(id(d))
         if id(d) in visited:
             return nid

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -171,7 +171,7 @@ class Record:
         names if not provided.
     """
 
-    __slots__ = ("_store", "_name", "_source")
+    __slots__ = ("_name", "_source", "_store")
 
     def __init__(
         self,
@@ -420,7 +420,7 @@ class Record:
                 result[name] = val
         return result
 
-    def to_numeric(self) -> "NumericRecord":  # type: ignore[name-defined]
+    def to_numeric(self) -> NumericRecord:  # type: ignore[name-defined]
         """Convert to a :class:`NumericRecord` with every leaf a ``jax.Array``.
 
         Per-field metadata that ``jnp.asarray`` would drop (xarray

--- a/probpipe/core/transition.py
+++ b/probpipe/core/transition.py
@@ -217,7 +217,6 @@ def with_resampling(
     :class:`~probpipe.core.distribution.EmpiricalDistribution` type.
     """
     import jax
-    import jax.numpy as jnp
 
     inner_name = _step_fn_name(step_fn)
     call_count = 0

--- a/probpipe/custom_types.py
+++ b/probpipe/custom_types.py
@@ -6,6 +6,7 @@ single place to change if the backend ever needs to swap.
 """
 
 from __future__ import annotations
+
 from typing import TypeAlias
 
 import jax

--- a/probpipe/distributions/__init__.py
+++ b/probpipe/distributions/__init__.py
@@ -1,52 +1,52 @@
-from ._tfp_base import TFPDistribution
-from .continuous import (
-    Normal,
-    Beta,
-    Gamma,
-    InverseGamma,
-    Exponential,
-    LogNormal,
-    StudentT,
-    Uniform,
-    Cauchy,
-    Laplace,
-    HalfNormal,
-    HalfCauchy,
-    Pareto,
-    TruncatedNormal,
-)
-from .discrete import (
-    Bernoulli,
-    Binomial,
-    Poisson,
-    Categorical,
-    NegativeBinomial,
-)
-from .transformed import TransformedDistribution
+from ..core._random_functions import ArrayRandomFunction, RandomFunction
 from ._bijector_dispatch import (
     bijector_for,
     register_bijector,
 )
-from .joint import (
-    ProductDistribution,
-    SequentialJointDistribution,
-    JointEmpirical,
-    NumericJointEmpirical,
-    JointGaussian,
+from ._tfp_base import TFPDistribution
+from .continuous import (
+    Beta,
+    Cauchy,
+    Exponential,
+    Gamma,
+    HalfCauchy,
+    HalfNormal,
+    InverseGamma,
+    Laplace,
+    LogNormal,
+    Normal,
+    Pareto,
+    StudentT,
+    TruncatedNormal,
+    Uniform,
 )
-from .multivariate import (
-    MultivariateNormal,
-    Dirichlet,
-    Multinomial,
-    Wishart,
-    VonMisesFisher,
+from .discrete import (
+    Bernoulli,
+    Binomial,
+    Categorical,
+    NegativeBinomial,
+    Poisson,
 )
-from ..core._random_functions import RandomFunction, ArrayRandomFunction
 from .gaussian_random_function import (
     GaussianRandomFunction,
     LinearBasisFunction,
 )
+from .joint import (
+    JointEmpirical,
+    JointGaussian,
+    NumericJointEmpirical,
+    ProductDistribution,
+    SequentialJointDistribution,
+)
 from .kde import KDEDistribution
+from .multivariate import (
+    Dirichlet,
+    Multinomial,
+    MultivariateNormal,
+    VonMisesFisher,
+    Wishart,
+)
+from .transformed import TransformedDistribution
 
 __all__ = [
     # TFP base

--- a/probpipe/distributions/_joint_empirical.py
+++ b/probpipe/distributions/_joint_empirical.py
@@ -26,9 +26,6 @@ from math import prod
 from types import MappingProxyType
 from typing import Any
 
-import jax.numpy as jnp
-import numpy as np
-
 from .._dtype import _as_float_array
 from .._utils import _is_numeric_array
 from .._weights import Weights
@@ -45,7 +42,7 @@ from ..core.protocols import (
     SupportsVariance,
 )
 from ..core.provenance import Provenance
-from ..core.record import Record, EventTemplate
+from ..core.record import EventTemplate, Record
 from ..custom_types import Array, ArrayLike, PRNGKey
 from ._joint_utils import (
     KeyPath,
@@ -249,7 +246,7 @@ class JointEmpirical(RecordDistribution, SupportsSampling, SupportsConditioning)
         observed_leaves = _parse_condition_args(self, observed, kwargs)
         return self._condition_on_impl(observed_leaves)
 
-    def _condition_on_impl(self, observed_leaves: dict[KeyPath, ArrayLike]) -> "JointEmpirical":
+    def _condition_on_impl(self, observed_leaves: dict[KeyPath, ArrayLike]) -> JointEmpirical:
         """Remove conditioned components and return a new JointEmpirical.
 
         Since ``JointEmpirical`` stores raw sample arrays keyed by name,

--- a/probpipe/distributions/_joint_utils.py
+++ b/probpipe/distributions/_joint_utils.py
@@ -8,13 +8,10 @@ used by :class:`ProductDistribution`, :class:`SequentialJointDistribution`,
 from __future__ import annotations
 
 import jax
-import jax.numpy as jnp
 
-from ..custom_types import ArrayLike
 from ..core._numeric_record_distribution import NumericRecordDistribution
-from ..core.record import Record
 from ..core._record_distribution import RecordDistribution
-
+from ..custom_types import ArrayLike
 
 # ---------------------------------------------------------------------------
 # Key-path helpers

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -18,33 +18,32 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 
-from ..custom_types import Array, ArrayLike, PRNGKey
+from ..core._distribution_base import Distribution
 from ..core._numeric_record_distribution import (
     NumericRecordDistribution,
     _mc_expectation,
 )
-from ..core.provenance import Provenance
-from ..core.record import Record
-from ..core._distribution_base import Distribution
 from ..core._record_distribution import (
     RecordDistribution,
-    _register_dynamic_subclass,
     _build_event_template,
+    _register_dynamic_subclass,
 )
 from ..core.protocols import (
-    protocols_supported_by_all,
     SupportsConditioning,
     SupportsLogProb,
     SupportsMean,
     SupportsSampling,
     SupportsVariance,
+    protocols_supported_by_all,
 )
+from ..core.provenance import Provenance
+from ..core.record import Record
+from ..custom_types import Array, ArrayLike, PRNGKey
 from ._joint_utils import (
     KeyPath,
     _parse_condition_args,
     _prune_leaves,
 )
-
 
 # ---------------------------------------------------------------------------
 # Dynamic protocol factory for ProductDistribution
@@ -513,7 +512,7 @@ class TFPProductDistribution(ProductDistribution):
         return tuple(self._tfp_dist.event_shape)
 
     @property
-    def dtypes(self) -> dict[str, "jnp.dtype"]:
+    def dtypes(self) -> dict[str, jnp.dtype]:
         """Per-field dtype — the TFP Blockwise's dtype spread
         across the auto-built single-field template."""
         return self._per_field_dict(self._tfp_dist.dtype)

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -14,18 +14,15 @@ from types import MappingProxyType
 import jax
 import jax.numpy as jnp
 
-from ..custom_types import Array, ArrayLike, PRNGKey
+from ..core._record_distribution import (
+    RecordDistribution,
+    _build_event_template,
+)
 from ..core.distribution import (
     Distribution,
     NumericRecordDistribution,
     _mc_expectation,
 )
-from ..core._record_distribution import (
-    RecordDistribution,
-    _build_event_template,
-)
-from ..core.record import Record
-from ..core.provenance import Provenance
 from ..core.protocols import (
     SupportsConditioning,
     SupportsLogProb,
@@ -34,6 +31,9 @@ from ..core.protocols import (
     SupportsVariance,
     protocols_supported_by_all,
 )
+from ..core.provenance import Provenance
+from ..core.record import Record
+from ..custom_types import Array, ArrayLike, PRNGKey
 from ._joint_utils import (
     KeyPath,
     _parse_condition_args,
@@ -432,7 +432,7 @@ class SequentialJointDistribution(
     def _condition_on_impl(
         self,
         observed_leaves: dict[KeyPath, ArrayLike],
-    ) -> "SequentialJointDistribution":
+    ) -> SequentialJointDistribution:
         """Condition on observed component values.
 
         The resulting distribution is sampleable as long as every conditioned

--- a/probpipe/distributions/_tfp_base.py
+++ b/probpipe/distributions/_tfp_base.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
-from typing import Any, Callable, Iterator
+from collections.abc import Callable, Iterator
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -31,7 +32,6 @@ from ..core.protocols import (
     SupportsVariance,
 )
 from ..custom_types import Array, ArrayLike, PRNGKey
-
 
 # ---------------------------------------------------------------------------
 # Internal bypass for the batched-parameters rejection
@@ -239,7 +239,7 @@ class TFPDistribution(
         name: str,
         batch_shape: tuple[int, ...],
         **batched_params: Any,
-    ) -> "_TFPArrayBackend":
+    ) -> _TFPArrayBackend:
         """Construct a fused TFP-batched backend for ``DistributionArray``.
 
         Inherited automatically by every concrete TFP-backed distribution
@@ -503,7 +503,7 @@ class _TFPArrayBackend:
         return children, aux
 
     @classmethod
-    def tree_unflatten(cls, aux, children) -> "_TFPArrayBackend":
+    def tree_unflatten(cls, aux, children) -> _TFPArrayBackend:
         """Reconstruct the backend without re-running the
         ``__init__`` shape sanity check.
 

--- a/probpipe/distributions/continuous.py
+++ b/probpipe/distributions/continuous.py
@@ -4,45 +4,36 @@ Continuous univariate distributions backed by TFP.
 
 from __future__ import annotations
 
-from typing import Any
-
-import jax
-import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
-from ._tfp_base import TFPDistribution
 from .._dtype import _as_float_array, _promote_floats
-from ..core.distribution import (
-    NumericRecordDistribution,
-    EmpiricalDistribution,
-)
-from ..core.provenance import Provenance
 from ..core.constraints import (
     Constraint,
-    real,
-    positive,
-    non_negative,
-    unit_interval,
-    interval,
     greater_than,
+    interval,
+    non_negative,
+    positive,
+    real,
+    unit_interval,
 )
-from ..custom_types import Array, ArrayLike, PRNGKey
+from ..custom_types import Array, ArrayLike
+from ._tfp_base import TFPDistribution
 
 __all__ = [
-    "Normal",
     "Beta",
-    "Gamma",
-    "InverseGamma",
-    "Exponential",
-    "LogNormal",
-    "StudentT",
-    "Uniform",
     "Cauchy",
-    "Laplace",
-    "HalfNormal",
+    "Exponential",
+    "Gamma",
     "HalfCauchy",
+    "HalfNormal",
+    "InverseGamma",
+    "Laplace",
+    "LogNormal",
+    "Normal",
     "Pareto",
+    "StudentT",
     "TruncatedNormal",
+    "Uniform",
 ]
 
 

--- a/probpipe/distributions/discrete.py
+++ b/probpipe/distributions/discrete.py
@@ -4,34 +4,28 @@ Discrete distributions backed by TFP.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
 
 import jax
 import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
-from ._tfp_base import TFPDistribution
 from .._dtype import _as_float_array, _promote_floats
-from .._utils import _auto_key
-from ..core.distribution import (
-    NumericRecordDistribution,
-    EmpiricalDistribution,
-)
-from ..core.provenance import Provenance
 from ..core.constraints import (
     Constraint,
     boolean,
-    non_negative_integer,
     integer_interval,
+    non_negative_integer,
 )
 from ..custom_types import Array, ArrayLike, PRNGKey
+from ._tfp_base import TFPDistribution
 
 __all__ = [
     "Bernoulli",
     "Binomial",
-    "Poisson",
     "Categorical",
     "NegativeBinomial",
+    "Poisson",
 ]
 
 

--- a/probpipe/distributions/gaussian_random_function.py
+++ b/probpipe/distributions/gaussian_random_function.py
@@ -17,10 +17,8 @@ from abc import abstractmethod
 from collections.abc import Callable
 from math import prod
 
-import jax
 import jax.numpy as jnp
 
-from .._utils import _auto_key
 from ..core._random_functions import ArrayRandomFunction
 from ..core.protocols import SupportsSampling
 from ..custom_types import Array, ArrayLike, PRNGKey

--- a/probpipe/distributions/joint.py
+++ b/probpipe/distributions/joint.py
@@ -8,15 +8,15 @@ Re-export facade --- all concrete classes live in their own modules:
 *  :mod:`._joint_gaussian`    --- :class:`JointGaussian`
 """
 
-from ._product import ProductDistribution
-from ._sequential_joint import SequentialJointDistribution
 from ._joint_empirical import JointEmpirical, NumericJointEmpirical
 from ._joint_gaussian import JointGaussian
+from ._product import ProductDistribution
+from ._sequential_joint import SequentialJointDistribution
 
 __all__ = [
+    "JointEmpirical",
+    "JointGaussian",
+    "NumericJointEmpirical",
     "ProductDistribution",
     "SequentialJointDistribution",
-    "JointEmpirical",
-    "NumericJointEmpirical",
-    "JointGaussian",
 ]

--- a/probpipe/distributions/kde.py
+++ b/probpipe/distributions/kde.py
@@ -75,7 +75,7 @@ class KDEDistribution(TFPDistribution):
         *,
         log_weights: ArrayLike | Weights | None = None,
         bandwidth: ArrayLike | None = None,
-        event_template: "EventTemplate | None" = None,
+        event_template: EventTemplate | None = None,
         name: str | None = None,
     ):
         samples = _as_float_array(samples)
@@ -192,7 +192,7 @@ class KDEDistribution(TFPDistribution):
         *,
         bandwidth: ArrayLike | None = None,
         name: str | None = None,
-    ) -> "KDEDistribution":
+    ) -> KDEDistribution:
         """Build a KDE from a :class:`RecordEmpiricalDistribution` source.
 
         Reuses the source's stored samples, weights, and record template,

--- a/probpipe/distributions/multivariate.py
+++ b/probpipe/distributions/multivariate.py
@@ -7,25 +7,25 @@ from __future__ import annotations
 import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
-from ._tfp_base import TFPDistribution
 from .._dtype import _as_float_array, _promote_floats
-from ..core.distribution import FlatNumericRecordDistribution
 from ..core.constraints import (
     Constraint,
-    real,
-    positive_definite,
-    simplex,
     non_negative_integer,
+    positive_definite,
+    real,
+    simplex,
     sphere,
 )
+from ..core.distribution import FlatNumericRecordDistribution
 from ..custom_types import Array, ArrayLike
+from ._tfp_base import TFPDistribution
 
 __all__ = [
-    "MultivariateNormal",
     "Dirichlet",
     "Multinomial",
-    "Wishart",
+    "MultivariateNormal",
     "VonMisesFisher",
+    "Wishart",
 ]
 
 

--- a/probpipe/distributions/transformed.py
+++ b/probpipe/distributions/transformed.py
@@ -4,26 +4,24 @@ Transformed distributions via TFP bijectors.
 
 from __future__ import annotations
 
-from typing import Any
-
 import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.bijectors as tfb
 import tensorflow_probability.substrates.jax.distributions as tfd
 
-from ._tfp_base import TFPDistribution
-from ..core.distribution import (
-    NumericRecordDistribution,
-)
-from ..core.provenance import Provenance
 from ..core.constraints import (
     Constraint,
-    real,
     positive,
+    real,
     unit_interval,
 )
-from ..core.distribution import _mc_expectation
+from ..core.distribution import (
+    NumericRecordDistribution,
+    _mc_expectation,
+)
 from ..core.protocols import SupportsLogProb, SupportsMean, SupportsSampling, SupportsVariance
+from ..core.provenance import Provenance
 from ..custom_types import Array, ArrayLike, PRNGKey
+from ._tfp_base import TFPDistribution
 
 __all__ = ["TransformedDistribution"]
 

--- a/probpipe/inference/__init__.py
+++ b/probpipe/inference/__init__.py
@@ -7,11 +7,7 @@ empirical distributions, and the inference method registry for
 """
 
 from __future__ import annotations
-from ._approximate_distribution import ApproximateDistribution
-from ._registry import (
-    InferenceMethod,
-    inference_method_registry,
-)
+
 from ..core._registry import (
     BaseDispatchMethod,
     BaseDispatchRegistry,
@@ -21,16 +17,7 @@ from ..core._registry import (
     UnaryDispatchMethod,
     UnaryDispatchRegistry,
 )
-from ._blackjax_rwmh import rwmh
-from ._blackjax_ess import elliptical_slice
-from ._nutpie import condition_on_nutpie
-from ._minibatch import MinibatchedDistribution
-
-# Amortized SBI (optional ``[bayesflow]`` extra). keras/bayesflow load lazily on
-# first call, so these eager imports stay cheap; the trained artifacts dispatch
-# via ``SupportsConditioning`` (NPE) or plug into ``SimpleModel`` as
-# ``Likelihood`` components (NLE/NRE) -- no inference-registry methods needed.
-from ._bayesflow_posteriors import BayesFlowModel, learn_amortized_posterior
+from ._approximate_distribution import ApproximateDistribution
 from ._bayesflow_likelihoods import (
     BayesFlowLikelihood,
     BayesFlowRatio,
@@ -38,27 +25,41 @@ from ._bayesflow_likelihoods import (
     learn_amortized_ratio,
 )
 
+# Amortized SBI (optional ``[bayesflow]`` extra). keras/bayesflow load lazily on
+# first call, so these eager imports stay cheap; the trained artifacts dispatch
+# via ``SupportsConditioning`` (NPE) or plug into ``SimpleModel`` as
+# ``Likelihood`` components (NLE/NRE) -- no inference-registry methods needed.
+from ._bayesflow_posteriors import BayesFlowModel, learn_amortized_posterior
+from ._blackjax_ess import elliptical_slice
+from ._blackjax_rwmh import rwmh
+from ._minibatch import MinibatchedDistribution
+from ._nutpie import condition_on_nutpie
+from ._registry import (
+    InferenceMethod,
+    inference_method_registry,
+)
+
 __all__ = [
     "ApproximateDistribution",
     "BaseDispatchMethod",
     "BaseDispatchRegistry",
+    "BayesFlowLikelihood",
+    "BayesFlowModel",
+    "BayesFlowRatio",
     "BinaryDispatchMethod",
     "BinaryDispatchRegistry",
+    "InferenceMethod",
     "MethodInfo",
+    "MinibatchedDistribution",
     "UnaryDispatchMethod",
     "UnaryDispatchRegistry",
-    "InferenceMethod",
-    "inference_method_registry",
-    "rwmh",
-    "elliptical_slice",
     "condition_on_nutpie",
-    "MinibatchedDistribution",
-    "learn_amortized_posterior",
-    "BayesFlowModel",
+    "elliptical_slice",
+    "inference_method_registry",
     "learn_amortized_likelihood",
+    "learn_amortized_posterior",
     "learn_amortized_ratio",
-    "BayesFlowLikelihood",
-    "BayesFlowRatio",
+    "rwmh",
 ]
 
 
@@ -68,27 +69,27 @@ __all__ = [
 
 # TFP-backed MCMC — registered at priority 0 (opt-in only); BlackJAX
 # methods below win auto-dispatch.
-from ._tfp_mcmc import TFPNutsMethod, TFPHmcMethod
+from ._tfp_mcmc import TFPHmcMethod, TFPNutsMethod
 
 inference_method_registry.register(TFPNutsMethod())
 inference_method_registry.register(TFPHmcMethod())
 
 # BlackJAX MCMC (gradient-based) — auto-dispatch default for any
 # JAX-traceable ``SupportsLogProb`` target.
-from ._blackjax_mcmc import BlackJAXNutsMethod, BlackJAXHmcMethod
+from ._blackjax_mcmc import BlackJAXHmcMethod, BlackJAXNutsMethod
 
 inference_method_registry.register(BlackJAXNutsMethod())
 inference_method_registry.register(BlackJAXHmcMethod())
 
 # BlackJAX gradient-free MCMC: RWMH (catch-all) and ESS (Gaussian-prior).
-from ._blackjax_rwmh import BlackJAXRWMHMethod
 from ._blackjax_ess import BlackJAXESSMethod
+from ._blackjax_rwmh import BlackJAXRWMHMethod
 
 inference_method_registry.register(BlackJAXRWMHMethod())
 inference_method_registry.register(BlackJAXESSMethod())
 
 # BlackJAX SGMCMC
-from ._blackjax_sgmcmc import BlackJAXSGLDMethod, BlackJAXSGHMCMethod
+from ._blackjax_sgmcmc import BlackJAXSGHMCMethod, BlackJAXSGLDMethod
 
 inference_method_registry.register(BlackJAXSGLDMethod())
 inference_method_registry.register(BlackJAXSGHMCMethod())
@@ -110,7 +111,7 @@ except ImportError:
     pass
 
 try:
-    from ._pymc_method import PyMCNutsMethod, PyMCADVIMethod
+    from ._pymc_method import PyMCADVIMethod, PyMCNutsMethod
 
     inference_method_registry.register(PyMCNutsMethod())
     inference_method_registry.register(PyMCADVIMethod())

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -10,11 +10,10 @@ if TYPE_CHECKING:
 import jax.numpy as jnp
 
 from .._weights import Weights
-from ..core._record_distribution import _RecordDistributionView
 from ..core.distribution import Distribution, RecordEmpiricalDistribution
 from ..core.provenance import Provenance
 from ..core.record import ArraySpec, EventTemplate, OpaqueSpec, Record, _spec_size
-from ..custom_types import Array, ArrayLike, PRNGKey
+from ..custom_types import Array, ArrayLike
 
 __all__ = ["ApproximateDistribution", "make_posterior"]
 

--- a/probpipe/inference/_blackjax_ess.py
+++ b/probpipe/inference/_blackjax_ess.py
@@ -52,7 +52,7 @@ from ._registry import InferenceMethod
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["elliptical_slice", "BlackJAXESSMethod"]
+__all__ = ["BlackJAXESSMethod", "elliptical_slice"]
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/inference/_blackjax_mcmc.py
+++ b/probpipe/inference/_blackjax_mcmc.py
@@ -40,7 +40,11 @@ import jax.numpy as jnp
 import numpy as np
 from blackjax.mcmc.dynamic_hmc import (
     build_kernel as _dynamic_hmc_build_kernel,
+)
+from blackjax.mcmc.dynamic_hmc import (
     halton_trajectory_length,
+)
+from blackjax.mcmc.dynamic_hmc import (
     init as _dynamic_hmc_init,
 )
 
@@ -60,7 +64,7 @@ from ._inference_utils import (
 )
 from ._registry import InferenceMethod
 
-__all__ = ["BlackJAXNutsMethod", "BlackJAXHmcMethod"]
+__all__ = ["BlackJAXHmcMethod", "BlackJAXNutsMethod"]
 
 Algorithm = Literal["nuts", "hmc"]
 

--- a/probpipe/inference/_blackjax_rwmh.py
+++ b/probpipe/inference/_blackjax_rwmh.py
@@ -52,7 +52,7 @@ from ._registry import InferenceMethod
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["rwmh", "BlackJAXRWMHMethod"]
+__all__ = ["BlackJAXRWMHMethod", "rwmh"]
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/inference/_blackjax_sgmcmc.py
+++ b/probpipe/inference/_blackjax_sgmcmc.py
@@ -34,15 +34,15 @@ import blackjax
 import jax
 import jax.numpy as jnp
 
-from ..core._registry import MethodInfo
 from ..core._random_measures import RandomMeasure
+from ..core._registry import MethodInfo
 from ..custom_types import PRNGKey
 from ._approximate_distribution import ApproximateDistribution, make_posterior
+from ._inference_utils import as_prng_key, get_init_state, is_simple_model
 from ._minibatch import MinibatchedDistribution
 from ._registry import InferenceMethod
-from ._inference_utils import as_prng_key, get_init_state, is_simple_model
 
-__all__ = ["BlackJAXSGLDMethod", "BlackJAXSGHMCMethod"]
+__all__ = ["BlackJAXSGHMCMethod", "BlackJAXSGLDMethod"]
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/inference/_inference_utils.py
+++ b/probpipe/inference/_inference_utils.py
@@ -39,9 +39,8 @@ logger = logging.getLogger(__name__)
 
 from ..core.distribution import Distribution
 from ..core.protocols import SupportsSampling
-from ..core.record import Record, EventTemplate
+from ..core.record import EventTemplate, Record
 from ..custom_types import Array, ArrayLike
-
 
 __all__ = [
     "as_prng_key",
@@ -50,13 +49,13 @@ __all__ = [
     "build_target_log_prob",
     "build_target_log_prob_flat",
     "extract_chain_columns",
-    "posterior_var_order",
+    "extract_event_template",
     "get_init_state",
     "get_prior",
-    "extract_event_template",
     "is_jax_traceable",
     "is_simple_model",
     "parallel_chain_map",
+    "posterior_var_order",
     "run_chain_scan",
 ]
 
@@ -440,7 +439,7 @@ def build_mcmc_datatree(
     chains: list[Array],
     sample_stats: dict[str, np.ndarray] | None = None,
     warmup_chains: list[Array] | None = None,
-) -> "DataTree":
+) -> DataTree:
     """Build an arviz-convention DataTree from MCMC chains + diagnostics.
 
     Groups: ``posterior``, ``sample_stats`` (if provided), ``warmup``

--- a/probpipe/inference/_minibatch.py
+++ b/probpipe/inference/_minibatch.py
@@ -190,7 +190,7 @@ class MinibatchedDistribution(
     def __init__(
         self,
         prior: SupportsLogProb,
-        likelihood: "ConditionallyIndependentLikelihood",
+        likelihood: ConditionallyIndependentLikelihood,
         data: ArrayLike | Record | RecordArray,
         batch_size: int,
         *,
@@ -261,7 +261,7 @@ class MinibatchedDistribution(
         return self._prior
 
     @property
-    def likelihood(self) -> "ConditionallyIndependentLikelihood":
+    def likelihood(self) -> ConditionallyIndependentLikelihood:
         """The conditionally-independent likelihood."""
         return self._likelihood
 
@@ -338,7 +338,7 @@ class _FixedMinibatchDistribution(
     def __init__(
         self,
         prior: SupportsLogProb,
-        likelihood: "ConditionallyIndependentLikelihood",
+        likelihood: ConditionallyIndependentLikelihood,
         batch: Any,
         rescale_factor: float,
         *,
@@ -358,7 +358,7 @@ class _FixedMinibatchDistribution(
         return self._prior
 
     @property
-    def likelihood(self) -> "ConditionallyIndependentLikelihood":
+    def likelihood(self) -> ConditionallyIndependentLikelihood:
         """The CIL likelihood carried from the parent measure."""
         return self._likelihood
 

--- a/probpipe/inference/_tfp_mcmc.py
+++ b/probpipe/inference/_tfp_mcmc.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from xarray import DataTree
+    pass
 
 import jax
 import jax.numpy as jnp

--- a/probpipe/linalg/linear_operator.py
+++ b/probpipe/linalg/linear_operator.py
@@ -30,13 +30,13 @@ class LinAlgError(Exception):
 
 
 __all__ = [
-    "LinOp",
+    "CholeskyLinOp",
     "DenseLinOp",
     "DiagonalLinOp",
+    "DiagonalRootLinOp",
+    "LinOp",
     "RootLinOp",
     "TriangularLinOp",
-    "CholeskyLinOp",
-    "DiagonalRootLinOp",
 ]
 
 

--- a/probpipe/linalg/operations.py
+++ b/probpipe/linalg/operations.py
@@ -8,14 +8,13 @@ Also included are more specialized operations like `mah_dist_squared()`
 that are not in one-to-one correspondence with `LinOp` methods.
 """
 
+from typing import Any
+
 import jax.numpy as jnp
-from .linear_operator import LinAlgError
-from typing import Any, TypeAlias
 
+from .._array_utils import _ensure_matrix
 from ..custom_types import Array, ArrayLike
-from .._array_utils import _is_array, _ensure_matrix
-from .linear_operator import _as_linear_operator, LinOpLike, CholeskyFactor
-
+from .linear_operator import CholeskyFactor, LinAlgError, LinOpLike, _as_linear_operator
 
 # -----------------------------------------------------------------------------
 # Expose LinOp methods as functions

--- a/probpipe/linalg/utils.py
+++ b/probpipe/linalg/utils.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
-from ..custom_types import Array, ArrayLike
+
 from .._array_utils import _ensure_real_scalar, _ensure_square_matrix
+from ..custom_types import Array, ArrayLike
 
 
 def add_diag_jitter(

--- a/probpipe/modeling/__init__.py
+++ b/probpipe/modeling/__init__.py
@@ -17,14 +17,14 @@ from ._simple import SimpleModel
 from ._simple_generative import SimpleGenerativeModel
 
 __all__ = [
-    "GLMLikelihood",
-    "Likelihood",
     "ConditionallyIndependentLikelihood",
+    "GLMLikelihood",
     "GenerativeLikelihood",
     "IncrementalConditioner",
+    "Likelihood",
     "ProbabilisticModel",
-    "SimpleModel",
     "SimpleGenerativeModel",
+    "SimpleModel",
 ]
 
 # Optional backends — available when their dependencies are installed.

--- a/probpipe/modeling/_glm.py
+++ b/probpipe/modeling/_glm.py
@@ -6,7 +6,7 @@ import jax
 import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.glm as tfp_glm
 
-from ..core.record import Record, EventTemplate
+from ..core.record import EventTemplate, Record
 from ..custom_types import Array, ArrayLike, PRNGKey
 
 __all__ = ["GLMLikelihood"]

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -11,10 +11,7 @@ from typing import Any
 
 import jax.numpy as jnp
 
-from ..core.distribution import Distribution
 from ..core.record import NumericEventTemplate
-from ..custom_types import Array
-from ..inference._approximate_distribution import ApproximateDistribution
 from ._base import ProbabilisticModel
 
 logger = logging.getLogger(__name__)

--- a/probpipe/modeling/_simple.py
+++ b/probpipe/modeling/_simple.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import jax.numpy as jnp
-
 from ..core.distribution import Distribution
 from ..core.protocols import SupportsLogProb
-from ..core.record import Record, EventTemplate
+from ..core.record import EventTemplate, Record
 from ..custom_types import Array
 from ._base import ProbabilisticModel
 from ._likelihood import Likelihood

--- a/probpipe/validation/_predictive_check.py
+++ b/probpipe/validation/_predictive_check.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
-
-import numpy as np
+from collections.abc import Callable
+from typing import Any
 
 import jax
-import jax.numpy as jnp
+import numpy as np
 
+from .._utils import _auto_key
 from ..core.distribution import RecordEmpiricalDistribution
 from ..core.node import workflow_function
 from ..core.protocols import SupportsSampling
 from ..custom_types import PRNGKey
-from .._utils import _auto_key
 from ..modeling._likelihood import GenerativeLikelihood  # needed for type hint resolution
 
 __all__ = ["predictive_check"]

--- a/tests/converters/test_converters.py
+++ b/tests/converters/test_converters.py
@@ -4,42 +4,39 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from probpipe import (
-    Normal,
-    Beta,
-    Gamma,
-    Exponential,
-    MultivariateNormal,
     Bernoulli,
-    Poisson,
+    Beta,
     Categorical,
-    RecordEmpiricalDistribution,
-    EmpiricalDistribution,
-    NumericRecordDistribution,
-    converter_registry,
     ConversionInfo,
     ConversionMethod,
     Converter,
+    EmpiricalDistribution,
+    Exponential,
+    Gamma,
+    MultivariateNormal,
+    Normal,
+    Poisson,
+    RecordEmpiricalDistribution,
+    converter_registry,
     from_distribution,
 )
 from probpipe.distributions.continuous import (
-    InverseGamma,
-    LogNormal,
-    StudentT,
-    Uniform,
     Cauchy,
-    Laplace,
-    HalfNormal,
     HalfCauchy,
+    HalfNormal,
+    InverseGamma,
+    Laplace,
+    LogNormal,
     Pareto,
+    StudentT,
     TruncatedNormal,
+    Uniform,
 )
 from probpipe.distributions.discrete import Binomial, NegativeBinomial
-from probpipe.distributions.multivariate import Dirichlet, Multinomial, Wishart, VonMisesFisher
-
+from probpipe.distributions.multivariate import Dirichlet, Multinomial, VonMisesFisher, Wishart
 
 # ---------------------------------------------------------------------------
 # Registry basics
@@ -426,7 +423,6 @@ class TestScipyConverter:
         np.testing.assert_allclose(float(result._rate), 0.5)  # rate = 1/scale
 
     def test_probpipe_to_scipy(self):
-        import scipy.stats as ss
         from scipy.stats._distn_infrastructure import rv_frozen
 
         n = Normal(loc=3.0, scale=1.0, name="x")
@@ -684,11 +680,11 @@ class TestEdgeCases:
 # ---------------------------------------------------------------------------
 
 from probpipe.core.protocols import (
-    SupportsLogProb,
-    SupportsSampling,
-    SupportsMean,
-    SupportsVariance,
     SupportsCovariance,
+    SupportsLogProb,
+    SupportsMean,
+    SupportsSampling,
+    SupportsVariance,
 )
 from probpipe.distributions.kde import KDEDistribution
 

--- a/tests/core/test_array_backend.py
+++ b/tests/core/test_array_backend.py
@@ -17,7 +17,6 @@ from probpipe import (
 )
 from probpipe.core._array_backend import aux_registry
 
-
 # ---------------------------------------------------------------------------
 # Registry lookup
 # ---------------------------------------------------------------------------

--- a/tests/core/test_array_distribution.py
+++ b/tests/core/test_array_distribution.py
@@ -2,23 +2,22 @@
 
 import jax
 import jax.numpy as jnp
-import math
 import numpy as np
 import pytest
 
 from probpipe import (
     Distribution,
     FlatNumericRecordDistribution,
+    FlattenedDistributionView,
+    MultivariateNormal,
+    Normal,
     NumericRecordDistribution,
     RecordEmpiricalDistribution,
-    FlattenedDistributionView,
-    Normal,
-    MultivariateNormal,
     from_distribution,
-    EmpiricalDistribution,
+    log_prob,
+    sample,
+    unnormalized_log_prob,
 )
-from probpipe import log_prob, sample, unnormalized_log_prob
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -459,11 +458,11 @@ class TestCanonicalConvenience:
         positionally; the first incompatible pair raises with both
         field names in the message.
         """
+        from probpipe import NumericRecord, positive, real
         from probpipe.core._numeric_record_distribution import (
             NumericRecordDistribution,
         )
         from probpipe.core.record import EventTemplate
-        from probpipe import NumericRecord, positive, real
 
         class TwoFieldSource(NumericRecordDistribution):
             @property

--- a/tests/core/test_bootstrap_replicate.py
+++ b/tests/core/test_bootstrap_replicate.py
@@ -6,20 +6,19 @@ import numpy as np
 import pytest
 
 from probpipe import (
-    NumericRecordDistribution,
-    RecordBootstrapReplicateDistribution,
     BootstrapDistribution,
+    BootstrapReplicateDistribution,
     Distribution,
     EmpiricalDistribution,
-    BootstrapReplicateDistribution,
+    NumericRecordDistribution,
+    Record,
+    RecordBootstrapReplicateDistribution,
     SupportsExpectation,
     SupportsSampling,
-    Record,
     expectation,
     sample,
 )
 from probpipe.core.record import ArraySpec
-
 
 # ---------------------------------------------------------------------------
 # Construction

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,11 +1,10 @@
 """Tests for ProvenanceConfig env-var initialisation."""
 
-import os
 import pytest
 
 from probpipe.core.config import (
-    ProvenanceMode,
     _PROVENANCE_MODE_ENV_VAR,
+    ProvenanceMode,
     _initial_provenance_mode,
 )
 

--- a/tests/core/test_distribution_array.py
+++ b/tests/core/test_distribution_array.py
@@ -33,7 +33,6 @@ from probpipe.core._distribution_array import (
     _make_distribution_array,
 )
 
-
 # ---------------------------------------------------------------------------
 # Construction & invariants
 # ---------------------------------------------------------------------------
@@ -211,7 +210,8 @@ class TestContainerSurface:
         ``_flat_component`` / ``components`` for the single cell.
         Fully-joint GRF predictions with no extra batch axes return
         a 0-d DA."""
-        from probpipe import DistributionArray, MultivariateNormal as _MVN
+        from probpipe import DistributionArray
+        from probpipe import MultivariateNormal as _MVN
 
         da = DistributionArray.from_batched_params(
             _MVN,
@@ -230,7 +230,8 @@ class TestContainerSurface:
         """``len(np.zeros(()))`` raises ``TypeError``; so does
         ``len(da)`` on a 0-d ``DistributionArray``. ``da.size``
         still works."""
-        from probpipe import DistributionArray, MultivariateNormal as _MVN
+        from probpipe import DistributionArray
+        from probpipe import MultivariateNormal as _MVN
 
         da = DistributionArray.from_batched_params(
             _MVN,
@@ -663,7 +664,7 @@ class TestFromBatchedParams:
     """Public entry point that dispatches on ``SupportsArrayBackend``."""
 
     def test_normal_uses_tfp_backend(self):
-        from probpipe import Normal, DistributionArray
+        from probpipe import DistributionArray, Normal
         from probpipe.distributions._tfp_base import _TFPArrayBackend
 
         da = DistributionArray.from_batched_params(
@@ -679,7 +680,7 @@ class TestFromBatchedParams:
         assert len(da) == 5
 
     def test_per_cell_name_auto_suffix(self):
-        from probpipe import Normal, DistributionArray
+        from probpipe import DistributionArray, Normal
 
         da = DistributionArray.from_batched_params(
             Normal,
@@ -692,7 +693,7 @@ class TestFromBatchedParams:
         assert da[2].name == "weights_2"
 
     def test_per_cell_params_correctly_sliced(self):
-        from probpipe import Normal, DistributionArray
+        from probpipe import DistributionArray, Normal
 
         da = DistributionArray.from_batched_params(
             Normal,
@@ -710,7 +711,7 @@ class TestFromBatchedParams:
             )
 
     def test_scalar_param_broadcasts_through_cells(self):
-        from probpipe import Normal, DistributionArray
+        from probpipe import DistributionArray, Normal
 
         da = DistributionArray.from_batched_params(
             Normal,
@@ -722,7 +723,7 @@ class TestFromBatchedParams:
             assert float(da[i].scale) == 2.5
 
     def test_inferred_batch_shape_uses_broadcast(self):
-        from probpipe import Normal, DistributionArray
+        from probpipe import DistributionArray, Normal
 
         # Both arrays imply batch_shape=(4,) — broadcast convention.
         da = DistributionArray.from_batched_params(
@@ -734,7 +735,7 @@ class TestFromBatchedParams:
         assert da.batch_shape == (4,)
 
     def test_explicit_batch_shape_honored(self):
-        from probpipe import Normal, DistributionArray
+        from probpipe import DistributionArray, Normal
 
         da = DistributionArray.from_batched_params(
             Normal,
@@ -749,7 +750,7 @@ class TestFromBatchedParams:
         assert da[1, 2].name == "g_5"
 
     def test_no_array_params_requires_explicit_batch_shape(self):
-        from probpipe import Normal, DistributionArray
+        from probpipe import DistributionArray, Normal
 
         with pytest.raises(ValueError, match="batch_shape"):
             DistributionArray.from_batched_params(
@@ -763,7 +764,7 @@ class TestFromBatchedParams:
         """MVN-style classes need explicit ``batch_shape`` because
         their per-param event ranks differ (``loc`` is
         ``(*batch, d)``, ``scale_tril`` is ``(*batch, d, d)``)."""
-        from probpipe import MultivariateNormal, DistributionArray
+        from probpipe import DistributionArray, MultivariateNormal
         from probpipe.distributions._tfp_base import _TFPArrayBackend
 
         d = 3
@@ -782,7 +783,7 @@ class TestFromBatchedParams:
     def test_inference_punts_on_event_rank_mismatch(self):
         """Without explicit ``batch_shape``, MVN-style heterogeneous
         event-rank params raise a clear ``ValueError``."""
-        from probpipe import MultivariateNormal, DistributionArray
+        from probpipe import DistributionArray, MultivariateNormal
 
         d = 3
         with pytest.raises(ValueError, match="batch_shape"):
@@ -837,8 +838,9 @@ class TestFromBatchedParams:
         against TFP's own batched form (which is what
         ``_TFPArrayBackend`` wraps internally anyway).
         """
-        from probpipe import Normal, DistributionArray
         import tensorflow_probability.substrates.jax.distributions as tfd
+
+        from probpipe import DistributionArray, Normal
 
         loc = jnp.array([0.5, -1.2, 3.7, 0.0])
         scale = jnp.array([0.1, 0.2, 0.3, 0.4])
@@ -863,7 +865,7 @@ class TestFromBatchedParams:
         )
 
     def test_iteration_matches_indexing(self):
-        from probpipe import Normal, DistributionArray
+        from probpipe import DistributionArray, Normal
 
         da = DistributionArray.from_batched_params(
             Normal,
@@ -885,7 +887,7 @@ class TestDistributionFromBatchedParamsAlias:
     """Ergonomic per-class alias on Distribution[T]."""
 
     def test_alias_dispatches_to_distribution_array_factory(self):
-        from probpipe import Normal, DistributionArray
+        from probpipe import DistributionArray, Normal
         from probpipe.distributions._tfp_base import _TFPArrayBackend
 
         da = Normal.from_batched_params(
@@ -899,7 +901,7 @@ class TestDistributionFromBatchedParamsAlias:
         assert da[0].name == "x_0"
 
     def test_alias_matches_classmethod_call(self):
-        from probpipe import Normal, DistributionArray
+        from probpipe import DistributionArray, Normal
 
         loc = jnp.arange(4.0)
         scale = jnp.linspace(0.1, 0.4, 4)
@@ -925,14 +927,14 @@ class TestDistributionFromBatchedParamsAlias:
             assert float(a.scale) == float(f.scale)
 
     def test_alias_inherited_by_all_distribution_subclasses(self):
-        from probpipe.core._distribution_base import Distribution
         from probpipe import (
-            Normal,
             Beta,
+            EmpiricalDistribution,
             Gamma,
             MultivariateNormal,
-            EmpiricalDistribution,
+            Normal,
         )
+        from probpipe.core._distribution_base import Distribution
 
         # Every Distribution subclass inherits the alias.
         for cls in (Distribution, Normal, Beta, Gamma, MultivariateNormal, EmpiricalDistribution):

--- a/tests/core/test_distribution_base.py
+++ b/tests/core/test_distribution_base.py
@@ -8,10 +8,9 @@ import numpy as np
 import pytest
 
 from probpipe import (
-    Normal,
     Gamma,
-    Record,
     MultivariateNormal,
+    Normal,
     RecordEmpiricalDistribution,
     TransformedDistribution,
 )
@@ -285,8 +284,9 @@ class TestRenamedTemplateRoundtrip:
         """Multi-field joints have explicit templates whose field
         names are independent of the distribution's name — renaming
         must not touch the template."""
-        from probpipe import JointGaussian
         import jax.numpy as jnp
+
+        from probpipe import JointGaussian
 
         jg = JointGaussian(
             mean=jnp.zeros(2),
@@ -305,6 +305,7 @@ class TestRenamedTemplateRoundtrip:
         metaclass invariant would be violated, since the non-numeric
         base has no auto-rebuild path)."""
         import numpy as np
+
         from probpipe import JointEmpirical
 
         je = JointEmpirical(

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -14,7 +14,6 @@ from probpipe.core.record import (
     OpaqueSpec,
 )
 
-
 # ---------------------------------------------------------------------------
 # Construction
 # ---------------------------------------------------------------------------
@@ -361,7 +360,6 @@ class TestFromRecord:
     def test_list_leaf_after_asarray_is_numeric(self):
         """The opposite end of the list-leaf story: wrapping the list
         in ``np.asarray`` produces a numeric template entry."""
-        import numpy as np
 
         r = Record(xs=np.asarray([1.0, 2.0, 3.0]))
         tpl = EventTemplate.from_record(r)

--- a/tests/core/test_expectation.py
+++ b/tests/core/test_expectation.py
@@ -5,31 +5,31 @@ import jax.numpy as jnp
 import jax.scipy.special as jsp
 import numpy as np
 import pytest
+import tensorflow_probability.substrates.jax.bijectors as tfb
 
 import probpipe.core.distribution as dist_mod
 from probpipe import (
-    NumericRecord,
-    NumericRecordDistribution,
-    RecordEmpiricalDistribution,
-    EmpiricalDistribution,
-    BootstrapDistribution,
-    Normal,
-    Gamma,
-    Beta,
-    Exponential,
     Bernoulli,
-    Categorical,
+    Beta,
     Binomial,
-    from_distribution,
+    BootstrapDistribution,
+    Categorical,
+    EmpiricalDistribution,
+    Exponential,
+    Gamma,
+    Normal,
+    NumericRecord,
+    RecordEmpiricalDistribution,
     TransformedDistribution,
-    DEFAULT_NUM_EVALUATIONS,
+    expectation,
+    from_distribution,
+    mean,
+    sample,
     set_default_num_evaluations,
     set_return_approx_dist,
+    variance,
 )
-import tensorflow_probability.substrates.jax.bijectors as tfb
-from probpipe import expectation, log_prob, mean, sample, variance
 from probpipe.core.protocols import SupportsExpectation, compute_expectation
-
 
 # ---------------------------------------------------------------------------
 # BootstrapDistribution tests

--- a/tests/core/test_iteration_protocol.py
+++ b/tests/core/test_iteration_protocol.py
@@ -16,7 +16,6 @@ The rule (codified in STYLE_GUIDE.md §1.11):
 
 from __future__ import annotations
 
-import jax
 import jax.numpy as jnp
 import pytest
 
@@ -37,9 +36,6 @@ from probpipe import (
     ProductDistribution,
     Record,
     RecordArray,
-    RecordEmpiricalDistribution,
-    RecordBootstrapReplicateDistribution,
-    SimpleModel,
     TransformedDistribution,
 )
 

--- a/tests/core/test_numeric_record.py
+++ b/tests/core/test_numeric_record.py
@@ -8,7 +8,6 @@ import pytest
 from probpipe import NumericRecord, Record
 from probpipe.core.record import EventTemplate
 
-
 # ---------------------------------------------------------------------------
 # Construction
 # ---------------------------------------------------------------------------
@@ -145,7 +144,7 @@ class TestConstruction:
         that they consume the same frozenset."""
         from probpipe.core._numeric_record import _NUMERIC_DTYPE_KINDS
 
-        assert _NUMERIC_DTYPE_KINDS == frozenset("biufc")
+        assert frozenset("biufc") == _NUMERIC_DTYPE_KINDS
         # Import path is also the import path used by
         # NumericRecordArray._validate_fields (see _record_array.py).
         from probpipe.core import _record_array

--- a/tests/core/test_numeric_record_distribution_view.py
+++ b/tests/core/test_numeric_record_distribution_view.py
@@ -16,14 +16,14 @@ import pytest
 
 from probpipe import (
     Dirichlet,
+    EventTemplate,
     FlatNumericRecordDistribution,
     MultivariateNormal,
     Normal,
+    NumericEventTemplate,
     NumericRecord,
     NumericRecordArray,
-    NumericEventTemplate,
     ProductDistribution,
-    EventTemplate,
     cov,
     expectation,
     log_prob,

--- a/tests/core/test_ops.py
+++ b/tests/core/test_ops.py
@@ -7,16 +7,14 @@ import pytest
 import scipy.stats
 
 from probpipe import (
-    Normal,
-    MultivariateNormal,
-    RecordEmpiricalDistribution,
-    EmpiricalDistribution,
     BootstrapDistribution,
+    MultivariateNormal,
+    Normal,
     ProductDistribution,
+    RecordEmpiricalDistribution,
     SequentialJointDistribution,
 )
 from probpipe.core import ops
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -164,8 +162,8 @@ class TestMean:
 
     def test_raises_without_supports_mean(self):
         """mean op raises TypeError for distributions without SupportsMean."""
-        from probpipe.core.protocols import SupportsSampling, SupportsExpectation
-        from probpipe.core.distribution import _mc_expectation, NumericRecordDistribution
+        from probpipe.core.distribution import NumericRecordDistribution, _mc_expectation
+        from probpipe.core.protocols import SupportsExpectation, SupportsSampling
 
         class NoMeanDist(NumericRecordDistribution, SupportsSampling, SupportsExpectation):
             _sampling_cost = "low"

--- a/tests/core/test_protocols.py
+++ b/tests/core/test_protocols.py
@@ -5,32 +5,30 @@ import jax.numpy as jnp
 import pytest
 
 from probpipe import (
-    Normal,
-    Beta,
-    Gamma,
     Bernoulli,
-    Categorical,
-    MultivariateNormal,
-    EmpiricalDistribution,
-    RecordEmpiricalDistribution,
+    Beta,
     BootstrapDistribution,
-    TransformedDistribution,
-    ProductDistribution,
-    SequentialJointDistribution,
+    EmpiricalDistribution,
+    Gamma,
     JointEmpirical,
     JointGaussian,
+    MultivariateNormal,
+    Normal,
+    ProductDistribution,
+    RecordEmpiricalDistribution,
+    SequentialJointDistribution,
+    TransformedDistribution,
 )
 from probpipe.core.protocols import (
+    SupportsConditioning,
+    SupportsCovariance,
     SupportsExpectation,
-    SupportsSampling,
-    SupportsUnnormalizedLogProb,
     SupportsLogProb,
     SupportsMean,
+    SupportsSampling,
+    SupportsUnnormalizedLogProb,
     SupportsVariance,
-    SupportsCovariance,
-    SupportsConditioning,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -277,7 +275,6 @@ class TestRecordDistributionViewDynamicProtocols:
         """Build a parent with an EventTemplate that supports only
         log_prob, and verify the view doesn't claim to be
         SupportsSampling / SupportsMean / SupportsVariance."""
-        from probpipe.core._distribution_base import Distribution
         from probpipe.core._record_distribution import (
             RecordDistribution,
             _RecordDistributionView,
@@ -332,8 +329,8 @@ class TestFlattenedDistributionViewDynamicProtocols:
     def test_flattened_view_over_sampling_only_base(self):
         """A sampling-only base produces a FlattenedDistributionView that isn't
         SupportsLogProb."""
-        import jax.numpy as jnp
         import jax
+
         from probpipe.core._numeric_record_distribution import (
             FlattenedDistributionView,
             NumericRecordDistribution,
@@ -362,6 +359,7 @@ class TestFlattenedDistributionViewDynamicProtocols:
         """A log-prob-only base produces a FlattenedDistributionView that isn't
         ``SupportsSampling`` (reverse direction of the sampling-only test)."""
         import jax.numpy as jnp
+
         from probpipe.core._numeric_record_distribution import (
             FlattenedDistributionView,
             NumericRecordDistribution,
@@ -411,7 +409,7 @@ class TestSampleReturnTypeConvention:
         assert dist._sample(k, (3, 4)).shape == (3, 4)
 
     def test_product_distribution_return_types(self):
-        from probpipe import NumericRecord, Record
+        from probpipe import Record
         from probpipe.core._record_array import NumericRecordArray
 
         dist = ProductDistribution(
@@ -446,6 +444,7 @@ class TestSampleReturnTypeConvention:
 
     def test_joint_empirical_return_types(self):
         import numpy as np
+
         from probpipe import Record
         from probpipe.core._record_array import NumericRecordArray
 
@@ -484,6 +483,7 @@ class TestMixtureSamplingDispatch:
 
     def test_array_components_stacked(self):
         import jax.numpy as jnp
+
         from probpipe.core._broadcast_distributions import _make_mixture_marginal
 
         comps = [Normal(loc=0.0, scale=1.0, name=f"c{i}") for i in range(3)]
@@ -493,9 +493,9 @@ class TestMixtureSamplingDispatch:
         assert s.shape == (4,)
 
     def test_record_components_stacked_as_record_array(self):
-        from probpipe.core._broadcast_distributions import _make_mixture_marginal
-        from probpipe.core._record_array import RecordArray, NumericRecordArray
         from probpipe import Record
+        from probpipe.core._broadcast_distributions import _make_mixture_marginal
+        from probpipe.core._record_array import NumericRecordArray, RecordArray
 
         comps = [
             ProductDistribution(
@@ -523,8 +523,9 @@ class TestTransformedDistributionDynamicProtocols:
     """TransformedDistribution inherits only protocols its base supports."""
 
     def test_over_full_tfp_base_has_all_protocols(self):
-        from probpipe import Normal, TransformedDistribution
         import tensorflow_probability.substrates.jax.bijectors as tfb
+
+        from probpipe import Normal
 
         td = TransformedDistribution(Normal(loc=0.0, scale=1.0, name="x"), tfb.Exp())
         assert isinstance(td, SupportsSampling)
@@ -534,10 +535,11 @@ class TestTransformedDistributionDynamicProtocols:
 
     def test_over_log_prob_only_base_no_sampling(self):
         """A base with log_prob but no sampling → transform has no SupportsSampling."""
-        from probpipe import TransformedDistribution, NumericRecordDistribution
-        from probpipe.core.record import EventTemplate
         import tensorflow_probability.substrates.jax.bijectors as tfb
+
+        from probpipe import NumericRecordDistribution
         from probpipe.core.protocols import SupportsLogProb
+        from probpipe.core.record import EventTemplate
 
         class _LogProbOnly(NumericRecordDistribution, SupportsLogProb):
             _sampling_cost = "low"
@@ -611,8 +613,9 @@ class TestJointEmpiricalDispatch:
         assert isinstance(je, SupportsVariance)
 
     def test_numeric_rejects_non_numeric(self):
-        from probpipe import NumericJointEmpirical
         import numpy as np
+
+        from probpipe import NumericJointEmpirical
 
         with pytest.raises(TypeError, match="numeric"):
             NumericJointEmpirical(
@@ -624,6 +627,7 @@ class TestJointEmpiricalDispatch:
         """``JointEmpirical`` with object-dtype fields stays on the
         generic base class and must not claim the numeric protocols."""
         import numpy as np
+
         from probpipe import JointEmpirical, NumericJointEmpirical
 
         je = JointEmpirical(
@@ -646,7 +650,6 @@ class TestSimpleGenerativeModelSampling:
 
     def test_supports_sampling(self):
         from probpipe import Normal, SimpleGenerativeModel
-        from probpipe.modeling import GenerativeLikelihood
 
         class _L:
             def generate_data(self, params, num_observations, *, key):

--- a/tests/core/test_random_function.py
+++ b/tests/core/test_random_function.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 import pytest
 
 from probpipe import (
+    ArrayRandomFunction,
     Distribution,
-    DistributionArray,
     Normal,
     RandomFunction,
-    ArrayRandomFunction,
+    log_prob,
+    sample,
 )
-from probpipe import log_prob, sample
 
 # Test fixtures construct ``Normal`` from batched arrays; the rejection
 # in ``TFPDistribution.__init__`` (PR-C.2) makes that a user-facing
@@ -22,7 +21,6 @@ from probpipe import log_prob, sample
 # library-internal code paths (RandomFunction subclasses), so the
 # bypass is appropriate.
 from probpipe.distributions._tfp_base import _allow_batched_tfp_init
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -7,7 +7,6 @@ import pytest
 
 from probpipe import Normal, Provenance, Record, provenance_ancestors
 
-
 # ---------------------------------------------------------------------------
 # Construction
 # ---------------------------------------------------------------------------

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -16,7 +16,6 @@ from probpipe import (
 )
 from probpipe.core.record import EventTemplate
 
-
 # ---------------------------------------------------------------------------
 # RecordArray construction
 # ---------------------------------------------------------------------------

--- a/tests/core/test_record_distribution.py
+++ b/tests/core/test_record_distribution.py
@@ -18,11 +18,9 @@ from probpipe import (
     Normal,
 )
 from probpipe.core._record_distribution import (
-    RecordDistribution,
     _RecordDistributionView,
 )
 from probpipe.distributions.joint import ProductDistribution
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -23,12 +23,11 @@ from probpipe import (
 from probpipe.core._empirical import BootstrapReplicateDistribution, EmpiricalDistribution
 from probpipe.core.record import (
     ArraySpec,
+    EventTemplate,
     NumericEventTemplate,
     OpaqueSpec,
     Record,
-    EventTemplate,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/core/test_transition.py
+++ b/tests/core/test_transition.py
@@ -7,16 +7,14 @@ import pytest
 from probpipe import (
     Distribution,
     EmpiricalDistribution,
+    IncrementalConditioner,
     MultivariateNormal,
     Provenance,
     iterate,
-    mean,
     with_conversion,
     with_resampling,
-    IncrementalConditioner,
 )
 from probpipe.core.node import WorkflowFunction
-
 
 # ---------------------------------------------------------------------------
 # Fixtures and helpers

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -6,24 +6,23 @@ import numpy as np
 import pytest
 import scipy.stats as _scipy
 
-from probpipe.distributions import (
-    Normal,
-    Beta,
-    Gamma,
-    InverseGamma,
-    Exponential,
-    LogNormal,
-    StudentT,
-    Uniform,
-    Cauchy,
-    Laplace,
-    HalfNormal,
-    HalfCauchy,
-    Pareto,
-    TruncatedNormal,
-)
 from probpipe import NumericRecordDistribution, log_prob, mean, sample, variance
-
+from probpipe.distributions import (
+    Beta,
+    Cauchy,
+    Exponential,
+    Gamma,
+    HalfCauchy,
+    HalfNormal,
+    InverseGamma,
+    Laplace,
+    LogNormal,
+    Normal,
+    Pareto,
+    StudentT,
+    TruncatedNormal,
+    Uniform,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -6,15 +6,14 @@ import numpy as np
 import pytest
 import scipy.stats
 
+from probpipe import NumericRecordDistribution, log_prob, mean, sample, variance
 from probpipe.distributions import (
     Bernoulli,
     Binomial,
-    Poisson,
     Categorical,
     NegativeBinomial,
+    Poisson,
 )
-from probpipe import NumericRecordDistribution, log_prob, mean, sample, variance
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -6,15 +6,20 @@ import numpy as np
 import pytest
 
 from probpipe import (
+    EmpiricalDistribution,
+    MultivariateNormal,
     NumericRecordDistribution,
+    Provenance,
     RecordEmpiricalDistribution,
     TFPDistribution,
-    EmpiricalDistribution,
-    Provenance,
-    MultivariateNormal,
+    cov,
+    from_distribution,
+    log_prob,
+    mean,
+    prob,
+    sample,
+    variance,
 )
-from probpipe import cov, from_distribution, log_prob, mean, prob, sample, variance
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -132,7 +137,6 @@ class TestMultivariateNormal:
 
     def test_mean_and_cov(self, gaussian, loc, cov_matrix, key):
         """Sample mean and cov from 50k draws must match analytical values."""
-        import scipy.stats
 
         draws = np.asarray(sample(gaussian, key=key, sample_shape=(50_000,)))
         np.testing.assert_allclose(draws.mean(0), np.asarray(loc), atol=0.02)
@@ -625,8 +629,8 @@ class TestDistributionABC:
 
     def test_mean_requires_supports_mean(self):
         """mean op raises TypeError for distributions without SupportsMean."""
-        from probpipe.core.protocols import SupportsSampling, SupportsExpectation
         from probpipe.core.distribution import _mc_expectation
+        from probpipe.core.protocols import SupportsExpectation, SupportsSampling
 
         class MinimalDist(NumericRecordDistribution, SupportsSampling, SupportsExpectation):
             _sampling_cost = "low"
@@ -650,8 +654,8 @@ class TestDistributionABC:
 
     def test_variance_requires_supports_variance(self):
         """variance op raises TypeError for distributions without SupportsVariance."""
-        from probpipe.core.protocols import SupportsSampling, SupportsExpectation
         from probpipe.core.distribution import _mc_expectation
+        from probpipe.core.protocols import SupportsExpectation, SupportsSampling
 
         class MinimalDist(NumericRecordDistribution, SupportsSampling, SupportsExpectation):
             _sampling_cost = "low"

--- a/tests/distributions/test_gaussian_random_function.py
+++ b/tests/distributions/test_gaussian_random_function.py
@@ -2,25 +2,22 @@
 
 from __future__ import annotations
 
-import math
-
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from probpipe import (
+    ArrayRandomFunction,
     Distribution,
     DistributionArray,
-    Normal,
-    MultivariateNormal,
-    RandomFunction,
-    ArrayRandomFunction,
     GaussianRandomFunction,
     LinearBasisFunction,
+    MultivariateNormal,
+    Normal,
+    RandomFunction,
+    sample,
 )
-from probpipe import sample
-
 
 # ---------------------------------------------------------------------------
 # Dense ground-truth helpers

--- a/tests/distributions/test_kde.py
+++ b/tests/distributions/test_kde.py
@@ -15,10 +15,10 @@ import pytest
 
 from probpipe import (
     EmpiricalDistribution,
-    NumericRecord,
-    NumericEventTemplate,
-    Record,
     EventTemplate,
+    NumericEventTemplate,
+    NumericRecord,
+    Record,
 )
 from probpipe.core._empirical import RecordEmpiricalDistribution
 from probpipe.core._numeric_record import NumericRecord as _NumericRecord

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -6,15 +6,14 @@ import numpy as np
 import pytest
 import scipy.stats
 
+from probpipe import cov, log_prob, mean, sample, variance
+from probpipe.core.distribution import NumericRecordDistribution
 from probpipe.distributions import (
     Dirichlet,
     Multinomial,
-    Wishart,
     VonMisesFisher,
+    Wishart,
 )
-from probpipe.core.distribution import NumericRecordDistribution
-from probpipe import cov, log_prob, mean, sample, variance
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -707,6 +707,7 @@ class TestProductProtocolDuckTyping:
         flat-representable.
         """
         import numpy as np
+
         from probpipe import JointEmpirical, Normal
 
         # Object-dtype JointEmpirical stays on the non-numeric base.
@@ -737,6 +738,7 @@ class TestProductProtocolDuckTyping:
         non-numeric leaves behind ``{...}``.
         """
         import numpy as np
+
         from probpipe import JointEmpirical, Normal
 
         je = JointEmpirical(

--- a/tests/distributions/test_support_and_conversion.py
+++ b/tests/distributions/test_support_and_conversion.py
@@ -3,56 +3,39 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import pytest
-from probpipe import from_distribution
+
 from probpipe import (
-    NumericRecordDistribution,
     RecordEmpiricalDistribution,
-    EmpiricalDistribution,
-    Provenance,
-)
-from probpipe.distributions import (
-    MultivariateNormal,
-    Normal,
-    Beta,
-    Gamma,
-    InverseGamma,
-    Exponential,
-    LogNormal,
-    StudentT,
-    Uniform,
-    Cauchy,
-    Laplace,
-    HalfNormal,
-    HalfCauchy,
-    Pareto,
-    TruncatedNormal,
-    Bernoulli,
-    Binomial,
-    Poisson,
-    Categorical,
-    NegativeBinomial,
-    Dirichlet,
-    Multinomial,
-    Wishart,
-    VonMisesFisher,
+    from_distribution,
 )
 from probpipe.core.constraints import (
-    Constraint,
-    real,
-    positive,
-    non_negative,
-    non_negative_integer,
+    _supports_compatible,
     boolean,
-    unit_interval,
-    simplex,
-    positive_definite,
-    sphere,
-    interval,
     greater_than,
     integer_interval,
-    _supports_compatible,
+    interval,
+    non_negative,
+    non_negative_integer,
+    positive,
+    positive_definite,
+    real,
+    simplex,
+    sphere,
+    unit_interval,
 )
-
+from probpipe.distributions import (
+    Bernoulli,
+    Beta,
+    Binomial,
+    Dirichlet,
+    Gamma,
+    MultivariateNormal,
+    Normal,
+    Poisson,
+    Uniform,
+    VonMisesFisher,
+    Wishart,
+)
 
 # ── Section 1: Constraint tests ──────────────────────────────────────────────
 

--- a/tests/distributions/test_tfp_array_backend.py
+++ b/tests/distributions/test_tfp_array_backend.py
@@ -26,7 +26,6 @@ import tensorflow_probability.substrates.jax.distributions as tfd
 from probpipe import Beta, Gamma, MultivariateNormal, Normal
 from probpipe.distributions._tfp_base import _TFPArrayBackend
 
-
 # ---------------------------------------------------------------------------
 # Construction + minimum surface
 # ---------------------------------------------------------------------------

--- a/tests/distributions/test_tfp_batch_rejection.py
+++ b/tests/distributions/test_tfp_batch_rejection.py
@@ -37,7 +37,6 @@ from probpipe import (
 from probpipe.distributions._tfp_base import _allow_batched_tfp_init
 from probpipe.distributions.kde import KDEDistribution
 
-
 # ---------------------------------------------------------------------------
 # Rejection fires across the TFP family
 # ---------------------------------------------------------------------------

--- a/tests/distributions/test_transformed.py
+++ b/tests/distributions/test_transformed.py
@@ -7,18 +7,24 @@ import jax.numpy as jnp
 import pytest
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
-from probpipe.distributions import (
-    TransformedDistribution,
-    Normal,
-    MultivariateNormal,
+from probpipe import (
+    EmpiricalDistribution,
+    NumericRecordDistribution,
+    log_prob,
+    mean,
+    sample,
+    variance,
 )
-from probpipe import NumericRecordDistribution, EmpiricalDistribution
 from probpipe.core.constraints import (
-    real,
     positive,
+    real,
     unit_interval,
 )
-from probpipe import log_prob, mean, sample, variance
+from probpipe.distributions import (
+    MultivariateNormal,
+    Normal,
+    TransformedDistribution,
+)
 
 
 @pytest.fixture

--- a/tests/inference/test_bayesflow_posteriors.py
+++ b/tests/inference/test_bayesflow_posteriors.py
@@ -20,9 +20,9 @@ import numpy as np
 import probpipe as pp
 from probpipe import (
     ApproximateDistribution,
+    EventTemplate,
     Normal,
     ProductDistribution,
-    EventTemplate,
     condition_on,
     learn_amortized_posterior,
 )

--- a/tests/inference/test_blackjax_sgmcmc.py
+++ b/tests/inference/test_blackjax_sgmcmc.py
@@ -30,7 +30,6 @@ from probpipe.inference._blackjax_sgmcmc import (
 )
 from probpipe.inference._minibatch import MinibatchedDistribution
 
-
 # -- Fixtures ------------------------------------------------------------------
 
 

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -16,12 +16,12 @@ import pytest
 
 from probpipe import (
     ApproximateDistribution,
+    EventTemplate,
     MultivariateNormal,
     Normal,
     ProductDistribution,
     Record,
     RecordArray,
-    EventTemplate,
     mean,
     sample,
     variance,

--- a/tests/inference/test_inference_registry.py
+++ b/tests/inference/test_inference_registry.py
@@ -3,17 +3,16 @@
 import warnings
 from typing import Any
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from probpipe import (
+    GLMLikelihood,
     MultivariateNormal,
     Normal,
     ProductDistribution,
     SimpleModel,
-    GLMLikelihood,
     condition_on,
     mean,
 )
@@ -24,7 +23,6 @@ from probpipe.core._registry import (
 )
 from probpipe.inference import inference_method_registry
 from probpipe.modeling._likelihood import Likelihood
-
 
 # ---------------------------------------------------------------------------
 # Shared test helper

--- a/tests/inference/test_inference_utils.py
+++ b/tests/inference/test_inference_utils.py
@@ -404,6 +404,7 @@ class TestParallelChainMap:
         the two on a single device).
         """
         import jax
+
         from probpipe.inference import _inference_utils as iu
 
         if jax.local_device_count() != 1:

--- a/tests/inference/test_minibatch.py
+++ b/tests/inference/test_minibatch.py
@@ -34,7 +34,6 @@ from probpipe.inference._minibatch import (
     _RandomMinibatchLogProb,
 )
 
-
 # -- Fixtures ------------------------------------------------------------------
 
 
@@ -229,7 +228,7 @@ class TestInnerDraw:
         per-minibatch surrogate regardless of which container type the
         user passes.
         """
-        from probpipe import NumericRecordArray, NumericEventTemplate
+        from probpipe import NumericEventTemplate, NumericRecordArray
 
         X, y = regression_data
         n = X.shape[0]

--- a/tests/linalg/test_operations.py
+++ b/tests/linalg/test_operations.py
@@ -1,18 +1,16 @@
 # tests/linalg/test_operations.py
 import jax
 import jax.numpy as jnp
-import numpy as np
 import pytest
 
 from probpipe.linalg.linear_operator import (
+    CholeskyLinOp,
     DenseLinOp,
     DiagonalLinOp,
-    TriangularLinOp,
-    RootLinOp,
-    CholeskyLinOp,
     LinAlgError,
+    RootLinOp,
+    TriangularLinOp,
 )
-
 from probpipe.linalg.operations import (
     logdet,
     mah_dist_squared,

--- a/tests/modeling/test_conditionally_independent_likelihood.py
+++ b/tests/modeling/test_conditionally_independent_likelihood.py
@@ -21,7 +21,6 @@ from probpipe import (
 )
 from probpipe.core.protocols import _default_per_datum_log_likelihood
 
-
 # -- Protocol structure --------------------------------------------------------
 
 

--- a/tests/modeling/test_glm.py
+++ b/tests/modeling/test_glm.py
@@ -1,6 +1,5 @@
 """Tests for GLMLikelihood."""
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -8,15 +7,15 @@ import scipy.stats
 import tensorflow_probability.substrates.jax.glm as tfp_glm
 
 from probpipe import (
+    EventTemplate,
     GLMLikelihood,
     MultivariateNormal,
-    SimpleModel,
     Record,
-    EventTemplate,
+    SimpleModel,
     condition_on,
     mean,
 )
-from probpipe.modeling import Likelihood, GenerativeLikelihood
+from probpipe.modeling import GenerativeLikelihood, Likelihood
 
 
 def _sigmoid(x):
@@ -253,9 +252,9 @@ class TestIncrementalConditionerAutoConvert:
 
     def test_auto_convert_to_kde(self):
         """update() should work without a custom condition_fn."""
-        from probpipe.modeling import IncrementalConditioner
-        from probpipe.inference import ApproximateDistribution
         from probpipe.core.protocols import SupportsLogProb
+        from probpipe.inference import ApproximateDistribution
+        from probpipe.modeling import IncrementalConditioner
 
         X = np.asarray(np.linspace(-1, 1, 20))[:, None].astype(float)
         lik = GLMLikelihood(tfp_glm.Poisson(), X)

--- a/tests/modeling/test_modeling.py
+++ b/tests/modeling/test_modeling.py
@@ -1,18 +1,16 @@
 """Tests for probpipe.modeling — Likelihood protocols, IncrementalConditioner, lazy imports."""
 
-import numpy as np
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
-from probpipe import MultivariateNormal, EmpiricalDistribution
+from probpipe import EmpiricalDistribution, MultivariateNormal
 from probpipe.modeling import (
     GenerativeLikelihood,
     IncrementalConditioner,
     Likelihood,
-    SimpleModel,
 )
-
 
 # ---------------------------------------------------------------------------
 # Lazy imports — probpipe.modeling.__getattr__ branches

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -7,11 +7,12 @@ import pytest
 
 pm = pytest.importorskip("pymc")
 
+from contextlib import contextmanager
+from unittest.mock import patch
+
 import jax
 import jax.numpy as jnp
 import numpy as np
-from contextlib import contextmanager
-from unittest.mock import patch
 
 from probpipe import ApproximateDistribution
 from probpipe.core.record import ArraySpec

--- a/tests/modeling/test_simple_generative_model.py
+++ b/tests/modeling/test_simple_generative_model.py
@@ -1,7 +1,6 @@
 """Tests for SimpleGenerativeModel."""
 
 import jax
-import jax.numpy as jnp
 import pytest
 
 from probpipe import Normal, SimpleGenerativeModel
@@ -78,7 +77,6 @@ class TestProtocols:
     def test_is_supports_sampling(self, model):
         """SimpleGenerativeModel now advertises SupportsSampling (joint draw:
         sample prior, call likelihood.generate_data)."""
-        from probpipe.core.protocols import SupportsSampling
 
         assert isinstance(model, SupportsSampling)
 

--- a/tests/modeling/test_simple_model.py
+++ b/tests/modeling/test_simple_model.py
@@ -9,23 +9,20 @@ Covers:
 - condition_on → ApproximateDistribution
 """
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from probpipe import (
-    Likelihood,
     ApproximateDistribution,
+    EventTemplate,
     MultivariateNormal,
+    Record,
     SimpleModel,
     SupportsLogProb,
     SupportsSampling,
-    Record,
-    EventTemplate,
     condition_on,
 )
-
 
 # ---------------------------------------------------------------------------
 # Test likelihood (plain class — satisfies Likelihood protocol)

--- a/tests/record/test_design.py
+++ b/tests/record/test_design.py
@@ -6,19 +6,18 @@ covers :class:`FullFactorialDesign`; other subclasses land in
 follow-up PRs.
 """
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from probpipe import (
+    FullFactorialDesign,
     NumericRecord,
     NumericRecordArray,
     Record,
     RecordArray,
     workflow_function,
 )
-from probpipe import FullFactorialDesign
 
 # Some assertions use NumericRecord / NumericRecordArray — these only
 # appear as WorkflowFunction outputs, not as Design types. A Design is

--- a/tests/test_binary_registry.py
+++ b/tests/test_binary_registry.py
@@ -12,16 +12,15 @@ from typing import Any
 import pytest
 
 from probpipe.core._registry import (
+    OPT_IN_ONLY_PRIORITY,
     BaseDispatchMethod,
     BaseDispatchRegistry,
     BinaryDispatchMethod,
     BinaryDispatchRegistry,
     MethodInfo,
-    OPT_IN_ONLY_PRIORITY,
     UnaryDispatchMethod,
     UnaryDispatchRegistry,
 )
-
 
 # ---------------------------------------------------------------------------
 # Synthetic type hierarchy for dispatch tests

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -21,22 +21,20 @@ import pytest
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
 from probpipe import (
-    RecordEmpiricalDistribution,
-    NumericRecord,
     BootstrapDistribution,
     EmpiricalDistribution,
     Normal,
+    NumericRecord,
+    RecordEmpiricalDistribution,
     TransformedDistribution,
     cov,
     expectation,
-    log_prob,
     mean,
     prob,
     sample,
     variance,
 )
 from probpipe.distributions.multivariate import MultivariateNormal
-
 
 # ---------------------------------------------------------------------------
 # BootstrapDistribution
@@ -336,9 +334,9 @@ class TestCovarianceRequiresProtocol:
     def test_cov_raises_without_supports_covariance(self):
         """A distribution with SupportsExpectation but not SupportsCovariance
         should raise TypeError from the cov op."""
-        from probpipe.core.distribution import _mc_expectation
-        from probpipe.core.protocols import SupportsSampling, SupportsExpectation
         from probpipe import NumericRecordDistribution, cov
+        from probpipe.core.distribution import _mc_expectation
+        from probpipe.core.protocols import SupportsExpectation, SupportsSampling
 
         class NoCovDist(NumericRecordDistribution, SupportsSampling, SupportsExpectation):
             _sampling_cost = "low"
@@ -374,7 +372,7 @@ class TestUnnormalizedProbDefault:
     """Cover the _unnormalized_prob default (exp of _unnormalized_log_prob)."""
 
     def test_unnormalized_prob_default(self):
-        from probpipe import unnormalized_prob, unnormalized_log_prob
+        from probpipe import unnormalized_log_prob, unnormalized_prob
 
         d = Normal(loc=0.0, scale=1.0, name="x")
         x = jnp.array(1.0)

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -13,7 +13,6 @@ import textwrap
 
 import jax
 import jax.numpy as jnp
-import pytest
 
 
 def _run_x64(snippet: str) -> str:
@@ -56,8 +55,8 @@ def _run_x64(snippet: str) -> str:
 
 
 def test_x32_default_normal_is_float32():
-    from probpipe.distributions.continuous import Normal
     import probpipe.core.ops as ops
+    from probpipe.distributions.continuous import Normal
 
     n = Normal(loc=0.0, scale=1.0, name="n")
     assert n.dtype == jnp.float32

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,10 +1,10 @@
 """Tests for probpipe._weights: Weights class and utility functions."""
 
-import pytest
 import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 from probpipe._weights import (
     Weights,
@@ -12,12 +12,11 @@ from probpipe._weights import (
     normalize_weights,
     normalized_log_weights,
     uniform_weights,
+    weighted_choice,
+    weighted_covariance,
     weighted_mean,
     weighted_variance,
-    weighted_covariance,
-    weighted_choice,
 )
-
 
 # ---------------------------------------------------------------------------
 # _validate_to_log_weights
@@ -519,8 +518,8 @@ class TestFactoryDispatch:
 
     def test_bootstrap_from_empirical_returns_array_variant(self):
         from probpipe import (
-            EmpiricalDistribution,
             BootstrapReplicateDistribution,
+            EmpiricalDistribution,
             RecordBootstrapReplicateDistribution,
         )
 

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -6,15 +6,12 @@ import numpy as np
 import pytest
 import tensorflow_probability.substrates.jax.glm as tfp_glm
 
-from probpipe import Normal, MultivariateNormal, GLMLikelihood, predictive_check
+from probpipe import GLMLikelihood, MultivariateNormal, Normal, predictive_check
 from probpipe.core.distribution import EmpiricalDistribution
 from probpipe.validation import predictive_check as pc_direct
 from probpipe.validation._predictive_check import (
-    _predictive_check_batched,
-    _predictive_check_loop,
     _supports_key_arg,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helper: JAX-based generative likelihood


### PR DESCRIPTION
## Summary

Burns down the safe portion of the `ruff check` lint backlog with `ruff check
--fix` on the **`.py` source**: **588 → 263** violations (325 fixed). This is
step 1 toward making `ruff check` a blocking gate; the remaining 263 (notebooks,
`__init__` re-exports, manual-judgment rules, and `--unsafe-fixes`) are the
follow-on triage.

> **Stacked on #295** (ruff format). Built on the reformatted tree so it stays
> format-gate-clean and conflict-free; merge after #295 (base retargets to main).

## What it does

`ruff check --fix` over `.py` source — **safe fixes only**: unused imports removed
(F401), imports sorted (I001), annotations unquoted (UP037), empty f-strings
(F541), and similar. Reformatted afterward (`ruff format .`) so the #295 format
gate stays green.

## Deliberately NOT touched (deferred to the lint-triage step)

- **`probpipe/__init__.py` + `probpipe/linalg/__init__.py`** — their 38
  unused-import flags are **intended public re-exports**; the right fix is
  `__all__` curation, not deletion, so they're left exactly as-is.
- **Docs notebooks** (`docs/**/*.ipynb`, ~91 flags) — `ruff check --fix` rewrites
  tutorial cells; like the ruff-format notebook exclusion, these stay
  hand-curated and out of an automated sweep.
- **The 54 `--unsafe-fixes`** and the manual-judgment rules (E402 conditional
  imports, RUF005, SIM102, E731, …).

## Test plan

- Full suite green: **3066 passed, 50 skipped** (bayesflow/stan legs run in CI).
- All 3114 tests still collect — no import broken by the removals.
- `ruff format --check .` clean; `import probpipe` works.
- `ruff check`: **588 → 263** remaining.
