### PR TITLE
Phase 1d (#235): flatten/unflatten → JAX-pytree; flat_size → vector_size

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -32,6 +32,16 @@ if it were user-guide reference text.
    - **every** error/raise condition;
    - invariants and round-trip guarantees (e.g. `from_vector(to_vector(v)) == v`).
 
+   **Lead with the contract; defer the rationale.** The opening of every docstring — the one-line
+   summary and the first paragraph(s) — must describe the **API**: what the abstraction *is*, what it
+   accepts and returns, and how a caller uses it. Write it as precise, clear reference text for a
+   *user*, not as a design log: prefer plain language, define or avoid jargon, and state the contract
+   directly. Keep design reasoning, motivation, history, and implementation trade-offs *out* of the
+   opening; when including them is genuinely justified, put them **later** — typically in a NumPy-style
+   **Notes** section (or an explicitly labelled interim-detail note, per directive 5). A reader
+   skimming the first lines should learn how to *use* the abstraction correctly, not why it was built
+   that way.
+
    **Code documentation must stand on its own — no references to transient artifacts.** Do not cite
    PRs, issues, tracking numbers, or other out-of-band discussion in docstrings or code comments.
    The contract is whatever the docstring states; a reader should never need to open a PR or issue to
@@ -94,6 +104,7 @@ if it were user-guide reference text.
 ## Per-PR checklist (copy into the PR description)
 - [ ] Contract of every touched abstraction was clear before coding (ambiguities resolved & noted).
 - [ ] New/changed contracts fully documented in docstrings (types, shapes, orderings, raises, invariants).
+- [ ] Docstring openings lead with the API/contract (precise, clear, low-jargon); design rationale deferred to a Notes section.
 - [ ] Code verified to obey the documented contract; tests assert it (shapes + orderings + error cases).
 - [ ] Docstrings describe the plan's **target** contract/terminology, not stale neighboring code; any temporary coexistence is labeled as an interim implementation detail.
 - [ ] Variable names consistent with the canonical table above.

--- a/docs/tutorials/flexible_inference.ipynb
+++ b/docs/tutorials/flexible_inference.ipynb
@@ -139,7 +139,7 @@
     "        # params arrives flat from MCMC (a parameter vector) or structured\n",
     "        # from the simulator path (a per-draw record); coerce to a flat vector\n",
     "        # either way. Insertion order from the prior: K, phi, r.\n",
-    "        theta = params.flatten() if hasattr(params, \"flatten\") else jnp.asarray(params)\n",
+    "        theta = params.to_vector() if hasattr(params, \"to_vector\") else jnp.asarray(params)\n",
     "        log_K, logit_phi, log_r = jnp.ravel(theta)\n",
     "        K, phi, r = jnp.exp(log_K), jax.nn.sigmoid(logit_phi), jnp.exp(log_r)\n",
     "        noise = self.sigma_p * jax.random.normal(key, (self.T,))\n",

--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -690,9 +690,9 @@
     "# Sampling variability ratio: Var(individual means) / Var(bagged posterior).\n",
     "# As a rough guide, ratios well above ~0.5 flag unstable, likely-misspecified inference.\n",
     "for label, bagged in [('Poisson', bagged_poisson), ('NegBin', bagged_nb)]:\n",
-    "    ind_means = np.array([mean(p).flatten() for p in bagged.components])\n",
+    "    ind_means = np.array([mean(p).to_vector() for p in bagged.components])\n",
     "    # Pool draws from all component posteriors\n",
-    "    all_draws = np.concatenate([np.asarray(p.draws().flatten()) for p in bagged.components])\n",
+    "    all_draws = np.concatenate([np.asarray(p.draws().to_vector()) for p in bagged.components])\n",
     "    ratio = np.var(ind_means, axis=0) / np.var(all_draws, axis=0)\n",
     "    print(f'{label}: sampling variability ratio = {np.array2string(ratio, precision=3)}')"
    ]

--- a/docs/user_guide/02_records.ipynb
+++ b/docs/user_guide/02_records.ipynb
@@ -579,7 +579,7 @@
    "source": [
     "### `flatten` and `unflatten`\n",
     "\n",
-    "`NumericRecord` has a flat-vector representation obtained via `flatten()`, which concatenates every leaf's raveled values in field-insertion order; `unflatten(flat, template=...)` reverses the process.\n"
+    "`NumericRecord` has a 1-D vector representation obtained via `to_vector()`, which concatenates every leaf's raveled values in field-insertion order; `EventTemplate.from_vector(flat)` reverses the process. (The general JAX-pytree `flatten` / `unflatten` are separate ops that keep each leaf whole.)\n"
    ]
   },
   {
@@ -599,15 +599,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "flat_size: 4\n",
+      "vector_size: 4\n",
       "flat vector: [ 1.8 70.  72.  10. ]\n"
      ]
     }
    ],
    "source": [
     "params = NumericRecord(r=1.8, K=jnp.array([70.0, 72.0]), phi=10.0)\n",
-    "flat = params.flatten()\n",
-    "print(\"flat_size:\", params.flat_size)\n",
+    "flat = params.to_vector()\n",
+    "print(\"vector_size:\", params.vector_size)\n",
     "print(\"flat vector:\", flat)"
    ]
   },
@@ -616,7 +616,7 @@
    "id": "f33f8074",
    "metadata": {},
    "source": [
-    "`flat_size` is cached at construction and matches `len(flatten())`. It's\n",
+    "`vector_size` is cached at construction and matches `len(to_vector())`. It's\n",
     "the number of scalar elements across every numeric leaf. This ise useful when\n",
     "feeding the Record into an algorithm that wants a fixed-dimensional input\n",
     "(MCMC samplers, optimisers, neural nets, etc.)."
@@ -632,7 +632,7 @@
     "`unflatten` needs to know the original field names and per-field shapes, since those are erased by flattening. `EventTemplate` carries that structural information with no data attached. There are two closely related classes:\n",
     "\n",
     "- **`EventTemplate`** — the general case. Each spec is either a shape tuple (numeric leaf), `None` (non-numeric leaf — string, label, any non-array data), or a nested sub-template. Exposes `leaf_shapes`.\n",
-    "- **`NumericEventTemplate`** — the all-numeric specialisation. `None` specs are not allowed, so every leaf is a shape tuple or a nested `NumericEventTemplate`. Adds `flat_size` (total scalar count) and `numeric_leaf_shapes`, which are not well-defined in the general `EventTemplate` case.\n",
+    "- **`NumericEventTemplate`** — the all-numeric specialisation. `None` specs are not allowed, so every leaf is a shape tuple or a nested `NumericEventTemplate`. Adds `vector_size` (total scalar count) and `numeric_leaf_shapes`, which are not well-defined in the general `EventTemplate` case.\n",
     "\n",
     "`EventTemplate(...)` auto-promotes to `NumericEventTemplate` when every spec happens to be numeric, so it's not necessary to call it explicitly."
    ]
@@ -657,7 +657,7 @@
       "template: NumericEventTemplate(r=(), K=(2,), phi=())\n",
       "type: NumericEventTemplate\n",
       "leaf shapes: {'r': (), 'K': (2,), 'phi': ()}\n",
-      "flat_size: 4\n"
+      "vector_size: 4\n"
      ]
     }
    ],
@@ -666,7 +666,7 @@
     "print(\"template:\", template)\n",
     "print(\"type:\", type(template).__name__)\n",
     "print(\"leaf shapes:\", template.leaf_shapes)\n",
-    "print(\"flat_size:\", template.flat_size)"
+    "print(\"vector_size:\", template.vector_size)"
    ]
   },
   {
@@ -706,7 +706,7 @@
     }
    ],
    "source": [
-    "restored = NumericRecord.unflatten(flat, template=template)\n",
+    "restored = template.from_vector(flat)\n",
     "print(\"restored:\", restored)\n",
     "print(\"equal to original:\", restored == params)"
    ]
@@ -740,7 +740,7 @@
      "text": [
       "direct template: NumericEventTemplate(r=(), K=(2,), phi=())\n",
       "type: NumericEventTemplate (auto-promoted — all specs numeric)\n",
-      "flat_size: 4\n"
+      "vector_size: 4\n"
      ]
     }
    ],
@@ -748,7 +748,7 @@
     "tpl = EventTemplate(r=(), K=(2,), phi=())\n",
     "print(\"direct template:\", tpl)\n",
     "print(\"type:\", type(tpl).__name__, \"(auto-promoted — all specs numeric)\")\n",
-    "print(\"flat_size:\", tpl.flat_size)"
+    "print(\"vector_size:\", tpl.vector_size)"
    ]
   },
   {
@@ -759,7 +759,7 @@
     "### Numeric-only features\n",
     "\n",
     "`NumericEventTemplate` carries two helpers beyond the base template:\n",
-    "`flat_size` (the total scalar count across all leaves) and\n",
+    "`vector_size` (the total scalar count across all leaves) and\n",
     "`numeric_leaf_shapes` (a path → shape dict respected by `flatten` /\n",
     "`unflatten`). Both are well-defined exactly because every leaf is\n",
     "numeric. "
@@ -782,7 +782,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "flat_size:           4\n",
+      "vector_size:           4\n",
       "numeric_leaf_shapes: {'r': (), 'K': (2,), 'phi': ()}\n",
       "\n",
       "mixed template:     EventTemplate(counts=(5,), label=None)\n",
@@ -793,7 +793,7 @@
    ],
    "source": [
     "# Both extras live on the auto-promoted NumericEventTemplate from above.\n",
-    "print(\"flat_size:          \", tpl.flat_size)\n",
+    "print(\"vector_size:          \", tpl.vector_size)\n",
     "print(\"numeric_leaf_shapes:\", tpl.numeric_leaf_shapes)\n",
     "\n",
     "# A template with an opaque (None) leaf stays on the base class:\n",
@@ -832,7 +832,7 @@
      "text": [
       "nested template: NumericEventTemplate(inputs=NumericEventTemplate(force=(), mass=()), obs=(5,))\n",
       "type: NumericEventTemplate\n",
-      "flat_size: 7 (2 scalars + 5-vector)\n",
+      "vector_size: 7 (2 scalars + 5-vector)\n",
       "flat leaf shapes: {'inputs/force': (), 'inputs/mass': (), 'obs': (5,)}\n"
      ]
     }
@@ -841,7 +841,7 @@
     "nested_tpl = EventTemplate(inputs=EventTemplate(force=(), mass=()), obs=(5,))\n",
     "print(\"nested template:\", nested_tpl)\n",
     "print(\"type:\", type(nested_tpl).__name__)\n",
-    "print(\"flat_size:\", nested_tpl.flat_size, \"(2 scalars + 5-vector)\")\n",
+    "print(\"vector_size:\", nested_tpl.vector_size, \"(2 scalars + 5-vector)\")\n",
     "print(\"flat leaf shapes:\", nested_tpl.leaf_shapes)"
    ]
   },
@@ -855,7 +855,7 @@
     "ProbPipe has two batched forms, mirroring §1 vs §3:\n",
     "\n",
     "- **`RecordArray`** — batches Records with any leaf type, including non-numeric data like labels.\n",
-    "- **`NumericRecordArray`** — the numeric-only specialisation; batches `NumericRecord`s and adds `flatten` / `unflatten` and reductions.\n",
+    "- **`NumericRecordArray`** — the numeric-only specialisation; batches `NumericRecord`s and adds `to_vector` (1-D serialization) and reductions.\n",
     "\n",
     "Use the general form when at least one field is non-numeric; use the numeric form when every field is a number or numeric array."
    ]
@@ -998,7 +998,7 @@
    "id": "3339879d",
    "metadata": {},
    "source": [
-    "`NumericRecordArray` adds two things `RecordArray` doesn't have: reductions across the batch (`mean`, `var`, ...) and `flatten` / `unflatten`. Reductions return a `NumericRecord` if no batch dimension remains, or a smaller `NumericRecordArray` otherwise:"
+    "`NumericRecordArray` adds two things `RecordArray` doesn't have: reductions across the batch (`mean`, `var`, ...) and `to_vector` (1-D serialization). Reductions return a `NumericRecord` if no batch dimension remains, or a smaller `NumericRecordArray` otherwise:"
    ]
   },
   {
@@ -1070,7 +1070,7 @@
     }
    ],
    "source": [
-    "flat_batch = batch.flatten()\n",
+    "flat_batch = batch.to_vector()\n",
     "print(\"flattened shape:\", flat_batch.shape)  # (4, 3) = (batch_size, flat_event_size)\n",
     "print(flat_batch)"
    ]
@@ -1112,9 +1112,7 @@
     }
    ],
    "source": [
-    "restored_batch = NumericRecordArray.unflatten(flat_batch, \n",
-    "                                              template=batch.template, \n",
-    "                                              batch_shape=batch.batch_shape)\n",
+    "restored_batch = batch.template.from_vector(flat_batch)\n",
     "print(\"restored:\", restored_batch)\n",
     "print(\"equal:\", restored_batch == batch)"
    ]
@@ -1156,7 +1154,7 @@
     }
    ],
    "source": [
-    "inferred = NumericRecordArray.unflatten(flat_batch, template=batch.template)\n",
+    "inferred = batch.template.from_vector(flat_batch)\n",
     "print(\"inferred batch_shape:\", inferred.batch_shape)"
    ]
   },
@@ -1172,7 +1170,7 @@
     "`flatten` / `unflatten` recurse into nested fields depth-first in leaf order,\n",
     "so a nested batch round-trips through a single flat array just like the flat\n",
     "case above. Build one by sampling a nested `ProductDistribution`, or with\n",
