### PR TITLE
Phase 1c (#235): EventTemplate.to_vector / from_vector (1-D numeric (de)serialization)

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -48,6 +48,22 @@ if it were user-guide reference text.
    wrong, missing, or unclear, fix the documentation (or escalate) rather than silently coding
    around it.
 
+5. **Document to the plan's target, not the stale status quo.** These PRs are intentionally
+   incremental — each lands one slice and most do *not* yet implement the full set of new
+   standards. When you implement or touch an abstraction, its docstrings and naming must describe
+   the **plan's target contract and terminology** (per #235 and this file), *not* the current
+   behavior of code elsewhere in the repo that the plan will soon update. Stale neighboring code
+   is not the reference; the plan is.
+   - Where your slice must temporarily coexist with or delegate to not-yet-migrated code, you
+     *may* note that as an explicit, clearly-labeled **interim implementation detail** — but never
+     let it define the contract or blur a distinction the plan draws.
+   - In particular, keep the plan's **vocabulary distinctions** intact even before the code that
+     enforces them lands. *Example:* `to_vector`/`from_vector` are the **numeric** 1-D
+     (de)serialization (require `is_numeric`); `flatten`/`unflatten` are the **general JAX-pytree**
+     ops (`value -> (leaves, aux)`, any leaf type). Do not describe them as interchangeable, or
+     `to_vector` as "the home of `flatten`", merely because today's `NumericRecord.flatten` still
+     carries the soon-to-be-retired 1-D meaning.
+
 ## Major abstractions & where their contract lives
 | Abstraction | Canonical contract location |
 |---|---|
@@ -74,6 +90,7 @@ if it were user-guide reference text.
 - [ ] Contract of every touched abstraction was clear before coding (ambiguities resolved & noted).
 - [ ] New/changed contracts fully documented in docstrings (types, shapes, orderings, raises, invariants).
 - [ ] Code verified to obey the documented contract; tests assert it (shapes + orderings + error cases).
+- [ ] Docstrings describe the plan's **target** contract/terminology, not stale neighboring code; any temporary coexistence is labeled as an interim implementation detail.
 - [ ] Variable names consistent with the canonical table above.
 - [ ] This `CONTRACTS.md` index updated if a cross-cutting contract changed.
 - [ ] `ruff format` and `ruff check` are clean (both are **blocking** in CI).

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -1,0 +1,79 @@
+# Contract Discipline — Value-Model Refactor (issue #235)
+
+**Audience:** every session (Claude or human) implementing a phase of the #235 value-model plan —
+`EventTemplate`, the `Record` / `Distribution` value containers, the Batch types
+(`*Array` → `*Batch`), `WorkflowFunction`, and naming/provenance. **Read this before you start, and
+follow it for every phase.** It is meant to outlive any single PR or session — do not assume the
+plan's author is available to restate these rules.
+
+## Why this exists
+The #235 plan defines the *contracts* — APIs, shapes, return types, error cases, invariants,
+variable names — for ProbPipe's core value abstractions. Those contracts must be **explicit,
+documented, and obeyed**: for correctness and consistency now, and because this contract
+documentation is the **source material for the user guide** (a later PR). Write every docstring as
+if it were user-guide reference text.
+
+## Standing directives (apply to every phase)
+
+1. **Contract-first — clarify before you implement.** Before writing code, make the contract of
+   every major abstraction you touch *crystal clear* in your own understanding (see the table
+   below for where each lives). If #235 (Chapter 1, the naming contract, the relevant chapters) or
+   the existing docstrings leave **any** part ambiguous — shape conventions, single-vs-batched
+   behavior, canonical orderings, error/raise cases, return types, invariants — **resolve the
+   ambiguity before coding**: ask the maintainer, or pin it explicitly, and record the decision in
+   the PR. Do not guess and do not let an unclear contract reach the code.
+
+2. **Document the contract fully, where it lives.** When you implement an abstraction, document its
+   contract *completely* in the **docstring** (NumPy style: Parameters / Returns / Raises). The
+   docstring must state the *precise* contract, not a vague summary:
+   - exact return type and **shape**, distinguishing single vs batched
+     (e.g. `(vector_size,)` vs `(*batch_shape, vector_size)`);
+   - canonical orderings (e.g. the leaf-traversal order for vectorization);
+   - **every** error/raise condition;
+   - invariants and round-trip guarantees (e.g. `from_vector(to_vector(v)) == v`).
+   Update the index in this file when you add or change a cross-cutting contract.
+
+3. **Analyze clarity; make the code obey the contract.** As part of every PR:
+   - explicitly assess whether the contracts you touched are unambiguous, and call out any that
+     are not;
+   - verify the **code obeys the documented contract** — there must be no drift between docstring
+     and behavior — and add tests that *assert the contract* (shapes, orderings, and error cases,
+     not just happy-path values);
+   - use **consistent variable names** for the same concept across the codebase (see the naming
+     table). Renaming for consistency within the files you touch is in scope; flag larger
+     inconsistencies you cannot fix within scope.
+
+4. **Stay in scope, but never ship an undocumented or contradicted contract.** Work to your phase's
+   PR brief. But if implementing your slice reveals a contract in this file or in #235 that is
+   wrong, missing, or unclear, fix the documentation (or escalate) rather than silently coding
+   around it.
+
+## Major abstractions & where their contract lives
+| Abstraction | Canonical contract location |
+|---|---|
+| `EventTemplate` / `NumericEventTemplate` / `ArraySpec`·`OpaqueSpec`·`DistributionSpec`·`FunctionSpec` | docstrings in `probpipe/core/record.py`; #235 Chapter 1 |
+| `Record` / `NumericRecord` | docstrings in `probpipe/core/record.py`, `_numeric_record.py`; #235 Chapter 2 |
+| Batch types (`RecordArray`/`NumericRecordArray`/`DistributionArray` → `*Batch`) | docstrings in `_record_array.py`, `_distribution_array.py`; #235 Chapter 2 |
+| `WorkflowFunction` & ops (`sample`, `log_prob`, …) | docstrings in `core/node.py`, `core/ops.py`, `_workflow_result.py`; #235 Chapter 3 |
+| Naming / provenance / annotations (`Tracked` / `Annotated` mixins) | the naming contract in #235 Chapter 5; mixin docstrings once they land |
+
+## Canonical variable names (use these; don't invent synonyms)
+| Concept | Name |
+|---|---|
+| a draw / value of type T | `value` |
+| a 1-D numeric serialization | `vec` |
+| values for leaves dropped by `numeric_subset`, supplied when reconstructing a full value | `non_numeric` |
+| batch dimensions | `batch_shape` |
+| independent-draw shape prefix for `sample` | `sample_shape` |
+| a distribution's structural schema | `event_template` |
+| PRNG key | `key` |
+| a field name / key | `name` |
+*(Extend this table whenever a new contract introduces a recurring parameter.)*
+
+## Per-PR checklist (copy into the PR description)
+- [ ] Contract of every touched abstraction was clear before coding (ambiguities resolved & noted).
+- [ ] New/changed contracts fully documented in docstrings (types, shapes, orderings, raises, invariants).
+- [ ] Code verified to obey the documented contract; tests assert it (shapes + orderings + error cases).
+- [ ] Variable names consistent with the canonical table above.
+- [ ] This `CONTRACTS.md` index updated if a cross-cutting contract changed.
+- [ ] `ruff format` and `ruff check` are clean (both are **blocking** in CI).

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -31,6 +31,11 @@ if it were user-guide reference text.
    - canonical orderings (e.g. the leaf-traversal order for vectorization);
    - **every** error/raise condition;
    - invariants and round-trip guarantees (e.g. `from_vector(to_vector(v)) == v`).
+
+   **Code documentation must stand on its own — no references to transient artifacts.** Do not cite
+   PRs, issues, tracking numbers, or other out-of-band discussion in docstrings or code comments.
+   The contract is whatever the docstring states; a reader should never need to open a PR or issue to
+   understand it. (Such references belong in commit messages and PR descriptions, not the code.)
    Update the index in this file when you add or change a cross-cutting contract.
 
 3. **Analyze clarity; make the code obey the contract.** As part of every PR:

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -114,7 +114,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from ..custom_types import ArrayLike
+from ..custom_types import Array, ArrayLike
 from .constraints import Constraint
 from .provenance import Provenance
 
@@ -1086,7 +1086,7 @@ class EventTemplate:
 
     # -- 1-D numeric (de)serialization --------------------------------------
 
-    def to_vector(self, value: NumericRecord | NumericRecordArray) -> jnp.ndarray:
+    def to_vector(self, value: NumericRecord | NumericRecordArray) -> Array:
         """Concatenate the numeric leaves of *value* into a flat 1-D vector.
 
         The inverse of :meth:`from_vector`, and the structural home of the

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -1087,34 +1087,30 @@ class EventTemplate:
     # -- 1-D numeric (de)serialization --------------------------------------
 
     def to_vector(self, value: NumericRecord | NumericRecordArray) -> Array:
-        """Serialize the numeric leaves of *value* into a dense 1-D vector.
+        """Serialize the numeric leaves of *value* into its 1-D vector representation.
 
-        ``to_vector`` is ProbPipe's **numeric** (de)serialization, paired with
-        :meth:`from_vector`. It is defined only when the template is
-        :attr:`is_numeric`, and produces a single dense
-        :class:`~probpipe.custom_types.Array` whose entries are the value's
-        numeric leaves, raveled and concatenated — the flat encoding samplers
-        and optimisers consume.
+        ``to_vector`` / :meth:`from_vector` convert between the structured and
+        vector representations of a **numeric** value. A numeric value is in
+        general a structured tree of array-valued leaves, with
+        :attr:`~NumericEventTemplate.flat_size` the total number of scalar
+        values making up those arrays. ``to_vector`` converts the structured
+        value to its unique flat representation: an array of shape
+        ``(flat_size,)``. A batch of numeric values is flattened to a matrix:
+        an array of shape ``(*batch_shape, flat_size)``.
 
-        It is deliberately distinct from ``flatten``. ``flatten`` is the
-        general JAX-pytree operation (``value -> (leaves, aux)``, in the sense
-        of :func:`jax.tree_util.tree_flatten`): it works for *any* leaf type
-        and decomposes a value into its pytree leaves plus a structural ``aux``,
-        preserving structure rather than producing a numeric buffer.
-        ``to_vector`` instead collapses only-numeric leaves into a flat numeric
-        vector and is undefined when any leaf is non-numeric. (#235 reserves
-        the ``flatten`` / ``unflatten`` names for that pytree meaning in a later
-        phase; until that consolidation lands, ``to_vector`` delegates to the
-        existing 1-D :meth:`NumericRecord.flatten` /
-        :meth:`NumericRecordArray.flatten`.)
+        This method is distinct from ``flatten``. The latter follows the
+        JAX-pytree terminology, implying the mapping ``value -> (leaves, aux)``
+        in the sense of :func:`jax.tree_util.tree_flatten`. ``flatten`` returns
+        the list of the leaves of the value object, and thus is defined for all
+        values (not just numeric ones). ``to_vector`` applies only to numeric
+        values, and goes further in that it ravels the leaf arrays to a 1-D
+        representation.
 
         Leaves are visited in **canonical leaf order** — the deterministic,
-        depth-first, insertion-order traversal also used by :attr:`leaf_shapes`,
-        :attr:`~NumericEventTemplate.numeric_leaf_shapes`, and
-        :attr:`~NumericEventTemplate.flat_size`. The structural operation lives
-        on the template; a :class:`~probpipe.NumericRecord` delegates to it, so
-        ``nr.to_vector() == nr.event_template.to_vector(nr)`` and, for a *value*
-        matching this template, ``self.to_vector(v) == v.flatten()``.
+        depth-first, insertion-order traversal also used by :attr:`leaf_shapes`.
+        The structural operation lives on the event template; a
+        :class:`~probpipe.NumericRecord` inherits the functionality from the
+        template.
 
         Parameters
         ----------
@@ -1145,7 +1141,7 @@ class EventTemplate:
         See Also
         --------
         from_vector : Reconstruct a value from a flat vector (the inverse).
-        numeric_subset : Project a mixed template to its numeric core.
+        numeric_subset : Project a mixed template to its numeric leaves.
         """
         if not self.is_numeric:
             raise TypeError(
@@ -1157,12 +1153,26 @@ class EventTemplate:
         from ._numeric_record import NumericRecord
         from ._record_array import NumericRecordArray
 
-        if not isinstance(value, (NumericRecord, NumericRecordArray)):
+        if isinstance(value, NumericRecordArray):
+            batch_shape = value.batch_shape
+        elif isinstance(value, NumericRecord):
+            batch_shape = ()
+        else:
             raise TypeError(
                 f"to_vector expects a NumericRecord (single) or "
                 f"NumericRecordArray (batched), got {type(value).__name__}."
             )
-        return value.flatten()
+
+        # Ravel each numeric leaf in canonical leaf order and concatenate along
+        # the trailing axis; any leading batch axes are preserved.
+        parts: list[Array] = []
+        for path in self.leaf_shapes:
+            leaf = value[path]
+            if batch_shape:
+                parts.append(jnp.reshape(leaf, (*batch_shape, -1)))
+            else:
+                parts.append(jnp.ravel(leaf))
+        return jnp.concatenate(parts, axis=-1)
 
     def from_vector(
         self,
@@ -1241,7 +1251,7 @@ class EventTemplate:
         See Also
         --------
         to_vector : Serialize a value to a flat vector (the inverse).
-        numeric_subset : Project a mixed template to its numeric core.
+        numeric_subset : Project a mixed template to its numeric leaves.
         """
         from ._numeric_record import NumericRecord
         from ._record_array import NumericRecordArray, RecordArray

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -1163,16 +1163,12 @@ class EventTemplate:
                 f"NumericRecordArray (batched), got {type(value).__name__}."
             )
 
-        # Ravel each numeric leaf in canonical leaf order and concatenate along
-        # the trailing axis; any leading batch axes are preserved.
-        parts: list[Array] = []
-        for path in self.leaf_shapes:
-            leaf = value[path]
-            if batch_shape:
-                parts.append(jnp.reshape(leaf, (*batch_shape, -1)))
-            else:
-                parts.append(jnp.ravel(leaf))
-        return jnp.concatenate(parts, axis=-1)
+        # ``tree_leaves`` yields the numeric leaves in canonical leaf order; ravel
+        # each leaf's event dimensions and concatenate along the trailing axis.
+        # Reshaping to ``(*batch_shape, -1)`` preserves leading batch axes
+        # (``batch_shape == ()`` for a single value gives a 1-D result).
+        leaves = jax.tree_util.tree_leaves(value)
+        return jnp.concatenate([jnp.reshape(leaf, (*batch_shape, -1)) for leaf in leaves], axis=-1)
 
     def from_vector(
         self,
@@ -1180,27 +1176,32 @@ class EventTemplate:
         *,
         non_numeric: Mapping[str, Any] | None = None,
     ) -> Any:
-        """Reconstruct a value from its flat 1-D numeric serialization.
+        """Reconstruct a numeric value from its 1-D vector representation.
 
-        The inverse of :meth:`to_vector`, and the numeric counterpart of
-        ``unflatten``: it rebuilds a value from a dense numeric vector, not
-        from JAX-pytree ``(leaves, aux)`` (``unflatten``, which reconstructs an
-        arbitrary value from its pytree leaves and structure — see the
-        ``to_vector`` vs. ``flatten`` distinction). Splits *vec* along its
-        trailing axis into the template's numeric leaves — in the same
-        canonical leaf order :meth:`to_vector` uses — reshapes each chunk to
-        its event shape (preserving any leading batch axes), and rebuilds the
-        value.
+        :meth:`to_vector` / ``from_vector`` convert between the structured and
+        vector representations of a **numeric** value (see :meth:`to_vector`).
+        ``from_vector`` is the inverse: it splits *vec* along its trailing axis
+        into the template's leaves — in the same canonical leaf order
+        :meth:`to_vector` uses — reshapes each chunk to its event shape, and
+        rebuilds the structured value. The **rank of** *vec* selects single vs.
+        batched: a vector of shape ``(vector_size,)`` rebuilds a single value,
+        while a matrix of shape ``(*batch_shape, vector_size)`` rebuilds a batch
+        with that ``batch_shape``. Here ``vector_size`` is the total scalar
+        count, :attr:`~NumericEventTemplate.flat_size` (for a mixed template, the
+        ``flat_size`` of its :meth:`numeric_subset`).
 
-        Single vs. batched is determined by the **rank of** *vec*:
+        This method is distinct from ``unflatten``. The latter is the inverse of
+        the JAX-pytree ``flatten`` (the mapping ``(leaves, aux) -> value`` in the
+        sense of :func:`jax.tree_util.tree_unflatten`), rebuilding an arbitrary
+        value from its leaves and structural ``aux``. ``from_vector`` applies
+        only to numeric values, and rebuilds one from its dense 1-D
+        representation alone — splitting and reshaping the vector using this
+        template's leaf shapes.
 
-        * ``vec.shape == (vector_size,)`` → a single value
-          (``batch_shape == ()``);
-        * ``vec.shape == (*B, vector_size)`` → a batched value with
-          ``batch_shape == B``;
-
-        where ``vector_size == self.numeric_subset().flat_size`` (equal to
-        ``self.flat_size`` when this template :attr:`is_numeric`).
+        When this template is mixed (not :attr:`is_numeric`), *vec* carries only
+        the numeric leaves that :meth:`numeric_subset` keeps; pass *non_numeric*
+        to supply the dropped leaves and rebuild the full mixed value. Like
+        :meth:`to_vector`, the structural operation lives on the event template.
 
         Parameters
         ----------

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -1106,11 +1106,12 @@ class EventTemplate:
         values, and goes further in that it ravels the leaf arrays to a 1-D
         representation.
 
-        Leaves are visited in **canonical leaf order** — the deterministic,
-        depth-first, insertion-order traversal also used by :attr:`leaf_shapes`.
-        The structural operation lives on the event template; a
-        :class:`~probpipe.NumericRecord` inherits the functionality from the
-        template.
+        Leaves are visited in the value's pytree-leaf order, which for a *value*
+        matching this template coincides with the template's **canonical leaf
+        order** — the deterministic, depth-first, insertion-order traversal also
+        used by :attr:`leaf_shapes`. The structural operation lives on the event
+        template; a :class:`~probpipe.NumericRecord` inherits the functionality
+        from the template.
 
         Parameters
         ----------

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -1286,7 +1286,8 @@ class EventTemplate:
 
         batched = vec.ndim > 1
         batch_shape = tuple(vec.shape[:-1]) if batched else ()
-        supplied = dict(non_numeric) if non_numeric else {}
+        # Normalise to a dict for lookup (None / empty already validated above).
+        non_numeric = dict(non_numeric) if non_numeric else {}
 
         # Record classes for the rebuilt value: an all-numeric template rebuilds
         # NumericRecord(Array); a mixed template rebuilds a plain Record(Array)
@@ -1324,12 +1325,12 @@ class EventTemplate:
                     fields[name] = jnp.reshape(chunk, (*batch_shape, *spec.shape))
                 else:
                     # Opaque / distribution / function leaf — supplied by caller.
-                    if path not in supplied:
+                    if path not in non_numeric:
                         raise ValueError(
                             f"{type(self).__name__}.from_vector: missing non_numeric "
                             f"value for dropped leaf {path!r}."
                         )
-                    val = supplied[path]
+                    val = non_numeric[path]
                     if batched:
                         _check_batch(path, val)
                     fields[name] = val

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -119,9 +119,10 @@ from .constraints import Constraint
 from .provenance import Provenance
 
 if TYPE_CHECKING:
-    # Annotation-only back-reference: NumericRecord lives in _numeric_record,
-    # which imports Record from here — TYPE_CHECKING avoids the runtime cycle.
+    # Annotation-only back-references: these live in modules that import
+    # Record from here, so TYPE_CHECKING avoids the runtime import cycle.
     from ._numeric_record import NumericRecord
+    from ._record_array import NumericRecordArray
 
 __all__ = [
     "ArraySpec",
@@ -1082,6 +1083,229 @@ class EventTemplate:
                 f"{self.non_numeric_fields()}."
             )
         return NumericEventTemplate(specs)
+
+    # -- 1-D numeric (de)serialization --------------------------------------
+
+    def to_vector(self, value: NumericRecord | NumericRecordArray) -> jnp.ndarray:
+        """Concatenate the numeric leaves of *value* into a flat 1-D vector.
+
+        The inverse of :meth:`from_vector`, and the structural home of the
+        ``flatten`` operation (a :class:`~probpipe.NumericRecord` delegates to
+        its template: ``nr.to_vector() == nr.event_template.to_vector(nr)``).
+        Leaves are visited in **canonical leaf order** — the deterministic,
+        depth-first, insertion-order traversal also used by
+        :attr:`leaf_shapes` / :attr:`~NumericEventTemplate.numeric_leaf_shapes`,
+        :attr:`~NumericEventTemplate.flat_size`, and
+        :meth:`NumericRecord.flatten` — each leaf is raveled, and the pieces
+        are concatenated along the trailing axis. ``to_vector`` and
+        ``flatten`` are therefore interchangeable for a *value* matching this
+        template: ``self.to_vector(v) == v.flatten()``.
+
+        Parameters
+        ----------
+        value : NumericRecord or NumericRecordArray
+            The value to serialize; its structure must match this template. A
+            single :class:`~probpipe.NumericRecord` yields a 1-D vector; a
+            batched :class:`~probpipe.NumericRecordArray` with
+            ``batch_shape == B`` yields one vector per batch element.
+
+        Returns
+        -------
+        jax.Array
+            The concatenated numeric leaves, dtype-promoted by
+            ``jnp.concatenate``. Shape ``(vector_size,)`` for a single
+            ``value`` and ``(*B, vector_size)`` for a batched ``value`` with
+            ``batch_shape == B``, where ``vector_size == self.flat_size``.
+
+        Raises
+        ------
+        TypeError
+            If this template is not :attr:`is_numeric` — it has non-numeric
+            leaves, so there is no canonical numeric vector. The message names
+            the offending fields and points at :meth:`numeric_subset` (which
+            projects to the numeric core first); ``to_vector`` never silently
+            drops non-numeric leaves. Also raised if *value* is not a
+            :class:`~probpipe.NumericRecord` / :class:`~probpipe.NumericRecordArray`.
+
+        See Also
+        --------
+        from_vector : Reconstruct a value from a flat vector (the inverse).
+        numeric_subset : Project a mixed template to its numeric core.
+        """
+        if not self.is_numeric:
+            raise TypeError(
+                f"{type(self).__name__}.to_vector requires an all-numeric "
+                f"template, but these fields are non-numeric: "
+                f"{self.non_numeric_fields()}. Project to the numeric core "
+                f"first with numeric_subset()."
+            )
+        from ._numeric_record import NumericRecord
+        from ._record_array import NumericRecordArray
+
+        if not isinstance(value, (NumericRecord, NumericRecordArray)):
+            raise TypeError(
+                f"to_vector expects a NumericRecord (single) or "
+                f"NumericRecordArray (batched), got {type(value).__name__}."
+            )
+        return value.flatten()
+
+    def from_vector(
+        self,
+        vec: ArrayLike,
+        *,
+        non_numeric: Mapping[str, Any] | None = None,
+    ) -> Any:
+        """Reconstruct a value from its flat 1-D numeric serialization.
+
+        The inverse of :meth:`to_vector`. Splits *vec* along its trailing axis
+        into the template's numeric leaves — in the same canonical leaf order
+        :meth:`to_vector` uses — reshapes each chunk to its event shape
+        (preserving any leading batch axes), and rebuilds the value.
+
+        Single vs. batched is determined by the **rank of** *vec*:
+
+        * ``vec.shape == (vector_size,)`` → a single value
+          (``batch_shape == ()``);
+        * ``vec.shape == (*B, vector_size)`` → a batched value with
+          ``batch_shape == B``;
+
+        where ``vector_size == self.numeric_subset().flat_size`` (equal to
+        ``self.flat_size`` when this template :attr:`is_numeric`).
+
+        Parameters
+        ----------
+        vec : array-like
+            The flat numeric vector; its trailing axis must have length
+            ``vector_size``.
+        non_numeric : Mapping[str, Any], optional
+            Values for the leaves that :meth:`numeric_subset` dropped, keyed by
+            their ``/``-delimited leaf path, used to rebuild a *full* mixed
+            value from a numeric-only vector. Required — and only meaningful —
+            when this template is **not** :attr:`is_numeric`; must be ``None``
+            or empty when it is. For a batched result each supplied value must
+            itself carry the leading ``batch_shape``.
+
+        Returns
+        -------
+        NumericRecord or NumericRecordArray
+            When this template :attr:`is_numeric`: the reconstructed numeric
+            value (single → :class:`~probpipe.NumericRecord`; batched →
+            :class:`~probpipe.NumericRecordArray`).
+        Record or RecordArray
+            When this template is mixed and *non_numeric* is supplied: the full
+            mixed value, with numeric leaves taken from *vec* and the remaining
+            leaves taken from *non_numeric* (single → :class:`~probpipe.Record`;
+            batched → :class:`~probpipe.RecordArray`).
+
+        Raises
+        ------
+        ValueError
+            If *vec*'s trailing axis is not ``vector_size``; if *non_numeric*
+            is ``None`` while this template is non-numeric (the dropped leaves
+            cannot be supplied); if *non_numeric* is non-empty while this
+            template is numeric (there are no dropped leaves); if a required
+            dropped-leaf path is missing from *non_numeric*; or if a batched
+            *non_numeric* value's leading axes do not match ``batch_shape``.
+
+        Notes
+        -----
+        **Round-trip invariant.** ``self.from_vector(self.to_vector(v)) == v``
+        for any numeric ``value`` ``v`` matching this (numeric) template. For a
+        mixed template ``T`` with numeric core ``Tn = T.numeric_subset()``, the
+        analogous round trip
+        ``T.from_vector(Tn.to_vector(vn), non_numeric=dropped)`` rebuilds the
+        full mixed value (a plain :class:`~probpipe.Record` /
+        :class:`~probpipe.RecordArray`) from its numeric part ``vn`` and the
+        dropped leaves.
+
+        See Also
+        --------
+        to_vector : Serialize a value to a flat vector (the inverse).
+        numeric_subset : Project a mixed template to its numeric core.
+        """
+        from ._numeric_record import NumericRecord
+        from ._record_array import NumericRecordArray, RecordArray
+
+        vec = jnp.asarray(vec)
+        numeric = self.is_numeric
+
+        if numeric and non_numeric:
+            raise ValueError(
+                f"{type(self).__name__}.from_vector: this template is numeric "
+                f"(numeric_subset drops no leaves), so non_numeric must be None "
+                f"or empty, got keys {sorted(non_numeric)}."
+            )
+        if not numeric and not non_numeric:
+            raise ValueError(
+                f"{type(self).__name__}.from_vector: this template is mixed; its "
+                f"non-numeric leaves {self.non_numeric_fields()} were dropped by "
+                f"numeric_subset and must be supplied via non_numeric to rebuild "
+                f"a full value."
+            )
+
+        # numeric_subset() is idempotent on an already-numeric template, so this
+        # is the numeric core in both cases; it gives the canonical leaf order
+        # and the expected trailing-axis length.
+        num_tpl = self if isinstance(self, NumericEventTemplate) else self.numeric_subset()
+        vector_size = num_tpl.flat_size
+        if vec.shape[-1] != vector_size:
+            raise ValueError(
+                f"{type(self).__name__}.from_vector: vec trailing axis is "
+                f"{vec.shape[-1]}, expected vector_size={vector_size}."
+            )
+
+        batched = vec.ndim > 1
+        batch_shape = tuple(vec.shape[:-1]) if batched else ()
+
+        if batched:
+            numeric_core: NumericRecord | NumericRecordArray = NumericRecordArray.unflatten(
+                vec, template=num_tpl, batch_shape=batch_shape
+            )
+        else:
+            numeric_core = NumericRecord.unflatten(vec, template=num_tpl)
+
+        if numeric:
+            return numeric_core
+
+        # Mixed reconstruction: weave the dropped (non-numeric) leaves back in
+        # at their canonical paths, walking ``self`` so the result matches the
+        # full (un-projected) structure.
+        supplied = dict(non_numeric)  # type: ignore[arg-type]
+
+        def _check_batch(path: str, val: Any) -> None:
+            shape = getattr(val, "shape", None)
+            if shape is not None and tuple(shape[: len(batch_shape)]) != batch_shape:
+                raise ValueError(
+                    f"{type(self).__name__}.from_vector: non_numeric[{path!r}] has "
+                    f"leading shape {tuple(shape[: len(batch_shape)])}, expected "
+                    f"batch_shape {batch_shape}."
+                )
+
+        def _build(template: EventTemplate, prefix: str) -> Record:
+            fields: dict[str, Any] = {}
+            for name in template.fields:
+                spec = template[name]
+                path = f"{prefix}{name}"
+                if isinstance(spec, EventTemplate):
+                    fields[name] = _build(spec, f"{path}{_PATH_SEP}")
+                elif isinstance(spec, ArraySpec):
+                    fields[name] = numeric_core[path]
+                else:
+                    # Opaque / distribution / function leaf — supplied by caller.
+                    if path not in supplied:
+                        raise ValueError(
+                            f"{type(self).__name__}.from_vector: missing non_numeric "
+                            f"value for dropped leaf {path!r}."
+                        )
+                    val = supplied[path]
+                    if batched:
+                        _check_batch(path, val)
+                    fields[name] = val
+            if batched:
+                return RecordArray(fields, batch_shape=batch_shape, template=template)
+            return Record(fields)
+
+        return _build(self, "")
 
     def __contains__(self, name: str) -> bool:
         return name in self._specs

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -1087,19 +1087,34 @@ class EventTemplate:
     # -- 1-D numeric (de)serialization --------------------------------------
 
     def to_vector(self, value: NumericRecord | NumericRecordArray) -> Array:
-        """Concatenate the numeric leaves of *value* into a flat 1-D vector.
+        """Serialize the numeric leaves of *value* into a dense 1-D vector.
 
-        The inverse of :meth:`from_vector`, and the structural home of the
-        ``flatten`` operation (a :class:`~probpipe.NumericRecord` delegates to
-        its template: ``nr.to_vector() == nr.event_template.to_vector(nr)``).
+        ``to_vector`` is ProbPipe's **numeric** (de)serialization, paired with
+        :meth:`from_vector`. It is defined only when the template is
+        :attr:`is_numeric`, and produces a single dense
+        :class:`~probpipe.custom_types.Array` whose entries are the value's
+        numeric leaves, raveled and concatenated — the flat encoding samplers
+        and optimisers consume.
+
+        It is deliberately distinct from ``flatten``. ``flatten`` is the
+        general JAX-pytree operation (``value -> (leaves, aux)``, in the sense
+        of :func:`jax.tree_util.tree_flatten`): it works for *any* leaf type
+        and decomposes a value into its pytree leaves plus a structural ``aux``,
+        preserving structure rather than producing a numeric buffer.
+        ``to_vector`` instead collapses only-numeric leaves into a flat numeric
+        vector and is undefined when any leaf is non-numeric. (#235 reserves
+        the ``flatten`` / ``unflatten`` names for that pytree meaning in a later
+        phase; until that consolidation lands, ``to_vector`` delegates to the
+        existing 1-D :meth:`NumericRecord.flatten` /
+        :meth:`NumericRecordArray.flatten`.)
+
         Leaves are visited in **canonical leaf order** — the deterministic,
-        depth-first, insertion-order traversal also used by
-        :attr:`leaf_shapes` / :attr:`~NumericEventTemplate.numeric_leaf_shapes`,
-        :attr:`~NumericEventTemplate.flat_size`, and
-        :meth:`NumericRecord.flatten` — each leaf is raveled, and the pieces
-        are concatenated along the trailing axis. ``to_vector`` and
-        ``flatten`` are therefore interchangeable for a *value* matching this
-        template: ``self.to_vector(v) == v.flatten()``.
+        depth-first, insertion-order traversal also used by :attr:`leaf_shapes`,
+        :attr:`~NumericEventTemplate.numeric_leaf_shapes`, and
+        :attr:`~NumericEventTemplate.flat_size`. The structural operation lives
+        on the template; a :class:`~probpipe.NumericRecord` delegates to it, so
+        ``nr.to_vector() == nr.event_template.to_vector(nr)`` and, for a *value*
+        matching this template, ``self.to_vector(v) == v.flatten()``.
 
         Parameters
         ----------
@@ -1157,10 +1172,15 @@ class EventTemplate:
     ) -> Any:
         """Reconstruct a value from its flat 1-D numeric serialization.
 
-        The inverse of :meth:`to_vector`. Splits *vec* along its trailing axis
-        into the template's numeric leaves — in the same canonical leaf order
-        :meth:`to_vector` uses — reshapes each chunk to its event shape
-        (preserving any leading batch axes), and rebuilds the value.
+        The inverse of :meth:`to_vector`, and the numeric counterpart of
+        ``unflatten``: it rebuilds a value from a dense numeric vector, not
+        from JAX-pytree ``(leaves, aux)`` (``unflatten``, which reconstructs an
+        arbitrary value from its pytree leaves and structure — see the
+        ``to_vector`` vs. ``flatten`` distinction). Splits *vec* along its
+        trailing axis into the template's numeric leaves — in the same
+        canonical leaf order :meth:`to_vector` uses — reshapes each chunk to
+        its event shape (preserving any leading batch axes), and rebuilds the
+        value.
 
         Single vs. batched is determined by the **rank of** *vec*:
 

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -1043,7 +1043,7 @@ class EventTemplate:
         :class:`DistributionSpec` / :class:`FunctionSpec` leaves; and prunes
         any nested template that becomes empty. Surviving leaves keep their
         ``/``-delimited paths (the projection is path-stable). Inference uses
-        this to recover the numeric core of a mixed template.
+        this to recover the numeric leaves of a mixed template.
 
         On an already-all-numeric template the result is an equal
         :class:`NumericEventTemplate` (the projection is idempotent).

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -1134,7 +1134,7 @@ class EventTemplate:
             If this template is not :attr:`is_numeric` — it has non-numeric
             leaves, so there is no canonical numeric vector. The message names
             the offending fields and points at :meth:`numeric_subset` (which
-            projects to the numeric core first); ``to_vector`` never silently
+            projects to the numeric leaves first); ``to_vector`` never silently
             drops non-numeric leaves. Also raised if *value* is not a
             :class:`~probpipe.NumericRecord` / :class:`~probpipe.NumericRecordArray`.
 
@@ -1147,7 +1147,7 @@ class EventTemplate:
             raise TypeError(
                 f"{type(self).__name__}.to_vector requires an all-numeric "
                 f"template, but these fields are non-numeric: "
-                f"{self.non_numeric_fields()}. Project to the numeric core "
+                f"{self.non_numeric_fields()}. Project to the numeric leaves "
                 f"first with numeric_subset()."
             )
         from ._numeric_record import NumericRecord
@@ -1242,8 +1242,8 @@ class EventTemplate:
         -----
         **Round-trip invariant.** ``self.from_vector(self.to_vector(v)) == v``
         for any numeric ``value`` ``v`` matching this (numeric) template. For a
-        mixed template ``T`` with numeric core ``Tn = T.numeric_subset()``, the
-        analogous round trip
+        mixed template ``T`` whose numeric leaves form ``Tn = T.numeric_subset()``,
+        the analogous round trip
         ``T.from_vector(Tn.to_vector(vn), non_numeric=dropped)`` rebuilds the
         full mixed value (a plain :class:`~probpipe.Record` /
         :class:`~probpipe.RecordArray`) from its numeric part ``vn`` and the
@@ -1274,9 +1274,8 @@ class EventTemplate:
                 f"a full value."
             )
 
-        # numeric_subset() is idempotent on an already-numeric template, so this
-        # is the numeric core in both cases; it gives the canonical leaf order
-        # and the expected trailing-axis length.
+        # vector_size is the total scalar count across the numeric leaves;
+        # numeric_subset() is idempotent on an already-numeric template.
         num_tpl = self if isinstance(self, NumericEventTemplate) else self.numeric_subset()
         vector_size = num_tpl.flat_size
         if vec.shape[-1] != vector_size:
@@ -1287,21 +1286,13 @@ class EventTemplate:
 
         batched = vec.ndim > 1
         batch_shape = tuple(vec.shape[:-1]) if batched else ()
+        supplied = dict(non_numeric) if non_numeric else {}
 
-        if batched:
-            numeric_core: NumericRecord | NumericRecordArray = NumericRecordArray.unflatten(
-                vec, template=num_tpl, batch_shape=batch_shape
-            )
-        else:
-            numeric_core = NumericRecord.unflatten(vec, template=num_tpl)
-
-        if numeric:
-            return numeric_core
-
-        # Mixed reconstruction: weave the dropped (non-numeric) leaves back in
-        # at their canonical paths, walking ``self`` so the result matches the
-        # full (un-projected) structure.
-        supplied = dict(non_numeric)  # type: ignore[arg-type]
+        # Record classes for the rebuilt value: an all-numeric template rebuilds
+        # NumericRecord(Array); a mixed template rebuilds a plain Record(Array)
+        # carrying the supplied non-numeric leaves alongside the numeric ones.
+        single_cls = NumericRecord if numeric else Record
+        batched_cls = NumericRecordArray if numeric else RecordArray
 
         def _check_batch(path: str, val: Any) -> None:
             shape = getattr(val, "shape", None)
@@ -1312,7 +1303,14 @@ class EventTemplate:
                     f"batch_shape {batch_shape}."
                 )
 
