### PR TITLE
ci: make ruff check (lint) a blocking gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,13 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Advisory ruff lint. Annotates PRs with violations but does NOT gate
-  # merges (continue-on-error). ProbPipe carries a backlog from a
-  # previously-unenforced linter, and several large refactors are in
-  # flight; advisory mode surfaces issues without blocking that work or
-  # forcing a repo-wide cleanup sweep. To enforce later: drop
-  # continue-on-error and scope to changed files. The ruff version is
-  # read from .pre-commit-config.yaml (single source of truth) so this job
-  # can't drift from the pre-commit pin that `pre-commit autoupdate` bumps;
-  # keep uv.lock's ruff in sync too for local `uv run ruff`. `ruff format
-  # --check` runs here too and IS blocking — the tree is autoformatted, so a
-  # misformatted file fails CI even while `ruff check` (lint) stays advisory.
+  # Ruff lint + format gate — both blocking. `ruff check` enforces a
+  # zero-violation tree and `ruff format --check` enforces the autoformat;
+  # a new lint violation or a misformatted file fails CI. Lint scope and
+  # rule selection live in pyproject.toml ([tool.ruff.lint]). The ruff
+  # version is read from .pre-commit-config.yaml (single source of truth) so
+  # this job can't drift from the pre-commit pin that `pre-commit autoupdate`
+  # bumps; keep uv.lock's ruff in sync too for local `uv run ruff`.
   lint:
     name: lint & format
     runs-on: ubuntu-latest
@@ -36,9 +32,9 @@ jobs:
         with:
           enable-cache: true
 
-      # Blocking: validates .pre-commit-config.yaml structure (all hooks, not
-      # just ruff) so a corrupted config can't slip through while the ruff
-      # check itself stays advisory. Cheap — it does not run any hook.
+      # Validates .pre-commit-config.yaml structure (all hooks, not just ruff)
+      # so a corrupted config can't slip through. Cheap — it does not run any
+      # hook.
       - name: Validate pre-commit config
         run: uvx pre-commit validate-config
 
@@ -53,8 +49,7 @@ jobs:
           echo "ruff=$ver" >> "$GITHUB_OUTPUT"
           echo "Resolved ruff $ver from .pre-commit-config.yaml"
 
-      - name: Ruff check (advisory — does not gate merges)
-        continue-on-error: true
+      - name: Ruff check (blocking)
         run: uvx "ruff@${{ steps.ruffver.outputs.ruff }}" check . --output-format=github
 
       - name: Ruff format check (blocking — the tree is autoformatted)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 # Pre-commit hooks for ProbPipe. Install once with `uvx pre-commit install`
 # (or `pre-commit install`); thereafter they run on staged files at commit time.
 #
-# Hooks only see the files you're changing, so they ratchet the codebase clean
-# file-by-file rather than demanding a big-bang cleanup. `ruff` here flags but
+# Hooks only see the files you're changing, so a commit is checked without
+# re-running over the whole tree. `ruff` here flags but
 # does NOT auto-fix (no `--fix`) — fixes stay intentional and reviewable. The
 # `ruff-format` hook DOES rewrite files (that is its job); notebooks are excluded
 # from formatting via `[tool.ruff.format]` in pyproject.toml.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ruff format` (Black-style) rather than the previous manual horizontal-packing
   conventions: the source tree was reformatted in one mechanical sweep (recorded
   in `.git-blame-ignore-revs`), a `ruff-format` pre-commit hook reformats on