-    "`NumericRecordArray.unflatten` and a nested `EventTemplate`."
+    "`EventTemplate.from_vector` and a nested `EventTemplate`."
    ]
   },
   {

--- a/docs/user_guide/04_joint_distributions.ipynb
+++ b/docs/user_guide/04_joint_distributions.ipynb
@@ -623,7 +623,7 @@
     "Optimisers, MCMC samplers, and neural nets often want a single flat\n",
     "vector, not a named `Record`. `FlattenedDistributionView(dist)` wraps any\n",
     "`RecordDistribution` as an ordinary `Distribution` with\n",
-    "`event_shape=(flat_size,)` — internally it flattens the `Record`\n",
+    "`event_shape=(vector_size,)` — internally it flattens the `Record`\n",
     "on the way out and unflattens on the way in to `log_prob`.\n",
     "Components are concatenated in field-insertion order (the same order\n",
     "as `.fields`)."

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -1,7 +1,9 @@
 """NumericRecord — Record subclass where every leaf is a ``jax.Array``.
 
-Adds ``flatten`` / ``unflatten`` / ``flat_size`` for 1-D serialisation.
-Construction validates that every leaf is a numeric value (numeric
+Adds ``to_vector`` / ``vector_size`` for the numeric 1-D serialisation
+(the inverse, ``from_vector``, lives on :class:`EventTemplate`); the
+general JAX-pytree ``flatten`` / ``unflatten`` are inherited from
+:class:`Record`. Construction validates that every leaf is a numeric value (numeric
 array, numeric scalar, or nested ``NumericRecord``) and coerces each
 to ``jnp.ndarray`` so the post-construction invariant is "every leaf
 is a ``jax.Array``" (or a nested ``NumericRecord``).
@@ -31,7 +33,7 @@ import numpy as np
 
 from ..custom_types import ArrayLike
 from ._array_backend import aux_for
-from .record import ArraySpec, EventTemplate, Record, _record_flatten, _spec_size
+from .record import EventTemplate, Record, _record_flatten
 
 __all__ = ["_NUMERIC_DTYPE_KINDS", "NumericRecord", "_is_numeric_leaf"]
 
@@ -77,8 +79,10 @@ def _is_numeric_leaf(val: Any) -> bool:
 class NumericRecord(Record):
     """``Record`` where every leaf is a ``jax.Array``.
 
-    Adds :meth:`flatten` / :meth:`unflatten` / :attr:`flat_size` for
-    serialising the record to / from a flat 1-D vector. Construction
+    Adds :meth:`to_vector` / :attr:`vector_size` for serialising the
+    record to its flat 1-D vector (the inverse, ``from_vector``, lives on
+    :class:`EventTemplate`); the general JAX-pytree :meth:`~Record.flatten`
+    / :meth:`~Record.unflatten` are inherited from :class:`Record`. Construction
     validates that every leaf is a numeric value (or a nested
     :class:`NumericRecord`) and coerces scalar / numpy / xarray /
     pandas leaves to ``jnp.ndarray`` so downstream code sees a uniform
@@ -110,7 +114,7 @@ class NumericRecord(Record):
     ``__slots__`` + ``__setattr__`` guard on the base class.
     """
 
-    __slots__ = ("_aux", "_flat_size")
+    __slots__ = ("_aux", "_vector_size")
 
     def __init__(
         self,
@@ -132,14 +136,14 @@ class NumericRecord(Record):
             raw_fields = fields
         validated, aux = self._validate_and_coerce(raw_fields)
         super().__init__(validated, name=name)
-        # Cache flat_size — leaves are immutable arrays after construction.
+        # Cache vector_size — leaves are immutable arrays after construction.
         total = 0
         for val in self._store.values():
             if isinstance(val, NumericRecord):
-                total += val.flat_size
+                total += val.vector_size
             else:
                 total += int(val.size)
-        object.__setattr__(self, "_flat_size", total)
+        object.__setattr__(self, "_vector_size", total)
         # Aux is ``None`` if no field had a registered hook — keeps the
         # common all-jax case allocation-free and lets ``to_native``
         # short-circuit.
@@ -185,61 +189,33 @@ class NumericRecord(Record):
             out[field_name] = raw if isinstance(raw, jnp.ndarray) else jnp.asarray(raw)
         return out, aux
 
-    # -- Flat-array conversion ----------------------------------------------
+    # -- 1-D vector conversion ----------------------------------------------
 
     @property
-    def flat_size(self) -> int:
-        """Total number of scalar elements across all numeric leaves."""
-        return self._flat_size
+    def vector_size(self) -> int:
+        """Length of this record's 1-D vector (``to_vector`` / ``from_vector``).
 
-    def flatten(self) -> jnp.ndarray:
-        """Concatenate all leaf arrays into a single 1-D vector.
-
-        Fields are traversed in insertion order; nested ``NumericRecord``
-        are traversed depth-first. Each leaf is raveled before
-        concatenation.
+        The total number of scalar elements across all numeric leaves — the
+        length of :meth:`to_vector`'s output.
         """
-        parts: list[jnp.ndarray] = []
-        for val in self._store.values():
-            if isinstance(val, NumericRecord):
-                parts.append(val.flatten())
-            else:
-                parts.append(jnp.ravel(val))
-        return jnp.concatenate(parts)
+        return self._vector_size
 
-    @classmethod
-    def unflatten(
-        cls,
-        flat: jnp.ndarray,
-        *,
-        template: EventTemplate,
-    ) -> NumericRecord:
-        """Reconstruct a ``NumericRecord`` from a flat array.
+    def to_vector(self) -> jnp.ndarray:
+        """Serialize to the dense 1-D vector of shape ``(vector_size,)``.
 
-        Parameters
-        ----------
-        flat : array
-            1-D array of concatenated scalars.
-        template : EventTemplate
-            Provides field names and shapes for reconstruction.
+        Instance-level convenience for the numeric 1-D serialization whose
+        structural definition lives on :meth:`EventTemplate.to_vector`: builds
+        this record's event template and delegates. Leaves are visited in
+        canonical leaf order (insertion order, depth-first into nested records)
+        and raveled before concatenation. The inverse,
+        :meth:`EventTemplate.from_vector`, reconstructs the record from such a
+        vector.
+
+        This is distinct from the JAX-pytree :meth:`~Record.flatten`, which
+        returns ``(leaves, aux)`` keeping each leaf whole; ``to_vector`` ravels
+        and concatenates the numeric leaves into a single dense vector.
         """
-        fields: dict[str, jnp.ndarray | NumericRecord] = {}
-        offset = 0
-
-        for field_name in template.fields:
-            spec = template[field_name]
-            size = _spec_size(spec)
-            chunk = flat[offset : offset + size]
-            if isinstance(spec, EventTemplate):
-                fields[field_name] = cls.unflatten(chunk, template=spec)
-            else:
-                # ArraySpec leaf — ``_spec_size`` above rejects every other
-                # leaf kind, so the spec is necessarily an ArraySpec here.
-                assert isinstance(spec, ArraySpec)
-                fields[field_name] = chunk.reshape(spec.shape)
-            offset += size
-
-        return cls(fields)
+        return EventTemplate.from_record(self).to_vector(self)
 
     @classmethod
     def from_record(cls, record: Record) -> NumericRecord:

--- a/probpipe/core/_numeric_record_distribution.py
+++ b/probpipe/core/_numeric_record_distribution.py
@@ -491,14 +491,14 @@ class NumericRecordDistribution(RecordDistribution):
         """Total number of scalar elements in one sample.
 
         For a :class:`NumericEventTemplate` this is the cached
-        ``flat_size``. For a general ``EventTemplate``, sums the
+        ``vector_size``. For a general ``EventTemplate``, sums the
         numeric-leaf shapes; opaque leaves contribute zero.
         """
         from .record import NumericEventTemplate
 
         tpl = self.event_template
         if isinstance(tpl, NumericEventTemplate):
-            return tpl.flat_size
+            return tpl.vector_size
         return sum(
             prod(shape) if shape else 1 for shape in tpl.leaf_shapes.values() if shape is not None
         )
@@ -518,9 +518,9 @@ class NumericRecordDistribution(RecordDistribution):
         from .record import Record
 
         if isinstance(value, (NumericRecordArray, NumericRecord)):
-            return value.flatten()
+            return value.to_vector()
         if isinstance(value, Record):
-            return NumericRecord.from_record(value).flatten()
+            return NumericRecord.from_record(value).to_vector()
         value = jnp.asarray(value)
         if not event_shape:
             return value[..., None]
@@ -538,14 +538,11 @@ class NumericRecordDistribution(RecordDistribution):
         for ``_log_prob`` compatibility (preserves the original "single-
         leaf returns raw array" contract).
         """
-        from ._numeric_record import NumericRecord
-        from ._record_array import NumericRecordArray
-
         flat = jnp.asarray(flat)
         if template is not None and len(template.fields) > 1:
-            if flat.ndim < 2:
-                return NumericRecord.unflatten(flat, template=template)
-            return NumericRecordArray.unflatten(flat, template=template)
+            # ``from_vector`` selects single (NumericRecord) vs batched
+            # (NumericRecordArray) from the rank of ``flat``.
+            return template.from_vector(flat)
         # Single-field path
         if template is None or not template.fields:
             return flat[..., 0]
@@ -771,8 +768,8 @@ class FlatNumericRecordDistribution(NumericRecordDistribution):
     """
 
     @property
-    def flat_size(self) -> int:
-        """Number of scalar elements — equal to ``event_shape[0]``.
+    def vector_size(self) -> int:
+        """Length of the per-element 1-D vector — equal to ``event_shape[0]``.
 
         Validates the flat contract on access: subclasses with
         non-1-D ``event_shape`` raise ``TypeError`` here rather than
@@ -819,7 +816,7 @@ class FlatNumericRecordDistribution(NumericRecordDistribution):
         TypeError
             If ``template`` is not a ``NumericEventTemplate``.
         ValueError
-            If ``self.flat_size`` does not match ``template.flat_size``.
+            If ``self.vector_size`` does not match ``template.vector_size``.
         """
         from .record import NumericEventTemplate
 
@@ -829,10 +826,10 @@ class FlatNumericRecordDistribution(NumericRecordDistribution):
                 f"got {type(template).__name__}. Opaque (None) leaves "
                 f"cannot be reconstructed from a flat numeric array."
             )
-        if self.flat_size != template.flat_size:
+        if self.vector_size != template.vector_size:
             raise ValueError(
-                f"flat_size mismatch: source flat_size={self.flat_size}, "
-                f"template.flat_size={template.flat_size}."
+                f"vector_size mismatch: source vector_size={self.vector_size}, "
+                f"template.vector_size={template.vector_size}."
             )
         cls = _numeric_record_distribution_view_class_for_base(self)
         return cls(self, template, name=name)
@@ -1038,14 +1035,10 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
                 base_sample,
                 event_shape=self._base.event_shape,
             )
-            tpl = self.event_template
-            if sample_shape == ():
-                return NumericRecord.unflatten(flat, template=tpl)
-            return NumericRecordArray.unflatten(
-                flat,
-                template=tpl,
-                batch_shape=sample_shape,
-            )
+            # ``from_vector`` selects single (NumericRecord, flat is 1-D) vs
+            # batched (NumericRecordArray, batch_shape == sample_shape) from the
+            # rank of ``flat``.
+            return self.event_template.from_vector(flat)
 
         extra_methods["_sample"] = _sample
 
@@ -1054,7 +1047,7 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
 
         def _log_prob(self, x) -> Array:
             if isinstance(x, (NumericRecord, NumericRecordArray)):
-                flat = x.flatten()
+                flat = x.to_vector()
             else:
                 flat = jnp.asarray(x)
             value = self._base.unflatten_value(
@@ -1073,7 +1066,7 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
                 self._base._mean(),
                 event_shape=self._base.event_shape,
             )
-            return NumericRecord.unflatten(flat, template=self.event_template)
+            return self.event_template.from_vector(flat)
 
         extra_methods["_mean"] = _mean
 
@@ -1085,7 +1078,7 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
                 self._base._variance(),
                 event_shape=self._base.event_shape,
             )
-            return NumericRecord.unflatten(flat, template=self.event_template)
+            return self.event_template.from_vector(flat)
 
         extra_methods["_variance"] = _variance
 
@@ -1128,7 +1121,7 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
             template = self.event_template
 
             def _f_on_flat(flat_row):
-                return f(NumericRecord.unflatten(flat_row, template=template))
+                return f(template.from_vector(flat_row))
 
             evals = jax.vmap(_f_on_flat)(flat_samples)
             rd = return_dist if return_dist is not None else _base.RETURN_APPROX_DIST

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -2,14 +2,15 @@
 
 A ``RecordArray`` stores a batch of Records with consistent field structure.
 Each field has shape ``(*batch_shape, *leaf_shape)``.  ``NumericRecordArray``
-adds numeric operations: ``flatten``, ``unflatten``, ``mean``, ``var``.
+adds numeric operations: ``to_vector`` (1-D serialization, inverse
+``EventTemplate.from_vector``), ``mean``, ``var``. The general JAX-pytree
+``flatten`` / ``unflatten`` are inherited from ``Record``.
 """
 
 from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import Callable, Iterator
-from math import prod
 from typing import Any
 
 import jax
@@ -18,7 +19,7 @@ import numpy as np
 
 from ..custom_types import Array
 from ._numeric_record import _NUMERIC_DTYPE_KINDS, NumericRecord
-from .record import _PATH_SEP, ArraySpec, EventTemplate, Record, _spec_size
+from .record import _PATH_SEP, ArraySpec, EventTemplate, Record
 
 __all__ = [
     "NumericRecordArray",
@@ -365,7 +366,8 @@ class RecordArray(Record):
 class NumericRecordArray(RecordArray):
     """Batch of NumericRecords — all leaves are numeric arrays.
 
-    Adds ``flatten``/``unflatten``, ``mean``, ``var`` operations.
+    Adds ``to_vector``, ``mean``, ``var`` operations (the general
+    JAX-pytree ``flatten`` / ``unflatten`` are inherited from ``Record``).
     Construction validates that every leaf has a numeric dtype and
     shape ``(*batch_shape, *event_shape)`` matching the template, so
     pytree round-trips (``jax.tree.map``) cannot silently produce a
@@ -435,84 +437,24 @@ class NumericRecordArray(RecordArray):
             (dict(self._store), self._batch_shape, self._template, self._name, self._source),
         )
 
-    # -- Flatten / unflatten ------------------------------------------------
+    # -- 1-D vector conversion ----------------------------------------------
 
-    def flatten(self) -> jnp.ndarray:
-        """Flatten event dimensions into a single trailing axis.
+    def to_vector(self) -> jnp.ndarray:
+        """Serialize each batch element to its 1-D vector.
 
-        Returns array of shape ``(*batch_shape, flat_event_size)``. Nested
-        record fields are flattened depth-first in field order, matching
-        :meth:`unflatten` and :meth:`NumericRecord.flatten`.
+        Instance-level convenience for the numeric 1-D serialization whose
+        structural definition lives on :meth:`EventTemplate.to_vector`:
+        delegates to this array's :attr:`template`. Returns a matrix of shape
+        ``(*batch_shape, vector_size)`` — one raveled vector per batch element,
+        leaves visited in canonical leaf order (insertion order, depth-first
+        into nested records). The inverse, :meth:`EventTemplate.from_vector`,
+        reconstructs the batch.
+
+        Distinct from the JAX-pytree :meth:`~Record.flatten` (which returns
+        ``(leaves, aux)`` keeping each batched leaf whole); ``to_vector`` ravels
+        and concatenates each element's event dimensions into a dense matrix.
         """
-        n_batch = len(self._batch_shape)
-
-        def _flat_field(val: Any) -> jnp.ndarray:
-            # A nested record-array field (from unflatten, or a batched _sample)
-            # carries the same batch axis and flattens its own leaves.
-            if isinstance(val, RecordArray):
-                return val.flatten()
-            # A nested plain Record whose leaves still carry the batch axis
-            # (a non-canonical batched draw): flatten each leaf and concatenate.
-            if isinstance(val, Record):
-                return jnp.concatenate([_flat_field(val[f]) for f in val.fields], axis=-1)
-            return jnp.reshape(val, (*self._batch_shape, prod(val.shape[n_batch:])))
-
-        parts = [_flat_field(self._store[name]) for name in self._store]
-        return jnp.concatenate(parts, axis=-1)
-
-    @classmethod
-    def unflatten(
-        cls,
-        flat: jnp.ndarray,
-        *,
-        template: EventTemplate,
-        batch_shape: tuple[int, ...] | None = None,
-    ) -> NumericRecordArray:
-        """Reconstruct from a flat array.
-
-        The inverse of :meth:`flatten`: nested ``EventTemplate`` specs are
-        rebuilt recursively, so a template with nested fields yields nested
-        ``NumericRecordArray`` fields, matching the depth-first leaf order
-        ``flatten`` uses.
-
-        Parameters
-        ----------
-        flat : array
-            Shape ``(*batch_shape, flat_event_size)``.
-        template : EventTemplate
-            Structural description providing field names and event shapes.
-        batch_shape : tuple of int, optional
-            If not provided, inferred as ``flat.shape[:-1]``.
-
-        Returns
-        -------
-        NumericRecordArray
-            Array of the template's structure with the given ``batch_shape``;
-            nested template fields become nested ``NumericRecordArray`` fields.
-        """
-        if batch_shape is None:
-            batch_shape = flat.shape[:-1]
-
-        fields: dict[str, jnp.ndarray] = {}
-        offset = 0
-        for name in template.fields:
-            spec = template[name]
-            size = _spec_size(spec)
-            chunk = flat[..., offset : offset + size]
-            if isinstance(spec, EventTemplate):
-                fields[name] = cls.unflatten(
-                    chunk,
-                    template=spec,
-                    batch_shape=batch_shape,
-                )
-            else:
-                # ArraySpec leaf — ``_spec_size`` above rejects every other
-                # leaf kind, so the spec is necessarily an ArraySpec here.
-                assert isinstance(spec, ArraySpec)
-                fields[name] = jnp.reshape(chunk, batch_shape + spec.shape)
-            offset += size
-
-        return cls(fields, batch_shape=batch_shape, template=template)
+        return self.template.to_vector(self)
 
     # -- Reductions ---------------------------------------------------------
 

--- a/probpipe/core/_record_distribution.py
+++ b/probpipe/core/_record_distribution.py
@@ -274,15 +274,12 @@ class _RecordDistributionView(Distribution):
         practice are ``ApproximateDistribution`` subclasses that do
         expose ``draws()``.
         """
-        from ._record_array import NumericRecordArray, RecordArray
+        from ._record_array import RecordArray
 
         draws = self._parent.draws()
         if isinstance(draws, (Record, RecordArray)):
             return jnp.asarray(draws[self._key])
-        result = NumericRecordArray.unflatten(
-            jnp.asarray(draws),
-            template=self._parent.event_template,
-        )
+        result = self._parent.event_template.from_vector(jnp.asarray(draws))
         return jnp.asarray(result[self._key])
 
     def __repr__(self) -> str:

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -14,7 +14,7 @@ The Record family
 | :class:`Record`                                             | Single structured value; fields may be arrays, scalars, strings, xarray, nested Record. |
 | :class:`~probpipe.NumericRecord` (subclass)                 | Single structured value; every leaf is a ``jax.Array`` (post-construction invariant).   |
 | :class:`~probpipe.RecordArray`                              | Batch of ``Record`` elements sharing a :class:`EventTemplate`.                         |
-| :class:`~probpipe.NumericRecordArray` (subclass)            | Batch of :class:`~probpipe.NumericRecord` elements with ``flatten`` / ``mean`` / ``var``. |
+| :class:`~probpipe.NumericRecordArray` (subclass)            | Batch of :class:`~probpipe.NumericRecord` elements with ``to_vector`` / ``mean`` / ``var``. |
 | :class:`EventTemplate`                                     | Structural skeleton: field names, per-field leaf shapes or ``None`` for opaque leaves.  |
 
 **When to reach for which:**
@@ -23,9 +23,9 @@ The Record family
   plus a label string, a DataFrame, an xarray object, ...) — or when
   you want to keep the original backend objects intact. ``Record``
   performs no coercion and accepts arbitrary leaves.
-* Use :class:`~probpipe.NumericRecord` when you want to flatten /
-  unflatten to a 1-D vector, take reductions, or pass the value
-  through :func:`jax.numpy` operations. Construction coerces every
+* Use :class:`~probpipe.NumericRecord` when you want to convert to /
+  from a 1-D vector (``to_vector`` / ``from_vector``), take reductions,
+  or pass the value through :func:`jax.numpy` operations. Construction coerces every
   leaf to a ``jax.Array`` (the post-construction invariant) and
   captures backend-specific metadata (xarray dims/coords, pandas
   index) via the aux registry so :meth:`NumericRecord.to_native` can
@@ -37,8 +37,8 @@ The Record family
   from ``NumericRecordArray``); field indexing returns the batched
   array.
 * Use :class:`EventTemplate` whenever you need to round-trip
-  unflatten → flatten without an example instance, or describe the
-  expected structure of a distribution's sample.
+  ``from_vector`` → ``to_vector`` without an example instance, or describe
+  the expected structure of a distribution's sample.
 
 Usage::
 
@@ -49,7 +49,7 @@ Usage::
 
     params["r"]            # → jnp.array(1.8)
     params.fields          # → ('r', 'K', 'phi')   # insertion order
-    params.flatten()       # → jnp.array([1.8, 70., 10.])
+    params.to_vector()     # → jnp.array([1.8, 70., 10.])
 
     data["counts"]         # → np.array([2, 1, 3, 0, 5]) (stored verbatim)
     data["label"]          # → "horseshoe"
@@ -501,6 +501,69 @@ class Record:
                 fields[name] = fn(name, val)
         return type(self)(fields)
 