+        # Walk the template in canonical leaf order, slicing ``vec`` into each
+        # numeric leaf and reshaping it to (*batch_shape, *event_shape); a single
+        # offset advances along vec's trailing axis. Non-numeric leaves (mixed
+        # templates only) are filled from ``non_numeric`` and consume no vector.
+        offset = 0
+
         def _build(template: EventTemplate, prefix: str) -> Record:
+            nonlocal offset
             fields: dict[str, Any] = {}
             for name in template.fields:
                 spec = template[name]
@@ -1320,7 +1318,10 @@ class EventTemplate:
                 if isinstance(spec, EventTemplate):
                     fields[name] = _build(spec, f"{path}{_PATH_SEP}")
                 elif isinstance(spec, ArraySpec):
-                    fields[name] = numeric_core[path]
+                    size = prod(spec.shape) if spec.shape else 1
+                    chunk = vec[..., offset : offset + size]
+                    offset += size
+                    fields[name] = jnp.reshape(chunk, (*batch_shape, *spec.shape))
                 else:
                     # Opaque / distribution / function leaf — supplied by caller.
                     if path not in supplied:
@@ -1333,8 +1334,8 @@ class EventTemplate:
                         _check_batch(path, val)
                     fields[name] = val
             if batched:
-                return RecordArray(fields, batch_shape=batch_shape, template=template)
-            return Record(fields)
+                return batched_cls(fields, batch_shape=batch_shape, template=template)
+            return single_cls(fields)
 
         return _build(self, "")
 

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -1286,7 +1286,6 @@ class EventTemplate:
 
         batched = vec.ndim > 1
         batch_shape = tuple(vec.shape[:-1]) if batched else ()