-  commit, and `ruff format --check` is a **blocking** CI step (the `ruff check`
-  lint stays advisory). Notebooks are excluded so the docs' tutorial cells keep
-  their hand layout; string quotes normalize to double. See
+  commit, and `ruff format --check` is a **blocking** CI step. Notebooks are
+  excluded so the docs' tutorial cells keep their hand layout; string quotes
+  normalize to double. See
   [CONTRIBUTING.md § Code formatting](CONTRIBUTING.md#code-formatting).
 
 - **`provenance_ancestors()` now returns `ParentInfo` descriptors, not live
@@ -369,17 +369,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   works for contributors with an existing pip setup. See
   [CONTRIBUTING.md](CONTRIBUTING.md#installation).
 
-- **Ruff linting + pre-commit hooks.** A `lint (advisory)` CI job runs
-  `ruff check` and annotates PRs with violations; it is **advisory for
-  now** (does not gate merges) while the pre-existing lint backlog is
-  burned down and large refactors are in flight. A new
+- **Ruff linting + pre-commit hooks.** The `lint & format` CI job runs
+  `ruff check` over the whole tree as a **blocking** gate. A
   `.pre-commit-config.yaml` (install with `uvx pre-commit install`) runs
-  ruff plus file-hygiene hooks on staged files. The ruff config gains
-  ignores for ambiguous-unicode rules (`RUF001/2/3` — false positives on
-  mathematical notation) and per-file ignores for notebook
-  import/semicolon idioms (`E402`/`E702`). `ruff format` is intentionally
-  not adopted; its style conflicts with the documented formatting
-  conventions. See [CONTRIBUTING.md](CONTRIBUTING.md#linting--pre-commit).
+  ruff (lint + format) plus file-hygiene hooks on staged files. The lint
+  config (`[tool.ruff.lint]`) selects the `E`/`W`/`F`/`I`/`UP`/`B`/`SIM`/`RUF`
+  families, ignores the ambiguous-unicode rules (`RUF001/2/3` — false
+  positives on mathematical notation), and excludes notebooks (executed in
+  CI instead). See [CONTRIBUTING.md](CONTRIBUTING.md#linting--pre-commit).
 
 - **`pymc_nuts` reclaims multi-core sampling.** The method previously
   forced `cores=1` to avoid an `os.fork()` deadlock against JAX's worker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,8 +188,9 @@ uv run ruff format .          # reformat the tree
 uv run ruff format --check .  # verify (this is what CI enforces)
 ```
 
-`ruff format --check` is a **blocking** CI step, so a misformatted file fails the
-build (`ruff check`, the linter, stays advisory). A few specifics: the line
+Both `ruff format --check` and `ruff check` (the linter) are **blocking** CI
+steps, so a misformatted file or a lint violation fails the build. A few
+specifics: the line
 length is 100 (`[tool.ruff]` in `pyproject.toml`); ruff keeps code on one line
 when it fits and explodes imports / call arguments one-item-per-line when it does
 not; string quotes normalize to double. Notebooks are excluded
@@ -226,34 +227,29 @@ uvx pre-commit install      # or: pre-commit install
 ```
 
 Thereafter `ruff` (lint + format) plus a few file-hygiene hooks run on your staged
-files at commit time. The hooks see only the files you're changing, so the
-codebase cleans up file-by-file rather than in one sweep. To run manually:
+files at commit time. The hooks see only the files you're changing, so a commit is
+checked without re-linting the whole tree. To run manually:
 
 ```bash
 uv run ruff check .              # lint the whole tree (uses the uv.lock-pinned ruff)
 uvx pre-commit run --all-files   # run every hook over everything
 ```
 
-A full `--all-files` run is **not** expected to be clean yet: the repo carries a
-lint and file-hygiene backlog that the hooks burn down file-by-file (see below),
-so it will report — and the fixer hooks will modify — pre-existing issues in
-files you did not touch. That is expected for now, not a regression.
+`ruff check .` and `ruff format --check .` are clean tree-wide. A full
+`--all-files` run may still surface pre-existing file-hygiene nits (trailing
+whitespace, end-of-file) in files you did not touch; the fixer hooks clean those
+as the relevant files are next edited.
 
-Two deliberate choices:
+Both `ruff check` (lint) and `ruff format` are enforced:
 
-- **`ruff check` (lint) is advisory in CI for now.** ProbPipe carries a lint
-  backlog from a period when ruff wasn't enforced, and several large
-  refactors are in flight. The `ruff check` step in the `lint & format` job
-  annotates PRs with violations but does not gate merges; it will become
-  blocking once the backlog is burned down. Locally, the pre-commit hook flags
-  issues on the
-  files you touch — fix them when practical; `git commit --no-verify`
-  bypasses it for a pre-existing-violation file you'd rather not clean in
-  an unrelated change.
+- **`ruff check` (lint) is blocking in CI.** The `lint & format` job runs
+  `ruff check .` over the whole tree, which is at zero violations; a new
+  violation fails the build. Rule selection and per-file ignores live in
+  `[tool.ruff.lint]` in `pyproject.toml`. The pre-commit hook flags the same
+  issues on your staged files at commit time.
 - **`ruff format` is enforced.** Formatting is owned by `ruff format` (see
   *Code formatting* above): `ruff format --check` is a blocking CI step and the
-  `ruff-format` pre-commit hook reformats on commit. `ruff check` (lint) is the
-  part that stays advisory.
+  `ruff-format` pre-commit hook reformats on commit.
 
 ### Type checking
 
@@ -353,8 +349,8 @@ GitHub Actions (`.github/workflows/ci.yml`):
   bayesflow leg — runs on pushes to main, foundational changes, or Stan-file
   changes
 - Coverage uploaded to Codecov
-- A `lint (advisory)` job runs `ruff check` and annotates PRs with
-  violations but does **not** gate merges yet (see *Linting & pre-commit*)
+- The `lint & format` job runs `ruff check` (lint) and `ruff format --check`;
+  both are **blocking** (see *Linting & pre-commit*)
 - Both the `test` and `notebooks` jobs choose what to run via a shared,
   unit-tested AST import-graph helper — `scripts/ci/import_graph.py` (tests
   in `tests/ci/`) — so a change to a source file also exercises the tests and


### PR DESCRIPTION
## Summary

Follows #298 (lint backlog cleared to zero). Flips the `lint & format` job's
`ruff check` step from advisory to **blocking** — a new lint violation now fails
CI. `ruff format --check` was already blocking; both halves of the job now
enforce. Pyright (the separate `typecheck` job) stays advisory.

## Changes

- **`.github/workflows/ci.yml`** — drop `continue-on-error` from the Ruff check
  step, rename it "Ruff check (blocking)", and update the job comment to the
  enforced state.
- **CONTRIBUTING.md** — § Linting & pre-commit now describes lint as blocking
  (dropped the advisory/backlog framing and the `--no-verify` escape hatch); the
  CI-overview bullet and the Code-formatting note match.
- **CHANGELOG.md** — consolidate the ruff entries to the final state: the prior
  "advisory for now", "`ruff format` intentionally not adopted", and notebook
  `E402`/`E702` notes were superseded within this unreleased cycle.

## Note on branch protection

This makes the **job** fail on a lint violation. For that to actually block a
merge, `lint & format` must be a required status check (a branch-protection
setting, not in-repo). It already runs the blocking format check, so if the job
is required today, this extends that gate to lint at no extra config.

## Test plan

- `ruff check .` and `ruff format --check .` clean locally.
- `ci.yml` parses; the lint job has no `continue-on-error` (pyright still does).
- Docs + CI config only — no code change.
