### PR TITLE
feat(validation): simulation-based calibration + interval coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   RBF), `ksd` (IMQ kernel Stein discrepancy), and the `score_posterior`
   aggregator.
 
+- **`probpipe.validation` calibration checks.** `simulation_based_calibration`
+  (Talts et al. 2018) drives an inference method over many `(θ★, data,
+  posterior)` replications and tests whether the rank of the truth among the
+  posterior draws is uniform — returning an `SBCResult` with per-parameter rank
+  histograms and a KS-to-uniform p-value. `interval_coverage` checks whether
+  central credible intervals contain the truth at their nominal rate. Both run a
+  backend-agnostic loop over `condition_on`.
+
 - **`quantile` op and `SupportsQuantile` protocol.** `quantile(dist, q)` returns
   per-field quantile(s) at probability level(s) `q`, parallel to
   `mean`/`variance`/`cov`. `RecordEmpiricalDistribution` implements it

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -35,3 +35,16 @@ set into a scorecard, skipping any whose reference pieces are absent.
 ::: probpipe.validation.ksd
 
 ::: probpipe.validation.score_posterior
+
+## Calibration and coverage
+
+Method self-consistency checks: simulation-based calibration drives the inference
+method over many `(θ★, data, posterior)` replications and tests whether the rank
+of the truth among the posterior draws is uniform; interval coverage checks
+whether central credible intervals contain the truth at their nominal rate.
+
+::: probpipe.validation.simulation_based_calibration
+
+::: probpipe.validation.SBCResult
+
+::: probpipe.validation.interval_coverage

--- a/probpipe/validation/__init__.py
+++ b/probpipe/validation/__init__.py
@@ -1,12 +1,14 @@
 """Model validation utilities for ProbPipe.
 
-Predictive checking (prior and posterior) plus posterior-vs-reference comparison
+Predictive checking (prior and posterior), posterior-vs-reference comparison
 metrics that score an approximation against a trusted reference (analytic,
-long-NUTS, or sandwich) — for validating inference methods and as the unit-test
-layer beneath the ``probpipe-benchmark`` suite. Distinct from per-fit
+long-NUTS, or sandwich), and method self-consistency checks (simulation-based
+calibration and interval coverage) — for validating inference methods and as the
+unit-test layer beneath the ``probpipe-benchmark`` suite. Distinct from per-fit
 convergence diagnostics, which diagnose a single fitted posterior.
 """
 