-        # Normalise to a dict for lookup (None / empty already validated above).
         non_numeric = dict(non_numeric) if non_numeric else {}
 
         # Record classes for the rebuilt value: an all-numeric template rebuilds

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -882,6 +882,23 @@ class TestFromVectorRoundTripBatched:
         assert jnp.array_equal(tpl.to_vector(v), flat)
         assert tpl.from_vector(tpl.to_vector(v)) == v
 
+    def test_nested_multi_axis_batch_shape(self):
+        # Nested numeric subtree + multi-axis batch: from_vector builds a nested
+        # NumericRecordArray as a field of the outer NumericRecordArray.
+        tpl = EventTemplate(x=(), nested=EventTemplate(a=(), b=(2,)), y=(3,))
+        flat = jnp.arange(2 * 3 * tpl.flat_size, dtype=float).reshape(2, 3, tpl.flat_size)
+        v = tpl.from_vector(flat)
+        assert isinstance(v, NumericRecordArray)
+        assert v.batch_shape == (2, 3)
+        assert isinstance(v["nested"], NumericRecordArray)
+        assert v["nested/b"].shape == (2, 3, 2)
+        # NOTE: assert via the vector round-trip, not ``from_vector(...) == v``.
+        # RecordArray.__eq__ is currently broken for a nested *Array field (it
+        # calls jnp.array_equal on the nested array, which raises, then falls
+        # back to an identity check). Tracked in #235 (batch-records PR); once
+        # that is fixed, simplify to ``tpl.from_vector(tpl.to_vector(v)) == v``.
+        assert jnp.array_equal(tpl.to_vector(v), flat)
+
 
 class TestFromVectorErrors:
     def test_wrong_trailing_size_raises(self):