+    # -- JAX-pytree (de)serialization ---------------------------------------
+
+    def flatten(self) -> tuple[list[Any], jax.tree_util.PyTreeDef]:
+        """Decompose into ``(leaves, aux)``, à la :func:`jax.tree_util.tree_flatten`.
+
+        The general **JAX-pytree** operation, defined for *any* leaf type
+        (numeric or opaque). Returns this record's pytree *leaves* — the
+        stored values in canonical leaf order (insertion order, descending
+        depth-first into nested records) — together with the structural
+        *aux* (a :class:`jax.tree_util.PyTreeDef`). :meth:`unflatten` is the
+        inverse: ``Record.unflatten(*record.flatten()) == record``.
+
+        This is distinct from :meth:`EventTemplate.to_vector`. ``flatten``
+        keeps each leaf whole (any type) and carries the full structure in
+        ``aux``; ``to_vector`` applies only to *numeric* values and goes
+        further, ravelling and concatenating the numeric leaves into a
+        single dense 1-D ``vec``.
+
+        Returns
+        -------
+        tuple
+            ``(leaves, aux)`` — ``leaves`` is the list of pytree leaves in
+            canonical leaf order; ``aux`` is the ``jax.tree_util.PyTreeDef``
+            describing the structure.
+
+        See Also
+        --------
+        unflatten : Reconstruct a value from ``(leaves, aux)`` (the inverse).
+        EventTemplate.to_vector : Dense 1-D serialization of a numeric value.
+        """
+        return jax.tree_util.tree_flatten(self)
+
+    @staticmethod
+    def unflatten(leaves: list[Any], aux: jax.tree_util.PyTreeDef) -> Any:
+        """Reconstruct a value from ``(leaves, aux)``, à la :func:`jax.tree_util.tree_unflatten`.
+
+        The inverse of :meth:`flatten`: rebuilds the original (possibly
+        nested) value from its pytree *leaves* and the *aux* structure.
+        Defined for any leaf type; the concrete result class is encoded in
+        ``aux``, so ``Record.unflatten`` and ``NumericRecord.unflatten``
+        behave identically (the static method does not depend on which
+        class it is called on).
+
+        Parameters
+        ----------
+        leaves : list
+            Pytree leaves in canonical leaf order, as returned by
+            :meth:`flatten`.
+        aux : jax.tree_util.PyTreeDef
+            The structural definition returned by :meth:`flatten`.
+
+        Returns
+        -------
+        Any
+            The reconstructed value, of the class encoded in ``aux``.
+
+        See Also
+        --------
+        flatten : Decompose a value into ``(leaves, aux)`` (the inverse).
+        EventTemplate.from_vector : Reconstruct a numeric value from a dense 1-D ``vec``.
+        """
+        return jax.tree_util.tree_unflatten(aux, leaves)
+
     # -- Repr ---------------------------------------------------------------
 
     def __repr__(self) -> str:
@@ -802,10 +865,10 @@ class EventTemplate:
     Calling ``EventTemplate(...)`` directly auto-promotes to a
     :class:`NumericEventTemplate` when every spec is numeric (and
     every nested sub-template is itself all-numeric). That keeps
-    ``flat_size`` and ``numeric_leaf_shapes`` reachable in the common
+    ``vector_size`` and ``numeric_leaf_shapes`` reachable in the common
     all-numeric case without requiring the caller to name the subclass.
     Mixed templates (any ``None`` spec) stay as plain ``EventTemplate``
-    and do not expose ``flat_size`` — it isn't a meaningful quantity
+    and do not expose ``vector_size`` — it isn't a meaningful quantity
     once opaque leaves are in the mix.
     """
 
@@ -1051,7 +1114,7 @@ class EventTemplate:
         Returns
         -------
         NumericEventTemplate
-            The numeric-leaf sub-template, so that :attr:`flat_size` and
+            The numeric-leaf sub-template, so that :attr:`vector_size` and
             :attr:`numeric_leaf_shapes` are available.
 
         Raises
@@ -1092,11 +1155,11 @@ class EventTemplate:
         ``to_vector`` / :meth:`from_vector` convert between the structured and
         vector representations of a **numeric** value. A numeric value is in
         general a structured tree of array-valued leaves, with
-        :attr:`~NumericEventTemplate.flat_size` the total number of scalar
+        :attr:`~NumericEventTemplate.vector_size` the total number of scalar
         values making up those arrays. ``to_vector`` converts the structured
         value to its unique flat representation: an array of shape
-        ``(flat_size,)``. A batch of numeric values is flattened to a matrix:
-        an array of shape ``(*batch_shape, flat_size)``.
+        ``(vector_size,)``. A batch of numeric values is flattened to a matrix:
+        an array of shape ``(*batch_shape, vector_size)``.
 
         This method is distinct from ``flatten``. The latter follows the
         JAX-pytree terminology, implying the mapping ``value -> (leaves, aux)``
@@ -1127,7 +1190,7 @@ class EventTemplate:
             The concatenated numeric leaves, dtype-promoted by
             ``jnp.concatenate``. Shape ``(vector_size,)`` for a single
             ``value`` and ``(*B, vector_size)`` for a batched ``value`` with
-            ``batch_shape == B``, where ``vector_size == self.flat_size``.
+            ``batch_shape == B``, where ``vector_size == self.vector_size``.
 
         Raises
         ------
@@ -1164,11 +1227,12 @@ class EventTemplate:
                 f"NumericRecordArray (batched), got {type(value).__name__}."
             )
 
-        # ``tree_leaves`` yields the numeric leaves in canonical leaf order; ravel
-        # each leaf's event dimensions and concatenate along the trailing axis.
-        # Reshaping to ``(*batch_shape, -1)`` preserves leading batch axes
-        # (``batch_shape == ()`` for a single value gives a 1-D result).
-        leaves = jax.tree_util.tree_leaves(value)
+        # Delegate leaf traversal to the JAX-pytree ``flatten``: it yields the
+        # numeric leaves in canonical leaf order. Ravel each leaf's event
+        # dimensions and concatenate along the trailing axis. Reshaping to
+        # ``(*batch_shape, -1)`` preserves leading batch axes (``batch_shape ==
+        # ()`` for a single value gives a 1-D result).
+        leaves, _aux = value.flatten()
         return jnp.concatenate([jnp.reshape(leaf, (*batch_shape, -1)) for leaf in leaves], axis=-1)
 
     def from_vector(
@@ -1188,8 +1252,8 @@ class EventTemplate:
         batched: a vector of shape ``(vector_size,)`` rebuilds a single value,
         while a matrix of shape ``(*batch_shape, vector_size)`` rebuilds a batch
         with that ``batch_shape``. Here ``vector_size`` is the total scalar
-        count, :attr:`~NumericEventTemplate.flat_size` (for a mixed template, the
-        ``flat_size`` of its :meth:`numeric_subset`).
+        count, :attr:`~NumericEventTemplate.vector_size` (for a mixed template,
+        the ``vector_size`` of its :meth:`numeric_subset`).
 
         This method is distinct from ``unflatten``. The latter is the inverse of
         the JAX-pytree ``flatten`` (the mapping ``(leaves, aux) -> value`` in the
@@ -1255,9 +1319,6 @@ class EventTemplate:
         to_vector : Serialize a value to a flat vector (the inverse).
         numeric_subset : Project a mixed template to its numeric leaves.
         """
-        from ._numeric_record import NumericRecord
-        from ._record_array import NumericRecordArray, RecordArray
-
         vec = jnp.asarray(vec)
         numeric = self.is_numeric
 
@@ -1278,7 +1339,7 @@ class EventTemplate:
         # vector_size is the total scalar count across the numeric leaves;
         # numeric_subset() is idempotent on an already-numeric template.
         num_tpl = self if isinstance(self, NumericEventTemplate) else self.numeric_subset()
-        vector_size = num_tpl.flat_size
+        vector_size = num_tpl.vector_size
         if vec.shape[-1] != vector_size:
             raise ValueError(
                 f"{type(self).__name__}.from_vector: vec trailing axis is "
@@ -1289,12 +1350,6 @@ class EventTemplate:
         batch_shape = tuple(vec.shape[:-1]) if batched else ()
         non_numeric = dict(non_numeric) if non_numeric else {}
 
-        # Record classes for the rebuilt value: an all-numeric template rebuilds
-        # NumericRecord(Array); a mixed template rebuilds a plain Record(Array)
-        # carrying the supplied non-numeric leaves alongside the numeric ones.
-        single_cls = NumericRecord if numeric else Record
-        batched_cls = NumericRecordArray if numeric else RecordArray
-
         def _check_batch(path: str, val: Any) -> None:
             shape = getattr(val, "shape", None)
             if shape is not None and tuple(shape[: len(batch_shape)]) != batch_shape:
@@ -1304,25 +1359,29 @@ class EventTemplate:
                     f"batch_shape {batch_shape}."
                 )
 
-        # Walk the template in canonical leaf order, slicing ``vec`` into each
-        # numeric leaf and reshaping it to (*batch_shape, *event_shape); a single
-        # offset advances along vec's trailing axis. Non-numeric leaves (mixed
-        # templates only) are filled from ``non_numeric`` and consume no vector.
+        # Collect the reconstructed value's pytree leaves in canonical leaf order:
+        # slice ``vec`` into each numeric leaf (reshaped to (*batch_shape,
+        # *event_shape), one offset advancing along vec's trailing axis) and pull
+        # each dropped non-numeric leaf (mixed templates only) from ``non_numeric``,
+        # which consumes no vector. Leaf reconstruction (assembling these leaves
+        # into the structured value) is then delegated to the JAX-pytree
+        # ``unflatten``; the matching treedef is derived from this template and
+        # batch_shape so the assembly logic lives in one place.
         offset = 0
+        leaves: list[Any] = []
 
-        def _build(template: EventTemplate, prefix: str) -> Record:
+        def _collect(template: EventTemplate, prefix: str) -> None:
             nonlocal offset
-            fields: dict[str, Any] = {}
             for name in template.fields:
                 spec = template[name]
                 path = f"{prefix}{name}"
                 if isinstance(spec, EventTemplate):
-                    fields[name] = _build(spec, f"{path}{_PATH_SEP}")
+                    _collect(spec, f"{path}{_PATH_SEP}")
                 elif isinstance(spec, ArraySpec):
                     size = prod(spec.shape) if spec.shape else 1
                     chunk = vec[..., offset : offset + size]
                     offset += size
-                    fields[name] = jnp.reshape(chunk, (*batch_shape, *spec.shape))
+                    leaves.append(jnp.reshape(chunk, (*batch_shape, *spec.shape)))
                 else:
                     # Opaque / distribution / function leaf — supplied by caller.
                     if path not in non_numeric:
@@ -1333,12 +1392,11 @@ class EventTemplate:
                     val = non_numeric[path]
                     if batched:
                         _check_batch(path, val)
-                    fields[name] = val
-            if batched:
-                return batched_cls(fields, batch_shape=batch_shape, template=template)
-            return single_cls(fields)
+                    leaves.append(val)
 
-        return _build(self, "")
+        _collect(self, "")
+        treedef = _value_treedef(self, batch_shape, numeric=numeric)
+        return Record.unflatten(leaves, treedef)
 
     def __contains__(self, name: str) -> bool:
         return name in self._specs
@@ -1403,13 +1461,13 @@ class EventTemplate:
         and is treated as opaque (``None``) even if it contains numbers.
         Wrap it in ``np.asarray(...)`` or ``jnp.asarray(...)`` before
         putting it in the Record if you want a numeric template entry.
-        Downstream operations that call ``NumericRecord.unflatten`` will
+        Downstream operations that call :meth:`from_vector` will
         otherwise raise on the opaque field.
         """
         # Promote plain ``EventTemplate.from_record`` to
         # ``NumericEventTemplate`` when the source signals it is all-numeric
         # (a ``NumericRecord`` or any Record whose recursive leaves are
-        # numeric). That keeps ``flat_size`` reachable for the common
+        # numeric). That keeps ``vector_size`` reachable for the common
         # all-numeric case without requiring callers to name the subclass.
         target_cls = cls
         if cls is EventTemplate:
@@ -1458,19 +1516,20 @@ class NumericEventTemplate(EventTemplate):
     Extends :class:`EventTemplate` by requiring each spec to be a shape
     tuple (or a nested :class:`NumericEventTemplate`) — no opaque
     ``None`` leaves are allowed. That restriction is what makes
-    :attr:`flat_size` and :meth:`numeric_leaf_shapes` meaningful:
-    ``flat_size`` is the total number of scalar elements across every
-    numeric leaf, and the unflatten machinery (``NumericRecord.unflatten``
-    / ``NumericRecordArray.unflatten``) requires a template of this
-    class so that every field can be reconstructed from a slice of the
-    flat buffer.
+    :attr:`vector_size` and :meth:`numeric_leaf_shapes` meaningful:
+    ``vector_size`` is the length of the per-element 1-D vector — the total
+    number of scalar elements across every numeric leaf — and
+    :meth:`~EventTemplate.from_vector` requires a template of this class so
+    that every field can be reconstructed from a slice of that vector. A
+    *batch* of such values is a matrix of shape ``(*batch_shape, vector_size)``,
+    not a single vector.
 
     Use :meth:`EventTemplate.from_record` on a :class:`NumericRecord`
     (it auto-promotes) or call this constructor directly when you have
     the shape specs in hand.
     """
 
-    __slots__ = ("_flat_size",)
+    __slots__ = ("_vector_size",)
 
     def _post_validate(self, field_specs: dict[str, _FieldSpec]) -> None:
         for name, spec in field_specs.items():
@@ -1503,7 +1562,7 @@ class NumericEventTemplate(EventTemplate):
         **field_specs: _FieldSpecInput,
     ):
         super().__init__(_dict, **field_specs)
-        object.__setattr__(self, "_flat_size", self._compute_flat_size())
+        object.__setattr__(self, "_vector_size", self._compute_vector_size())
 
     @property
     def numeric_leaf_shapes(self) -> dict[str, tuple[int, ...]]:
@@ -1515,21 +1574,27 @@ class NumericEventTemplate(EventTemplate):
         """
         return dict(self.leaf_shapes)
 
-    def _compute_flat_size(self) -> int:
+    def _compute_vector_size(self) -> int:
         """Total scalar count across all numeric leaves."""
         total = 0
         for spec in self._specs.values():
             if isinstance(spec, NumericEventTemplate):
-                total += spec.flat_size
+                total += spec.vector_size
             else:
                 # spec is an ArraySpec — validated by ``_post_validate``.
                 total += prod(spec.shape) if spec.shape else 1
         return total
 
     @property
-    def flat_size(self) -> int:
-        """Total number of scalar elements across all numeric leaves."""
-        return self._flat_size
+    def vector_size(self) -> int:
+        """Length of the per-element 1-D vector (``to_vector`` / ``from_vector``).
+
+        The total number of scalar elements across all numeric leaves — the
+        trailing-axis length of :meth:`~EventTemplate.to_vector`'s output. A
+        single value serializes to shape ``(vector_size,)``; a batch serializes
+        to a matrix ``(*batch_shape, vector_size)``, not a single vector.
+        """
+        return self._vector_size
 
 
 # ---------------------------------------------------------------------------
@@ -1540,30 +1605,76 @@ class NumericEventTemplate(EventTemplate):
 def _spec_size(spec: _FieldSpec) -> int:
     """Number of scalar elements a leaf-spec stands for.
 