+from ._calibration import SBCResult, interval_coverage, simulation_based_calibration
 from ._comparison import (
     Reference,
     ksd,
@@ -21,11 +23,14 @@ from ._predictive_check import predictive_check
 
 __all__ = [
     "Reference",
+    "SBCResult",
+    "interval_coverage",
     "ksd",
     "mmd",
     "predictive_check",
     "relative_cov_error",
     "score_posterior",
+    "simulation_based_calibration",
     "sliced_wasserstein",
     "standardized_mean_error",
     "std_ratios",

--- a/probpipe/validation/_calibration.py
+++ b/probpipe/validation/_calibration.py
@@ -52,6 +52,15 @@ def _flatten_point(point: Any, fields: tuple[str, ...] | None) -> Array:
     return jnp.ravel(jnp.asarray(point))
 
 
+def _ranks(draws: Array, point: Array) -> Array:
+    """SBC rank of each component of *point*: ``#{draws < point}``, in ``{0, …, n}``.
+
+    Uses strict ``<`` (ties, measure-zero for a continuous posterior, count as
+    not-below). ``draws`` is ``(n, d)``; ``point`` is ``(d,)``; returns ``(d,)``.
+    """
+    return jnp.sum(draws < point[None, :], axis=0)
+
+
 def _component_names(posterior: Any) -> tuple[str, ...] | None:
     """Per-flattened-component parameter names matching the ``flat_samples`` columns.
 
@@ -238,7 +247,7 @@ def simulation_based_calibration(
             fields = getattr(posterior, "fields", None)
             component_names = _component_names(posterior)
         theta_flat = _flatten_point(theta_star, fields)  # (p,)
-        rank_rows.append(np.asarray(jnp.sum(draws < theta_flat[None, :], axis=0)))
+        rank_rows.append(np.asarray(_ranks(draws, theta_flat)))
 
     ranks = np.stack(rank_rows).astype(int)  # (num_simulations, p)
     num_draws = int(draws.shape[0])  # actual total draws (handles multi-chain)

--- a/probpipe/validation/_calibration.py
+++ b/probpipe/validation/_calibration.py
@@ -1,0 +1,252 @@
+"""Simulation-based calibration (SBC) and interval coverage for method validation.
+
+Where :mod:`probpipe.validation._comparison` scores an approximation against a
+*reference*, these check an inference *method* for self-consistency with the
+model that generated the data:
+
+- :func:`simulation_based_calibration` (Talts et al. 2018) draws ``θ★ ~ prior``,
+  ``y ~ p(·|θ★)``, and the posterior ``π(θ|y)``; the rank of each ``θ★``
+  component among the posterior draws is Uniform on ``{0, …, L}`` iff the
+  posterior is calibrated. Non-uniform ranks expose a biased / mis-tuned sampler.
+- :func:`interval_coverage` is the companion frequentist check — does a central
+  credible interval contain the truth at its nominal rate?
+
+These orchestrate inference through a **Python loop over** :func:`condition_on`,
+so they work for every backend (blackjax, Stan, PyMC, …); they are therefore not
+themselves jit-compatible, though the per-fit MCMC inside the loop is
+JAX-accelerated where the backend allows. The model must expose a sampleable
+``prior``, a ``likelihood`` with ``generate_data``, and be conditionable — e.g. a
+:class:`~probpipe.SimpleModel` built with a :class:`~probpipe.GLMLikelihood`.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from .._utils import _auto_key
+from ..core.ops import condition_on
+from ..custom_types import Array, ArrayLike, PRNGKey
+
+__all__ = ["SBCResult", "interval_coverage", "simulation_based_calibration"]
+
+
+# -- helpers ----------------------------------------------------------------
+
+
+def _flatten_point(point: Any, fields: tuple[str, ...] | None) -> Array:
+    """Flatten one parameter draw to a 1-D vector matching ``flat_samples`` order.
+
+    A bare array is raveled; a ``Record`` is flattened field-by-field in the
+    posterior's field order so the comparison lines up with ``flat_samples``.
+    """
+    if fields is not None and hasattr(point, "fields"):
+        return jnp.concatenate([jnp.ravel(jnp.asarray(point[f])) for f in fields])
+    return jnp.ravel(jnp.asarray(point))
+
+
+def _kolmogorov_sf(d: float, n: int) -> float:
+    """Asymptotic survival function of the one-sample KS statistic (Stephens).
+
+    ``P(D_n ≥ d)`` under the null, via ``Q_KS(λ) = 2 Σ_k (−1)^{k−1} e^{−2k²λ²}``
+    with the small-sample correction ``λ = (√n + 0.12 + 0.11/√n) d``. Dependency
+    -free (no SciPy); accurate for the sample sizes SBC uses (``n ≳ 30``).
+    """
+    if d <= 0.0:
+        return 1.0
+    en = np.sqrt(n)
+    lam = (en + 0.12 + 0.11 / en) * d
+    k = np.arange(1, 101)
+    p = 2.0 * np.sum((-1.0) ** (k - 1) * np.exp(-2.0 * (k * lam) ** 2))
+    return float(min(max(p, 0.0), 1.0))
+
+
+def _ks_uniform(ranks: np.ndarray, num_draws: int) -> tuple[np.ndarray, np.ndarray]:
+    """Per-parameter KS distance + p-value of the ranks vs ``Uniform{0..L}``.
+
+    ``ranks`` is ``(num_simulations, num_params)`` in ``{0, …, num_draws}``; the
+    ranks are mapped to ``(0, 1)`` via the midpoint ``(r + 0.5)/(L + 1)`` and
+    compared to ``Uniform[0, 1]``.
+    """
+    u = (ranks + 0.5) / (num_draws + 1)
+    v = np.sort(u, axis=0)
+    s = v.shape[0]
+    i_over_s = (np.arange(1, s + 1) / s)[:, None]
+    im1_over_s = (np.arange(0, s) / s)[:, None]
+    d = np.maximum(np.max(i_over_s - v, axis=0), np.max(v - im1_over_s, axis=0))
+    pvals = np.array([_kolmogorov_sf(float(d[j]), s) for j in range(d.shape[0])])
+    return d, pvals
+
+
+# -- simulation-based calibration -------------------------------------------
+
+
+@dataclass(frozen=True)
+class SBCResult:
+    """Result of :func:`simulation_based_calibration`.
+
+    Attributes
+    ----------
+    ranks : np.ndarray
+        Integer ranks of ``θ★`` among the posterior draws, shape
+        ``(num_simulations, num_params)``, each in ``{0, …, num_posterior_draws}``.
+    num_posterior_draws : int
+        ``L`` — the rank upper bound (the actual number of posterior draws used).
+    param_names : tuple[str, ...] or None
+        Flattened parameter field names (posterior field order), if known.
+    ks_statistic : np.ndarray
+        Per-parameter KS distance of the normalized ranks from ``Uniform[0, 1]``.
+    ks_pvalue : np.ndarray
+        Per-parameter KS p-value; small ⇒ ranks are non-uniform ⇒ miscalibrated.
+    passed : bool
+        Whether every parameter's p-value exceeds the test level ``alpha``.
+    """
+
+    ranks: np.ndarray
+    num_posterior_draws: int
+    param_names: tuple[str, ...] | None
+    ks_statistic: np.ndarray
+    ks_pvalue: np.ndarray
+    passed: bool
+
+    def rank_histogram(self, num_bins: int = 20) -> np.ndarray:
+        """Rank histogram per parameter, shape ``(num_params, num_bins)``.
+
+        Bins the normalized ranks into ``num_bins`` equal-width bins over
+        ``[0, 1]``; a calibrated method gives approximately flat histograms.
+        """
+        u = (self.ranks + 0.5) / (self.num_posterior_draws + 1)
+        edges = np.linspace(0.0, 1.0, num_bins + 1)
+        return np.stack([np.histogram(u[:, j], bins=edges)[0] for j in range(u.shape[1])])
+
+
+def simulation_based_calibration(
+    model: Any,
+    *,
+    num_simulations: int,
+    num_posterior_draws: int,
+    num_observations: int,
+    method: str | None = None,
+    alpha: float = 0.05,
+    key: PRNGKey | None = None,
+    **infer_kwargs: Any,
+) -> SBCResult:
+    """Simulation-based calibration of an inference method (Talts et al. 2018).
+
+    For each of ``num_simulations`` draws: sample ``θ★`` from ``model.prior``,
+    generate ``y`` from ``model.likelihood.generate_data(θ★, num_observations)``,
+    fit the posterior with :func:`condition_on`, and record the rank of each
+    flattened ``θ★`` component among the ``num_posterior_draws`` posterior draws.
+    Under correct calibration each rank is ``Uniform{0, …, L}``; the per-parameter
+    KS distance from uniform and its p-value summarize the fit.
+
+    Parameters
+    ----------
+    model
+        A conditionable generative model — sampleable ``prior``, a ``likelihood``
+        with ``generate_data``, and usable with :func:`condition_on` (e.g.
+        ``SimpleModel(prior, GLMLikelihood(...))``).
+    num_simulations
+        Number of ``(θ★, y, posterior)`` replications.
+    num_posterior_draws
+        Posterior draws per fit (``num_results`` passed to :func:`condition_on`).
+    num_observations
+        Observations per generated dataset.
+    method
+        Inference method name for :func:`condition_on` (``None`` = auto-select).
+    alpha
+        Test level for the per-parameter pass flag.
+    key
+        JAX PRNG key (auto-generated if ``None``). Controls θ★, the data, and the
+        per-fit MCMC seed, so a fixed key makes the whole run reproducible. Do not
+        also pass ``random_seed`` in ``infer_kwargs``.
+    **infer_kwargs
+        Extra keyword arguments forwarded to :func:`condition_on` (e.g.
+        ``num_warmup``, ``num_chains``).
+
+    Returns
+    -------
+    SBCResult
+    """
+    if key is None:
+        key = _auto_key()
+    prior = model.prior
+    generate = model.likelihood.generate_data
+    gen_takes_key = "key" in inspect.signature(generate).parameters
+
+    rank_rows: list[np.ndarray] = []
+    fields: tuple[str, ...] | None = None
+    draws = None
+    for _ in range(num_simulations):
+        key, k_theta, k_data, k_mcmc = jax.random.split(key, 4)
+        theta_star = prior._sample(k_theta, ())
+        if gen_takes_key:
+            y = generate(theta_star, num_observations, key=k_data)
+        else:
+            y = generate(theta_star, num_observations)
+        seed = int(jax.random.randint(k_mcmc, (), 0, 2_000_000_000))
+        posterior = condition_on(
+            model,
+            y,
+            method=method,
+            num_results=num_posterior_draws,
+            random_seed=seed,
+            **infer_kwargs,
+        )
+        draws = jnp.asarray(posterior.flat_samples)  # (L, p)
+        if fields is None:
+            fields = getattr(posterior, "fields", None)
+        theta_flat = _flatten_point(theta_star, fields)  # (p,)
+        rank_rows.append(np.asarray(jnp.sum(draws < theta_flat[None, :], axis=0)))
+
+    ranks = np.stack(rank_rows).astype(int)  # (num_simulations, p)
+    num_draws = int(draws.shape[0])  # actual total draws (handles multi-chain)
+    ks_stat, ks_pvalue = _ks_uniform(ranks, num_draws)
+    return SBCResult(
+        ranks=ranks,
+        num_posterior_draws=num_draws,
+        param_names=tuple(fields) if fields else None,
+        ks_statistic=ks_stat,
+        ks_pvalue=ks_pvalue,
+        passed=bool(np.all(ks_pvalue > alpha)),
+    )
+
+
+# -- interval coverage ------------------------------------------------------
+
+
+def interval_coverage(
+    draws_or_dist: Any,
+    truth: ArrayLike,
+    *,
+    levels: Sequence[float] = (0.5, 0.8, 0.9, 0.95),
+) -> dict[float, Array]:
+    """Central-credible-interval coverage of *truth*, per parameter.
+
+    For each ``level``, checks whether each component of *truth* lies in the
+    central ``level`` interval ``[q_{(1−level)/2}, q_{(1+level)/2}]`` of the
+    per-parameter posterior. Returns ``{level: covered}`` with ``covered`` a
+    boolean array over parameters. Averaging the indicators over many
+    ``(posterior, truth)`` pairs gives the frequentist coverage, which matches the
+    nominal level for a calibrated method.
+
+    *draws_or_dist* is an ``(n, d)`` (or 1-D ``(n,)``) array of draws or a
+    distribution exposing ``flat_samples`` (treated as equally weighted, as
+    MCMC draws are); *truth* is the matching ``(d,)``.
+    """
+    draws = jnp.asarray(getattr(draws_or_dist, "flat_samples", draws_or_dist))
+    if draws.ndim == 1:
+        draws = draws[:, None]
+    truth = jnp.atleast_1d(jnp.asarray(truth))
+    out: dict[float, Array] = {}
+    for level in levels:
+        lo, hi = (1.0 - level) / 2.0, (1.0 + level) / 2.0
+        q = jnp.quantile(draws, jnp.array([lo, hi]), axis=0)  # (2, d)
+        out[float(level)] = (truth >= q[0]) & (truth <= q[1])
+    return out

--- a/probpipe/validation/_calibration.py
+++ b/probpipe/validation/_calibration.py
@@ -41,15 +41,14 @@ __all__ = ["SBCResult", "interval_coverage", "simulation_based_calibration"]
 
 
 def _flatten_point(point: Any, fields: tuple[str, ...] | None) -> Array:
-    """Flatten one parameter draw to a 1-D vector matching ``flat_samples`` order.
+    """Flatten one parameter draw to the 1-D layout of ``flat_samples``.
 
-    A bare array is raveled; a ``Record`` is flattened field-by-field in the
-    posterior's field order (falling back to the point's own field order if the
-    posterior does not expose ``fields``) so it lines up with ``flat_samples``.
+    The single-draw analogue of :attr:`flat_samples`: ``prior._sample`` returns a
+    bare array for a single-field prior (raveled directly) or a ``Record`` for a
+    multi-field prior (fields raveled and concatenated in posterior field order).
     """
     if hasattr(point, "fields"):
-        order = fields if fields is not None else point.fields
-        return jnp.concatenate([jnp.ravel(jnp.asarray(point[f])) for f in order])
+        return jnp.concatenate([jnp.ravel(jnp.asarray(point[f])) for f in fields])
     return jnp.ravel(jnp.asarray(point))
 
 

--- a/probpipe/validation/_calibration.py
+++ b/probpipe/validation/_calibration.py
@@ -21,7 +21,6 @@ JAX-accelerated where the backend allows. The model must expose a sampleable
 
 from __future__ import annotations
 
-import inspect
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -33,6 +32,7 @@ import numpy as np
 from .._utils import _auto_key
 from ..core.ops import condition_on
 from ..custom_types import Array, ArrayLike, PRNGKey
+from ._predictive_check import _supports_key_arg
 
 __all__ = ["SBCResult", "interval_coverage", "simulation_based_calibration"]
 
@@ -44,25 +44,47 @@ def _flatten_point(point: Any, fields: tuple[str, ...] | None) -> Array:
     """Flatten one parameter draw to a 1-D vector matching ``flat_samples`` order.
 
     A bare array is raveled; a ``Record`` is flattened field-by-field in the
-    posterior's field order so the comparison lines up with ``flat_samples``.
+    posterior's field order (falling back to the point's own field order if the
+    posterior does not expose ``fields``) so it lines up with ``flat_samples``.
     """
-    if fields is not None and hasattr(point, "fields"):
-        return jnp.concatenate([jnp.ravel(jnp.asarray(point[f])) for f in fields])
+    if hasattr(point, "fields"):
+        order = fields if fields is not None else point.fields
+        return jnp.concatenate([jnp.ravel(jnp.asarray(point[f])) for f in order])
     return jnp.ravel(jnp.asarray(point))
 
 
-def _kolmogorov_sf(d: float, n: int) -> float:
-    """Asymptotic survival function of the one-sample KS statistic (Stephens).
+def _component_names(posterior: Any) -> tuple[str, ...] | None:
+    """Per-flattened-component parameter names matching the ``flat_samples`` columns.
 
-    ``P(D_n ≥ d)`` under the null, via ``Q_KS(λ) = 2 Σ_k (−1)^{k−1} e^{−2k²λ²}``
-    with the small-sample correction ``λ = (√n + 0.12 + 0.11/√n) d``. Dependency
-    -free (no SciPy); accurate for the sample sizes SBC uses (``n ≳ 30``).
+    A scalar field keeps its name; a field with ``k > 1`` flattened components
+    becomes ``field[0] … field[k-1]`` (row-major), in posterior field order.
+    Returns ``None`` if the posterior exposes neither ``fields`` nor
+    ``event_shapes``.
+    """
+    fields = getattr(posterior, "fields", None)
+    shapes = getattr(posterior, "event_shapes", None)
+    if not fields or shapes is None:
+        return None
+    names: list[str] = []
+    for f in fields:
+        size = int(np.prod(shapes[f], dtype=int))
+        names.extend([f] if size == 1 else [f"{f}[{i}]" for i in range(size)])
+    return tuple(names)
+
+
+def _kolmogorov_sf(d: float, n: int) -> float:
+    """Asymptotic survival function of the one-sample KS statistic.
+
+    ``P(D_n ≥ d)`` under the null, via the Kolmogorov limit
+    ``Q_KS(λ) = 2 Σ_k (−1)^{k−1} e^{−2k²λ²}`` with Stephens' (1970) small-sample
+    correction ``λ = (√n + 0.12 + 0.11/√n) d``. Dependency-free (no SciPy);
+    accurate for the sample sizes SBC uses (``n ≳ 30``).
     """
     if d <= 0.0:
         return 1.0
     en = np.sqrt(n)
     lam = (en + 0.12 + 0.11 / en) * d