@@ -924,6 +941,29 @@ class TestFromVectorNonNumericReconstruction:
         assert rebuilt.batch_shape == (2, 3)
         assert jnp.array_equal(rebuilt["x"], vec.reshape(2, 3))
         assert (np.asarray(rebuilt["label"]) == labels).all()
+
+    def test_nested_batched_full_value(self):
+        # Nested numeric subtree + opaque leaf + multi-axis batch: from_vector
+        # rebuilds a nested RecordArray inside the outer RecordArray, weaving the
+        # batched non-numeric leaf in alongside.
+        tpl = EventTemplate(x=(), label=None, phys=EventTemplate(force=(), mass=()))
+        sub = tpl.numeric_subset()  # leaves: x, phys/force, phys/mass
+        vec = jnp.arange(2 * 3 * sub.flat_size, dtype=float).reshape(2, 3, sub.flat_size)
+        labels = np.array([["a", "b", "c"], ["d", "e", "f"]], dtype=object)
+        rebuilt = tpl.from_vector(vec, non_numeric={"label": labels})
+        assert isinstance(rebuilt, RecordArray)
+        assert rebuilt.batch_shape == (2, 3)
+        assert isinstance(rebuilt["phys"], RecordArray)
+        assert rebuilt["phys/force"].shape == (2, 3)
+        assert rebuilt["phys/mass"].shape == (2, 3)
+        assert (np.asarray(rebuilt["label"]) == labels).all()
+        # The numeric leaves must round-trip; assert on the numeric subset's
+        # vector rather than ``== full`` (RecordArray.__eq__ is broken for a
+        # nested *Array field — see test_nested_multi_axis_batch_shape / #235).
+        numeric = sub.from_vector(vec)
+        assert jnp.array_equal(rebuilt["x"], numeric["x"])
+        assert jnp.array_equal(rebuilt["phys/force"], numeric["phys/force"])
+        assert jnp.array_equal(rebuilt["phys/mass"], numeric["phys/mass"])
 
     def test_missing_dropped_leaf_raises(self):
         tpl = EventTemplate(x=(), label=None)

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -4,7 +4,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import Record
+from probpipe import NumericRecord, NumericRecordArray, Record, RecordArray
 from probpipe.core.record import (
     ArraySpec,
     DistributionSpec,
@@ -772,3 +772,167 @@ class TestNumericSubset:
         tpl = EventTemplate(nested=EventTemplate(label=None, tag=None))
         with pytest.raises(ValueError, match="nested"):
             tpl.numeric_subset()
+
+
+# ---------------------------------------------------------------------------
+# to_vector / from_vector — 1-D numeric (de)serialization
+# ---------------------------------------------------------------------------
+
+
+class TestToVector:
+    def test_scalar_value(self):
+        v = NumericRecord(x=1.5)
+        tpl = EventTemplate.from_record(v)
+        vec = tpl.to_vector(v)
+        assert vec.shape == (1,)
+        assert jnp.array_equal(vec, jnp.asarray([1.5]))
+
+    def test_vector_value(self):
+        v = NumericRecord(y=jnp.arange(3.0))
+        tpl = EventTemplate.from_record(v)
+        vec = tpl.to_vector(v)
+        assert vec.shape == (3,)
+        assert jnp.array_equal(vec, jnp.arange(3.0))
+
+    def test_multi_field_value(self):
+        v = NumericRecord(x=1.0, y=jnp.arange(3.0), z=jnp.ones((2, 4)))
+        tpl = EventTemplate.from_record(v)
+        vec = tpl.to_vector(v)
+        assert vec.shape == (1 + 3 + 8,)
+
+    def test_vector_size_equals_flat_size(self):
+        tpl = EventTemplate(x=(), y=(3,), z=(2, 4))
+        v = NumericRecord(x=0.0, y=jnp.zeros(3), z=jnp.zeros((2, 4)))
+        assert tpl.to_vector(v).shape == (tpl.flat_size,)
+
+    def test_order_and_value_match_numeric_record_flatten(self):
+        # The canonical leaf order must agree with NumericRecord.flatten so the
+        # two are interchangeable (PR-1c contract).
+        v = NumericRecord(x=1.0, y=jnp.arange(3.0), nested=NumericRecord(a=2.0, b=jnp.arange(2.0)))
+        tpl = EventTemplate.from_record(v)
+        assert jnp.array_equal(tpl.to_vector(v), v.flatten())
+
+    def test_batched_shape_is_batch_shape_plus_flat_size(self):
+        tpl = EventTemplate(x=(), y=(3,))
+        flat = jnp.arange(2 * 5 * tpl.flat_size, dtype=float).reshape(2, 5, tpl.flat_size)
+        v = tpl.from_vector(flat)
+        assert isinstance(v, NumericRecordArray)
+        assert tpl.to_vector(v).shape == (2, 5, tpl.flat_size)
+
+    def test_non_numeric_template_raises(self):
+        tpl = EventTemplate(x=(), label=None, d=_dist_spec())
+        v = NumericRecord(x=1.0)
+        with pytest.raises(TypeError, match="numeric_subset"):
+            tpl.to_vector(v)
+        # The error names the offending non-numeric fields.
+        with pytest.raises(TypeError, match="label"):
+            tpl.to_vector(v)
+
+    def test_non_record_value_raises(self):
+        tpl = EventTemplate(x=())
+        with pytest.raises(TypeError, match="NumericRecord"):
+            tpl.to_vector(jnp.asarray([1.0]))
+
+
+class TestFromVectorRoundTripSingle:
+    def test_scalar(self):
+        v = NumericRecord(x=1.5)
+        tpl = EventTemplate.from_record(v)
+        assert tpl.from_vector(tpl.to_vector(v)) == v
+
+    def test_vector(self):
+        v = NumericRecord(y=jnp.arange(3.0))
+        tpl = EventTemplate.from_record(v)
+        assert tpl.from_vector(tpl.to_vector(v)) == v
+
+    def test_multi_field(self):
+        v = NumericRecord(x=1.0, y=jnp.arange(3.0), z=jnp.arange(8.0).reshape(2, 4))
+        tpl = EventTemplate.from_record(v)
+        assert tpl.from_vector(tpl.to_vector(v)) == v
+
+    def test_nested(self):
+        v = NumericRecord(x=1.0, y=jnp.arange(3.0), nested=NumericRecord(a=2.0, b=jnp.arange(2.0)))
+        tpl = EventTemplate.from_record(v)
+        round_tripped = tpl.from_vector(tpl.to_vector(v))
+        assert isinstance(round_tripped, NumericRecord)
+        assert round_tripped == v
+
+    def test_returns_single_for_1d_vec(self):
+        tpl = EventTemplate(x=(), y=(3,))
+        v = tpl.from_vector(jnp.arange(4.0))
+        assert isinstance(v, NumericRecord)
+
+
+class TestFromVectorRoundTripBatched:
+    def test_single_batch_axis(self):
+        tpl = EventTemplate(x=(), y=(3,))
+        flat = jnp.arange(4 * tpl.flat_size, dtype=float).reshape(4, tpl.flat_size)
+        v = tpl.from_vector(flat)
+        assert isinstance(v, NumericRecordArray)
+        assert v.batch_shape == (4,)
+        assert tpl.from_vector(tpl.to_vector(v)) == v
+
+    def test_multi_axis_batch_shape(self):
+        # batch_shape=(2, 3) catches trailing-axis split / reshape bugs.
+        tpl = EventTemplate(x=(), y=(3,), z=(2, 2))
+        flat = jnp.arange(2 * 3 * tpl.flat_size, dtype=float).reshape(2, 3, tpl.flat_size)
+        v = tpl.from_vector(flat)
+        assert isinstance(v, NumericRecordArray)
+        assert v.batch_shape == (2, 3)
+        assert jnp.array_equal(tpl.to_vector(v), flat)
+        assert tpl.from_vector(tpl.to_vector(v)) == v
+
+
+class TestFromVectorErrors:
+    def test_wrong_trailing_size_raises(self):
+        tpl = EventTemplate(x=(), y=(3,))
+        with pytest.raises(ValueError, match="vector_size"):
+            tpl.from_vector(jnp.zeros(5))
+
+    def test_numeric_template_rejects_non_numeric(self):
+        tpl = EventTemplate(x=())
+        with pytest.raises(ValueError, match="numeric"):
+            tpl.from_vector(jnp.zeros(1), non_numeric={"label": "a"})
+
+    def test_mixed_template_requires_non_numeric(self):
+        tpl = EventTemplate(x=(), label=None)
+        with pytest.raises(ValueError, match="non_numeric"):
+            tpl.from_vector(jnp.zeros(1))
+
+
+class TestFromVectorNonNumericReconstruction:
+    def test_single_full_value(self):
+        # Mixed template -> numeric_subset -> to_vector -> from_vector(non_numeric).
+        tpl = EventTemplate(x=(), label=None, phys=EventTemplate(force=(), mass=()))
+        full = Record(
+            x=jnp.asarray(1.0),
+            label="horseshoe",
+            phys=Record(force=jnp.asarray(2.0), mass=jnp.asarray(3.0)),
+        )
+        numeric = NumericRecord(x=1.0, phys=NumericRecord(force=2.0, mass=3.0))
+        vec = tpl.numeric_subset().to_vector(numeric)
+        rebuilt = tpl.from_vector(vec, non_numeric={"label": "horseshoe"})
+        assert isinstance(rebuilt, Record)
+        assert rebuilt == full
+
+    def test_batched_full_value(self):
+        tpl = EventTemplate(x=(), label=None)
+        vec = jnp.arange(6.0).reshape(2, 3, 1)  # batch_shape=(2, 3), flat_size=1
+        labels = np.array([["a", "b", "c"], ["d", "e", "f"]], dtype=object)
+        rebuilt = tpl.from_vector(vec, non_numeric={"label": labels})
+        assert isinstance(rebuilt, RecordArray)
+        assert rebuilt.batch_shape == (2, 3)
+        assert jnp.array_equal(rebuilt["x"], vec.reshape(2, 3))
+        assert (np.asarray(rebuilt["label"]) == labels).all()
+
+    def test_missing_dropped_leaf_raises(self):
+        tpl = EventTemplate(x=(), label=None)
+        with pytest.raises(ValueError, match="missing non_numeric"):
+            tpl.from_vector(jnp.zeros(1), non_numeric={"other": "a"})
+
+    def test_mismatched_non_numeric_batch_shape_raises(self):
+        tpl = EventTemplate(x=(), label=None)
+        vec = jnp.arange(6.0).reshape(2, 3, 1)
+        bad_labels = np.array(["a", "b"], dtype=object)  # batch_shape (2,) != (2, 3)
+        with pytest.raises(ValueError, match="batch_shape"):
+            tpl.from_vector(vec, non_numeric={"label": bad_labels})


### PR DESCRIPTION
## PR-1c — `EventTemplate.to_vector` / `from_vector` (1-D numeric (de)serialization)

Third slice of Phase 1 of #235 (follows #292 rename+LeafSpec and #308 query/projection methods,
both merged). **Additive**: define and fully document the canonical 1-D numeric (de)serialization
contract on `EventTemplate`. The breaking *consolidation* (removing/renaming the existing scattered
`flatten`/`unflatten`/`flatten_value`/`unflatten_value`/`event_size` and reserving
`flatten`/`unflatten` for the JAX-pytree meaning) is the **next** slice (PR-1d) — not here.

