### PR TITLE
Phase 1b (#235): EventTemplate numeric query & projection methods

### DIFF
--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -974,14 +974,42 @@ class EventTemplate:
         """
         return len(self._specs) > 1
 
+    def numeric_fields(self) -> tuple[str, ...]:
+        """Top-level field names whose leaf is numeric.
+
+        A top-level field is numeric if its spec is an :class:`ArraySpec` or a
+        nested :class:`EventTemplate` that is itself all-numeric (see
+        :attr:`is_numeric`). The exact complement of :meth:`non_numeric_fields`:
+        together the two partition :attr:`fields` (each in insertion order).
+
+        Note that this reports *top-level* fields only, so a field is numeric
+        here iff its nested sub-template is *entirely* numeric — it does not
+        descend to count partially-numeric nestings. Use :meth:`numeric_subset`
+        for the recursive, path-stable projection to numeric leaves.
+
+        Returns
+        -------
+        tuple of str
+            Names of the numeric top-level fields, in insertion order. Empty
+            when every top-level field is non-numeric.
+        """
+        result: list[str] = []
+        for name, spec in self._specs.items():
+            if isinstance(spec, ArraySpec) or (
+                isinstance(spec, EventTemplate) and spec.is_numeric
+            ):
+                result.append(name)
+        return tuple(result)
+
     def non_numeric_fields(self) -> tuple[str, ...]:
         """Top-level field names whose leaf is non-numeric.
 
         A top-level field is non-numeric if its spec is an
         :class:`OpaqueSpec` / :class:`DistributionSpec` / :class:`FunctionSpec`
         leaf, or a nested :class:`EventTemplate` that is not itself all-numeric
-        (see :attr:`is_numeric`). Used to build clear inference error messages
-        when a template cannot be projected to a numeric subset.
+        (see :attr:`is_numeric`). The exact complement of :meth:`numeric_fields`:
+        together the two partition :attr:`fields`. Used to build clear inference
+        error messages when a template cannot be projected to a numeric subset.
 
         Returns
         -------

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -995,9 +995,7 @@ class EventTemplate:
         """
         result: list[str] = []
         for name, spec in self._specs.items():
-            if isinstance(spec, ArraySpec) or (
-                isinstance(spec, EventTemplate) and spec.is_numeric
-            ):
+            if isinstance(spec, ArraySpec) or (isinstance(spec, EventTemplate) and spec.is_numeric):
                 result.append(name)
         return tuple(result)
 

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -930,6 +930,120 @@ class EventTemplate:
         """
         return _pack_fields(self.fields, field_kwargs, owner=type(self).__name__)
 
+    # -- Numeric queries & projection ---------------------------------------
+
+    @property
+    def is_numeric(self) -> bool:
+        """Whether every reachable leaf is an :class:`ArraySpec`.
+
+        Recursive: descends into nested :class:`EventTemplate` fields and
+        returns ``True`` only if *all* leaves (at every depth) are numeric
+        array leaves. Any :class:`OpaqueSpec` / :class:`DistributionSpec` /
+        :class:`FunctionSpec` leaf — or a nested sub-template that is not
+        itself all-numeric — makes the whole template non-numeric.
+
+        This is computed as an explicit recursive leaf check rather than
+        ``isinstance(self, NumericEventTemplate)``. Under the ``__new__``
+        auto-promotion invariant the two agree, but the recursive form is
+        also correct for hand-built mixed nestings.
+
+        Returns
+        -------
+        bool
+            ``True`` iff every reachable leaf is an :class:`ArraySpec`.
+        """
+        for spec in self._specs.values():
+            if isinstance(spec, ArraySpec):
+                continue
+            if isinstance(spec, EventTemplate):
+                if not spec.is_numeric:
+                    return False
+                continue
+            # Opaque / distribution / function leaf — not numeric.
+            return False
+        return True
+
+    @property
+    def is_multi_field(self) -> bool:
+        """Whether this template has more than one top-level field.
+
+        Returns
+        -------
+        bool
+            ``True`` iff ``len(self.fields) > 1``.
+        """
+        return len(self._specs) > 1
+
+    def non_numeric_fields(self) -> tuple[str, ...]:
+        """Top-level field names whose leaf is non-numeric.
+
+        A top-level field is non-numeric if its spec is an
+        :class:`OpaqueSpec` / :class:`DistributionSpec` / :class:`FunctionSpec`
+        leaf, or a nested :class:`EventTemplate` that is not itself all-numeric
+        (see :attr:`is_numeric`). Used to build clear inference error messages
+        when a template cannot be projected to a numeric subset.
+
+        Returns
+        -------
+        tuple of str
+            Names of the non-numeric top-level fields, in insertion order.
+            Empty when the template :attr:`is_numeric`.
+        """
+        result: list[str] = []
+        for name, spec in self._specs.items():
+            if isinstance(spec, ArraySpec):
+                continue
+            if isinstance(spec, EventTemplate) and spec.is_numeric:
+                continue
+            result.append(name)
+        return tuple(result)
+
+    def numeric_subset(self) -> NumericEventTemplate:
+        """Project to the :class:`ArraySpec`-leaf sub-template.
+
+        Keeps every numeric leaf, recursing into nested
+        :class:`EventTemplate` fields (each contributes its own
+        ``numeric_subset()``); drops :class:`OpaqueSpec` /
+        :class:`DistributionSpec` / :class:`FunctionSpec` leaves; and prunes
+        any nested template that becomes empty. Surviving leaves keep their
+        ``/``-delimited paths (the projection is path-stable). Inference uses
+        this to recover the numeric core of a mixed template.
+
+        On an already-all-numeric template the result is an equal
+        :class:`NumericEventTemplate` (the projection is idempotent).
+
+        Returns
+        -------
+        NumericEventTemplate
+            The numeric-leaf sub-template, so that :attr:`flat_size` and
+            :attr:`numeric_leaf_shapes` are available.
+
+        Raises
+        ------
+        ValueError
+            If no numeric leaves survive — an :class:`EventTemplate` needs at
+            least one field, so an empty numeric subset is meaningless. The
+            message names the dropped (non-numeric) fields.
+        """
+        specs: dict[str, _FieldSpec] = {}
+        for name, spec in self._specs.items():
+            if isinstance(spec, ArraySpec):
+                specs[name] = spec
+            elif isinstance(spec, EventTemplate):
+                try:
+                    specs[name] = spec.numeric_subset()
+                except ValueError:
+                    # Nested template has no numeric leaves — prune it.
+                    continue
+            # Opaque / distribution / function leaves are dropped.
+        if not specs:
+            raise ValueError(
+                f"numeric_subset() of {type(self).__name__} is empty: no "
+                f"ArraySpec leaves survive. Dropped non-numeric fields: "
+                f"{self.non_numeric_fields()}."
+            )
+        return NumericEventTemplate(specs)
+
     def __contains__(self, name: str) -> bool:
         return name in self._specs
 

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -965,14 +965,23 @@ class EventTemplate:
 
     @property
     def is_multi_field(self) -> bool:
-        """Whether this template has more than one top-level field.
+        """Whether this template describes more than one leaf.
+
+        Counts *reachable* leaves recursively (descending into nested
+        sub-templates), not top-level fields — so a single top-level field that
+        nests several leaves is multi-field. For example
+        ``EventTemplate(a=EventTemplate(b=(), c=()))`` has leaves ``a/b`` and
+        ``a/c`` and is multi-field, whereas ``EventTemplate(a=EventTemplate(b=()))``
+        describes the single leaf ``a/b`` and is not. Equivalent to
+        ``len(self.leaf_shapes) > 1``.
 
         Returns
         -------
         bool
-            ``True`` iff ``len(self.fields) > 1``.
+            ``True`` iff the template has more than one leaf; ``False`` iff it
+            describes exactly one leaf.
         """
-        return len(self._specs) > 1
+        return len(self.leaf_shapes) > 1
 
     def numeric_fields(self) -> tuple[str, ...]:
         """Top-level field names whose leaf is numeric.

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -1059,7 +1059,11 @@ class EventTemplate:
                 try:
                     specs[name] = spec.numeric_subset()
                 except ValueError:
-                    # Nested template has no numeric leaves — prune it.
+                    # The empty-projection guard below is the *only* ValueError
+                    # numeric_subset() raises, so catching it here means the
+                    # nested template had no numeric leaves — prune it. If a
+                    # future change adds another ValueError path, narrow this
+                    # catch so it can't mask an unrelated failure.
                     continue
             # Opaque / distribution / function leaves are dropped.
         if not specs:

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -654,6 +654,26 @@ class TestIsMultiField:
         assert EventTemplate(x=(), y=()).is_multi_field is True
 
 
+class TestNumericFields:
+    def test_all_numeric(self):
+        assert EventTemplate(x=(), y=(3,)).numeric_fields() == ("x", "y")
+
+    def test_exact_numeric_names(self):
+        tpl = EventTemplate(x=(), label=None, d=_dist_spec(), y=(2,), f=_func_spec())
+        assert tpl.numeric_fields() == ("x", "y")
+
+    def test_nested_all_numeric_is_numeric(self):
+        tpl = EventTemplate(x=(), nested=EventTemplate(a=(), b=(3,)))
+        assert tpl.numeric_fields() == ("x", "nested")
+
+    def test_nested_mixed_not_listed(self):
+        tpl = EventTemplate(x=(), nested=EventTemplate(a=(), label=None))
+        assert tpl.numeric_fields() == ("x",)
+
+    def test_all_non_numeric_empty(self):
+        assert EventTemplate(label=None, d=_dist_spec()).numeric_fields() == ()
+
+
 class TestNonNumericFields:
     def test_all_numeric_empty(self):
         assert EventTemplate(x=(), y=(3,)).non_numeric_fields() == ()
@@ -669,6 +689,19 @@ class TestNonNumericFields:
     def test_nested_numeric_not_listed(self):
         tpl = EventTemplate(x=(), nested=EventTemplate(a=(), b=(3,)))
         assert tpl.non_numeric_fields() == ()
+
+    def test_complement_partitions_fields(self):
+        tpl = EventTemplate(
+            x=(),
+            label=None,
+            nested_num=EventTemplate(a=(), b=(3,)),
+            d=_dist_spec(),
+            nested_mixed=EventTemplate(a=(), label=None),
+        )
+        numeric = tpl.numeric_fields()
+        non_numeric = tpl.non_numeric_fields()
+        assert set(numeric).isdisjoint(non_numeric)
+        assert set(numeric) | set(non_numeric) == set(tpl.fields)
 
 
 class TestNumericSubset:

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -606,3 +606,118 @@ class TestShapeAccessorBackCompat:
         assert hash(a) == hash(b)
         assert a != c
         assert hash(a) != hash(c)
+
+
+# ---------------------------------------------------------------------------
+# Numeric queries & projection: is_numeric / is_multi_field /
+# non_numeric_fields / numeric_subset
+# ---------------------------------------------------------------------------
+
+
+def _dist_spec() -> DistributionSpec:
+    return DistributionSpec(inner_template=EventTemplate(a=()))
+
+
+def _func_spec() -> FunctionSpec:
+    return FunctionSpec(
+        input_template=EventTemplate(a=()), output_template=EventTemplate(b=())
+    )
+
+
+class TestIsNumeric:
+    def test_all_arrayspec(self):
+        assert EventTemplate(x=(), y=(3,)).is_numeric is True
+
+    def test_nested_all_numeric(self):
+        tpl = EventTemplate(x=(), params=EventTemplate(a=(), b=(3,)))
+        assert tpl.is_numeric is True
+
+    def test_mixed_opaque(self):
+        assert EventTemplate(x=(), label=None).is_numeric is False
+
+    def test_distribution_leaf(self):
+        assert EventTemplate(x=(), d=_dist_spec()).is_numeric is False
+
+    def test_function_leaf(self):
+        assert EventTemplate(x=(), f=_func_spec()).is_numeric is False
+
+    def test_nested_mixed(self):
+        tpl = EventTemplate(x=(), nested=EventTemplate(a=(), label=None))
+        assert tpl.is_numeric is False
+
+
+class TestIsMultiField:
+    def test_single_field(self):
+        assert EventTemplate(x=()).is_multi_field is False
+
+    def test_multi_field(self):
+        assert EventTemplate(x=(), y=()).is_multi_field is True
+
+
+class TestNonNumericFields:
+    def test_all_numeric_empty(self):
+        assert EventTemplate(x=(), y=(3,)).non_numeric_fields() == ()
+
+    def test_exact_non_numeric_names(self):
+        tpl = EventTemplate(x=(), label=None, d=_dist_spec(), y=(2,), f=_func_spec())
+        assert tpl.non_numeric_fields() == ("label", "d", "f")
+
+    def test_nested_mixed_is_non_numeric(self):
+        tpl = EventTemplate(x=(), nested=EventTemplate(a=(), label=None))
+        assert tpl.non_numeric_fields() == ("nested",)
+
+    def test_nested_numeric_not_listed(self):
+        tpl = EventTemplate(x=(), nested=EventTemplate(a=(), b=(3,)))
+        assert tpl.non_numeric_fields() == ()
+
+
+class TestNumericSubset:
+    def test_drops_non_numeric_keeps_numeric(self):
+        tpl = EventTemplate(x=(), label=None, d=_dist_spec(), y=(3,))
+        sub = tpl.numeric_subset()
+        assert isinstance(sub, NumericEventTemplate)
+        assert sub.fields == ("x", "y")
+
+    def test_recurses_into_nested(self):
+        tpl = EventTemplate(x=(), nested=EventTemplate(a=(), label=None, b=(3,)))
+        sub = tpl.numeric_subset()
+        assert sub.fields == ("x", "nested")
+        assert isinstance(sub["nested"], NumericEventTemplate)
+        assert sub["nested"].fields == ("a", "b")
+
+    def test_prunes_emptied_nested(self):
+        tpl = EventTemplate(x=(), nested=EventTemplate(label=None, tag=None))
+        sub = tpl.numeric_subset()
+        assert sub.fields == ("x",)
+
+    def test_path_stable(self):
+        tpl = EventTemplate(x=(), nested=EventTemplate(a=(), label=None, b=(3,)))
+        sub = tpl.numeric_subset()
+        assert sub.leaf_shapes == {"x": (), "nested/a": (), "nested/b": (3,)}
+
+    def test_idempotent_on_all_numeric(self):
+        tpl = EventTemplate(x=(), y=(3,), nested=EventTemplate(a=(), b=(2,)))
+        sub = tpl.numeric_subset()
+        assert sub == tpl
+        assert sub.numeric_subset() == sub
+
+    def test_returns_numeric_template_with_flat_size(self):
+        tpl = EventTemplate(x=(), label=None, y=(3,), z=(2, 4))
+        sub = tpl.numeric_subset()
+        assert isinstance(sub, NumericEventTemplate)
+        assert sub.flat_size == 1 + 3 + 8
+
+    def test_raises_when_no_numeric_leaves(self):
+        tpl = EventTemplate(label=None, tag=None)
+        with pytest.raises(ValueError, match="ArraySpec leaves survive"):
+            tpl.numeric_subset()
+
+    def test_raises_names_dropped_fields(self):
+        tpl = EventTemplate(label=None, d=_dist_spec())
+        with pytest.raises(ValueError, match="label"):
+            tpl.numeric_subset()
+
+    def test_raises_when_only_nested_empties(self):
+        tpl = EventTemplate(nested=EventTemplate(label=None, tag=None))
+        with pytest.raises(ValueError, match="nested"):
+            tpl.numeric_subset()

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -651,6 +651,26 @@ class TestIsMultiField:
     def test_multi_field(self):
         assert EventTemplate(x=(), y=()).is_multi_field is True
 
+    def test_single_opaque_leaf(self):
+        assert EventTemplate(label=None).is_multi_field is False
+
+    def test_two_leaves_mixed(self):
+        assert EventTemplate(x=(), label=None).is_multi_field is True
+
+    def test_single_leaf_under_nested_field(self):
+        # One top-level field nesting a single leaf -> one leaf -> not multi.
+        assert EventTemplate(a=EventTemplate(b=())).is_multi_field is False
+
+    def test_multiple_leaves_under_one_nested_field(self):
+        # jhuggins' case: a single top-level field 'a' with leaves a/b, a/c.
+        tpl = EventTemplate(a=EventTemplate(b=(), c=()))
+        assert tpl.fields == ("a",)  # one top-level field ...
+        assert tpl.is_multi_field is True  # ... but two leaves -> multi-field
+
+    def test_deeply_nested_single_leaf(self):
+        tpl = EventTemplate(a=EventTemplate(b=EventTemplate(c=())))
+        assert tpl.is_multi_field is False
+
 
 class TestNumericFields:
     def test_all_numeric(self):

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -619,9 +619,7 @@ def _dist_spec() -> DistributionSpec:
 
 
 def _func_spec() -> FunctionSpec:
-    return FunctionSpec(
-        input_template=EventTemplate(a=()), output_template=EventTemplate(b=())
-    )
+    return FunctionSpec(input_template=EventTemplate(a=()), output_template=EventTemplate(b=()))
 
 
 class TestIsNumeric:


### PR DESCRIPTION
## PR-1b — EventTemplate numeric query & projection methods

Second slice of Phase 1 of #235 (follows #292 — rename + LeafSpec representation, merged).
**Purely additive**: new methods on `EventTemplate`; no renames, no breaking changes, no
dependency on later-phase batch types.

### Scope — add four methods to `EventTemplate` (`probpipe/core/record.py`), per #235 Chapter 1
- `is_numeric -> bool` (property): True iff every reachable leaf is an `ArraySpec` (recurse into
  nested templates). Implement as an explicit recursive leaf check — the source of truth; it should
  agree with `isinstance(self, NumericEventTemplate)` under the auto-promotion invariant, but the
  recursive form is robust to hand-built mixed nestings.
- `is_multi_field -> bool` (property): True iff the template describes **more than one reachable
  leaf** (recurse into nested sub-templates) — `len(self.leaf_shapes) > 1`. Note this counts leaves,
  not top-level fields, so a single top-level field nesting several leaves (e.g. leaves `a/b` and
  `a/c`) is multi-field. (Refined from #235 Chapter 1's `len(self.fields) > 1` per PR review — a
  top-level-field count is unintuitive when one field nests multiple leaves.)
- `non_numeric_fields() -> tuple[str, ...]`: top-level field names whose leaf is non-numeric
  (`OpaqueSpec`/`DistributionSpec`/`FunctionSpec`, or a nested template that isn't all-numeric).
  Powers clear inference error messages.
- `numeric_subset() -> NumericEventTemplate`: project to the `ArraySpec`-leaf subtemplate — keep
  numeric leaves (recursing into nested templates), drop opaque/distribution/function leaves, prune
  any nested template that becomes empty. Path-stable (surviving leaves keep their `/`-paths).
  Returns a `NumericEventTemplate` so `flat_size` / `numeric_leaf_shapes` are available.

### Decisions (flag if you disagree)
- `numeric_subset()` on an already-all-numeric template → returns an equal `NumericEventTemplate`
  (idempotent).
- `numeric_subset()` when **no** numeric leaves survive → raise `ValueError` (an `EventTemplate`
  needs ≥1 field; an empty numeric subset is meaningless); name the dropped fields.
- Nested fields contribute `nested.numeric_subset()`; if that would be empty, the field is dropped.
- `is_numeric` via recursive leaf check, not just `isinstance(self, NumericEventTemplate)`.

### Out of scope (do NOT do here)
- `to_vector` / `from_vector` and the `NumericRecord.flatten → to_vector` rename + consumer audit
  → **PR-1c**.
- `make_batch` / `vectorize` → later, with the `Batch` ABC / `*Array→*Batch` work (Phase 2/3); they
  consume/produce batch containers and shouldn't bind to the soon-to-be-renamed `*Array` types.
- Rewiring inference (`_inference_utils.py` / `_tfp_mcmc.py`) to call `numeric_subset()` → separate
  change (also wants `to_vector`/`from_vector`). Keep 1b additive — no behavior change to existing
  paths.
- `RandomFunction`/`RandomMeasure` population; `Tracked`/`Annotated` mixins; any `*Batch` work.

### Definition of done
- Four methods added with NumPy-style docstrings; all existing behavior unchanged (additive only).
- Full test suite green (nothing renamed → no consumer audit).
- New tests added (below).
- New code conforms to the repo's **ruff lint + format** standard (`[tool.ruff]` in
  `pyproject.toml`: line-length 100, isort import order; ruff version pinned in
  `.pre-commit-config.yaml`). The CI `lint & format` job enforces **both** `ruff check .` and
  `ruff format --check .`, so match both: run `uv run ruff check --fix` and `uv run ruff format`
  on your changed files (or `pre-commit run --files <changed>`). The repo is fully
  `ruff format`-clean — earlier guidance to skip `ruff format` was stale and produced a red CI
  check; format your files to match.

### New tests (extend `tests/core/test_event_template.py`)
- `is_numeric`: True for all-`ArraySpec` (incl. nested all-numeric); False for mixed, for a
  `DistributionSpec`/`FunctionSpec` leaf, and for a nested mixed template.
- `is_multi_field`: True/False by reachable-leaf count, incl. nested (a single top-level field with
  leaves `a/b`, `a/c` is multi-field; a single nested leaf is not) and a single opaque leaf.
- `non_numeric_fields`: exactly the non-numeric top-level names; empty for all-numeric.
- `numeric_subset`: drops opaque/dist/func; keeps numeric; recurses nested; prunes an emptied nested
  field; path-stable; idempotent on all-numeric; returns `NumericEventTemplate` with correct
  `flat_size`; raises when no numeric leaves survive.

Rationale: #235 Chapter 1 (EventTemplate API) and §7 (why inference uses `numeric_subset`). This PR
adds the methods only; inference adoption follows later.

---
*Draft/handoff PR — to be implemented by a separate session per this brief.*