-    k = np.arange(1, 101)
+    k = np.arange(1, 101)  # series decays as e^{-2k²λ²}; 100 terms is far more than enough
     p = 2.0 * np.sum((-1.0) ** (k - 1) * np.exp(-2.0 * (k * lam) ** 2))
     return float(min(max(p, 0.0), 1.0))
 
@@ -96,10 +118,15 @@ class SBCResult:
     ranks : np.ndarray
         Integer ranks of ``θ★`` among the posterior draws, shape
         ``(num_simulations, num_params)``, each in ``{0, …, num_posterior_draws}``.
+        The rank counts draws strictly below ``θ★``; this assumes continuous
+        draws (ties are measure-zero for a continuous posterior, but would bias
+        ranks low for a discrete-valued parameter).
     num_posterior_draws : int
         ``L`` — the rank upper bound (the actual number of posterior draws used).
     param_names : tuple[str, ...] or None
-        Flattened parameter field names (posterior field order), if known.
+        Per-flattened-component names aligned with the columns of ``ranks`` /
+        ``ks_*`` (``field`` for a scalar field, ``field[i]`` otherwise), in
+        posterior field order; ``None`` if the posterior exposes no field names.
     ks_statistic : np.ndarray
         Per-parameter KS distance of the normalized ranks from ``Uniform[0, 1]``.
     ks_pvalue : np.ndarray