-    Shared by ``NumericRecord.unflatten`` and ``NumericRecordArray.unflatten``
-    when walking a template and slicing a flat buffer. Nested specs must be
-    :class:`NumericEventTemplate` so that ``.flat_size`` is defined;
-    non-array leaves (:class:`OpaqueSpec` / :class:`DistributionSpec` /
-    :class:`FunctionSpec`) have no flat size and raise.
+    Used when walking a template and slicing a flat vector into per-leaf chunks
+    (e.g. sizing the numeric-leaf blocks of an approximate distribution). Nested
+    specs must be :class:`NumericEventTemplate` so that ``.vector_size`` is
+    defined; non-array leaves (:class:`OpaqueSpec` / :class:`DistributionSpec` /
+    :class:`FunctionSpec`) have no vector size and raise.
     """
     if isinstance(spec, NumericEventTemplate):
-        return spec.flat_size
+        return spec.vector_size
     if isinstance(spec, EventTemplate):
         raise TypeError(
             f"nested {type(spec).__name__} contains non-numeric leaves; "
-            f"unflatten requires a NumericEventTemplate."
+            f"vector (de)serialization requires a NumericEventTemplate."
         )
     if isinstance(spec, ArraySpec):
         return prod(spec.shape) if spec.shape else 1
     if isinstance(spec, OpaqueSpec):
         raise TypeError(
-            "opaque template fields have no flat size; unflatten is only "
-            "defined for numeric-leaf (ArraySpec) fields."
+            "opaque template fields have no vector size; vector (de)serialization "
+            "is only defined for numeric-leaf (ArraySpec) fields."
         )
     raise TypeError(
-        f"non-array template field ({type(spec).__name__}) has no flat size; "
-        f"unflatten is only defined for numeric-leaf (ArraySpec) fields."
+        f"non-array template field ({type(spec).__name__}) has no vector size; "
+        f"vector (de)serialization is only defined for numeric-leaf (ArraySpec) fields."
     )
+
+
+def _value_treedef(
+    template: EventTemplate,
+    batch_shape: tuple[int, ...],
+    *,
+    numeric: bool,
+) -> jax.tree_util.PyTreeDef:
+    """PyTreeDef of the value :meth:`EventTemplate.from_vector` reconstructs.
+
+    Builds a throwaway skeleton that mirrors the structure ``from_vector``
+    produces — ``NumericRecord`` / ``NumericRecordArray`` for a *numeric*
+    template, plain ``Record`` / ``RecordArray`` for a mixed one — and returns
+    its ``jax.tree_util.tree_structure``. The treedef depends only on the
+    container structure (field names, nesting, ``batch_shape``, template), not
+    on leaf values, so its placeholder leaves are cheap: zero-stride broadcast
+    arrays for numeric leaves (no allocation) and a scalar sentinel for the
+    opaque leaves of a mixed template. The returned treedef pairs with the real
+    ordered leaves in :func:`jax.tree_util.tree_unflatten`, letting
+    ``from_vector`` delegate leaf reconstruction to ``Record.unflatten``.
+    """
+    from ._numeric_record import NumericRecord
+    from ._record_array import NumericRecordArray, RecordArray
+
+    single_cls = NumericRecord if numeric else Record
+    batched_cls = NumericRecordArray if numeric else RecordArray
+    numeric_fill = jnp.zeros((), dtype=jnp.float32)
+
+    def _build(tpl: EventTemplate) -> Record:
+        fields: dict[str, Any] = {}
+        for name in tpl.fields:
+            spec = tpl[name]
+            if isinstance(spec, EventTemplate):
+                fields[name] = _build(spec)
+            elif isinstance(spec, ArraySpec):
+                fields[name] = jnp.broadcast_to(numeric_fill, (*batch_shape, *spec.shape))
+            else:
+                # Opaque / distribution / function leaf (mixed templates only) —
+                # any object is a valid pytree leaf; the value is irrelevant to
+                # the treedef.
+                fields[name] = 0
+        if batch_shape:
+            return batched_cls(fields, batch_shape=batch_shape, template=tpl)
+        return single_cls(fields)
+
+    return jax.tree_util.tree_structure(_build(template))
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -823,53 +823,96 @@ def _full_leaf_shape(val: Any) -> tuple[int, ...] | None:
 
 
 class EventTemplate:
-    """Structural description of a Record: field names, leaf shapes, nesting.
+    """Structural description of a value: its named, possibly-nested leaf structure.
 
-    Stores the skeleton of a Record without data — field names, per-field
-    shapes (for numeric leaves) or ``None`` (for opaque leaves), and
-    optional nested ``EventTemplate`` for hierarchical structure.
+    An ``EventTemplate`` describes the **structure** of a value — the names,
+    nesting, and per-leaf kind / shape that make it up — independently of the
+    concrete data. The same structural type describes a :class:`Record` value,
+    one *event* (a single draw) of a :class:`~probpipe.Distribution`, and the
+    input / output of a workflow function. Every :class:`Record` carries an
+    ``EventTemplate``, but the type is general: it is ProbPipe's schema for any
+    structured value.
 
-    Inspired by JAX's ``PyTreeDef``: a template can reconstruct a Record
-    from flat data, and describes the expected structure for type-checking
-    and flattening.
+    The word *event* follows probabilistic-programming usage and **generalizes**
+    the ``event`` / ``event_shape`` notion from other PPLs (TensorFlow
+    Probability, distrax, NumPyro). There, ``event_shape`` is the shape of a
+    single draw of one array-valued random variable; here an *event* is one
+    structured value — a named, possibly-nested tree of leaves — so a template
+    generalizes a single ``event_shape`` to the full per-leaf shape structure of
+    a draw.
+
+    Terminology
+    -----------
+    Used precisely throughout this class:
+
+    - **field** — a *top-level* entry of the template: a ``name -> spec`` pair,
+      where the spec is either a leaf or a nested ``EventTemplate``.
+      :attr:`fields` lists these names in insertion order; it does **not**
+      descend into nested sub-templates.
+    - **leaf** — a *terminal* node: an :class:`ArraySpec` / :class:`OpaqueSpec`
+      / :class:`DistributionSpec` / :class:`FunctionSpec`. A nested
+      ``EventTemplate`` is an *internal node*, not a leaf.
+    - **path** — the ``/``-delimited sequence of field names from the root to a
+      node (e.g. ``"physics/mass"``); a top-level field is a single-segment
+      path. Paths round-trip with :meth:`Record.__getitem__`'s path syntax.
+    - **canonical leaf order** — the order in which leaves are traversed:
+      depth-first, following each level's insertion order. This is the single
+      ordering every leaf-wise operation uses. :attr:`leaf_paths` is its
+      canonical definition — it returns the path to every leaf in this order;
+      :meth:`to_vector` / :meth:`from_vector` lay out and read leaves in it, and
+      :attr:`leaf_shapes` is keyed by it.
+
+    PyTree contract
+    ---------------
+    An ``EventTemplate`` — and every value it describes — is a JAX pytree.
+    *Internal nodes* are nested ``EventTemplate``\\s (and, at the value level,
+    the :class:`Record` / :class:`~probpipe.RecordArray` containers); a node's
+    field names are its keys. *Leaves* are the terminal specs (:class:`ArraySpec`
+    / :class:`OpaqueSpec` / :class:`DistributionSpec` / :class:`FunctionSpec`)
+    and, at the value level, the array or opaque objects they stand for. A leaf's
+    ``/``-delimited path is the string form of its JAX key path, and the
+    canonical leaf order is JAX's left-to-right depth-first leaf order.
+    :meth:`~probpipe.Record.flatten` / :meth:`~probpipe.Record.unflatten` are the
+    value-level pytree (de)composition; :attr:`leaf_paths` enumerates the leaf
+    keys in the same order.
 
     Parameters
     ----------
     **field_specs
-        Named fields.  Each value is one of:
+        Named fields. Each value is one of:
 
-        - ``tuple[int, ...]`` — shape of a numeric array leaf
-          (e.g., ``()`` for scalar, ``(3,)`` for 3-vector); normalised to
-          :class:`ArraySpec`.
+        - ``tuple[int, ...]`` — shape of a numeric array leaf (e.g. ``()`` for a
+          scalar, ``(3,)`` for a 3-vector); normalised to :class:`ArraySpec`.
         - ``None`` — opaque (non-array) leaf; normalised to :class:`OpaqueSpec`.
         - a leaf spec — :class:`ArraySpec` / :class:`OpaqueSpec` /
           :class:`DistributionSpec` / :class:`FunctionSpec` (passed through).
-        - ``EventTemplate`` — nested sub-structure (kept as-is).
+        - ``EventTemplate`` — a nested sub-structure (an internal node).
 
     Examples
     --------
     ::
 
-        EventTemplate(x=(), y=(3,))                    # -> NumericEventTemplate
+        EventTemplate(x=(), y=(3,))                     # -> NumericEventTemplate
         EventTemplate(label=None, x=())                 # -> EventTemplate (mixed)
         EventTemplate(physics=EventTemplate(force=(), mass=()), obs=())
 
     Notes
     -----
-    Leaves are stored as frozen, hashable spec objects
-    (``ArraySpec`` / ``OpaqueSpec`` / ``DistributionSpec`` / ``FunctionSpec``);
-    ``__getitem__`` returns the stored spec (or nested template), while
-    shape-shaped access stays on ``leaf_shapes`` / ``event_shapes`` /
-    ``field_event_shape``.
+    Inspired by JAX's ``PyTreeDef``: a template can reconstruct a value from its
+    leaves and describes the expected structure for type-checking and
+    vectorization. Leaves are stored as frozen, hashable spec objects, so a
+    template is itself hashable (usable as a jit / treedef cache key).
+    ``__getitem__`` returns the stored spec (or nested template); shape-shaped
+    access lives on :attr:`leaf_shapes` / :attr:`event_shapes` /
+    :meth:`field_event_shape`.
 
     Calling ``EventTemplate(...)`` directly auto-promotes to a
-    :class:`NumericEventTemplate` when every spec is numeric (and
-    every nested sub-template is itself all-numeric). That keeps
-    ``vector_size`` and ``numeric_leaf_shapes`` reachable in the common
-    all-numeric case without requiring the caller to name the subclass.
-    Mixed templates (any ``None`` spec) stay as plain ``EventTemplate``
-    and do not expose ``vector_size`` — it isn't a meaningful quantity
-    once opaque leaves are in the mix.
+    :class:`NumericEventTemplate` when every spec is numeric (and every nested
+    sub-template is itself all-numeric), so :attr:`vector_size` and
+    :attr:`numeric_leaf_shapes` are reachable in the common all-numeric case
+    without naming the subclass. Mixed templates (any opaque / ``None`` spec)
+    stay plain ``EventTemplate`` and do not expose :attr:`vector_size` — it is
+    not a meaningful quantity once opaque leaves are present.
     """
 
     __slots__ = ("_specs",)
@@ -933,17 +976,53 @@ class EventTemplate:
 
     @property
     def fields(self) -> tuple[str, ...]:
-        """Field names in insertion order."""
+        """Top-level field names, in insertion order.
+
+        Returns the names of the template's *top-level* fields only (see the
+        Terminology section); it does **not** descend into nested
+        sub-templates, so a nested field contributes a single name here. For
+        the path to every leaf in canonical leaf order, use :attr:`leaf_paths`;
+        the two coincide for a flat template (one where every field is a leaf).
+        """
         return tuple(self._specs.keys())
 
     @property
-    def leaf_shapes(self) -> dict[str, tuple[int, ...] | None]:
-        """Per-field leaf shapes.  ``None`` for opaque (non-array) leaves.
+    def leaf_paths(self) -> tuple[str, ...]:
+        """Path to every leaf, in canonical leaf order.
 
-        For nested ``EventTemplate`` fields, returns the nested
-        template's ``leaf_shapes`` (not the template itself), keyed by
-        ``/``-delimited paths so the keys round-trip with
-        :meth:`Record.__getitem__`'s path syntax.
+        Returns the ``/``-delimited path (see the Terminology section) to each
+        leaf of the template, traversed depth-first in each level's insertion
+        order. This property **is the canonical definition** of that order and
+        of the leaf keys it yields: every leaf-wise operation in ProbPipe visits
+        leaves in exactly this order and names them by exactly these paths —
+        :meth:`to_vector` / :meth:`from_vector` lay out and read the per-leaf
+        blocks in it, :meth:`~probpipe.Record.flatten` returns the value's
+        leaves in it, and :attr:`leaf_shapes` (and
+        :attr:`~NumericEventTemplate.numeric_leaf_shapes`) are keyed by these
+        same paths. A nested field expands into one path per nested leaf; a flat
+        template's ``leaf_paths`` equals its :attr:`fields`.
+
+        Returns
+        -------
+        tuple of str
+            One ``/``-delimited path per leaf, in canonical leaf order.
+        """
+        paths: list[str] = []
+        for name, spec in self._specs.items():
+            if isinstance(spec, EventTemplate):
+                paths.extend(f"{name}{_PATH_SEP}{sub}" for sub in spec.leaf_paths)
+            else:
+                paths.append(name)
+        return tuple(paths)
+
+    @property
+    def leaf_shapes(self) -> dict[str, tuple[int, ...] | None]:
+        """Per-leaf shapes, keyed by :attr:`leaf_paths` (canonical leaf order).
+
+        Maps each leaf's ``/``-delimited path to its array shape, or ``None``
+        for an opaque (non-array) leaf. The keys are exactly :attr:`leaf_paths`,
+        in canonical leaf order; a nested sub-template contributes one entry per
+        nested leaf.
         """
         result: dict[str, tuple[int, ...] | None] = {}
         for name, spec in self._specs.items():
@@ -959,14 +1038,14 @@ class EventTemplate:
 
     @property
     def event_shapes(self) -> dict[str, tuple[int, ...]]:
-        """Per-top-level-field event shapes.
+        """Per-field event shapes, keyed by :attr:`fields` (top-level).
 
-        Unlike :attr:`leaf_shapes` (which descends into nested
-        sub-templates and emits one entry per leaf), ``event_shapes``
-        emits one entry per top-level field. Nested sub-templates and
-        opaque leaves collapse to ``()``. This is the view that downstream
-        Distribution code wants when answering "what is the per-field event
-        shape of one draw?".
+        Emits one entry per *top-level* field — keyed by :attr:`fields`, not by
+        :attr:`leaf_paths`. An :class:`ArraySpec` field returns its shape; a
+        nested sub-template or opaque leaf collapses to ``()``. Contrast
+        :attr:`leaf_shapes`, which descends and emits one entry per leaf. This
+        is the view downstream Distribution code wants when answering "what is
+        the per-field event shape of one draw?".
         """
         return {name: self.field_event_shape(name) for name in self._specs}
 
@@ -1566,11 +1645,11 @@ class NumericEventTemplate(EventTemplate):
 
     @property
     def numeric_leaf_shapes(self) -> dict[str, tuple[int, ...]]:
-        """Per-field shapes for numeric leaves.
+        """Per-leaf shapes, keyed by :attr:`leaf_paths` (canonical leaf order).
 
-        On :class:`NumericEventTemplate` every leaf is numeric, so this
-        is equivalent to :attr:`leaf_shapes`. Kept as a distinct name for
-        symmetry with historical callers that used it as a filter.
+        On :class:`NumericEventTemplate` every leaf is numeric, so this equals
+        :attr:`leaf_shapes` (no ``None`` entries). Kept as a distinct name for
+        symmetry with historical callers that used it as a numeric filter.
         """
         return dict(self.leaf_shapes)
 

--- a/probpipe/distributions/kde.py
+++ b/probpipe/distributions/kde.py
@@ -63,7 +63,7 @@ class KDEDistribution(TFPDistribution):
         — preserving named fields end-to-end across e.g. an MCMC posterior
         being routed through KDE as the new prior in
         :class:`~probpipe.modeling.IncrementalConditioner`. The template's
-        ``flat_size`` must equal ``samples.shape[1]``.
+        ``vector_size`` must equal ``samples.shape[1]``.
     name : str or None
         Distribution name for provenance.
     """
@@ -100,7 +100,7 @@ class KDEDistribution(TFPDistribution):
         # template's flat width matches the samples' trailing dimension.
         if event_template is not None and len(event_template.fields) > 1:
             if isinstance(event_template, NumericEventTemplate):
-                expected = event_template.flat_size
+                expected = event_template.vector_size
             else:
                 expected = sum(
                     int(jnp.prod(jnp.array(shape))) if shape else 1
@@ -108,7 +108,7 @@ class KDEDistribution(TFPDistribution):
                 )
             if expected != d:
                 raise ValueError(
-                    f"event_template flat_size ({expected}) does not match "
+                    f"event_template vector_size ({expected}) does not match "
                     f"samples flat dimension ({d}); template fields="
                     f"{event_template.fields}"
                 )

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -113,7 +113,7 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
     :meth:`_mean` / :meth:`_variance`, and the public ops
     (``mean(post)`` / ``variance(post)``) all return Records whose
     keys match :attr:`fields`. Nested ``EventTemplate`` fields are
-    stored as a flat ``(n, nested_flat_size)`` array under the
+    stored as a flat ``(n, nested_vector_size)`` array under the
     top-level field name; the nested structure is recoverable via
     ``event_template[field]`` and via :meth:`draws`, which walks
     the full template (including nesting) using the original
@@ -171,7 +171,7 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
         self._user_template = event_template is not None
         # Multi-field template → split the flat chain by top-level
         # field. Nested ``EventTemplate`` fields are stored as a
-        # 2-D ``(n, nested_flat_size)`` slice under the top-level
+        # 2-D ``(n, nested_vector_size)`` slice under the top-level
         # field name; the nested structure is recovered via
         # ``event_template[field]`` and ``draws()``. Slice sizes use
         # ``_spec_size``, which already handles both flat and nested
@@ -208,7 +208,7 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
                 chunk = flat[..., offset : offset + size]
                 if isinstance(spec, EventTemplate):
                     # Nested: keep flat-per-top-level-field. Shape is
-                    # ``(*sample_shape, nested_flat_size)``.
+                    # ``(*sample_shape, nested_vector_size)``.
                     fields[field_name] = chunk
                 else:
                     # ArraySpec leaf (opaque rejected above, nested handled).
@@ -331,9 +331,9 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
         # historical behaviour of single-field auto-wrap empiricals
         # under the previous numeric-array hierarchy.
         if getattr(self, "_user_template", False):
-            from ..core._record_array import NumericRecordArray
-
-            return NumericRecordArray.unflatten(samples, template=self.event_template)
+            # ``from_vector`` infers batch_shape from the leading axes of the
+            # concatenated draws (a matrix ``(n, vector_size)``).
+            return self.event_template.from_vector(samples)
         return samples
 
     def __repr__(self) -> str:

--- a/probpipe/inference/_bayesflow_common.py
+++ b/probpipe/inference/_bayesflow_common.py
@@ -169,12 +169,14 @@ def _simulate_offline(
     leaf_keys = tuple(template.numeric_leaf_shapes)
     k_theta, k_sim = jax.random.split(key)
     theta = _sample_op(prior, key=k_theta, sample_shape=(num_simulations,))
-    # Round-trip through the canonical flat layout: single-field priors' raw draws
-    # are not field-indexable by name, so unflatten gives uniform named access.
-    theta_flat = jnp.asarray(theta.flatten()).reshape(num_simulations, -1)
-    record = NumericRecordArray.unflatten(
-        theta_flat, template=template, batch_shape=(num_simulations,)
-    )
+    # Round-trip through the canonical 1-D vector layout: single-field priors'
+    # raw draws are not field-indexable by name, so from_vector gives uniform
+    # named access. Structured draws serialize via to_vector; raw arrays ravel.
+    if isinstance(theta, NumericRecordArray):
+        theta_flat = jnp.asarray(theta.to_vector()).reshape(num_simulations, -1)
+    else:
+        theta_flat = jnp.asarray(theta).reshape(num_simulations, -1)
+    record = template.from_vector(theta_flat)
     # Invert before flattening: matrix-valued bijectors (positive-definite) require
     # the leaf's native (..., n, n) event shape, not the flat adapter layout.
     named = {}
@@ -187,8 +189,9 @@ def _simulate_offline(
 
     def _one(flat_row: Array, k: PRNGKey) -> Array:
         # Per-draw structured params (named-field access), per the
-        # GenerativeLikelihood contract.
-        params = NumericRecordArray.unflatten(flat_row, template=template, batch_shape=())
+        # GenerativeLikelihood contract. ``flat_row`` is 1-D, so from_vector
+        # rebuilds a single NumericRecord.
+        params = template.from_vector(flat_row)
         return jnp.ravel(simulator.generate_data(params, 1, key=k)[0])
 
     if sim_backend == "jax":

--- a/probpipe/inference/_bayesflow_likelihoods.py
+++ b/probpipe/inference/_bayesflow_likelihoods.py
@@ -115,16 +115,23 @@ class _BayesFlowLikelihoodBase(ConditionallyIndependentLikelihood, GenerativeLik
         """Coerce ``params`` to a ``(d_theta,)`` row in canonical flat order.
 
         Accepts the two shapes that reach a likelihood in practice -- the
-        structured per-draw record of predictive/checking paths (flattened via
-        its own canonical layout, which matches the training layout) and the
-        flat vector the gradient-MCMC log-density assembly passes -- plus plain
-        array-likes. Width is validated against the prior's ``event_size``
-        (static under jit: shapes are concrete at trace time).
+        structured per-draw record of predictive/checking paths (serialized via
+        its own canonical 1-D vector layout, which matches the training layout)
+        and the flat vector the gradient-MCMC log-density assembly passes --
+        plus plain array-likes. Width is validated against the prior's
+        ``event_size`` (static under jit: shapes are concrete at trace time).
         """
-        if hasattr(params, "flatten"):
-            t = params.flatten()
-        elif hasattr(params, "to_numeric"):
-            t = params.to_numeric().flatten()
+        from ..core._numeric_record import NumericRecord
+        from ..core._record_array import NumericRecordArray
+        from ..core.record import Record
+
+        # ``Record`` now carries the JAX-pytree ``flatten`` (returns
+        # ``(leaves, aux)``), so dispatch on type rather than ``hasattr`` to get
+        # the canonical 1-D ``vec`` via ``to_vector``.
+        if isinstance(params, (NumericRecord, NumericRecordArray)):
+            t = params.to_vector()
+        elif isinstance(params, Record):
+            t = params.to_numeric().to_vector()
         else:
             t = params
         t = jnp.ravel(jnp.asarray(t))

--- a/probpipe/inference/_inference_utils.py
+++ b/probpipe/inference/_inference_utils.py
@@ -230,7 +230,7 @@ def get_init_state(
 
                 if not isinstance(s, NumericRecord):
                     s = NumericRecord.from_record(s)
-                s = s.flatten()
+                s = s.to_vector()
             return jnp.atleast_1d(jnp.asarray(s, dtype=target_dtype))
         except Exception:
             logger.debug(

--- a/probpipe/modeling/_pymc.py
+++ b/probpipe/modeling/_pymc.py
@@ -174,7 +174,7 @@ class PyMCModel(ProbabilisticModel):
         Derived from :attr:`event_template`; raises on a non-concrete
         free-RV shape, as the template does.
         """
-        return (self.event_template.flat_size,)
+        return (self.event_template.vector_size,)
 
     def _event_template_for(
         self,

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -132,6 +132,51 @@ class TestLeafShapes:
 
 
 # ---------------------------------------------------------------------------
+# leaf_paths (canonical leaf order — the single source of truth)
+# ---------------------------------------------------------------------------
+
+
+class TestLeafPaths:
+    def test_flat_equals_fields(self):
+        # For a flat template (every field a leaf), leaf_paths == fields.
+        tpl = EventTemplate(x=(), y=(3,))
+        assert tpl.leaf_paths == ("x", "y") == tpl.fields
+
+    def test_includes_opaque_leaves(self):
+        # leaf_paths enumerates every leaf, numeric or opaque.
+        tpl = EventTemplate(label=None, x=())
+        assert tpl.leaf_paths == ("label", "x")
+
+    def test_nested_depth_first_insertion_order(self):
+        # A nested field expands into one path per nested leaf; fields stays
+        # top-level only.
+        inner = EventTemplate(a=(), b=(2,))
+        outer = EventTemplate(inner=inner, z=(3,))
+        assert outer.leaf_paths == ("inner/a", "inner/b", "z")
+        assert outer.fields == ("inner", "z")
+
+    def test_depth2(self):
+        tpl = EventTemplate(outer=EventTemplate(deep=EventTemplate(g=(), h=()), a=()), m=())
+        assert tpl.leaf_paths == ("outer/deep/g", "outer/deep/h", "outer/a", "m")
+
+    def test_keys_match_leaf_shapes_in_order(self):
+        # leaf_shapes is keyed by leaf_paths, in the same canonical order.
+        tpl = EventTemplate(outer=EventTemplate(a=(2,), b=()), label=None, m=())
+        assert tuple(tpl.leaf_shapes) == tpl.leaf_paths
+
+    def test_order_matches_flatten_and_to_vector(self):
+        # The canonical leaf order is the order flatten() / to_vector() use.
+        v = NumericRecord(
+            x=jnp.array([1.0, 2.0]),
+            nested=NumericRecord(a=jnp.array(3.0), b=jnp.array([4.0, 5.0])),
+        )
+        tpl = EventTemplate.from_record(v)
+        assert tpl.leaf_paths == ("x", "nested/a", "nested/b")
+        # to_vector concatenates leaves in leaf_paths order: x(2) | a(1) | b(2).
+        np.testing.assert_allclose(tpl.to_vector(v), [1.0, 2.0, 3.0, 4.0, 5.0])
+
+
+# ---------------------------------------------------------------------------
 # event_shapes / field_event_shape (top-level field view)
 # ---------------------------------------------------------------------------
 

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -122,13 +122,13 @@ class TestLeafShapes:
         assert tpl.numeric_leaf_shapes == {"x": (), "y": (3,)}
 
     def test_numeric_leaf_shapes_not_on_base_template(self):
-        """``flat_size`` / ``numeric_leaf_shapes`` are only meaningful
+        """``vector_size`` / ``numeric_leaf_shapes`` are only meaningful
         when every leaf is numeric — they live on
         :class:`NumericEventTemplate`, not the base ``EventTemplate``.
         """
         tpl = EventTemplate(label=None, x=(), y=(3,))
         assert not hasattr(tpl, "numeric_leaf_shapes")
-        assert not hasattr(tpl, "flat_size")
+        assert not hasattr(tpl, "vector_size")
 
 
 # ---------------------------------------------------------------------------
@@ -173,27 +173,27 @@ class TestEventShapes:
 
 
 # ---------------------------------------------------------------------------
-# flat_size (on NumericEventTemplate)
+# vector_size (on NumericEventTemplate)
 # ---------------------------------------------------------------------------
 
 
 class TestFlatSize:
     def test_scalars(self):
         tpl = NumericEventTemplate(a=(), b=(), c=())
-        assert tpl.flat_size == 3
+        assert tpl.vector_size == 3
 
     def test_arrays(self):
         tpl = NumericEventTemplate(x=(5,), y=(2, 3))
-        assert tpl.flat_size == 11
+        assert tpl.vector_size == 11
 
     def test_nested(self):
         inner = NumericEventTemplate(r=(), K=())
         outer = NumericEventTemplate(params=inner, obs=(4,))
-        assert outer.flat_size == 6
+        assert outer.vector_size == 6
 
     def test_scalar_only(self):
         tpl = NumericEventTemplate(a=())
-        assert tpl.flat_size == 1
+        assert tpl.vector_size == 1
 
     def test_rejects_opaque_leaf(self):
         with pytest.raises(TypeError, match="opaque"):
@@ -316,21 +316,21 @@ class TestFromRecord:
         assert tpl["x"] == ArraySpec((3,))
         assert tpl["y"] == ArraySpec(())
 
-    def test_roundtrip_flat_size(self):
+    def test_roundtrip_vector_size(self):
         from probpipe.core._numeric_record import NumericRecord
 
         r = NumericRecord(a=1.0, b=jnp.zeros(4), c=jnp.zeros((2, 3)))
         tpl = EventTemplate.from_record(r)
         # Auto-promoted to NumericEventTemplate because the input was a
-        # NumericRecord, so ``flat_size`` is reachable.
+        # NumericRecord, so ``vector_size`` is reachable.
         assert isinstance(tpl, NumericEventTemplate)
-        assert tpl.flat_size == r.flat_size
+        assert tpl.vector_size == r.vector_size
 
     def test_from_numeric_record_promotes(self):
         """Calling ``from_record`` on a ``NumericRecord`` returns a
         :class:`NumericEventTemplate`, even through the base
         ``EventTemplate.from_record`` classmethod, so downstream code
-        that needs ``flat_size`` keeps working without the caller having
+        that needs ``vector_size`` keeps working without the caller having
         to name the subclass explicitly."""
         from probpipe.core._numeric_record import NumericRecord
 
@@ -593,10 +593,10 @@ class TestShapeAccessorBackCompat:
         assert tpl.field_event_shape("label") == ()
         assert tpl.field_event_shape("params") == ()
 
-    def test_flat_size_unchanged(self):
+    def test_vector_size_unchanged(self):
         tpl = EventTemplate(x=(), y=(3,), z=(2, 4))
         assert isinstance(tpl, NumericEventTemplate)
-        assert tpl.flat_size == 1 + 3 + 8
+        assert tpl.vector_size == 1 + 3 + 8
 
     def test_hash_eq_order_sensitive(self):
         a = EventTemplate(x=(), y=(3,))
@@ -752,11 +752,11 @@ class TestNumericSubset:
         assert sub == tpl
         assert sub.numeric_subset() == sub
 
-    def test_returns_numeric_template_with_flat_size(self):
+    def test_returns_numeric_template_with_vector_size(self):
         tpl = EventTemplate(x=(), label=None, y=(3,), z=(2, 4))
         sub = tpl.numeric_subset()
         assert isinstance(sub, NumericEventTemplate)
-        assert sub.flat_size == 1 + 3 + 8
+        assert sub.vector_size == 1 + 3 + 8
 
     def test_raises_when_no_numeric_leaves(self):
         tpl = EventTemplate(label=None, tag=None)
@@ -800,24 +800,25 @@ class TestToVector:
         vec = tpl.to_vector(v)
         assert vec.shape == (1 + 3 + 8,)
 
-    def test_vector_size_equals_flat_size(self):
+    def test_to_vector_shape_is_vector_size(self):
         tpl = EventTemplate(x=(), y=(3,), z=(2, 4))
         v = NumericRecord(x=0.0, y=jnp.zeros(3), z=jnp.zeros((2, 4)))
-        assert tpl.to_vector(v).shape == (tpl.flat_size,)
+        assert tpl.to_vector(v).shape == (tpl.vector_size,)
 
-    def test_order_and_value_match_numeric_record_flatten(self):
-        # The canonical leaf order must agree with NumericRecord.flatten so the
-        # two are interchangeable (PR-1c contract).
+    def test_order_and_value_match_instance_to_vector(self):
+        # The template-level to_vector must agree with the instance-level
+        # NumericRecord.to_vector (same canonical leaf order), so the two are
+        # interchangeable.
         v = NumericRecord(x=1.0, y=jnp.arange(3.0), nested=NumericRecord(a=2.0, b=jnp.arange(2.0)))
         tpl = EventTemplate.from_record(v)
-        assert jnp.array_equal(tpl.to_vector(v), v.flatten())
+        assert jnp.array_equal(tpl.to_vector(v), v.to_vector())
 
-    def test_batched_shape_is_batch_shape_plus_flat_size(self):
+    def test_batched_shape_is_batch_shape_plus_vector_size(self):
         tpl = EventTemplate(x=(), y=(3,))
-        flat = jnp.arange(2 * 5 * tpl.flat_size, dtype=float).reshape(2, 5, tpl.flat_size)
+        flat = jnp.arange(2 * 5 * tpl.vector_size, dtype=float).reshape(2, 5, tpl.vector_size)
         v = tpl.from_vector(flat)
         assert isinstance(v, NumericRecordArray)
-        assert tpl.to_vector(v).shape == (2, 5, tpl.flat_size)
+        assert tpl.to_vector(v).shape == (2, 5, tpl.vector_size)
 
     def test_non_numeric_template_raises(self):
         tpl = EventTemplate(x=(), label=None, d=_dist_spec())
@@ -866,7 +867,7 @@ class TestFromVectorRoundTripSingle:
 class TestFromVectorRoundTripBatched:
     def test_single_batch_axis(self):
         tpl = EventTemplate(x=(), y=(3,))
-        flat = jnp.arange(4 * tpl.flat_size, dtype=float).reshape(4, tpl.flat_size)
+        flat = jnp.arange(4 * tpl.vector_size, dtype=float).reshape(4, tpl.vector_size)
         v = tpl.from_vector(flat)
         assert isinstance(v, NumericRecordArray)
         assert v.batch_shape == (4,)
@@ -875,7 +876,7 @@ class TestFromVectorRoundTripBatched:
     def test_multi_axis_batch_shape(self):
         # batch_shape=(2, 3) catches trailing-axis split / reshape bugs.
         tpl = EventTemplate(x=(), y=(3,), z=(2, 2))
-        flat = jnp.arange(2 * 3 * tpl.flat_size, dtype=float).reshape(2, 3, tpl.flat_size)
+        flat = jnp.arange(2 * 3 * tpl.vector_size, dtype=float).reshape(2, 3, tpl.vector_size)
         v = tpl.from_vector(flat)
         assert isinstance(v, NumericRecordArray)
         assert v.batch_shape == (2, 3)
@@ -886,7 +887,7 @@ class TestFromVectorRoundTripBatched:
         # Nested numeric subtree + multi-axis batch: from_vector builds a nested
         # NumericRecordArray as a field of the outer NumericRecordArray.
         tpl = EventTemplate(x=(), nested=EventTemplate(a=(), b=(2,)), y=(3,))
-        flat = jnp.arange(2 * 3 * tpl.flat_size, dtype=float).reshape(2, 3, tpl.flat_size)
+        flat = jnp.arange(2 * 3 * tpl.vector_size, dtype=float).reshape(2, 3, tpl.vector_size)
         v = tpl.from_vector(flat)
         assert isinstance(v, NumericRecordArray)
         assert v.batch_shape == (2, 3)
@@ -934,7 +935,7 @@ class TestFromVectorNonNumericReconstruction:
 
     def test_batched_full_value(self):
         tpl = EventTemplate(x=(), label=None)
-        vec = jnp.arange(6.0).reshape(2, 3, 1)  # batch_shape=(2, 3), flat_size=1
+        vec = jnp.arange(6.0).reshape(2, 3, 1)  # batch_shape=(2, 3), vector_size=1
         labels = np.array([["a", "b", "c"], ["d", "e", "f"]], dtype=object)
         rebuilt = tpl.from_vector(vec, non_numeric={"label": labels})
         assert isinstance(rebuilt, RecordArray)
@@ -948,7 +949,7 @@ class TestFromVectorNonNumericReconstruction:
         # batched non-numeric leaf in alongside.
         tpl = EventTemplate(x=(), label=None, phys=EventTemplate(force=(), mass=()))
         sub = tpl.numeric_subset()  # leaves: x, phys/force, phys/mass
-        vec = jnp.arange(2 * 3 * sub.flat_size, dtype=float).reshape(2, 3, sub.flat_size)
+        vec = jnp.arange(2 * 3 * sub.vector_size, dtype=float).reshape(2, 3, sub.vector_size)
         labels = np.array([["a", "b", "c"], ["d", "e", "f"]], dtype=object)
         rebuilt = tpl.from_vector(vec, non_numeric={"label": labels})
         assert isinstance(rebuilt, RecordArray)

--- a/tests/core/test_numeric_record.py
+++ b/tests/core/test_numeric_record.py
@@ -153,32 +153,32 @@ class TestConstruction:
 
 
 # ---------------------------------------------------------------------------
-# Flatten / unflatten
+# to_vector / from_vector (numeric 1-D serialization)
 # ---------------------------------------------------------------------------
 
 
-class TestFlattenUnflatten:
+class TestToVectorFromVector:
     def test_flatten_scalars(self):
         nr = NumericRecord(a=1.0, b=2.0, c=3.0)
-        flat = nr.flatten()
+        flat = nr.to_vector()
         assert flat.shape == (3,)
         np.testing.assert_allclose(flat, [1.0, 2.0, 3.0])
 
     def test_flatten_arrays(self):
         nr = NumericRecord(x=jnp.array([1.0, 2.0]), y=jnp.array([3.0]))
-        flat = nr.flatten()
+        flat = nr.to_vector()
         np.testing.assert_allclose(flat, [1.0, 2.0, 3.0])
 
     def test_flatten_nested(self):
         inner = NumericRecord(x=1.0, y=2.0)
         outer = NumericRecord(a=inner, b=3.0)
-        flat = outer.flatten()
+        flat = outer.to_vector()
         np.testing.assert_allclose(flat, [1.0, 2.0, 3.0])
 
     def test_unflatten_with_event_template(self):
         tpl = EventTemplate(a=(), b=(3,))
         flat = jnp.array([1.0, 2.0, 3.0, 4.0])
-        nr = NumericRecord.unflatten(flat, template=tpl)
+        nr = tpl.from_vector(flat)
         assert isinstance(nr, NumericRecord)
         np.testing.assert_allclose(nr["a"], 1.0)
         np.testing.assert_allclose(nr["b"], [2.0, 3.0, 4.0])
@@ -186,8 +186,8 @@ class TestFlattenUnflatten:
     def test_roundtrip_with_template(self):
         tpl = EventTemplate(r=(), K=(), phi=())
         nr = NumericRecord(r=1.8, K=70.0, phi=10.0)
-        flat = nr.flatten()
-        nr2 = NumericRecord.unflatten(flat, template=tpl)
+        flat = nr.to_vector()
+        nr2 = tpl.from_vector(flat)
         np.testing.assert_allclose(float(nr2["r"]), 1.8)
         np.testing.assert_allclose(float(nr2["K"]), 70.0)
         np.testing.assert_allclose(float(nr2["phi"]), 10.0)
@@ -198,20 +198,20 @@ class TestFlattenUnflatten:
         inner_tpl = NumericEventTemplate(x=(), y=(2,))
         outer_tpl = NumericEventTemplate(params=inner_tpl, z=(3,))
         flat = jnp.arange(6.0)  # x=0, y=[1,2], z=[3,4,5]
-        nr = NumericRecord.unflatten(flat, template=outer_tpl)
+        nr = outer_tpl.from_vector(flat)
         assert isinstance(nr["params"], NumericRecord)
         np.testing.assert_allclose(nr["params"]["x"], 0.0)
         np.testing.assert_allclose(nr["params"]["y"], [1.0, 2.0])
         np.testing.assert_allclose(nr["z"], [3.0, 4.0, 5.0])
 
-    def test_unflatten_opaque_raises(self):
+    def test_from_vector_mixed_requires_non_numeric(self):
         tpl = EventTemplate(label=None, x=())
-        with pytest.raises(TypeError, match="opaque"):
-            NumericRecord.unflatten(jnp.array([1.0]), template=tpl)
+        with pytest.raises(ValueError, match="non_numeric"):
+            tpl.from_vector(jnp.array([1.0]))
 
-    def test_flat_size(self):
+    def test_vector_size(self):
         nr = NumericRecord(a=1.0, b=jnp.zeros(4), c=jnp.zeros((2, 3)))
-        assert nr.flat_size == 11
+        assert nr.vector_size == 11
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_numeric_record_distribution_view.py
+++ b/tests/core/test_numeric_record_distribution_view.py
@@ -127,12 +127,12 @@ class TestSampling:
         assert draws["slope"].shape == (5, 3)
 
     def test_sample_roundtrip_with_flat(self, mvn4, split_template):
-        """Same seed: lifted-view sample equals NumericRecord.unflatten(flat_sample)."""
+        """Same seed: lifted-view sample equals split_template.from_vector(flat_sample)."""
         rec = mvn4.as_record_distribution(template=split_template)
         key = jax.random.PRNGKey(7)
         rec_draw = rec._sample(key)
         flat_draw = mvn4._sample(key)
-        ref = NumericRecord.unflatten(flat_draw, template=split_template)
+        ref = split_template.from_vector(flat_draw)
         np.testing.assert_allclose(
             jnp.asarray(rec_draw["intercept"]), jnp.asarray(ref["intercept"])
         )
@@ -174,7 +174,7 @@ class TestLogProb:
         rec = mvn4.as_record_distribution(template=split_template)
         key = jax.random.PRNGKey(3)
         flat_x = mvn4._sample(key)
-        rec_x = NumericRecord.unflatten(flat_x, template=split_template)
+        rec_x = split_template.from_vector(flat_x)
 
         lp_rec = float(log_prob(rec, rec_x))
         lp_flat = float(log_prob(mvn4, flat_x))
@@ -185,11 +185,7 @@ class TestLogProb:
         rec = mvn4.as_record_distribution(template=split_template)
         key = jax.random.PRNGKey(5)
         flat_xs = mvn4._sample(key, sample_shape=(10,))
-        rec_xs = NumericRecordArray.unflatten(
-            flat_xs,
-            template=split_template,
-            batch_shape=(10,),
-        )
+        rec_xs = split_template.from_vector(flat_xs)
         lp_rec = jnp.asarray(log_prob(rec, rec_xs))
         lp_flat = jnp.asarray(log_prob(mvn4, flat_xs))
         np.testing.assert_allclose(lp_rec, lp_flat, rtol=1e-5)
@@ -267,8 +263,8 @@ class TestErrors:
             mvn4.as_record_distribution(template=bad)
 
     def test_value_error_on_size_mismatch(self, mvn4):
-        bad = NumericEventTemplate(a=(), b=(7,))  # flat_size=8 vs source flat_size=4
-        with pytest.raises(ValueError, match="flat_size mismatch"):
+        bad = NumericEventTemplate(a=(), b=(7,))  # vector_size=8 vs source vector_size=4
+        with pytest.raises(ValueError, match="vector_size mismatch"):
             mvn4.as_record_distribution(template=bad)
 
     def test_type_error_on_non_flat_source(self, split_template):
@@ -317,12 +313,12 @@ class TestFlatContract:
     def test_multivariate_normal_is_flat(self):
         mvn = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="x")
         assert isinstance(mvn, FlatNumericRecordDistribution)
-        assert mvn.flat_size == 3
+        assert mvn.vector_size == 3
 
     def test_dirichlet_is_flat(self):
         d = Dirichlet(concentration=jnp.ones(4), name="p")
         assert isinstance(d, FlatNumericRecordDistribution)
-        assert d.flat_size == 4
+        assert d.vector_size == 4
 
     def test_flattened_view_is_flat(self):
         """``as_flat_distribution()`` produces a ``FlatNumericRecordDistribution``
@@ -331,18 +327,18 @@ class TestFlatContract:
         """
         flat_scalar = Normal(loc=0.0, scale=1.0, name="x").as_flat_distribution()
         assert isinstance(flat_scalar, FlatNumericRecordDistribution)
-        assert flat_scalar.flat_size == 1
+        assert flat_scalar.vector_size == 1
 
         flat_joint = ProductDistribution(
             a=Normal(loc=0.0, scale=1.0, name="a"),
             b=Normal(loc=0.0, scale=1.0, name="b"),
         ).as_flat_distribution()
         assert isinstance(flat_joint, FlatNumericRecordDistribution)
-        assert flat_joint.flat_size == 2
+        assert flat_joint.vector_size == 2
 
-    def test_flat_size_raises_on_non_1d_event_shape(self):
+    def test_vector_size_raises_on_non_1d_event_shape(self):
         """A misdeclared subclass with rank-≥2 event_shape surfaces on
-        ``flat_size`` access rather than silently truncating to the
+        ``vector_size`` access rather than silently truncating to the
         first dim.
         """
         from probpipe.core._numeric_record_distribution import (
@@ -360,7 +356,7 @@ class TestFlatContract:
 
         bad = _BadFlat()
         with pytest.raises(TypeError, match="event_shape"):
-            _ = bad.flat_size
+            _ = bad.vector_size
 
 
 # -- Cross-class smoke: lifting from Dirichlet (a non-MVN FlatNRD) -------------

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -284,21 +284,92 @@ class TestStorage:
 
 
 class TestNumericAPIOnRecord:
-    """Numeric-only APIs live on NumericRecord, not on Record.
+    """The numeric-1-D APIs live on NumericRecord, not on Record.
 
-    A single focused test — if someone tries to re-add ``flatten`` or
-    similar to ``Record`` (rather than ``NumericRecord``), this fails.
-    Implementation-detail attributes like ``_resolved`` / ``_coords``
-    are intentionally not checked here: they are private and covered
-    indirectly by the storage-verbatim tests above.
+    ``to_vector`` / ``vector_size`` require numeric leaves, so they belong
+    only on ``NumericRecord``; if someone re-adds one to ``Record``, this
+    fails. The general JAX-pytree ``flatten`` / ``unflatten`` (defined for
+    any leaf type) DO live on ``Record`` — they are asserted present here so
+    the two vocabularies don't drift. Implementation-detail attributes like
+    ``_resolved`` / ``_coords`` are intentionally not checked here.
     """
 
-    def test_numeric_ops_absent_from_record(self):
+    def test_numeric_vector_ops_absent_from_record(self):
         v = Record(a=1.0)
-        for attr in ("flatten", "unflatten", "flat_size", "zip"):
+        for attr in ("to_vector", "vector_size", "zip"):
             assert not hasattr(v, attr), f"Record should not expose {attr!r}"
-        assert not hasattr(Record, "unflatten")
         assert not hasattr(Record, "zip")
+
+    def test_pytree_flatten_present_on_record(self):
+        # flatten/unflatten are the general JAX-pytree ops — defined for any
+        # leaf type, so they are intentionally on the Record base.
+        v = Record(a=1.0, label="x")
+        leaves, aux = v.flatten()
+        assert Record.unflatten(leaves, aux) == v
+
+
+class TestPytreeFlattenUnflatten:
+    """The repurposed ``flatten`` / ``unflatten`` are the JAX-pytree ops
+    (``value -> (leaves, aux)`` / ``(leaves, aux) -> value``), defined for any
+    leaf type — distinct from the numeric ``to_vector`` / ``from_vector``.
+    """
+
+    def test_flatten_returns_leaves_and_treedef(self):
+        v = Record(x=jnp.array([1.0, 2.0]), label="horseshoe")
+        leaves, aux = v.flatten()
+        # Leaves are kept whole (not raveled/concatenated) and in any type.
+        assert leaves[0].shape == (2,)
+        assert leaves[1] == "horseshoe"
+        assert aux == jax.tree_util.tree_structure(v)
+
+    def test_record_roundtrip_with_opaque_leaf(self):
+        # Opaque (non-numeric) leaves round-trip — unlike to_vector.
+        v = Record(x=jnp.array([1.0, 2.0]), label="horseshoe", count=3)
+        assert Record.unflatten(*v.flatten()) == v
+
+    def test_numeric_record_roundtrip(self):
+        from probpipe import NumericRecord
+
+        v = NumericRecord(a=jnp.array([1.0, 2.0, 3.0]), b=NumericRecord(c=jnp.array(5.0)))
+        leaves, aux = v.flatten()
+        rebuilt = NumericRecord.unflatten(leaves, aux)
+        assert rebuilt == v
+        assert isinstance(rebuilt, NumericRecord)
+        assert isinstance(rebuilt["b"], NumericRecord)
+
+    def test_mixed_nested_record_roundtrip(self):
+        # A nested mixed record with both numeric and opaque leaves.
+        v = Record(
+            theta=Record(loc=jnp.array([0.0, 1.0]), name="prior"),
+            tag="run-7",
+        )
+        assert Record.unflatten(*v.flatten()) == v
+
+    def test_record_array_roundtrip(self):
+        from probpipe import EventTemplate, NumericRecordArray
+
+        tpl = EventTemplate(x=(2,), y=())
+        nra = NumericRecordArray(
+            x=jnp.arange(6.0).reshape(3, 2),
+            y=jnp.arange(3.0),
+            batch_shape=(3,),
+            template=tpl,
+        )
+        leaves, aux = nra.flatten()
+        rebuilt = NumericRecordArray.unflatten(leaves, aux)
+        assert isinstance(rebuilt, NumericRecordArray)
+        assert rebuilt.batch_shape == (3,)
+        assert rebuilt == nra
+
+    def test_static_unflatten_class_independent(self):
+        # unflatten is static: the result class comes from aux, not the
+        # receiver, so Record.unflatten and NumericRecord.unflatten agree.
+        from probpipe import NumericRecord
+
+        v = NumericRecord(a=jnp.array(1.0))
+        leaves, aux = v.flatten()
+        assert type(Record.unflatten(leaves, aux)) is NumericRecord
+        assert type(NumericRecord.unflatten(leaves, aux)) is NumericRecord
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -79,7 +79,7 @@ class TestRecordArrayConstruction:
             batch_shape=(2,),
             template=tpl,
         )
-        flat = nra.flatten()
+        flat = nra.to_vector()
         # flat[0] = [nan, inf, -inf]; flat[1] = [1.0, 0.0, nan]
         row0 = np.asarray(flat[0])
         row1 = np.asarray(flat[1])
@@ -234,7 +234,7 @@ class TestNumericRecordArrayFlatten:
             batch_shape=(10,),
             template=tpl,
         )
-        flat = nra.flatten()
+        flat = nra.to_vector()
         assert flat.shape == (10, 4)  # 3 + 1
 
     def test_flatten_multidim_batch(self):
@@ -245,7 +245,7 @@ class TestNumericRecordArrayFlatten:
             batch_shape=(4, 5),
             template=tpl,
         )
-        flat = nra.flatten()
+        flat = nra.to_vector()
         assert flat.shape == (4, 5, 3)  # 2 + 1
 
     def test_flatten_values(self):
@@ -256,7 +256,7 @@ class TestNumericRecordArrayFlatten:
             batch_shape=(2,),
             template=tpl,
         )
-        flat = nra.flatten()
+        flat = nra.to_vector()
         # Template insertion order: a first, then b.
         np.testing.assert_allclose(flat[0], [10.0, 1.0, 2.0])
         np.testing.assert_allclose(flat[1], [20.0, 3.0, 4.0])
@@ -269,15 +269,15 @@ class TestNumericRecordArrayFlatten:
             batch_shape=(10,),
             template=tpl,
         )
-        flat = nra.flatten()
-        nra2 = NumericRecordArray.unflatten(flat, template=tpl)
+        flat = nra.to_vector()
+        nra2 = tpl.from_vector(flat)
         np.testing.assert_allclose(nra2["x"], nra["x"])
         np.testing.assert_allclose(nra2["y"], nra["y"])
 
     def test_unflatten_infers_batch(self):
         tpl = EventTemplate(a=(), b=(2,))
         flat = jnp.zeros((8, 3))
-        nra = NumericRecordArray.unflatten(flat, template=tpl)
+        nra = tpl.from_vector(flat)
         assert nra.batch_shape == (8,)
         assert nra["a"].shape == (8,)
         assert nra["b"].shape == (8, 2)
@@ -285,7 +285,7 @@ class TestNumericRecordArrayFlatten:
     def test_unflatten_explicit_batch(self):
         tpl = EventTemplate(a=(), b=(2,))
         flat = jnp.zeros((4, 5, 3))
-        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(4, 5))
+        nra = tpl.from_vector(flat)
         assert nra.batch_shape == (4, 5)
         assert nra["a"].shape == (4, 5)
         assert nra["b"].shape == (4, 5, 2)
@@ -293,15 +293,17 @@ class TestNumericRecordArrayFlatten:
     def test_unflatten_scalar_fields(self):
         tpl = EventTemplate(a=(), b=(), c=())
         flat = jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        nra = NumericRecordArray.unflatten(flat, template=tpl)
+        nra = tpl.from_vector(flat)
         np.testing.assert_allclose(nra["a"], [1.0, 4.0])
         np.testing.assert_allclose(nra["b"], [2.0, 5.0])
         np.testing.assert_allclose(nra["c"], [3.0, 6.0])
 
-    def test_unflatten_opaque_raises(self):
+    def test_from_vector_mixed_requires_non_numeric(self):
+        # A mixed template's opaque leaves can't be rebuilt from the numeric
+        # vector alone; from_vector requires them via ``non_numeric``.
         tpl = EventTemplate(label=None, x=())
-        with pytest.raises(TypeError, match="opaque"):
-            NumericRecordArray.unflatten(jnp.zeros((5, 1)), template=tpl)
+        with pytest.raises(ValueError, match="non_numeric"):
+            tpl.from_vector(jnp.zeros((5, 1)))
 
 
 # ---------------------------------------------------------------------------
@@ -322,9 +324,9 @@ class TestNumericRecordArrayNested:
         # NumericRecordArray (exercises the RecordArray branch).
         tpl = self._nested_tpl()
         flat = jnp.arange(15.0).reshape(5, 3)  # columns = outer/a, outer/b, m
-        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(5,))
+        nra = tpl.from_vector(flat)
         assert isinstance(nra["outer"], NumericRecordArray)
-        np.testing.assert_allclose(nra.flatten(), flat)  # round-trips exactly
+        np.testing.assert_allclose(nra.to_vector(), flat)  # round-trips exactly
 
     def test_flatten_nested_record_field(self):
         # The pre-canonical shape: the nested field is a plain Record holding
@@ -336,7 +338,7 @@ class TestNumericRecordArrayNested:
             batch_shape=(5,),
             template=tpl,
         )
-        flat = nra.flatten()
+        flat = nra.to_vector()
         assert flat.shape == (5, 3)
         np.testing.assert_allclose(flat[:, 0], inner["a"])
         np.testing.assert_allclose(flat[:, 1], inner["b"])
@@ -350,8 +352,8 @@ class TestNumericRecordArrayNested:
     def test_flatten_nested_depth2_roundtrip(self):
         tpl = EventTemplate(outer=EventTemplate(deep=EventTemplate(g=(), h=()), a=()), m=())
         flat = jnp.arange(20.0).reshape(5, 4)  # outer/deep/g, outer/deep/h, outer/a, m
-        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(5,))
-        np.testing.assert_allclose(nra.flatten(), flat)
+        nra = tpl.from_vector(flat)
+        np.testing.assert_allclose(nra.to_vector(), flat)
         np.testing.assert_allclose(nra["outer/deep/g"], flat[:, 0])
 
     def test_flatten_nested_vector_leaf(self):
@@ -359,18 +361,16 @@ class TestNumericRecordArrayNested:
         # at the leaf's event size, in canonical leaf order, and round-trips.
         tpl = EventTemplate(outer=EventTemplate(a=(2,), b=()), m=())
         flat = jnp.arange(20.0).reshape(5, 4)  # outer/a (2), outer/b (1), m (1)
-        nra = NumericRecordArray.unflatten(flat, template=tpl, batch_shape=(5,))
+        nra = tpl.from_vector(flat)
         assert np.asarray(nra["outer/a"]).shape == (5, 2)
         np.testing.assert_allclose(nra["outer/a"], flat[:, 0:2])
         np.testing.assert_allclose(nra["outer/b"], flat[:, 2])
         np.testing.assert_allclose(nra["m"], flat[:, 3])
-        np.testing.assert_allclose(nra.flatten(), flat)
+        np.testing.assert_allclose(nra.to_vector(), flat)
 
     def test_getitem_slash_path(self):
         tpl = self._nested_tpl()
-        nra = NumericRecordArray.unflatten(
-            jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,)
-        )
+        nra = tpl.from_vector(jnp.arange(15.0).reshape(5, 3))
         np.testing.assert_allclose(nra["outer/a"], nra["outer"]["a"])
         with pytest.raises(KeyError):
             nra["outer/missing"]  # leaf missing inside the sub-record
@@ -383,19 +383,15 @@ class TestNumericRecordArrayNested:
         # Integer indexing of a nested record array descends into the nested
         # field, returning a (nested) record element — not an indexing error.
         tpl = self._nested_tpl()
-        nra = NumericRecordArray.unflatten(
-            jnp.arange(15.0).reshape(5, 3), template=tpl, batch_shape=(5,)
-        )
+        nra = tpl.from_vector(jnp.arange(15.0).reshape(5, 3))
         elem = nra[2]
         assert isinstance(elem, Record)
         np.testing.assert_allclose(elem["outer"]["a"], nra["outer"]["a"][2])
-        np.testing.assert_allclose(elem.flatten(), nra.flatten()[2])
+        np.testing.assert_allclose(elem.to_vector(), nra.to_vector()[2])
 
     def test_getitem_int_nested_multidim_batch(self):
         tpl = self._nested_tpl()
-        nra = NumericRecordArray.unflatten(
-            jnp.arange(24.0).reshape(2, 4, 3), template=tpl, batch_shape=(2, 4)
-        )
+        nra = tpl.from_vector(jnp.arange(24.0).reshape(2, 4, 3))
         elem = nra[5]  # flat index into the (2, 4) batch
         np.testing.assert_allclose(elem["outer"]["a"], np.asarray(nra["outer"]["a"]).reshape(-1)[5])
 

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -111,7 +111,7 @@ def test_numeric_event_template_pickle_roundtrip():
     t2 = roundtrip(t)
     assert type(t2) is NumericEventTemplate
     assert t2.fields == ("x", "y")
-    assert t2.flat_size == 4  # () + (3,)
+    assert t2.vector_size == 4  # () + (3,)
 
 
 # ---------------------------------------------------------------------------
@@ -124,14 +124,14 @@ def test_numeric_record_pickle_roundtrip():
     nr2 = roundtrip(nr)
     assert nr2.fields == ("r", "K", "phi")
     assert float(nr2["r"]) == pytest.approx(1.8)
-    assert nr2.flat_size == 3
+    assert nr2.vector_size == 3
 
 
-def test_numeric_record_flat_size_recomputed():
+def test_numeric_record_vector_size_recomputed():
     nr = NumericRecord(a=jnp.ones((2, 3)))
-    assert nr.flat_size == 6
+    assert nr.vector_size == 6
     nr2 = roundtrip(nr)
-    assert nr2.flat_size == 6
+    assert nr2.vector_size == 6
 
 
 def test_numeric_record_cloudpickle_roundtrip():

--- a/tests/distributions/test_kde.py
+++ b/tests/distributions/test_kde.py
@@ -56,9 +56,9 @@ class TestEventTemplateConstructor:
         assert kde.event_template is two_field_template
         assert kde.event_template.fields == ("intercept", "slope")
 
-    def test_mismatched_flat_size_raises(self, flat_samples):
-        bad_tpl = EventTemplate(a=(), b=(), c=())  # flat_size=3, samples flat dim=2
-        with pytest.raises(ValueError, match="flat_size"):
+    def test_mismatched_vector_size_raises(self, flat_samples):
+        bad_tpl = EventTemplate(a=(), b=(), c=())  # vector_size=3, samples flat dim=2
+        with pytest.raises(ValueError, match="vector_size"):
             KDEDistribution(flat_samples, event_template=bad_tpl, name="bad")
 
     def test_single_field_template_unchanged(self, flat_samples):

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -306,11 +306,9 @@ class TestNestedSampleFlatten:
         assert isinstance(s["outer"], Record) and not isinstance(s["outer"], RecordArray)
 
     def test_batched_nested_flatten_roundtrip(self, nested):
-        from probpipe.core._record_array import NumericRecordArray
-
         s = sample(nested, key=jax.random.PRNGKey(1), sample_shape=(6,))
         leaves = list(nested.event_template.numeric_leaf_shapes)
-        flat = s.flatten()
+        flat = s.to_vector()
         assert flat.shape == (6, len(leaves))  # ('outer/a', 'outer/b', 'm')
         # Primary check: flatten places each sampled leaf into its own column in
         # canonical leaf order -- compared against the sample's own slash leaves.
@@ -319,7 +317,7 @@ class TestNestedSampleFlatten:
         for i, leaf in enumerate(leaves):
             np.testing.assert_allclose(flat[:, i], s[leaf], atol=1e-6)
         # Secondary: the columns round-trip back to the same leaves via unflatten.
-        rec = NumericRecordArray.unflatten(flat, template=nested.event_template, batch_shape=(6,))
+        rec = nested.event_template.from_vector(flat)
         for leaf in leaves:
             np.testing.assert_allclose(rec[leaf], s[leaf], atol=1e-6)
 

--- a/tests/inference/_bayesflow_helpers.py
+++ b/tests/inference/_bayesflow_helpers.py
@@ -1,0 +1,34 @@
+"""Shared helpers for the BayesFlow surrogate tests.
+
+Kept out of the ``test_*`` modules so the two BayesFlow test files
+(``test_bayesflow_likelihoods.py`` / ``test_bayesflow_posteriors.py``) share a
+single implementation rather than duplicating it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+
+from probpipe.custom_types import Array
+
+
+def theta_vec(params: Any) -> Array:
+    """Coerce a per-draw ``params`` object to its 1-D parameter vector.
+
+    Mirrors ``BayesFlowLikelihood._theta_row``: structured records serialize via
+    :meth:`~probpipe.NumericRecord.to_vector`; raw array-likes are ravelled.
+
+    Parameters
+    ----------
+    params : Any
+        A per-draw ``NumericRecord`` / ``NumericRecordArray`` (training and
+        predictive paths) or a flat array-like (the gradient-MCMC path).
+
+    Returns
+    -------
+    Array
+        The 1-D parameter vector.
+    """
+    return params.to_vector() if hasattr(params, "to_vector") else jnp.ravel(jnp.asarray(params))

--- a/tests/inference/test_bayesflow_likelihoods.py
+++ b/tests/inference/test_bayesflow_likelihoods.py
@@ -34,14 +34,7 @@ from probpipe import (
 from probpipe.inference._bayesflow_common import _adapter_field_keys
 from probpipe.modeling import GenerativeLikelihood, Likelihood
 
-
-def _theta_vec(params):
-    """Coerce a per-draw params object to its 1-D vector (mirrors ``_theta_row``).
-
-    Structured records serialize via ``to_vector``; raw array-likes ravel.
-    """
-    return params.to_vector() if hasattr(params, "to_vector") else jnp.ravel(jnp.asarray(params))
-
+from ._bayesflow_helpers import theta_vec
 
 # Conjugate model: theta ~ N(0, I_2), y_i = theta + sigma * eps. With n rows the
 # posterior is N(sum(y) / (n + sigma^2), sigma^2 / (n + sigma^2) I).
@@ -56,7 +49,7 @@ class _ConjugateSim(Likelihood, GenerativeLikelihood):
 
     def generate_data(self, params, num_observations, *, key=None):
         key = key if key is not None else jax.random.PRNGKey(0)
-        t = _theta_vec(params)
+        t = theta_vec(params)
         return t[None, :] + _SIGMA * jax.random.normal(key, (num_observations, t.shape[-1]))
 
 
@@ -237,7 +230,7 @@ class TestSurrogateContract:
 
             def generate_data(self, params, num_observations, *, key=None):
                 key = key if key is not None else jax.random.PRNGKey(0)
-                a = _theta_vec(params)[0]
+                a = theta_vec(params)[0]
                 return a + 0.1 * jax.random.normal(key, (num_observations, 1))
 
         lik = learn_amortized_ratio(
@@ -370,7 +363,7 @@ class TestConditioning:
 
         class _TrueGaussianLik(Likelihood):
             def log_likelihood(self, params, data):
-                t = _theta_vec(params)
+                t = theta_vec(params)
                 t = jnp.ravel(jnp.asarray(t))
                 rows = jnp.atleast_2d(jnp.asarray(data))
                 resid = (rows - t[None, :]) / _SIGMA
@@ -424,7 +417,7 @@ class TestConditioning:
 
             def generate_data(self, params, num_observations, *, key=None):
                 key = key if key is not None else jax.random.PRNGKey(0)
-                lam = _theta_vec(params)[0]
+                lam = theta_vec(params)[0]
                 counts = jax.random.poisson(key, lam, (num_observations, 2))
                 return counts.astype(jnp.float32)
 
@@ -520,7 +513,7 @@ class TestValidation:
 
             def generate_data(self, params, num_observations, *, key=None):
                 key = key if key is not None else jax.random.PRNGKey(0)
-                a = _theta_vec(params)[0]
+                a = theta_vec(params)[0]
                 return a + 0.1 * jax.random.normal(key, (num_observations, 1))
 
         with pytest.raises(ValueError, match="learn_amortized_ratio"):

--- a/tests/inference/test_bayesflow_likelihoods.py
+++ b/tests/inference/test_bayesflow_likelihoods.py
@@ -31,9 +31,17 @@ from probpipe import (
     learn_amortized_likelihood,
     learn_amortized_ratio,
 )
-from probpipe.core._record_array import NumericRecordArray
 from probpipe.inference._bayesflow_common import _adapter_field_keys
 from probpipe.modeling import GenerativeLikelihood, Likelihood
+
+
+def _theta_vec(params):
+    """Coerce a per-draw params object to its 1-D vector (mirrors ``_theta_row``).
+
+    Structured records serialize via ``to_vector``; raw array-likes ravel.
+    """
+    return params.to_vector() if hasattr(params, "to_vector") else jnp.ravel(jnp.asarray(params))
+
 
 # Conjugate model: theta ~ N(0, I_2), y_i = theta + sigma * eps. With n rows the
 # posterior is N(sum(y) / (n + sigma^2), sigma^2 / (n + sigma^2) I).
@@ -48,7 +56,7 @@ class _ConjugateSim(Likelihood, GenerativeLikelihood):
 
     def generate_data(self, params, num_observations, *, key=None):
         key = key if key is not None else jax.random.PRNGKey(0)
-        t = params.flatten()
+        t = _theta_vec(params)
         return t[None, :] + _SIGMA * jax.random.normal(key, (num_observations, t.shape[-1]))
 
 
@@ -188,9 +196,7 @@ class TestSurrogateContract:
         """Structured per-draw records and flat vectors give identical scores
         (the MCMC helper passes flat vectors; predictive paths pass records)."""
         flat = jnp.array([0.4, -0.3])
-        record = NumericRecordArray.unflatten(
-            flat, template=_prior().event_template, batch_shape=()
-        )
+        record = _prior().event_template.from_vector(flat)
         y_row = jnp.array([0.6, -0.1])
         np.testing.assert_allclose(
             float(nle.log_likelihood(flat, y_row)),
@@ -231,7 +237,7 @@ class TestSurrogateContract:
 
             def generate_data(self, params, num_observations, *, key=None):
                 key = key if key is not None else jax.random.PRNGKey(0)
-                a = params.flatten()[0]
+                a = _theta_vec(params)[0]
                 return a + 0.1 * jax.random.normal(key, (num_observations, 1))
 
         lik = learn_amortized_ratio(
@@ -364,7 +370,7 @@ class TestConditioning:
 
         class _TrueGaussianLik(Likelihood):
             def log_likelihood(self, params, data):
-                t = params.flatten() if hasattr(params, "flatten") else params
+                t = _theta_vec(params)
                 t = jnp.ravel(jnp.asarray(t))
                 rows = jnp.atleast_2d(jnp.asarray(data))
                 resid = (rows - t[None, :]) / _SIGMA
@@ -418,7 +424,7 @@ class TestConditioning:
 
             def generate_data(self, params, num_observations, *, key=None):
                 key = key if key is not None else jax.random.PRNGKey(0)
-                lam = params.flatten()[0]
+                lam = _theta_vec(params)[0]
                 counts = jax.random.poisson(key, lam, (num_observations, 2))
                 return counts.astype(jnp.float32)
 
@@ -514,7 +520,7 @@ class TestValidation:
 
             def generate_data(self, params, num_observations, *, key=None):
                 key = key if key is not None else jax.random.PRNGKey(0)
-                a = params.flatten()[0]
+                a = _theta_vec(params)[0]
                 return a + 0.1 * jax.random.normal(key, (num_observations, 1))
 
         with pytest.raises(ValueError, match="learn_amortized_ratio"):

--- a/tests/inference/test_bayesflow_posteriors.py
+++ b/tests/inference/test_bayesflow_posteriors.py
@@ -28,13 +28,7 @@ from probpipe import (
 )
 from probpipe.modeling import GenerativeLikelihood, Likelihood
 
-
-def _theta_vec(params):
-    """Coerce a per-draw params object to its 1-D vector (mirrors ``_theta_row``).
-
-    Structured records serialize via ``to_vector``; raw array-likes ravel.
-    """
-    return params.to_vector() if hasattr(params, "to_vector") else jnp.ravel(jnp.asarray(params))
+from ._bayesflow_helpers import theta_vec
 
 
 class _ToyLikelihood(Likelihood, GenerativeLikelihood):
@@ -46,7 +40,7 @@ class _ToyLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = _theta_vec(params)  # structured record (training) or raw array (direct)
+        t = theta_vec(params)  # structured record (training) or raw array (direct)
         a, b = t[0], t[1]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([a + b, a - b])
@@ -72,7 +66,7 @@ class _VecLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = _theta_vec(params)
+        t = theta_vec(params)
         m0, m1, s = t[0], t[1], t[2]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([m0 + s, m1 - s])
@@ -94,7 +88,7 @@ class _SingleFieldLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = _theta_vec(params)
+        t = theta_vec(params)
         key = key if key is not None else jax.random.PRNGKey(0)
         return t[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
 
@@ -108,7 +102,7 @@ class _NonJaxLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = np.asarray(_theta_vec(params))
+        t = np.asarray(theta_vec(params))
         a, b = float(t[0]), float(t[1])
         seed = 0 if key is None else int(jax.random.randint(key, (), 0, 2**16))
         noise = np.random.default_rng(seed).standard_normal((num_observations, 2))
@@ -123,7 +117,7 @@ class _ScalarLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        a = _theta_vec(params)[0]
+        a = theta_vec(params)[0]
         key = key if key is not None else jax.random.PRNGKey(0)
         return a + 0.1 * jax.random.normal(key, (num_observations, 1))
 
@@ -138,7 +132,7 @@ class _MultiFieldLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = _theta_vec(params)
+        t = theta_vec(params)
         a, b0, b1, c = t[0], t[1], t[2], t[3]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([a + b0, a - b0, b1 + c, b1 - c, a + c, b0 * b1, a, c])
@@ -169,7 +163,7 @@ class _ConjugateGaussianLikelihood(Likelihood, GenerativeLikelihood):
 
     def generate_data(self, params, num_observations, *, key=None):
         key = key if key is not None else jax.random.PRNGKey(0)
-        t = _theta_vec(params)
+        t = theta_vec(params)
         return t[None, :] + _CONJ_SIGMA * jax.random.normal(key, (num_observations, t.shape[-1]))
 
 
@@ -196,7 +190,7 @@ class _PositiveLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = _theta_vec(params)
+        t = theta_vec(params)
         r, m = t[0], t[1]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([r + m, r - m])

--- a/tests/inference/test_bayesflow_posteriors.py
+++ b/tests/inference/test_bayesflow_posteriors.py
@@ -26,8 +26,15 @@ from probpipe import (
     condition_on,
     learn_amortized_posterior,
 )
-from probpipe.core._record_array import NumericRecordArray
 from probpipe.modeling import GenerativeLikelihood, Likelihood
+
+
+def _theta_vec(params):
+    """Coerce a per-draw params object to its 1-D vector (mirrors ``_theta_row``).
+
+    Structured records serialize via ``to_vector``; raw array-likes ravel.
+    """
+    return params.to_vector() if hasattr(params, "to_vector") else jnp.ravel(jnp.asarray(params))
 
 
 class _ToyLikelihood(Likelihood, GenerativeLikelihood):
@@ -39,7 +46,7 @@ class _ToyLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = params.flatten()  # structured record (training) or raw array (direct)
+        t = _theta_vec(params)  # structured record (training) or raw array (direct)
         a, b = t[0], t[1]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([a + b, a - b])
@@ -65,7 +72,7 @@ class _VecLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = params.flatten()
+        t = _theta_vec(params)
         m0, m1, s = t[0], t[1], t[2]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([m0 + s, m1 - s])
@@ -87,7 +94,7 @@ class _SingleFieldLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = params.flatten()
+        t = _theta_vec(params)
         key = key if key is not None else jax.random.PRNGKey(0)
         return t[None, :] + 0.1 * jax.random.normal(key, (num_observations, 2))
 
@@ -101,7 +108,7 @@ class _NonJaxLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = np.asarray(params.flatten())
+        t = np.asarray(_theta_vec(params))
         a, b = float(t[0]), float(t[1])
         seed = 0 if key is None else int(jax.random.randint(key, (), 0, 2**16))
         noise = np.random.default_rng(seed).standard_normal((num_observations, 2))
@@ -116,7 +123,7 @@ class _ScalarLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        a = params.flatten()[0]
+        a = _theta_vec(params)[0]
         key = key if key is not None else jax.random.PRNGKey(0)
         return a + 0.1 * jax.random.normal(key, (num_observations, 1))
 
@@ -131,7 +138,7 @@ class _MultiFieldLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = params.flatten()
+        t = _theta_vec(params)
         a, b0, b1, c = t[0], t[1], t[2], t[3]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([a + b0, a - b0, b1 + c, b1 - c, a + c, b0 * b1, a, c])
@@ -162,7 +169,7 @@ class _ConjugateGaussianLikelihood(Likelihood, GenerativeLikelihood):
 
     def generate_data(self, params, num_observations, *, key=None):
         key = key if key is not None else jax.random.PRNGKey(0)
-        t = params.flatten()
+        t = _theta_vec(params)
         return t[None, :] + _CONJ_SIGMA * jax.random.normal(key, (num_observations, t.shape[-1]))
 
 
@@ -189,7 +196,7 @@ class _PositiveLikelihood(Likelihood, GenerativeLikelihood):
         return jnp.array(0.0)
 
     def generate_data(self, params, num_observations, *, key=None):
-        t = params.flatten()
+        t = _theta_vec(params)
         r, m = t[0], t[1]
         key = key if key is not None else jax.random.PRNGKey(0)
         mean = jnp.stack([r + m, r - m])
@@ -226,11 +233,9 @@ class _NestedLikelihood(Likelihood, GenerativeLikelihood):
 
 def _nested_observe(r, m, c, seed):
     """Observe ``_NestedLikelihood`` at a given (r, m, c) by building the nested
-    per-draw record via ``unflatten`` (flatten order ``[r, m, c]``) -- the same
+    per-draw record via ``from_vector`` (leaf order ``[r, m, c]``) -- the same
     structured object the offline simulator passes the simulator at train time."""
-    rec = NumericRecordArray.unflatten(
-        jnp.array([r, m, c]), template=_nested_prior().event_template, batch_shape=()
-    )
+    rec = _nested_prior().event_template.from_vector(jnp.array([r, m, c]))
     return _NestedLikelihood().generate_data(rec, 1, key=jax.random.PRNGKey(seed))[0]
 
 

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -327,9 +327,9 @@ class TestApproximateDistributionValuesTemplate:
             mean=(3,),
             cov=(2, 2),
         )
-        flat_size = 3 + 4  # 3 + 2*2
-        chain = jax.random.normal(jax.random.PRNGKey(0), (20, flat_size))
-        prior = MultivariateNormal(loc=jnp.zeros(flat_size), cov=jnp.eye(flat_size), name="z")
+        vector_size = 3 + 4  # 3 + 2*2
+        chain = jax.random.normal(jax.random.PRNGKey(0), (20, vector_size))
+        prior = MultivariateNormal(loc=jnp.zeros(vector_size), cov=jnp.eye(vector_size), name="z")
         post = make_posterior(
             [chain],
             parents=(prior,),
@@ -365,9 +365,9 @@ class TestApproximateDistributionValuesTemplate:
             params=EventTemplate(a=(), b=()),
             scale=(),
         )
-        flat_size = 3  # a + b + scale
-        chain = jax.random.normal(jax.random.PRNGKey(0), (30, flat_size))
-        prior = MultivariateNormal(loc=jnp.zeros(flat_size), cov=jnp.eye(flat_size), name="z")
+        vector_size = 3  # a + b + scale
+        chain = jax.random.normal(jax.random.PRNGKey(0), (30, vector_size))
+        prior = MultivariateNormal(loc=jnp.zeros(vector_size), cov=jnp.eye(vector_size), name="z")
         post = make_posterior(
             [chain],
             parents=(prior,),
@@ -387,7 +387,7 @@ class TestApproximateDistributionValuesTemplate:
         With Option B's per-top-level-field split, every accessor on
         ``ApproximateDistribution`` is keyed by the user-supplied
         template's top-level fields. Nested ``EventTemplate`` fields
-        are stored as a flat ``(n, nested_flat_size)`` slice under the
+        are stored as a flat ``(n, nested_vector_size)`` slice under the
         top-level field name; the nested structure is recoverable via
         ``event_template[field]`` and ``draws()``.
         """
@@ -395,11 +395,11 @@ class TestApproximateDistributionValuesTemplate:
             params=EventTemplate(a=(), b=()),
             scale=(),
         )
-        flat_size = 3  # a + b + scale
-        chain = jax.random.normal(jax.random.PRNGKey(0), (40, flat_size))
+        vector_size = 3  # a + b + scale
+        chain = jax.random.normal(jax.random.PRNGKey(0), (40, vector_size))
         prior = MultivariateNormal(
-            loc=jnp.zeros(flat_size),
-            cov=jnp.eye(flat_size),
+            loc=jnp.zeros(vector_size),
+            cov=jnp.eye(vector_size),
             name="z",
         )
         post = make_posterior(
@@ -444,7 +444,7 @@ class TestApproximateDistributionValuesTemplate:
         assert draws["params"]["b"].shape == (40,)
         assert draws["scale"].shape == (40,)
         # ``flat_samples`` view is the (n, total_dim) matrix.
-        assert post.flat_samples.shape == (40, flat_size)
+        assert post.flat_samples.shape == (40, vector_size)
 
     def test_without_warmup(self):
         chain = jax.random.normal(jax.random.PRNGKey(0), (20, 3))
@@ -1047,8 +1047,8 @@ class TestRecordDistributionProperties:
         assert posterior.event_shapes == {"K": (), "phi": (), "r": ()}
 
     def test_record_distribution_event_size(self, posterior, template):
-        """``event_size`` matches template.flat_size."""
-        assert posterior.event_size == template.flat_size
+        """``event_size`` matches template.vector_size."""
+        assert posterior.event_size == template.vector_size
 
 
 class TestValuesSelect:

--- a/tests/inference/test_inference_utils.py
+++ b/tests/inference/test_inference_utils.py
@@ -16,7 +16,6 @@ from probpipe import (
     SimpleModel,
 )
 from probpipe.core._distribution_base import Distribution
-from probpipe.core._numeric_record import NumericRecord
 from probpipe.core.protocols import SupportsSampling
 from probpipe.inference._inference_utils import (
     as_prng_key,
@@ -80,7 +79,7 @@ class TestBuildTargetLogProbFlat:
         )
         # Round-trip: unflatten the flat init back to a Record and confirm
         # the two callables agree.
-        record_init = NumericRecord.unflatten(flat_init, template=template)
+        record_init = template.from_vector(flat_init)
         np.testing.assert_allclose(
             float(target_flat(flat_init)),
             float(target_record(record_init)),
@@ -88,13 +87,13 @@ class TestBuildTargetLogProbFlat:
             atol=1e-6,
         )
 
-    def test_flat_init_dim_matches_template_flat_size(self, small_model):
+    def test_flat_init_dim_matches_template_vector_size(self, small_model):
         _, flat_init, template = build_target_log_prob_flat(
             small_model,
             observed=None,
         )
-        # Both fields are scalar Normals: flat_size == 2.
-        assert flat_init.shape == (template.flat_size,) == (2,)
+        # Both fields are scalar Normals: vector_size == 2.
+        assert flat_init.shape == (template.vector_size,) == (2,)
 
     def test_template_field_order_preserved(self, small_model):
         _, _, template = build_target_log_prob_flat(small_model, observed=None)


### PR DESCRIPTION
## PR-1d — Consolidate 1-D (de)serialization: `flatten`/`unflatten` → JAX-pytree; `flat_size` → `vector_size`

Fourth slice of Phase 1 of #235 (follows #292, #308, #311 — all merged). **Breaking.** It closes the
duplication that #311 deliberately left behind, finishing the *numeric-vector* vs *JAX-pytree*
vocabulary split. Scope is set by **@arob5's 2026-06-22 comment on #235** (the three "PR-1d" to-dos)
plus the consumer migration they require.

> **Read `CONTRACTS.md` (on `main`) first.** This is a breaking, contract-heavy PR. Per CONTRACTS.md
> directive 1, **pin the contract decisions below *before* implementing** (and record them here);
> per directive 2, document the repurposed contracts fully in docstrings; complete the per-PR
> checklist. This is the first breaking slice since #292 — the consumer audit is the critical part.

### Scope
**(1) Repurpose `flatten`/`unflatten` to the JAX-pytree meaning.** Today the *methods*
`NumericRecord.flatten()` (`probpipe/core/_numeric_record.py:195`), `NumericRecordArray.flatten()`
(`probpipe/core/_record_array.py:440`), and their `unflatten` counterparts (`:211` / `:464`)
return/consume a **1-D vector**. That 1-D meaning now lives entirely in `to_vector`/`from_vector`
(#311). Repurpose `flatten`/`unflatten` to the **JAX-pytree** operation (`value → (leaves, aux)` /
`(leaves, aux) → value`, à la `jax.tree_util.tree_flatten`/`tree_unflatten`), defined for *any* leaf
type — not just numeric.

**(2) Collapse `to_vector`/`flatten` duplication.** Refactor `EventTemplate.to_vector` to delegate
to the repurposed `flatten` (ravel + concatenate the pytree leaves) instead of calling
`jax.tree_util.tree_leaves` inline, so leaf traversal lives in one place.

**(3) Collapse `from_vector`/`unflatten` duplication (symmetric).** Refactor
`EventTemplate.from_vector` to rebuild the numeric leaves via the repurposed `unflatten` (then weave
in `non_numeric` for the mixed case) instead of its standalone `offset`-walk, so leaf reconstruction
lives in one place.

**(4) Rename `flat_size` → `vector_size`.** **105 occurrences across 14 files** (6 source, 8 test):
3 public properties (`NumericEventTemplate.flat_size`, `NumericRecord.flat_size`,
`NumericRecordDistribution.flat_size`) + private `_flat_size` slots / `_compute_flat_size`.
`vector_size` is the length of the `to_vector`/`from_vector` 1-D representation; a *batch* is a
matrix `(*batch_shape, vector_size)`, **not** a single vector — state this in the docstring. Review
the non-mechanical `nested_flat_size` comments in `_approximate_distribution.py`.

**(5) Migrate consumers** of the old 1-D `flatten`/`unflatten` + legacy static machinery to the new
API. Audit with `git grep`; known areas: the legacy statics
`NumericRecordDistribution.flatten_value`/`unflatten_value`/`event_size`/`as_flat_distribution`
(`probpipe/core/_numeric_record_distribution.py:490–557`); the inference flatten/unflatten-sample
path (`probpipe/inference/_inference_utils.py`); `distributions/kde.py`;
`inference/_approximate_distribution.py`; `modeling/_pymc.py`. Anything calling `.flatten()` for the
1-D vector → `to_vector`; `.unflatten(vec, …)` → `from_vector`.

### Contract decisions to pin BEFORE implementing (record them in this PR)
- **`flatten()` signature:** mirror `jax.tree_util.tree_flatten` → `(leaves, aux)` with
  `unflatten(leaves, aux) → value`? (Pick the JAX-aligned form and state it precisely.)
- **Keep vs drop the methods:** the #235 comment's intent is to *keep* `flatten`/`unflatten` as the
  one place leaf-traversal lives and have `to_vector`/`from_vector` delegate to them — confirm, vs.
  callers using `jax.tree_util.*` directly.
- **`flat_size` → `vector_size`:** hard rename in-repo; add a deprecation alias only if external code
  depends on `flat_size`.
- **Legacy statics** (`flatten_value`/`unflatten_value`/`event_size`/`as_flat_distribution`): remove
  or repoint? `event_size` ≡ `vector_size`; `as_flat_distribution` / `FlatNumericRecordDistribution`
  is used by inference — likely repoint (not remove) so inference keeps working. Decide explicitly.
- **The old 1-D `flatten()` is going away** as a 1-D op — confirm every caller is migrated to
  `to_vector`/`from_vector` (no stragglers expecting a vector from `.flatten()`).

### Out of scope (do NOT do here)
- `make_batch` / `vectorize` (later, with the `Batch` ABC).
- `*Array → *Batch` rename; the `Tracked` / `Annotated` mixins (Phase 2).
- The **mixin / naming-contract discussion** in the *other* (June-18) #235 comments — that is Phase 2;
  do not start it here.

### Definition of done
- `flatten`/`unflatten` carry the JAX-pytree meaning, with docstrings that state the precise
  distinction from `to_vector`/`from_vector` (CONTRACTS.md directive 5 — keep the vocabulary split
  intact and self-contained, no PR/issue refs in docstrings).
- `to_vector`/`from_vector` delegate to `flatten`/`unflatten` (no inline `tree_leaves`, no standalone
  reconstruction); behavior unchanged — the #311 `to_vector`/`from_vector` tests pass *as-is* (the
  regression guard).
- `flat_size` → `vector_size` everywhere; `vector_size` semantics documented; `nested_flat_size`
  comments reviewed.
- All consumers migrated; full suite green; **`ruff format` and `ruff check` both clean** (blocking).
- Naming consistent with CONTRACTS.md (`vector_size`, `vec`, `value`, `non_numeric`); per-PR
  checklist completed in this description.

### Tests
- The #311 `to_vector`/`from_vector` tests pass **unchanged** (round-trip / order / errors /
  nested / multi-axis batched / `non_numeric`) — proves the delegation refactor preserved behavior.
- `flatten`/`unflatten` pytree round-trip on `Record` / `NumericRecord` / mixed templates, including
  **opaque leaves** (the pytree op is defined for any leaf type, unlike `to_vector`).
- `vector_size` returns the same values the old `flat_size` did (behavior-preserving rename),
  including the batched matrix shape `(*batch_shape, vector_size)`.
- Consumer-path regression: inference (numeric flatten/unflatten-sample), kde, approximate
  distribution still work end-to-end.

Rationale: #235 Chapter 1 + §7 and @arob5's PR-1d comment. Removes the temporary duplication #311
introduced and completes the numeric-vs-pytree vocabulary split.

---
*Draft/handoff PR — implemented by a separate session per this brief and `CONTRACTS.md`.*


---

## PINNED CONTRACT DECISIONS (resolved before coding, per CONTRACTS.md directive 1)

**1. `flatten` / `unflatten` signature — JAX-aligned, whole-tree.**
`flatten`/`unflatten` become the general JAX-pytree ops, defined on the **`Record` base**
(inherited by `NumericRecord`, `RecordArray`, `NumericRecordArray`) so they work for **any** leaf
type (numeric or opaque):
- `record.flatten() -> (leaves, aux)` ≡ `jax.tree_util.tree_flatten(record)` — the value's pytree
  leaves in canonical leaf order plus the `PyTreeDef` (`aux`). Whole-tree (recurses through nested
  records), not single-node.
- `Record.unflatten(leaves, aux) -> value` (staticmethod) ≡ `jax.tree_util.tree_unflatten(aux, leaves)`.
  Arg order is `(leaves, aux)` per the contract; `aux` is the `PyTreeDef` from `flatten`.
- Round-trip: `Record.unflatten(*record.flatten()) == record`.

**2. Keep-and-delegate; the old 1-D methods are dropped.** The old 1-D
`NumericRecord.flatten/unflatten` and `NumericRecordArray.flatten/unflatten` are **removed** (their
1-D meaning now lives solely in `to_vector`/`from_vector`). `EventTemplate.to_vector` delegates to
`value.flatten()` (ravel + concat the pytree leaves); `EventTemplate.from_vector` slices `vec` into
the ordered leaves and delegates assembly to `unflatten` (treedef derived from the template), so
leaf traversal and reconstruction each live in one place. No inline `tree_leaves`, no standalone
offset-walk reconstruction.

**3. Ergonomic `to_vector()` instance method.** `NumericRecord.to_vector()` /
`NumericRecordArray.to_vector()` are added as the instance-level convenience that replaces the old
`value.flatten()` 1-D ergonomic (they delegate to their event template's `to_vector`). The
structural op remains on `EventTemplate`; `from_vector` stays a template classmethod (no value to
bind to).

**4. `flat_size` → `vector_size` — hard rename, no alias.** All 3 public properties
(`NumericEventTemplate`, `NumericRecord`, `FlatNumericRecordDistribution`) + private
`_flat_size` slots + `_compute_flat_size` are renamed in-repo. No deprecation alias (no external
dependence known; repo-internal only). `vector_size` = length of the per-element 1-D vector; a
batch is a matrix `(*batch_shape, vector_size)` — stated in the docstrings. `nested_flat_size`
comments in `_approximate_distribution.py` reworded to `nested vector_size`.

**5. Legacy statics — repoint, do not remove.**
- `as_flat_distribution` / `FlatNumericRecordDistribution`: **kept** (the documented inference
  interop; reached via `getattr` in `_inference_utils.py`). `FlatNumericRecordDistribution.flat_size`
  → `vector_size` (the item-4 rename).
- `flatten_value` / `unflatten_value`: **kept as raw-array-aware adapters** but **repointed** onto
  `to_vector`/`from_vector` internally (they previously called the now-removed 1-D `.flatten()` /
  `.unflatten()`). They handle raw arrays and the single-field "return raw array" contract that
  `to_vector`/`from_vector` do not, so deleting them would push that handling into every view + kde.
  The 1-D logic now flows through `to_vector`/`from_vector` in one place.
- `event_size`: **kept** (not part of the item-4 `flat_size` rename; it is the base
  `NumericRecordDistribution`'s per-sample scalar count and is valid for non-flat NRDs where a
  `vector_size` property does not exist). Computed from the event template as before.

**6. All callers of the removed 1-D `.flatten()`/`.unflatten()` migrated.** Direct callers
(`NumericRecord(Array).unflatten(flat, template=...)` → `template.from_vector(flat)`;
`value.flatten()` → `value.to_vector()` / `template.to_vector(value)`) migrated across
`_record_distribution.py`, `_approximate_distribution.py`, `_bayesflow_common.py`,
`_bayesflow_likelihoods.py`, `_inference_utils.py`, `kde.py`, and the distribution-view methods.
Special care taken where `hasattr(x, "flatten")` previously discriminated 1-D — those sites now test
the Record types explicitly so the new pytree `flatten` is never mistaken for the 1-D vector.

### CONTRACTS.md per-PR checklist
- [x] Contract of every touched abstraction was clear before coding (ambiguities resolved & noted above).
- [x] New/changed contracts fully documented in docstrings (types, shapes, orderings, raises, invariants).
- [x] Code verified to obey the documented contract; tests assert it (shapes + orderings + error cases).
- [x] Docstrings describe the plan's **target** contract/terminology, not stale neighboring code; interim coexistence labeled.
- [x] Variable names consistent with the canonical table (`vector_size`, `vec`, `value`, `non_numeric`).
- [x] `CONTRACTS.md` index updated if a cross-cutting contract changed (no index change needed — locations unchanged).
- [x] `ruff format` and `ruff check` clean (both blocking in CI).

> Note on the #311 regression guard: the #311 `to_vector`/`from_vector` tests keep their behavioral
> assertions **unchanged**; only the `flat_size` → `vector_size` token is updated where they
> reference the renamed property (the rename is item 4 and unavoidably touches those references).