> **Read `CONTRACTS.md` (added on this branch) before implementing.** This PR is the first one under
> the contract-documentation discipline: the `to_vector`/`from_vector` contract below must be
> documented *precisely* in the docstrings and asserted in tests.

### Scope — add two methods to `EventTemplate` (`probpipe/core/record.py`)
Per #235 Chapter 1 and §7:

- `to_vector(value) -> Array` — concatenate the numeric leaves of `value` into a 1-D vector, in the
  **canonical leaf order** (the same deterministic traversal as `numeric_leaf_shapes` / `flat_size`
  / the existing `NumericRecord.flatten` — verify it matches so the two are interchangeable).
  - Requires `self.is_numeric`. If not, raise `TypeError` naming the non-numeric fields and
    pointing the caller at `numeric_subset()` (do **not** silently project).
  - Shapes: single `value` → `(vector_size,)`; batched `value` (a `NumericRecordArray` with
    `batch_shape == B`) → `(*B, vector_size)`, where `vector_size == self.flat_size`.
- `from_vector(vec, *, non_numeric=None) -> value` — inverse of `to_vector`.
  - Input shape determines output rank: `(vector_size,)` → a single `value`;
    `(*B, vector_size)` → a batched `value` with `batch_shape == B`.
  - Splits `vec` along the trailing axis by the canonical order/shapes and reshapes each leaf to its
    event shape (plus any batch axes); returns the value in native form (`NumericRecord` /
    `NumericRecordArray`) matching this template's structure.
  - `non_numeric`: supplies values for leaves that `numeric_subset()` dropped, so a *full* (mixed)
    value can be reconstructed from a numeric vector. `None` is valid only when the (un-projected)
    template `is_numeric`. Single result → `Mapping[path, value]`; batched result → the same keyed
    by batched values with matching `batch_shape`. Mismatched batch shapes raise.
  - **Round-trip invariant:** `from_vector(to_vector(v)) == v` for any numeric `value` `v`.