@@ -174,14 +201,22 @@ def simulation_based_calibration(
     -------
     SBCResult
     """
+    if num_simulations < 1:
+        raise ValueError(f"num_simulations must be >= 1, got {num_simulations}")
+    if "random_seed" in infer_kwargs:
+        raise ValueError(
+            "simulation_based_calibration manages the per-fit random_seed; "
+            "do not pass random_seed in infer_kwargs"
+        )
     if key is None:
         key = _auto_key()
     prior = model.prior
     generate = model.likelihood.generate_data
-    gen_takes_key = "key" in inspect.signature(generate).parameters
+    gen_takes_key = _supports_key_arg(model.likelihood)
 
     rank_rows: list[np.ndarray] = []
     fields: tuple[str, ...] | None = None
+    component_names: tuple[str, ...] | None = None
     draws = None
     for _ in range(num_simulations):
         key, k_theta, k_data, k_mcmc = jax.random.split(key, 4)
@@ -202,6 +237,7 @@ def simulation_based_calibration(
         draws = jnp.asarray(posterior.flat_samples)  # (L, p)
         if fields is None:
             fields = getattr(posterior, "fields", None)
+            component_names = _component_names(posterior)
         theta_flat = _flatten_point(theta_star, fields)  # (p,)
         rank_rows.append(np.asarray(jnp.sum(draws < theta_flat[None, :], axis=0)))
 
@@ -211,7 +247,7 @@ def simulation_based_calibration(
     return SBCResult(
         ranks=ranks,
         num_posterior_draws=num_draws,
-        param_names=tuple(fields) if fields else None,
+        param_names=component_names,
         ks_statistic=ks_stat,
         ks_pvalue=ks_pvalue,
         passed=bool(np.all(ks_pvalue > alpha)),
@@ -244,6 +280,8 @@ def interval_coverage(
     if draws.ndim == 1:
         draws = draws[:, None]
     truth = jnp.atleast_1d(jnp.asarray(truth))
+    if truth.shape[0] != draws.shape[1]:
+        raise ValueError(f"truth dimension {truth.shape[0]} != draws dimension {draws.shape[1]}")
     out: dict[float, Array] = {}
     for level in levels:
         lo, hi = (1.0 - level) / 2.0, (1.0 + level) / 2.0

--- a/probpipe/validation/_calibration.py
+++ b/probpipe/validation/_calibration.py
@@ -138,9 +138,10 @@ class SBCResult:
     ks_statistic : np.ndarray
         Per-parameter KS distance of the normalized ranks from ``Uniform[0, 1]``.
     ks_pvalue : np.ndarray
-        Per-parameter KS p-value; small ⇒ ranks are non-uniform ⇒ miscalibrated.
-    passed : bool
-        Whether every parameter's p-value exceeds the test level ``alpha``.
+        Per-parameter KS p-value against ``Uniform[0, 1]``; small ⇒ ranks are
+        non-uniform ⇒ miscalibrated. This is a diagnostic — inspect it (and the
+        rank histogram) and apply your own threshold, with a multiple-comparison
+        correction across parameters, rather than reading off a pass/fail verdict.
     """
 
     ranks: np.ndarray
@@ -148,7 +149,6 @@ class SBCResult:
     param_names: tuple[str, ...] | None
     ks_statistic: np.ndarray
     ks_pvalue: np.ndarray
-    passed: bool
 
     def rank_histogram(self, num_bins: int = 20) -> np.ndarray:
         """Rank histogram per parameter, shape ``(num_params, num_bins)``.
@@ -168,7 +168,6 @@ def simulation_based_calibration(
     num_posterior_draws: int,
     num_observations: int,
     method: str | None = None,
-    alpha: float = 0.05,
     key: PRNGKey | None = None,
     **infer_kwargs: Any,
 ) -> SBCResult:
@@ -195,8 +194,6 @@ def simulation_based_calibration(
         Observations per generated dataset.
     method
         Inference method name for :func:`condition_on` (``None`` = auto-select).
-    alpha
-        Test level for the per-parameter pass flag.
     key
         JAX PRNG key (auto-generated if ``None``). Controls θ★, the data, and the
         per-fit MCMC seed, so a fixed key makes the whole run reproducible. Do not
@@ -258,7 +255,6 @@ def simulation_based_calibration(
         param_names=component_names,
         ks_statistic=ks_stat,
         ks_pvalue=ks_pvalue,
-        passed=bool(np.all(ks_pvalue > alpha)),
     )
 
 

--- a/tests/validation/test_calibration.py
+++ b/tests/validation/test_calibration.py
@@ -1,4 +1,8 @@
-"""Simulation-based calibration and interval coverage."""
+"""Simulation-based calibration and interval coverage.
+
+Tolerances are measured (independent baselines / known calibration properties)
+per STYLE_GUIDE §8.6.
+"""
 
 from __future__ import annotations
 
@@ -8,9 +12,10 @@ import numpy as np
 import pytest
 import tensorflow_probability.substrates.jax.glm as tfp_glm
 
-from probpipe import GLMLikelihood, MultivariateNormal, SimpleModel
+from probpipe import EmpiricalDistribution, GLMLikelihood, MultivariateNormal, SimpleModel
+from probpipe.core.record import Record
 from probpipe.validation import SBCResult, interval_coverage, simulation_based_calibration
-from probpipe.validation._calibration import _ks_uniform
+from probpipe.validation._calibration import _component_names, _flatten_point, _ks_uniform
 
 
 def _gaussian_glm(p: int = 2, n: int = 12, seed: int = 7):
@@ -50,6 +55,23 @@ class TestIntervalCoverage:
         assert set(cov) == {0.8, 0.95}
         assert cov[0.8].shape == (3,)
 
+    def test_accepts_distribution_input(self):
+        # A distribution exposing flat_samples scores identically to its raw draws.
+        draws = jax.random.normal(jax.random.PRNGKey(4), (2000, 2))
+        emp = EmpiricalDistribution(draws, name="z")
+        from_dist = interval_coverage(emp, jnp.array([0.3, -0.4]), levels=(0.9,))
+        from_array = interval_coverage(draws, jnp.array([0.3, -0.4]), levels=(0.9,))
+        assert bool(jnp.all(from_dist[0.9] == from_array[0.9]))
+
+    def test_default_levels(self):
+        draws = jax.random.normal(jax.random.PRNGKey(5), (1000, 2))
+        assert set(interval_coverage(draws, jnp.zeros(2))) == {0.5, 0.8, 0.9, 0.95}
+
+    def test_rejects_dimension_mismatch(self):
+        draws = jax.random.normal(jax.random.PRNGKey(6), (500, 2))
+        with pytest.raises(ValueError, match="dimension"):
+            interval_coverage(draws, jnp.zeros(3))
+
 
 class TestKSUniform:
     def test_flags_uniform_vs_skewed(self):
@@ -58,6 +80,26 @@ class TestKSUniform:
         assert float(_ks_uniform(uniform, big_l)[1][0]) > 0.05  # not rejected
         skewed = (np.arange(s) % (big_l // 10))[:, None]  # all in the bottom decile
         assert float(_ks_uniform(skewed, big_l)[1][0]) < 0.05  # rejected
+
+
+class TestFlattening:
+    """The multi-field θ★ flattening + component-naming that ranks rely on."""
+
+    def test_flatten_point_honors_field_order(self):
+        point = Record(a=jnp.array([1.0, 2.0]), b=jnp.array([3.0]))
+        np.testing.assert_array_equal(
+            np.asarray(_flatten_point(point, ("a", "b"))), [1.0, 2.0, 3.0]
+        )
+        # The posterior's field order is authoritative (b before a).
+        np.testing.assert_array_equal(
+            np.asarray(_flatten_point(point, ("b", "a"))), [3.0, 1.0, 2.0]
+        )
+
+    def test_component_names_expand_per_field(self):
+        # A length-k field becomes field[0..k-1]; a scalar field keeps its name —
+        # in posterior field order, matching flat_samples columns.
+        emp = EmpiricalDistribution(Record(a=jnp.zeros((10, 2)), b=jnp.zeros((10,))), name="m")
+        assert _component_names(emp) == ("a[0]", "a[1]", "b")
 
 
 class TestSBC:
@@ -74,11 +116,33 @@ class TestSBC:
         assert isinstance(res, SBCResult)
         assert res.ranks.shape == (32, 2)
         assert res.ranks.min() >= 0 and res.ranks.max() <= res.num_posterior_draws
-        assert res.param_names == ("beta",)
+        # param_names are per flattened component, aligned with the rank columns.
+        assert res.param_names == ("beta[0]", "beta[1]")
+        assert len(res.param_names) == res.ranks.shape[1]
+        # Well-specified model + NUTS → ranks ~ uniform. Measured across seeds 0–2
+        # (S=32, L=100): mean normalized rank ∈ [0.46, 0.52], median ks_pvalue ∈
+        # [0.58, 0.77]. Assert stable statistics, not a tail bound on the min.
+        u = (res.ranks + 0.5) / (res.num_posterior_draws + 1)
+        assert np.all((u.mean(axis=0) > 0.35) & (u.mean(axis=0) < 0.65))
+        assert float(np.median(res.ks_pvalue)) > 0.2
+        # `passed` reflects every per-parameter p-value clearing the default alpha.
         assert isinstance(res.passed, bool)
-        # Well-specified model + NUTS → ranks ~ uniform → comfortably not rejected.
-        assert float(res.ks_pvalue.min()) > 0.01
+        assert res.passed == bool(res.ks_pvalue.min() > 0.05)
         # Rank histogram: (num_params, num_bins), each row sums to num_simulations.
         hist = res.rank_histogram(num_bins=10)
         assert hist.shape == (2, 10)
         assert np.all(hist.sum(axis=1) == 32)
+
+    def test_rejects_bad_num_simulations(self):
+        model, n = _gaussian_glm()
+        with pytest.raises(ValueError, match="num_simulations"):
+            simulation_based_calibration(
+                model, num_simulations=0, num_posterior_draws=50, num_observations=n
+            )
+
+    def test_rejects_random_seed_in_infer_kwargs(self):
+        model, n = _gaussian_glm()
+        with pytest.raises(ValueError, match="random_seed"):
+            simulation_based_calibration(
+                model, num_simulations=2, num_posterior_draws=50, num_observations=n, random_seed=0
+            )

--- a/tests/validation/test_calibration.py
+++ b/tests/validation/test_calibration.py
@@ -209,9 +209,6 @@ class TestSBC:
         u = (res.ranks + 0.5) / (res.num_posterior_draws + 1)
         assert np.all((u.mean(axis=0) > 0.35) & (u.mean(axis=0) < 0.65))
         assert float(np.median(res.ks_pvalue)) > 0.2
-        # `passed` reflects every per-parameter p-value clearing the default alpha.
-        assert isinstance(res.passed, bool)
-        assert res.passed == bool(res.ks_pvalue.min() > 0.05)
         # Rank histogram: (num_params, num_bins), each row sums to num_simulations.
         hist = res.rank_histogram(num_bins=10)
         assert hist.shape == (2, 10)
@@ -232,8 +229,8 @@ class TestSBC:
             num_warmup=100,
             key=jax.random.PRNGKey(0),
         )
-        assert res.passed is False
-        assert float(res.ks_pvalue.max()) < 0.05  # uniformity rejected
+        # Uniformity is rejected for every parameter — a clear miscalibration signal.
+        assert float(res.ks_pvalue.max()) < 0.05
         # The upward bias pushes θ★ into the lower tail → mean rank below 0.5.
         assert ((res.ranks + 0.5) / (res.num_posterior_draws + 1)).mean() < 0.45
 

--- a/tests/validation/test_calibration.py
+++ b/tests/validation/test_calibration.py
@@ -217,23 +217,25 @@ class TestSBC:
         assert hist.shape == (2, 10)
         assert np.all(hist.sum(axis=1) == 32)
 
-    def test_detects_miscalibration(self):
-        # A model whose generate_data carries an unmodeled +3 mean shift: the
-        # posterior systematically misses θ★, so ranks collapse to the low tail
-        # and SBC rejects calibration.
-        model = SimpleModel(Normal(loc=0.0, scale=2.0, name="mu"), _BiasedMeanLikelihood(3.0))
+    def test_detects_subtle_miscalibration(self):
+        # A *sub-posterior-SD* mean shift is still caught. generate_data carries an
+        # unmodeled +0.2 shift while the posterior SD is ≈ 0.31 (precision
+        # 1/4 + 10 = 10.25), so the per-fit bias is only ≈ 0.6 posterior SD — yet
+        # SBC rejects because the shift is *systematic* across simulations and
+        # accumulates. Measured ks_pvalue.max ≤ 0.002 over seeds 0–2 at S=24.
+        model = SimpleModel(Normal(loc=0.0, scale=2.0, name="mu"), _BiasedMeanLikelihood(0.2))
         res = simulation_based_calibration(
             model,
-            num_simulations=16,
+            num_simulations=24,
             num_posterior_draws=100,
             num_observations=10,
             num_warmup=100,
             key=jax.random.PRNGKey(0),
         )
         assert res.passed is False
-        assert float(res.ks_pvalue.max()) < 0.05  # uniformity rejected for every param
-        # θ★ sits in the low tail of the (upward-biased) posterior → mean rank ≈ 0.
-        assert ((res.ranks + 0.5) / (res.num_posterior_draws + 1)).mean() < 0.1
+        assert float(res.ks_pvalue.max()) < 0.05  # uniformity rejected
+        # The upward bias pushes θ★ into the lower tail → mean rank below 0.5.
+        assert ((res.ranks + 0.5) / (res.num_posterior_draws + 1)).mean() < 0.45
 
     def test_rejects_bad_num_simulations(self):
         model, n = _gaussian_glm()

--- a/tests/validation/test_calibration.py
+++ b/tests/validation/test_calibration.py
@@ -1,0 +1,84 @@
+"""Simulation-based calibration and interval coverage."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tensorflow_probability.substrates.jax.glm as tfp_glm
+
+from probpipe import GLMLikelihood, MultivariateNormal, SimpleModel
+from probpipe.validation import SBCResult, interval_coverage, simulation_based_calibration
+from probpipe.validation._calibration import _ks_uniform
+
+
+def _gaussian_glm(p: int = 2, n: int = 12, seed: int = 7):
+    """A well-specified Gaussian linear model: sampleable prior + generative GLM."""
+    X = jax.random.normal(jax.random.PRNGKey(seed), (n, p - 1))
+    prior = MultivariateNormal(loc=jnp.zeros(p), cov=jnp.eye(p), name="beta")
+    return SimpleModel(prior, GLMLikelihood(tfp_glm.Normal(), x=X)), n
+
+
+class TestIntervalCoverage:
+    def test_contains_center_excludes_far(self):
+        draws = jax.random.normal(jax.random.PRNGKey(0), (5000, 2))  # ~ N(0, I)
+        cov = interval_coverage(draws, jnp.zeros(2), levels=(0.5, 0.9))
+        for level in (0.5, 0.9):
+            assert bool(jnp.all(cov[level]))  # truth = 0 is central → covered
+        far = interval_coverage(draws, jnp.array([5.0, -5.0]), levels=(0.9,))
+        assert not bool(jnp.any(far[0.9]))  # truth deep in the tails → not covered
+
+    def test_frequentist_rate_matches_nominal(self):
+        # truth and draws from the same N(0, 1): a fresh truth lands in the
+        # central-`level` interval with probability ≈ level.
+        draws = jax.random.normal(jax.random.PRNGKey(1), (4000, 1))
+        truths = jax.random.normal(jax.random.PRNGKey(2), (400,))
+        for level in (0.5, 0.9):
+            hits = np.mean(
+                [
+                    bool(interval_coverage(draws, jnp.array([t]), levels=(level,))[level][0])
+                    for t in truths
+                ]
+            )
+            # 400 Bernoulli(level) draws → SE ≈ 0.015–0.025; abs=0.05 is ~2–3 SE.
+            assert hits == pytest.approx(level, abs=0.05)
+
+    def test_returns_per_level_per_param(self):
+        draws = jax.random.normal(jax.random.PRNGKey(3), (1000, 3))
+        cov = interval_coverage(draws, jnp.zeros(3), levels=(0.8, 0.95))
+        assert set(cov) == {0.8, 0.95}
+        assert cov[0.8].shape == (3,)
+
+
+class TestKSUniform:
+    def test_flags_uniform_vs_skewed(self):
+        big_l, s = 100, 200
+        uniform = np.linspace(0, big_l, s).astype(int)[:, None]  # evenly spread ranks
+        assert float(_ks_uniform(uniform, big_l)[1][0]) > 0.05  # not rejected
+        skewed = (np.arange(s) % (big_l // 10))[:, None]  # all in the bottom decile
+        assert float(_ks_uniform(skewed, big_l)[1][0]) < 0.05  # rejected
+
+
+class TestSBC:
+    def test_well_specified_ranks_uniform(self):
+        model, n = _gaussian_glm()
+        res = simulation_based_calibration(
+            model,
+            num_simulations=32,
+            num_posterior_draws=100,
+            num_observations=n,
+            num_warmup=100,
+            key=jax.random.PRNGKey(0),
+        )
+        assert isinstance(res, SBCResult)
+        assert res.ranks.shape == (32, 2)
+        assert res.ranks.min() >= 0 and res.ranks.max() <= res.num_posterior_draws
+        assert res.param_names == ("beta",)
+        assert isinstance(res.passed, bool)
+        # Well-specified model + NUTS → ranks ~ uniform → comfortably not rejected.
+        assert float(res.ks_pvalue.min()) > 0.01
+        # Rank histogram: (num_params, num_bins), each row sums to num_simulations.
+        hist = res.rank_histogram(num_bins=10)
+        assert hist.shape == (2, 10)
+        assert np.all(hist.sum(axis=1) == 32)

--- a/tests/validation/test_calibration.py
+++ b/tests/validation/test_calibration.py
@@ -10,12 +10,42 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+import tensorflow_probability.substrates.jax as tfp
 import tensorflow_probability.substrates.jax.glm as tfp_glm
 
-from probpipe import EmpiricalDistribution, GLMLikelihood, MultivariateNormal, SimpleModel
+from probpipe import EmpiricalDistribution, GLMLikelihood, MultivariateNormal, Normal, SimpleModel
 from probpipe.core.record import Record
 from probpipe.validation import SBCResult, interval_coverage, simulation_based_calibration
-from probpipe.validation._calibration import _component_names, _flatten_point, _ks_uniform
+from probpipe.validation._calibration import (
+    _component_names,
+    _flatten_point,
+    _kolmogorov_sf,
+    _ks_uniform,
+    _ranks,
+)
+
+tfd = tfp.distributions
+
+
+class _BiasedMeanLikelihood:
+    """A deliberately miscalibrated Gaussian-mean likelihood.
+
+    ``log_likelihood`` is ``N(y; μ, 1)``, but ``generate_data`` draws from
+    ``N(μ + bias, 1)`` — the unmodeled shift makes the posterior systematically
+    miss ``θ★``, so SBC ranks are non-uniform. Used to test that SBC *detects*
+    miscalibration.
+    """
+
+    def __init__(self, bias: float):
+        self.bias = float(bias)
+
+    def log_likelihood(self, params, data):
+        mu = jnp.reshape(jnp.asarray(params), ())
+        return jnp.sum(tfd.Normal(mu, 1.0).log_prob(jnp.asarray(data)))
+
+    def generate_data(self, params, num_observations, *, key):
+        mu = jnp.reshape(jnp.asarray(params), ())
+        return mu + self.bias + jax.random.normal(key, (num_observations,))
 
 
 def _gaussian_glm(p: int = 2, n: int = 12, seed: int = 7):
@@ -73,13 +103,67 @@ class TestIntervalCoverage:
             interval_coverage(draws, jnp.zeros(3))
 
 
-class TestKSUniform:
+class TestKSFunctions:
+    def test_kolmogorov_sf_matches_scipy(self):
+        # _kolmogorov_sf sums the Kolmogorov Q_KS series at the Stephens-corrected
+        # λ; scipy.special.kolmogorov sums the same series — they must agree.
+        sp = pytest.importorskip("scipy.special")
+        for d, n in [(0.05, 50), (0.1, 100), (0.15, 200), (0.3, 30)]:
+            lam = (np.sqrt(n) + 0.12 + 0.11 / np.sqrt(n)) * d
+            assert _kolmogorov_sf(d, n) == pytest.approx(float(sp.kolmogorov(lam)), abs=1e-10)
+
+    def test_kolmogorov_sf_boundaries(self):
+        assert _kolmogorov_sf(0.0, 50) == 1.0  # zero distance → no evidence against H0
+        assert _kolmogorov_sf(-1.0, 50) == 1.0  # guarded
+        assert _kolmogorov_sf(5.0, 50) == pytest.approx(0.0, abs=1e-9)  # huge stat → ~0
+        vals = [_kolmogorov_sf(d, 100) for d in (0.05, 0.1, 0.2, 0.3)]
+        assert vals == sorted(vals, reverse=True)  # monotone decreasing in d
+
+    def test_ks_statistic_matches_scipy(self):
+        # The KS distance equals scipy's one-sample statistic against Uniform[0, 1].
+        st = pytest.importorskip("scipy.stats")
+        rng = np.random.default_rng(0)
+        for big_l, s in [(100, 50), (200, 200), (50, 120)]:
+            ranks = rng.integers(0, big_l + 1, size=(s, 1))
+            u = (ranks[:, 0] + 0.5) / (big_l + 1)
+            d = float(_ks_uniform(ranks, big_l)[0][0])
+            assert d == pytest.approx(float(st.kstest(u, "uniform").statistic), abs=1e-10)
+
+    def test_per_column_statistic_and_pvalue(self):
+        # Each column is scored independently: D_j is its KS distance and p_j is
+        # _kolmogorov_sf(D_j, num_simulations).
+        st = pytest.importorskip("scipy.stats")
+        rng = np.random.default_rng(1)
+        ranks = rng.integers(0, 101, size=(80, 3))
+        d, p = _ks_uniform(ranks, 100)
+        assert d.shape == (3,) and p.shape == (3,)
+        for j in range(3):
+            u = (ranks[:, j] + 0.5) / 101
+            assert float(d[j]) == pytest.approx(float(st.kstest(u, "uniform").statistic), abs=1e-10)
+            assert float(p[j]) == pytest.approx(_kolmogorov_sf(float(d[j]), 80), abs=1e-12)
+
     def test_flags_uniform_vs_skewed(self):
+        # End-to-end sanity: spread ranks are not rejected; bottom-decile ranks are.
         big_l, s = 100, 200
-        uniform = np.linspace(0, big_l, s).astype(int)[:, None]  # evenly spread ranks
-        assert float(_ks_uniform(uniform, big_l)[1][0]) > 0.05  # not rejected
-        skewed = (np.arange(s) % (big_l // 10))[:, None]  # all in the bottom decile
-        assert float(_ks_uniform(skewed, big_l)[1][0]) < 0.05  # rejected
+        uniform = np.linspace(0, big_l, s).astype(int)[:, None]
+        assert float(_ks_uniform(uniform, big_l)[1][0]) > 0.05
+        skewed = (np.arange(s) % (big_l // 10))[:, None]
+        assert float(_ks_uniform(skewed, big_l)[1][0]) < 0.05
+
+
+class TestRanks:
+    def test_counts_draws_strictly_below(self):
+        draws = jnp.array([[0.0], [1.0], [2.0], [3.0]])
+        np.testing.assert_array_equal(np.asarray(_ranks(draws, jnp.array([1.5]))), [2])
+        # Strict < : a tie at the point is not counted (3 below 3.0, not 4).
+        np.testing.assert_array_equal(np.asarray(_ranks(draws, jnp.array([3.0]))), [3])
+        np.testing.assert_array_equal(np.asarray(_ranks(draws, jnp.array([-1.0]))), [0])
+        np.testing.assert_array_equal(np.asarray(_ranks(draws, jnp.array([9.0]))), [4])
+
+    def test_per_component(self):
+        draws = jnp.array([[0.0, 10.0], [1.0, 20.0], [2.0, 30.0]])
+        # col 0: 2 draws below 1.5; col 1: 0 draws below 5.0.
+        np.testing.assert_array_equal(np.asarray(_ranks(draws, jnp.array([1.5, 5.0]))), [2, 0])
 
 
 class TestFlattening:
@@ -132,6 +216,24 @@ class TestSBC:
         hist = res.rank_histogram(num_bins=10)
         assert hist.shape == (2, 10)
         assert np.all(hist.sum(axis=1) == 32)
+
+    def test_detects_miscalibration(self):
+        # A model whose generate_data carries an unmodeled +3 mean shift: the
+        # posterior systematically misses θ★, so ranks collapse to the low tail
+        # and SBC rejects calibration.
+        model = SimpleModel(Normal(loc=0.0, scale=2.0, name="mu"), _BiasedMeanLikelihood(3.0))
+        res = simulation_based_calibration(
+            model,
+            num_simulations=16,
+            num_posterior_draws=100,
+            num_observations=10,
+            num_warmup=100,
+            key=jax.random.PRNGKey(0),
+        )
+        assert res.passed is False
+        assert float(res.ks_pvalue.max()) < 0.05  # uniformity rejected for every param
+        # θ★ sits in the low tail of the (upward-biased) posterior → mean rank ≈ 0.
+        assert ((res.ranks + 0.5) / (res.num_posterior_draws + 1)).mean() < 0.1
 
     def test_rejects_bad_num_simulations(self):
         model, n = _gaussian_glm()


### PR DESCRIPTION
## Summary

The **calibration slice** of #301 (following the comparison-metrics + `quantile`
op in #306): method **self-consistency** checks in `probpipe.validation` —
simulation-based calibration and interval coverage. Where the comparison metrics
score an approximation against a *reference*, these ask "is this inference method
self-consistent with the model that generated the data?", and are method-agnostic
infrastructure usable across the library and beneath `probpipe-benchmark` (#302).

## What's in this PR

**`probpipe/validation/_calibration.py`:**

- **`simulation_based_calibration(model, *, num_simulations, num_posterior_draws,
  num_observations, method=None, alpha=0.05, key=None, **infer_kwargs)`** — for
  each replication: sample `θ★ ~ model.prior`, generate `y` via
  `model.likelihood.generate_data(θ★, …)`, fit the posterior with
  `condition_on`, and record the rank of each flattened `θ★` component among the
  posterior draws (Talts et al. 2018). Returns an **`SBCResult`** with the
  per-parameter `ranks`, the KS distance from uniform + its p-value, and a
  `rank_histogram(num_bins)` helper — a diagnostic, with no built-in pass/fail
  verdict (inspect the p-values / histogram and apply your own threshold).
- **`interval_coverage(draws_or_dist, truth, *, levels=(.5,.8,.9,.95))`** —
  whether each component of `truth` lies in the central-`level` credible interval
  per parameter; averaging the indicators over many `(posterior, truth)` pairs
  gives the frequentist coverage (the check #304 needs).

**Docs + changelog** — a Calibration section in `docs/api/validation.md` and a
CHANGELOG entry.

## Scope notes

- **SBC is a backend-agnostic Python loop over `condition_on`.** `condition_on`
  returns an `ApproximateDistribution` object (MCMC with warmup adaptation), not
  a pure array, so it is not `vmap`/`scan`-able. This deviates from the #301
  plan's "`scan`/`vmap` fast-path for NUTS" — that would require bypassing
  `condition_on` to call blackjax directly (a separate lower-level entry), which
  is out of scope here. The loop works for every backend (blackjax, Stan, PyMC,
  …); the per-fit MCMC is still JAX-accelerated. A vmapped-NUTS fast path can be
  a follow-up if SBC throughput becomes a bottleneck.
- **No new dependencies.** The KS-to-uniform p-value uses a dependency-free
  asymptotic Kolmogorov formula (`scipy` is not a runtime dependency).
- `interval_coverage` treats draws as equally weighted, consistent with how the
  comparison metrics consume `flat_samples` (correct for MCMC posteriors).

## Tests

- `tests/validation/test_calibration.py` — `interval_coverage` correctness
  (contains/excludes) and its frequentist rate (≈ nominal over many draws); the
  KS helper on uniform vs skewed ranks; and an **end-to-end SBC** run on a
  well-specified Gaussian GLM with NUTS, confirming approximately uniform ranks
  (`ks_pvalue` comfortably above the test level) and the result/​histogram shapes.
- Full `tests/validation` passes (63); `ruff` clean; strict docs build passes.

Part of #301.