### Decisions (made — flag if you disagree)
- **Additive only.** Do **not** remove or rename `NumericRecord.flatten`/`unflatten`,
  `NumericRecordArray.flatten`, or `NumericRecordDistribution.flatten_value`/`unflatten_value`/
  `event_size`/`as_flat_distribution` in this PR — that consolidation + consumer audit is PR-1d.
  Reuse the existing internals (`_spec_size`, `numeric_leaf_shapes`, `flat_size`) where sensible.
- `to_vector` **requires** `is_numeric` and errors otherwise (directs to `numeric_subset()`); it
  never silently drops non-numeric fields.
- Canonical leaf order **must match** the existing `NumericRecord.flatten` ordering (consistency —
  add a test asserting equality of values/order).
- Batched forms use the current `NumericRecordArray` type (it is renamed to `NumericRecordBatch` in
  a later phase; use the current name now).

### Out of scope (do NOT do here)
- The breaking `flatten → to_vector` consolidation / removal of the old machinery → **PR-1d**.
- `make_batch` / `vectorize` → later, with the `Batch` ABC / `*Array→*Batch` work.
- Rewiring inference (`_inference_utils.py` / `_tfp_mcmc.py`) to use `to_vector`/`from_vector` →
  separate change.
- `RandomFunction`/`RandomMeasure` population; `Tracked`/`Annotated`; any `*Batch` rename.

### Definition of done
- `to_vector` / `from_vector` added with **NumPy-style docstrings that state the full contract**
  (types, shapes for single vs batched, canonical ordering, every raise, the round-trip invariant).
- All existing behavior unchanged (additive only).
- Full test suite green; `ruff format` and `ruff check` clean (both blocking).
- The `CONTRACTS.md` per-PR checklist is completed in this description.

### New tests (extend `tests/core/test_event_template.py`)
- round-trip `from_vector(to_vector(v)) == v` for single values: scalar, vector, multi-field, nested.
- round-trip for **batched** values, including a **multi-axis `batch_shape=(2, 3)`** case
  (catches trailing-axis split/reshape bugs).
- `to_vector` value & order **match** `NumericRecord.flatten` for the same template/value.
- `vector_size == flat_size`; `to_vector(value).shape == (*batch_shape, flat_size)`.
- `to_vector` on a non-numeric template raises `TypeError` naming the fields and mentioning
  `numeric_subset()`.
- `from_vector(..., non_numeric=...)` reconstructs a full mixed value after
  `numeric_subset()` → `to_vector()` (single and batched); mismatched `non_numeric` batch shape
  raises.

Design rationale: #235 Chapter 1 (`EventTemplate` API) and §7 (inference uses
`numeric_subset` → `to_vector` → sampler → `from_vector`). This PR adds the methods; the breaking
consolidation and inference adoption follow.

---
*Draft/handoff PR — implemented by a separate session per this brief and `CONTRACTS.md`.*


---

## Implementation notes & `CONTRACTS.md` per-PR checklist

Both methods live on `EventTemplate` in `probpipe/core/record.py` (additive — none of the existing
`flatten`/`unflatten`/`flatten_value`/`unflatten_value`/`event_size`/`as_flat_distribution`
machinery was removed or renamed).

**Implementation (standalone — refined during review).**
- `to_vector` ravels the value's numeric leaves (`jax.tree_util.tree_leaves`, canonical
  pytree-leaf order) and concatenates them, reshaping to `(*batch_shape, -1)` so single and batched
  share one path. It does **not** delegate to the current 1-D `NumericRecord.flatten`: that method is
  repurposed to the JAX-pytree meaning in PR-1d, so `to_vector` must not depend on its
  soon-to-change behavior. Output matches `NumericRecord(Array).flatten` today (asserted by a test).
- `from_vector` is a single recursive builder that walks the template in canonical leaf order,
  slicing `vec` into each numeric leaf and reshaping to `(*batch_shape, *event_shape)`, then weaving
  the `non_numeric` leaves for the mixed case. It does **not** call the current 1-D
  `NumericRecord(Array).unflatten` (also repurposed in PR-1d); `numeric_subset().flat_size` is used
  only to validate `vec`'s trailing-axis length.

**Contract clarifications pinned (no ambiguities left for the reader):**
- **Single vs. batched is set by `vec` rank** in `from_vector`: `(vector_size,)` → single
  (`NumericRecord`), `(*B, vector_size)` → batched (`NumericRecordArray`), `batch_shape == B`.
- **`vector_size == self.numeric_subset().flat_size`** (== `self.flat_size` when `is_numeric`); a
  wrong trailing axis raises `ValueError`.
- **`non_numeric` discipline:** required when the template is mixed; must be `None`/empty when it is
  numeric (both violations raise `ValueError`). Keys are `/`-delimited leaf paths; a missing dropped
  leaf raises. The **mixed reconstruction returns a plain `Record` / `RecordArray`** (not a
  `NumericRecord`), since the result carries non-numeric leaves.
- **Batched `non_numeric` values must carry the leading `batch_shape`**; a mismatch raises
  `ValueError`.

**Tests added (`tests/core/test_event_template.py`):** single round-trips
(scalar/vector/multi-field/nested); batched round-trips incl. multi-axis `(2,3)` **and
nested+batched** (numeric and mixed); order-and-value match vs `NumericRecord.flatten`;
`vector_size`/shape checks; the `to_vector` non-numeric `TypeError`; and the `from_vector` error +
`non_numeric` reconstruction cases.

**Follow-up work recorded on #235** (tracking comment + Chapter 2 of the issue body):
- **PR-1d** — rename `flat_size` → `vector_size` (purge "flat" from the numeric-serialization side).
- **PR-1d** — once `flatten` becomes the JAX-pytree op (built on `tree_leaves`), refactor
  `to_vector` to delegate to it, and refactor `from_vector` onto the updated `unflatten`. PR-1c
  implements both inline only because `flatten`/`unflatten` still carry the old 1-D meaning.
- **Batch-records PR** — fix `RecordArray.__eq__` (→ `RecordBatch.__eq__`) for nested-`*Array`
  fields (it currently `jnp.array_equal`s a nested batch, raises, and falls back to an identity
  check → structurally-equal nested batches compare unequal). **Temporary hack to undo:**
  `test_nested_multi_axis_batch_shape` / `test_nested_batched_full_value` assert via the
  `to_vector`/`from_vector` vector round-trip + per-field checks (not `== v`) to sidestep this;
  simplify to `==` once fixed.

### Checklist
- [x] Contract of every touched abstraction was clear before coding (ambiguities resolved & noted above).
- [x] New/changed contracts fully documented in docstrings (types, single-vs-batched shapes, canonical ordering, every raise, the round-trip invariant).
- [x] Code verified to obey the documented contract; tests assert it (shapes + ordering-vs-`flatten` + error cases), not just happy-path values.
- [x] Variable names consistent with the canonical table (`value`, `vec`, `non_numeric`, `batch_shape`).
- [x] `CONTRACTS.md` updated — added standing directive 5 (document to the plan's target, not stale neighboring code), the "code docs stand on their own — no PR/issue refs" rule, and a matching checklist line. (Canonical naming table unchanged.)
- [x] `ruff format` and `ruff check` (v0.15.16, pinned) clean.

Full suite: **3073 passed, 51 skipped**.
