### PR TITLE
feat(core): add stable content fingerprinting for provenance parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ParentInfo` descriptor** (new public export).  A frozen dataclass carrying
   `type_name`, `name`, `source` (the parent's own `Provenance`, kept in all
   non-OFF modes so the ancestry DAG remains traversable), `fingerprint`
-  (reserved for a future caching layer), and `obj` (the live parent object,
-  set only in FULL mode).
+  (a 16-character stable content hash — see below), and `obj` (the live parent
+  object, set only in FULL mode).
+
+- **`ParentInfo.fingerprint` — stable content hashing for provenance parents.**
+  Every `ParentInfo` descriptor now carries a `fingerprint: str` — a
+  16-character hex digest (64-bit SHA-256 prefix) that stably identifies the
+  parent's content across processes.  The hash covers the full value: numeric
+  parameters for TFP-backed distributions, field-by-field content for Records,
+  and actual user-function bytecode for WorkflowFunctions (not the Prefect
+  wrapper closure, so changes to the function body are detected reliably).
+  Large arrays (> 1 MB) are sampled at evenly-spaced offsets rather than read
+  in full.  The fingerprint is visible in `to_dict()` output and is the
+  foundation for a future Prefect `cache_key_fn` that will enable cross-run
+  task caching and failure recovery.
 
 - **`Provenance.create()` factory classmethod.**  Centralises mode-checking:
   reads `provenance_config.mode`, wraps each parent in a `ParentInfo`, and

--- a/docs/api/provenance.md
+++ b/docs/api/provenance.md
@@ -84,6 +84,37 @@ assert any(a.obj is prior for a in ancestors)
 ancestors[0].obj.sample(key, (10,))
 ```
 
+## Content fingerprints
+
+Every `ParentInfo` descriptor carries a `fingerprint` — a 16-character hex
+string that stably identifies the parent's content across processes.  It is
+populated automatically by `Provenance.create()` and visible in `to_dict()`
+output:
+
+```python
+prior = Normal(loc=0.0, scale=1.0, name="prior")
+posterior = wf(prior)
+
+anc = provenance_ancestors(posterior)[0]
+print(anc.fingerprint)   # e.g. "8d86780c50cea472"
+
+d = posterior.source.to_dict()
+print(d["parents"][0]["fingerprint"])   # same digest
+```
+
+The fingerprint covers the full content of the parent:
+
+| Parent type | What is hashed |
+|---|---|
+| TFP-backed distribution (`Normal`, `Gamma`, …) | class name + distribution name + all TFP constructor parameters |
+| `EmpiricalDistribution` | class name + name + sample arrays |
+| `Record` | field names + values, recursively |
+| `WorkflowFunction` | user function bytecode (not the Prefect wrapper closure) |
+| JAX / NumPy array | shape + dtype + raw bytes (large arrays are sampled) |
+
+The fingerprint is intended as the foundation for a future Prefect
+`cache_key_fn` that will enable cross-run task caching and failure recovery.
+
 ## API reference
 
 ::: probpipe.ProvenanceMode

--- a/docs/api/provenance.md
+++ b/docs/api/provenance.md
@@ -107,7 +107,7 @@ The fingerprint covers the full content of the parent:
 | Parent type | What is hashed |
 |---|---|
 | TFP-backed distribution (`Normal`, `Gamma`, …) | class name + distribution name + all TFP constructor parameters |
-| `EmpiricalDistribution` | class name + name + sample arrays |
+| `EmpiricalDistribution` | class name + name + sample arrays + log-normalised weight array |
 | `Record` | field names + values, recursively |
 | `WorkflowFunction` | user function bytecode (not the Prefect wrapper closure) |
 | JAX / NumPy array | shape + dtype + raw bytes (large arrays are sampled) |

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -7,7 +7,8 @@ same inputs.  Intended for provenance tracking (populating
 
 Supported types
 ---------------
-- ``jax.Array`` / ``numpy.ndarray`` — shape + dtype + bytes (capped at 1 MB)
+- ``jax.Array`` / ``numpy.ndarray`` — shape + dtype + bytes (up to
+  ``max_array_bytes``; sampled beyond that)
 - Python scalars (``int``, ``float``, ``bool``, ``str``, ``None``)
 - ``Record`` — field names + values, hashed recursively
 - ``Distribution`` — class name + distribution name + numeric parameters
@@ -16,6 +17,21 @@ Supported types
 
 All imports of ProbPipe types are deferred to call time so this module can
 be imported early in the package without triggering circular-import issues.
+
+Notes
+-----
+**Collision semantics:** the digest is a 64-bit prefix of SHA-256.  At
+ProbPipe scale a collision is negligible in probability, but when one does
+occur it produces a *wrong cached result*, not a cache miss.
+
+**JAX x64 mode:** ``str(dtype)`` is used for array dtype, so digests for
+the same array differ between ``jax_enable_x64=False`` (default, float32)
+and ``jax_enable_x64=True`` (float64).  Digests are stable within a fixed
+JAX configuration.
+
+**Python version portability:** bytecode (``WorkflowFunction``) is not
+portable across Python minor versions — a 3.12-compiled digest differs from
+a 3.13 one for the same source.
 """
 
 from __future__ import annotations
@@ -26,13 +42,25 @@ from typing import Any
 
 __all__ = ["fingerprint"]
 
-# Arrays larger than this threshold are hashed by sampling bytes at
-# evenly-spaced offsets instead of reading the whole buffer.  1 MB is
-# large enough that most parameter arrays are hashed completely.
-_FULL_HASH_BYTES = 1 << 20  # 1 MB
+import numpy as _np
+
+try:
+    import jax as _jax
+
+    _JAX_ARRAY_TYPE = _jax.Array
+except ImportError:
+    _JAX_ARRAY_TYPE = type(None)  # type: ignore[assignment,misc]
+
+_NP_ARRAY_TYPE = _np.ndarray
+
+# Default cap: arrays up to 256 MB are hashed in full (zero-copy via
+# memoryview).  Arrays beyond this are sampled at evenly-spaced offsets so
+# large posteriors are still discriminated without a full buffer read.
+# Pass ``max_array_bytes=None`` to always hash the full buffer.
+_DEFAULT_MAX_ARRAY_BYTES: int = 256 << 20  # 256 MB
 
 
-def fingerprint(obj: Any) -> str:
+def fingerprint(obj: Any, *, max_array_bytes: int | None = _DEFAULT_MAX_ARRAY_BYTES) -> str:
     """Return a 16-character hex digest that stably identifies *obj*'s content.
 
     The digest is deterministic within a Python session and across processes
@@ -44,6 +72,11 @@ def fingerprint(obj: Any) -> str:
     obj:
         Any ProbPipe object or Python primitive.  Unknown types fall back
         to a ``repr()``-based hash.
+    max_array_bytes:
+        Arrays whose byte size is at or below this threshold are hashed in
+        full (zero-copy via ``memoryview``).  Larger arrays are sampled at
+        evenly-spaced offsets.  Pass ``None`` to always hash the full buffer.
+        Default: 256 MB.
 
     Returns
     -------
@@ -51,7 +84,7 @@ def fingerprint(obj: Any) -> str:
         A 16-character hex string (64-bit prefix of a SHA-256 digest).
     """
     h = hashlib.sha256()
-    _update(h, obj, depth=0)
+    _update(h, obj, depth=0, max_array_bytes=max_array_bytes)
     return h.hexdigest()[:16]
 
 
@@ -60,35 +93,26 @@ def fingerprint(obj: Any) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _update(h: hashlib._Hash, obj: Any, depth: int) -> None:
+def _update(h: hashlib._Hash, obj: Any, depth: int, max_array_bytes: int | None) -> None:
     if depth > 32:
         h.update(b"[max_depth]")
         return
 
-    import numpy as np
-
-    try:
-        import jax
-
-        _jax_array = jax.Array
-    except ImportError:
-        _jax_array = type(None)
-
-    if isinstance(obj, (np.ndarray, _jax_array)):
-        _update_array(h, obj)
+    if isinstance(obj, (_NP_ARRAY_TYPE, _JAX_ARRAY_TYPE)):
+        _update_array(h, obj, max_array_bytes)
     elif _is_record(obj):
-        _update_record(h, obj, depth)
+        _update_record(h, obj, depth, max_array_bytes)
     elif _is_distribution(obj):
-        _update_distribution(h, obj, depth)
+        _update_distribution(h, obj, depth, max_array_bytes)
     elif _is_workflow_function(obj):
-        _update_workflow_function(h, obj)
+        _update_workflow_function(h, obj, max_array_bytes)
     elif isinstance(obj, bool):
         # bool before int — bool is a subclass of int
         h.update(b"bool:")
         h.update(b"1" if obj else b"0")
     elif isinstance(obj, int):
         h.update(b"int:")
-        h.update(struct.pack(">q", obj))
+        h.update(str(obj).encode())
     elif isinstance(obj, float):
         h.update(b"float:")
         h.update(struct.pack(">d", obj))
@@ -102,13 +126,15 @@ def _update(h: hashlib._Hash, obj: Any, depth: int) -> None:
         h.update(tag)
         h.update(struct.pack(">I", len(obj)))
         for item in obj:
-            _update(h, item, depth + 1)
+            _update(h, item, depth + 1, max_array_bytes)
     elif isinstance(obj, dict):
         h.update(b"dict:")
         h.update(struct.pack(">I", len(obj)))
         for k, v in sorted(obj.items(), key=lambda kv: str(kv[0])):
-            _update(h, k, depth + 1)
-            _update(h, v, depth + 1)
+            _update(h, k, depth + 1, max_array_bytes)
+            _update(h, v, depth + 1, max_array_bytes)
+    elif _is_tfp_object(obj):
+        _update_tfp_object(h, obj, depth, max_array_bytes)
     else:
         h.update(b"repr:")
         h.update(repr(obj)[:500].encode())
@@ -119,36 +145,66 @@ def _update(h: hashlib._Hash, obj: Any, depth: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _update_array(h: hashlib._Hash, arr: Any) -> None:
-    """Hash an array by shape, dtype, and content bytes."""
-    import numpy as np
+def _update_array(h: hashlib._Hash, arr: Any, max_bytes: int | None) -> None:
+    """Hash an array by shape, dtype, and content bytes.
 
-    # Normalise to a numpy array for a uniform bytes() interface.
-    # For large JAX arrays this triggers a device→host transfer; that is
-    # acceptable here since fingerprinting happens at provenance-creation
-    # time, not inside a JIT-compiled function.
+    For large JAX arrays, ``np.asarray`` triggers a device→host transfer.
+    That is acceptable here — fingerprinting happens at provenance-creation
+    time, not inside a JIT-compiled function.
+    """
     try:
-        arr_np = np.asarray(arr)
+        buf = _np.ascontiguousarray(_np.asarray(arr))
     except Exception:
         h.update(b"array:unreadable")
         return
 
-    h.update(b"array:")
-    h.update(str(arr_np.shape).encode())
-    h.update(b":")
-    h.update(str(arr_np.dtype).encode())
-    h.update(b":")
+    h.update(f"array:{buf.shape}:{buf.dtype}:".encode())
 
-    raw = arr_np.tobytes()
-    if len(raw) <= _FULL_HASH_BYTES:
-        h.update(raw)
+    if max_bytes is None or buf.nbytes <= max_bytes:
+        # Full hash, zero-copy: memoryview avoids an extra .tobytes() copy.
+        h.update(memoryview(buf).cast("B"))
     else:
-        # Sample 16 evenly-spaced 256-byte windows so large arrays are still
-        # discriminated without reading the full buffer.
-        step = max(1, len(raw) // 16)
-        for i in range(0, len(raw), step):
-            h.update(raw[i : i + 256])
-        h.update(struct.pack(">Q", len(raw)))
+        # Sample ~16 evenly-spaced windows directly from the contiguous
+        # buffer view — O(sample) slices, no full copy.
+        view = memoryview(buf).cast("B")
+        n = len(view)
+        window = max(1, max_bytes // 16)
+        step = max(1, n // 16)
+        for i in range(0, n, step):
+            h.update(view[i : i + window])
+        h.update(struct.pack(">Q", n))
+
+
+# ---------------------------------------------------------------------------
+# TFP-native object hashing (nested distributions, bijectors)
+# ---------------------------------------------------------------------------
+
+
+def _is_tfp_object(obj: Any) -> bool:
+    """Return True for TFP-native distributions and bijectors.
+
+    Detected by duck-typing: they carry a ``parameters`` dict and expose
+    ``log_prob`` (distributions) or ``forward`` (bijectors).  This avoids
+    an explicit TFP import and lets the check degrade gracefully if TFP is
+    not installed.
+    """
+    params = getattr(obj, "parameters", None)
+    if not isinstance(params, dict):
+        return False
+    return hasattr(obj, "log_prob") or hasattr(obj, "forward")
+
+
+def _update_tfp_object(h: hashlib._Hash, obj: Any, depth: int, max_array_bytes: int | None) -> None:
+    """Hash a TFP-native distribution or bijector by type and parameters."""
+    h.update(b"tfp:")
+    h.update(type(obj).__name__.encode())
+    h.update(b":")
+    params = getattr(obj, "parameters", {}) or {}
+    for k, v in sorted(params.items()):
+        h.update(k.encode())
+        h.update(b"=")
+        _update(h, v, depth + 1, max_array_bytes)
+        h.update(b";")
 
 
 # ---------------------------------------------------------------------------
@@ -165,7 +221,7 @@ def _is_record(obj: Any) -> bool:
         return False
 
 
-def _update_record(h: hashlib._Hash, record: Any, depth: int) -> None:
+def _update_record(h: hashlib._Hash, record: Any, depth: int, max_array_bytes: int | None) -> None:
     """Hash a Record field-by-field in insertion order."""
     h.update(b"record:")
     h.update(type(record).__name__.encode())
@@ -173,7 +229,7 @@ def _update_record(h: hashlib._Hash, record: Any, depth: int) -> None:
     for field in record.fields:
         h.update(field.encode())
         h.update(b"=")
-        _update(h, record[field], depth + 1)
+        _update(h, record[field], depth + 1, max_array_bytes)
         h.update(b";")
 
 
@@ -191,7 +247,9 @@ def _is_distribution(obj: Any) -> bool:
         return False
 
 
-def _update_distribution(h: hashlib._Hash, dist: Any, depth: int) -> None:
+def _update_distribution(
+    h: hashlib._Hash, dist: Any, depth: int, max_array_bytes: int | None
+) -> None:
     """Hash a distribution by class name, distribution name, and parameters.
 
     For TFP-backed distributions (those with a ``_tfp_dist`` attribute) the
@@ -208,23 +266,41 @@ def _update_distribution(h: hashlib._Hash, dist: Any, depth: int) -> None:
     h.update(b":")
 
     tfp_dist = getattr(dist, "_tfp_dist", None)
+    samples = getattr(dist, "_samples", None)
+
     if tfp_dist is not None:
         params = getattr(tfp_dist, "parameters", {}) or {}
+        # Skip construction flags and the name (already hashed above).
+        _TFP_SKIP = frozenset({"name", "validate_args", "allow_nan_stats"})
         for k, v in sorted(params.items()):
+            if k in _TFP_SKIP:
+                continue
             h.update(k.encode())
             h.update(b"=")
-            _update(h, v, depth + 1)
+            _update(h, v, depth + 1, max_array_bytes)
             h.update(b";")
+    elif samples is not None:
+        # EmpiricalDistribution / RecordEmpiricalDistribution: hash the
+        # sample data and weight array explicitly so reweighted posteriors
+        # (IS/SMC) are distinguished from the original.
+        h.update(b"samples=")
+        _update(h, samples, depth + 1, max_array_bytes)
+        w = getattr(dist, "_w", None)
+        log_w = getattr(w, "log_normalized", None)
+        h.update(b"log_weights=")
+        if log_w is not None:
+            _update(h, log_w, depth + 1, max_array_bytes)
+        else:
+            h.update(b"uniform")
     else:
-        # Non-TFP distribution: hash public attributes that look numeric or
-        # array-like, skipping framework internals.
+        # Generic fallback for other non-TFP distributions.
         _SKIP = frozenset({"_name", "_source", "_auxiliary", "_sampling_cost"})
         for attr, val in sorted(vars(dist).items()):
             if attr in _SKIP or attr.startswith("__"):
                 continue
             h.update(attr.encode())
             h.update(b"=")
-            _update(h, val, depth + 1)
+            _update(h, val, depth + 1, max_array_bytes)
             h.update(b";")
 
 
@@ -242,7 +318,26 @@ def _is_workflow_function(obj: Any) -> bool:
         return False
 
 
-def _update_workflow_function(h: hashlib._Hash, wf: Any) -> None:
+def _hash_code(h: hashlib._Hash, code: Any, max_array_bytes: int | None) -> None:
+    """Recursively hash a code object without repr-ing nested code objects.
+
+    ``repr(code.co_consts)`` embeds memory addresses for any nested ``def``,
+    ``lambda``, or generator — making the digest process-dependent.  Instead
+    we walk ``co_consts`` and recurse into nested code objects directly.
+    ``co_filename`` and ``co_firstlineno`` are intentionally excluded: they
+    are machine- and position-dependent and defeat cross-machine caching.
+    """
+    import types
+
+    h.update(code.co_code)
+    for c in code.co_consts:
+        if isinstance(c, types.CodeType):
+            _hash_code(h, c, max_array_bytes)
+        else:
+            _update(h, c, 0, max_array_bytes)
+
+
+def _update_workflow_function(h: hashlib._Hash, wf: Any, max_array_bytes: int | None) -> None:
     """Hash a WorkflowFunction by its user function's bytecode.
 
     Hashes ``_func.__code__`` directly rather than the Prefect task-wrapper
@@ -260,10 +355,4 @@ def _update_workflow_function(h: hashlib._Hash, wf: Any) -> None:
         h.update(repr(func)[:200].encode())
         return
 
-    h.update(code.co_code)
-    # co_consts captures literal values in the function body (strings,
-    # numbers, nested code objects).  Stringifying avoids hashing nested
-    # code objects recursively, which would require special casing.
-    h.update(repr(code.co_consts).encode())
-    h.update(code.co_filename.encode())
-    h.update(struct.pack(">I", code.co_firstlineno))
+    _hash_code(h, code, max_array_bytes)

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -1,0 +1,269 @@
+"""Stable content hashing for ProbPipe objects.
+
+Produces a short hex digest that is deterministic across processes for the
+same inputs.  Intended for provenance tracking (populating
+``ParentInfo.fingerprint``) and as the foundation for a future Prefect
+``cache_key_fn``.
+
+Supported types
+---------------
+- ``jax.Array`` / ``numpy.ndarray`` — shape + dtype + bytes (capped at 1 MB)
+- Python scalars (``int``, ``float``, ``bool``, ``str``, ``None``)
+- ``Record`` — field names + values, hashed recursively
+- ``Distribution`` — class name + distribution name + numeric parameters
+- ``WorkflowFunction`` — bytecode of the wrapped user function
+- Everything else — ``repr()`` truncated to 500 characters
+
+All imports of ProbPipe types are deferred to call time so this module can
+be imported early in the package without triggering circular-import issues.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+from typing import Any
+
+__all__ = ["fingerprint"]
+
+# Arrays larger than this threshold are hashed by sampling bytes at
+# evenly-spaced offsets instead of reading the whole buffer.  1 MB is
+# large enough that most parameter arrays are hashed completely.
+_FULL_HASH_BYTES = 1 << 20  # 1 MB
+
+
+def fingerprint(obj: Any) -> str:
+    """Return a 16-character hex digest that stably identifies *obj*'s content.
+
+    The digest is deterministic within a Python session and across processes
+    for the same inputs.  It is NOT cryptographically secure — use it only
+    for cache keying and provenance labelling.
+
+    Parameters
+    ----------
+    obj:
+        Any ProbPipe object or Python primitive.  Unknown types fall back
+        to a ``repr()``-based hash.
+
+    Returns
+    -------
+    str
+        A 16-character hex string (64-bit prefix of a SHA-256 digest).
+    """
+    h = hashlib.sha256()
+    _update(h, obj, depth=0)
+    return h.hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Internal dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _update(h: "hashlib._Hash", obj: Any, depth: int) -> None:
+    if depth > 32:
+        h.update(b"[max_depth]")
+        return
+
+    import numpy as np
+
+    try:
+        import jax
+
+        _jax_array = jax.Array
+    except ImportError:
+        _jax_array = type(None)
+
+    if isinstance(obj, (np.ndarray, _jax_array)):
+        _update_array(h, obj)
+    elif _is_record(obj):
+        _update_record(h, obj, depth)
+    elif _is_distribution(obj):
+        _update_distribution(h, obj, depth)
+    elif _is_workflow_function(obj):
+        _update_workflow_function(h, obj)
+    elif isinstance(obj, bool):
+        # bool before int — bool is a subclass of int
+        h.update(b"bool:")
+        h.update(b"1" if obj else b"0")
+    elif isinstance(obj, int):
+        h.update(b"int:")
+        h.update(struct.pack(">q", obj))
+    elif isinstance(obj, float):
+        h.update(b"float:")
+        h.update(struct.pack(">d", obj))
+    elif isinstance(obj, str):
+        h.update(b"str:")
+        h.update(obj.encode())
+    elif obj is None:
+        h.update(b"none")
+    elif isinstance(obj, (list, tuple)):
+        tag = b"list:" if isinstance(obj, list) else b"tuple:"
+        h.update(tag)
+        h.update(struct.pack(">I", len(obj)))
+        for item in obj:
+            _update(h, item, depth + 1)
+    elif isinstance(obj, dict):
+        h.update(b"dict:")
+        h.update(struct.pack(">I", len(obj)))
+        for k, v in sorted(obj.items(), key=lambda kv: str(kv[0])):
+            _update(h, k, depth + 1)
+            _update(h, v, depth + 1)
+    else:
+        h.update(b"repr:")
+        h.update(repr(obj)[:500].encode())
+
+
+# ---------------------------------------------------------------------------
+# Array hashing
+# ---------------------------------------------------------------------------
+
+
+def _update_array(h: "hashlib._Hash", arr: Any) -> None:
+    """Hash an array by shape, dtype, and content bytes."""
+    import numpy as np
+
+    # Normalise to a numpy array for a uniform bytes() interface.
+    # For large JAX arrays this triggers a device→host transfer; that is
+    # acceptable here since fingerprinting happens at provenance-creation
+    # time, not inside a JIT-compiled function.
+    try:
+        arr_np = np.asarray(arr)
+    except Exception:
+        h.update(b"array:unreadable")
+        return
+
+    h.update(b"array:")
+    h.update(str(arr_np.shape).encode())
+    h.update(b":")
+    h.update(str(arr_np.dtype).encode())
+    h.update(b":")
+
+    raw = arr_np.tobytes()
+    if len(raw) <= _FULL_HASH_BYTES:
+        h.update(raw)
+    else:
+        # Sample 16 evenly-spaced 256-byte windows so large arrays are still
+        # discriminated without reading the full buffer.
+        step = max(1, len(raw) // 16)
+        for i in range(0, len(raw), step):
+            h.update(raw[i : i + 256])
+        h.update(struct.pack(">Q", len(raw)))
+
+
+# ---------------------------------------------------------------------------
+# Record hashing
+# ---------------------------------------------------------------------------
+
+
+def _is_record(obj: Any) -> bool:
+    try:
+        from .record import Record
+
+        return isinstance(obj, Record)
+    except Exception:
+        return False
+
+
+def _update_record(h: "hashlib._Hash", record: Any, depth: int) -> None:
+    """Hash a Record field-by-field in insertion order."""
+    h.update(b"record:")
+    h.update(type(record).__name__.encode())
+    h.update(b":")
+    for field in record.fields:
+        h.update(field.encode())
+        h.update(b"=")
+        _update(h, record[field], depth + 1)
+        h.update(b";")
+
+
+# ---------------------------------------------------------------------------
+# Distribution hashing
+# ---------------------------------------------------------------------------
+
+
+def _is_distribution(obj: Any) -> bool:
+    try:
+        from ._distribution_base import Distribution
+
+        return isinstance(obj, Distribution)
+    except Exception:
+        return False
+
+
+def _update_distribution(h: "hashlib._Hash", dist: Any, depth: int) -> None:
+    """Hash a distribution by class name, distribution name, and parameters.
+
+    For TFP-backed distributions (those with a ``_tfp_dist`` attribute) the
+    TFP parameter dict is hashed directly — this covers every concrete
+    parametric (Normal, Gamma, Beta, ...) without needing per-class logic.
+    For other distributions (EmpiricalDistribution, etc.) we fall back to
+    iterating public instance attributes.
+    """
+    h.update(b"dist:")
+    h.update(type(dist).__name__.encode())
+    h.update(b":")
+    name = getattr(dist, "name", None) or ""
+    h.update(name.encode())
+    h.update(b":")
+
+    tfp_dist = getattr(dist, "_tfp_dist", None)
+    if tfp_dist is not None:
+        params = getattr(tfp_dist, "parameters", {}) or {}
+        for k, v in sorted(params.items()):
+            h.update(k.encode())
+            h.update(b"=")
+            _update(h, v, depth + 1)
+            h.update(b";")
+    else:
+        # Non-TFP distribution: hash public attributes that look numeric or
+        # array-like, skipping framework internals.
+        _SKIP = frozenset({"_name", "_source", "_auxiliary", "_sampling_cost"})
+        for attr, val in sorted(vars(dist).items()):
+            if attr in _SKIP or attr.startswith("__"):
+                continue
+            h.update(attr.encode())
+            h.update(b"=")
+            _update(h, val, depth + 1)
+            h.update(b";")
+
+
+# ---------------------------------------------------------------------------
+# WorkflowFunction hashing
+# ---------------------------------------------------------------------------
+
+
+def _is_workflow_function(obj: Any) -> bool:
+    try:
+        from .node import WorkflowFunction
+
+        return isinstance(obj, WorkflowFunction)
+    except Exception:
+        return False
+
+
+def _update_workflow_function(h: "hashlib._Hash", wf: Any) -> None:
+    """Hash a WorkflowFunction by its user function's bytecode.
+
+    Hashes ``_func.__code__`` directly rather than the Prefect task-wrapper
+    closure, so changes to the user function body are detected even when the
+    wrapper source is unchanged.
+    """
+    h.update(b"wf:")
+    func = getattr(wf, "_func", None)
+    if func is None:
+        h.update(b"unknown")
+        return
+
+    code = getattr(func, "__code__", None)
+    if code is None:
+        h.update(repr(func)[:200].encode())
+        return
+
+    h.update(code.co_code)
+    # co_consts captures literal values in the function body (strings,
+    # numbers, nested code objects).  Stringifying avoids hashing nested
+    # code objects recursively, which would require special casing.
+    h.update(repr(code.co_consts).encode())
+    h.update(code.co_filename.encode())
+    h.update(struct.pack(">I", code.co_firstlineno))

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -60,7 +60,7 @@ def fingerprint(obj: Any) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _update(h: "hashlib._Hash", obj: Any, depth: int) -> None:
+def _update(h: hashlib._Hash, obj: Any, depth: int) -> None:
     if depth > 32:
         h.update(b"[max_depth]")
         return
@@ -119,7 +119,7 @@ def _update(h: "hashlib._Hash", obj: Any, depth: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _update_array(h: "hashlib._Hash", arr: Any) -> None:
+def _update_array(h: hashlib._Hash, arr: Any) -> None:
     """Hash an array by shape, dtype, and content bytes."""
     import numpy as np
 
@@ -165,7 +165,7 @@ def _is_record(obj: Any) -> bool:
         return False
 
 
-def _update_record(h: "hashlib._Hash", record: Any, depth: int) -> None:
+def _update_record(h: hashlib._Hash, record: Any, depth: int) -> None:
     """Hash a Record field-by-field in insertion order."""
     h.update(b"record:")
     h.update(type(record).__name__.encode())
@@ -191,7 +191,7 @@ def _is_distribution(obj: Any) -> bool:
         return False
 
 
-def _update_distribution(h: "hashlib._Hash", dist: Any, depth: int) -> None:
+def _update_distribution(h: hashlib._Hash, dist: Any, depth: int) -> None:
     """Hash a distribution by class name, distribution name, and parameters.
 
     For TFP-backed distributions (those with a ``_tfp_dist`` attribute) the
@@ -242,7 +242,7 @@ def _is_workflow_function(obj: Any) -> bool:
         return False
 
 
-def _update_workflow_function(h: "hashlib._Hash", wf: Any) -> None:
+def _update_workflow_function(h: hashlib._Hash, wf: Any) -> None:
     """Hash a WorkflowFunction by its user function's bytecode.
 
     Hashes ``_func.__code__`` directly rather than the Prefect task-wrapper

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -8,12 +8,17 @@ same inputs.  Intended for provenance tracking (populating
 Supported types
 ---------------
 - ``jax.Array`` / ``numpy.ndarray`` — shape + dtype + bytes (up to
-  ``max_array_bytes``; sampled beyond that)
-- Python scalars (``int``, ``float``, ``bool``, ``str``, ``None``)
-- ``Record`` — field names + values, hashed recursively
-- ``Distribution`` — class name + distribution name + numeric parameters
-- ``WorkflowFunction`` — bytecode of the wrapped user function
-- Everything else — ``repr()`` truncated to 500 characters
+  ``max_array_bytes``; sampled, tail included, beyond that). Object-dtype
+  arrays are hashed element-wise (their raw bytes are per-process pointers).
+- Python scalars (``int``, ``float``, ``bool``, ``str``, ``None``) and numpy
+  scalars; ``float`` ``-0.0``/``0.0`` and all NaN payloads are canonicalized
+- ``set`` / ``frozenset`` — order-independent (element sub-digests, sorted)
+- ``Record`` — leaf paths + leaf values (leaf-keyed collection)
+- ``Distribution`` — class + name + parameters; ``EmpiricalDistribution``
+  hashes samples + weights; ``Weights`` are hashed by content
+- ``WorkflowFunction`` — user-function bytecode, referenced names, and
+  captured/default values
+- Everything else — ``repr()`` (may be process-dependent for opaque types)
 
 All imports of ProbPipe types are deferred to call time so this module can
 be imported early in the package without triggering circular-import issues.
@@ -37,21 +42,22 @@ a 3.13 one for the same source.
 from __future__ import annotations
 
 import hashlib
+import math
 import struct
 from typing import Any
 
-__all__ = ["fingerprint"]
-
+import jax as _jax
 import numpy as _np
 
-try:
-    import jax as _jax
+__all__ = ["fingerprint"]
 
-    _JAX_ARRAY_TYPE = _jax.Array
-except ImportError:
-    _JAX_ARRAY_TYPE = type(None)  # type: ignore[assignment,misc]
-
+# JAX is a hard dependency of probpipe, so ``jax.Array`` is always importable.
+_JAX_ARRAY_TYPE = _jax.Array
 _NP_ARRAY_TYPE = _np.ndarray
+
+# Canonical NaN payload — every NaN hashes identically regardless of the bit
+# pattern a computation happened to produce.
+_CANONICAL_NAN = struct.pack(">d", float("nan"))
 
 # Default cap: arrays up to 256 MB are hashed in full (zero-copy via
 # memoryview).  Arrays beyond this are sampled at evenly-spaced offsets so
@@ -106,6 +112,15 @@ def _update(h: hashlib._Hash, obj: Any, depth: int, max_array_bytes: int | None)
         _update_distribution(h, obj, depth, max_array_bytes)
     elif _is_workflow_function(obj):
         _update_workflow_function(h, obj, max_array_bytes)
+    elif _is_weights(obj):
+        _update_weights(h, obj, depth, max_array_bytes)
+    elif isinstance(obj, _np.generic):
+        # numpy scalars: np.int64 is NOT an int subclass, and np.float32's repr
+        # is numpy-version-dependent — hash by dtype + raw bytes, never repr.
+        h.update(b"npscalar:")
+        h.update(str(obj.dtype).encode())
+        h.update(b":")
+        h.update(obj.tobytes())
     elif isinstance(obj, bool):
         # bool before int — bool is a subclass of int
         h.update(b"bool:")
@@ -115,7 +130,12 @@ def _update(h: hashlib._Hash, obj: Any, depth: int, max_array_bytes: int | None)
         h.update(str(obj).encode())
     elif isinstance(obj, float):
         h.update(b"float:")
-        h.update(struct.pack(">d", obj))
+        if math.isnan(obj):
+            h.update(_CANONICAL_NAN)  # collapse all NaN payloads
+        elif obj == 0.0:
+            h.update(struct.pack(">d", 0.0))  # collapse -0.0 and 0.0
+        else:
+            h.update(struct.pack(">d", obj))
     elif isinstance(obj, str):
         h.update(b"str:")
         h.update(obj.encode())
@@ -127,6 +147,14 @@ def _update(h: hashlib._Hash, obj: Any, depth: int, max_array_bytes: int | None)
         h.update(struct.pack(">I", len(obj)))
         for item in obj:
             _update(h, item, depth + 1, max_array_bytes)
+    elif isinstance(obj, (set, frozenset)):
+        # Order-independent: hash each element to a sub-digest and combine the
+        # sorted digests, so the result never depends on set iteration order
+        # (which is PYTHONHASHSEED-randomized across processes).
+        h.update(b"set:")
+        h.update(struct.pack(">I", len(obj)))
+        for d in sorted(_subdigest(e, depth + 1, max_array_bytes) for e in obj):
+            h.update(d)
     elif isinstance(obj, dict):
         h.update(b"dict:")
         h.update(struct.pack(">I", len(obj)))
@@ -136,8 +164,20 @@ def _update(h: hashlib._Hash, obj: Any, depth: int, max_array_bytes: int | None)
     elif _is_tfp_object(obj):
         _update_tfp_object(h, obj, depth, max_array_bytes)
     else:
+        # Last resort. ``repr`` may embed a memory address for objects with the
+        # default ``__repr__`` (making the digest process-dependent); the
+        # branches above cover ProbPipe's content-bearing types, so this is
+        # reached only for genuinely opaque values. Hash the full repr — no
+        # truncation, which would collide objects sharing a 500-char prefix.
         h.update(b"repr:")
-        h.update(repr(obj)[:500].encode())
+        h.update(repr(obj).encode())
+
+
+def _subdigest(obj: Any, depth: int, max_array_bytes: int | None) -> bytes:
+    """Content digest of a single object, for order-independent combination."""
+    sub = hashlib.sha256()
+    _update(sub, obj, depth, max_array_bytes)
+    return sub.digest()
 
 
 # ---------------------------------------------------------------------------
@@ -152,27 +192,60 @@ def _update_array(h: hashlib._Hash, arr: Any, max_bytes: int | None) -> None:
     That is acceptable here — fingerprinting happens at provenance-creation
     time, not inside a JIT-compiled function.
     """
-    try:
-        buf = _np.ascontiguousarray(_np.asarray(arr))
-    except Exception:
-        h.update(b"array:unreadable")
+    # Shape + dtype up front — available even on a JAX tracer — so arrays of
+    # different structure never collide, including on the unreadable path below.
+    shape = getattr(arr, "shape", None)
+    dtype = getattr(arr, "dtype", None)
+    h.update(f"array:{shape}:{dtype}:".encode())
+
+    # Object-dtype arrays hold Python-object *pointers*; their raw buffer bytes
+    # are per-process addresses, so hash the elements by content instead.
+    if dtype is not None and getattr(dtype, "kind", None) == "O":
+        try:
+            flat = _np.asarray(arr).ravel()
+        except Exception:
+            h.update(b"unreadable")
+            return
+        h.update(b"O")
+        h.update(struct.pack(">Q", flat.size))
+        for el in flat:
+            _update(h, el, 1, max_bytes)
         return
 
-    h.update(f"array:{buf.shape}:{buf.dtype}:".encode())
-
-    if max_bytes is None or buf.nbytes <= max_bytes:
-        # Full hash, zero-copy: memoryview avoids an extra .tobytes() copy.
-        h.update(memoryview(buf).cast("B"))
-    else:
-        # Sample ~16 evenly-spaced windows directly from the contiguous
-        # buffer view — O(sample) slices, no full copy.
-        view = memoryview(buf).cast("B")
-        n = len(view)
-        window = max(1, max_bytes // 16)
-        step = max(1, n // 16)
-        for i in range(0, n, step):
-            h.update(view[i : i + window])
-        h.update(struct.pack(">Q", n))
+    nbytes = getattr(arr, "nbytes", None)
+    try:
+        if (
+            max_bytes is not None
+            and nbytes is not None
+            and nbytes > max_bytes
+            and dtype is not None
+        ):
+            # Above the cap: transfer and hash only evenly-spaced windows —
+            # sliced device-side so the whole array is never copied host-side —
+            # always including the final tail window, plus the total byte count.
+            # Lossy (arrays differing only outside the windows can collide) but
+            # it never silently ignores the tail.
+            flat = arr.reshape(-1)
+            total = int(flat.shape[0])
+            win = max(1, (max_bytes // 16) // max(1, dtype.itemsize))
+            tail = max(0, total - win)
+            # 16 evenly-spaced window starts spanning 0..tail *inclusive*, so the
+            # final window is anchored at the buffer end (tail) and the last
+            # element is always hashed.
+            starts = sorted({(i * tail) // 15 for i in range(16)})
+            h.update(struct.pack(">Q", int(nbytes)))
+            for off in starts:
+                window = _np.ascontiguousarray(_np.asarray(flat[off : off + win]))
+                h.update(memoryview(window).cast("B"))
+        else:
+            buf = _np.ascontiguousarray(_np.asarray(arr))
+            # Full hash, zero-copy: memoryview avoids an extra .tobytes() copy.
+            h.update(memoryview(buf).cast("B"))
+    except Exception:
+        # No concrete content (e.g. a JAX tracer under jit/vmap). Shape+dtype
+        # above still discriminate by structure; two same-shape tracers are
+        # indistinguishable at trace time — inherent, not a defect here.
+        h.update(b"unreadable")
 
 
 # ---------------------------------------------------------------------------
@@ -217,19 +290,25 @@ def _is_record(obj: Any) -> bool:
         from .record import Record
 
         return isinstance(obj, Record)
-    except Exception:
+    except ImportError:
         return False
 
 
 def _update_record(h: hashlib._Hash, record: Any, depth: int, max_array_bytes: int | None) -> None:
-    """Hash a Record field-by-field in insertion order."""
+    """Hash a Record by its leaf-keyed items (full ``/``-paths → leaf values).
+
+    ``Record`` is a leaf-keyed collection: ``items()`` yields every leaf by its
+    canonical ``/``-joined path, so this flat walk captures the full nested
+    structure without recursing — and without indexing interior sub-Records,
+    which raises under the leaf-keyed API.
+    """
     h.update(b"record:")
     h.update(type(record).__name__.encode())
     h.update(b":")
-    for field in record.fields:
-        h.update(field.encode())
+    for path, value in record.items():
+        h.update(path.encode())
         h.update(b"=")
-        _update(h, record[field], depth + 1, max_array_bytes)
+        _update(h, value, depth + 1, max_array_bytes)
         h.update(b";")
 
 
@@ -243,8 +322,41 @@ def _is_distribution(obj: Any) -> bool:
         from ._distribution_base import Distribution
 
         return isinstance(obj, Distribution)
-    except Exception:
+    except ImportError:
         return False
+
+
+def _is_empirical(obj: Any) -> bool:
+    try:
+        from ._empirical import EmpiricalDistribution
+
+        return isinstance(obj, EmpiricalDistribution)
+    except ImportError:
+        return False
+
+
+def _is_weights(obj: Any) -> bool:
+    try:
+        from .._weights import Weights
+
+        return isinstance(obj, Weights)
+    except ImportError:
+        return False
+
+
+def _update_weights(h: hashlib._Hash, w: Any, depth: int, max_array_bytes: int | None) -> None:
+    """Hash a ``Weights`` object by content: uniformity, count, and log-weights.
+
+    Hashed via the public API so a ``Weights`` reached through a distribution's
+    generic ``vars()`` fallback (e.g. a mixture or broadcast distribution) is
+    distinguished by its actual weights rather than by ``repr`` (which drops the
+    values, collapsing reweighted distributions to one digest).
+    """
+    h.update(b"weights:")
+    h.update(b"1" if w.is_uniform else b"0")
+    h.update(struct.pack(">Q", int(w.n)))
+    if not w.is_uniform:
+        _update(h, w.log_normalized, depth + 1, max_array_bytes)
 
 
 def _update_distribution(
@@ -266,7 +378,6 @@ def _update_distribution(
     h.update(b":")
 
     tfp_dist = getattr(dist, "_tfp_dist", None)
-    samples = getattr(dist, "_samples", None)
 
     if tfp_dist is not None:
         params = getattr(tfp_dist, "parameters", {}) or {}
@@ -279,19 +390,20 @@ def _update_distribution(
             h.update(b"=")
             _update(h, v, depth + 1, max_array_bytes)
             h.update(b";")
-    elif samples is not None:
-        # EmpiricalDistribution / RecordEmpiricalDistribution: hash the
-        # sample data and weight array explicitly so reweighted posteriors
-        # (IS/SMC) are distinguished from the original.
+    elif _is_empirical(dist):
+        # EmpiricalDistribution / RecordEmpiricalDistribution: hash the sample
+        # data and weights via the PUBLIC accessors. The Record-backed subclass
+        # stores no ``_samples`` attribute, so keying on it silently dropped
+        # into the generic fallback below and hashed weights by repr (losing the
+        # values); using ``.samples`` / ``.is_uniform`` / ``.log_weights``
+        # distinguishes reweighted posteriors (IS/SMC) from the original.
         h.update(b"samples=")
-        _update(h, samples, depth + 1, max_array_bytes)
-        w = getattr(dist, "_w", None)
-        log_w = getattr(w, "log_normalized", None)
-        h.update(b"log_weights=")
-        if log_w is not None:
-            _update(h, log_w, depth + 1, max_array_bytes)
-        else:
-            h.update(b"uniform")
+        _update(h, dist.samples, depth + 1, max_array_bytes)
+        h.update(b"uniform=")
+        h.update(b"1" if dist.is_uniform else b"0")
+        if not dist.is_uniform:
+            h.update(b"log_weights=")
+            _update(h, dist.log_weights, depth + 1, max_array_bytes)
     else:
         # Generic fallback for other non-TFP distributions.
         _SKIP = frozenset({"_name", "_source", "_auxiliary", "_sampling_cost"})
@@ -314,27 +426,40 @@ def _is_workflow_function(obj: Any) -> bool:
         from .node import WorkflowFunction
 
         return isinstance(obj, WorkflowFunction)
-    except Exception:
+    except ImportError:
         return False
 
 
-def _hash_code(h: hashlib._Hash, code: Any, max_array_bytes: int | None) -> None:
+def _hash_code(h: hashlib._Hash, code: Any, depth: int, max_array_bytes: int | None) -> None:
     """Recursively hash a code object without repr-ing nested code objects.
 
+    Hashes the executable bytecode (``co_code``) *and* the symbol names it
+    references by index — ``co_names`` (globals / attributes / methods),
+    ``co_varnames`` (locals / arguments) and ``co_freevars`` — so a body that
+    only changes *which* name it calls (``jnp.sin`` vs ``jnp.cos``, ``r.mean()``
+    vs ``r.sum()``) is detected; ``co_code`` alone is identical for those.
+
     ``repr(code.co_consts)`` embeds memory addresses for any nested ``def``,
-    ``lambda``, or generator — making the digest process-dependent.  Instead
-    we walk ``co_consts`` and recurse into nested code objects directly.
-    ``co_filename`` and ``co_firstlineno`` are intentionally excluded: they
-    are machine- and position-dependent and defeat cross-machine caching.
+    ``lambda``, or generator — making the digest process-dependent — so we walk
+    ``co_consts`` and recurse into nested code objects directly (threading
+    ``depth`` so the recursion guard bounds deeply nested closures).
+    ``co_filename`` and ``co_firstlineno`` are intentionally excluded: they are
+    machine- and position-dependent and defeat cross-machine caching.
     """
     import types
 
+    h.update(b"code:")
     h.update(code.co_code)
+    for names in (code.co_names, code.co_varnames, code.co_freevars):
+        h.update(struct.pack(">I", len(names)))
+        for n in names:
+            h.update(n.encode())
+            h.update(b",")
     for c in code.co_consts:
         if isinstance(c, types.CodeType):
-            _hash_code(h, c, max_array_bytes)
+            _hash_code(h, c, depth + 1, max_array_bytes)
         else:
-            _update(h, c, 0, max_array_bytes)
+            _update(h, c, depth + 1, max_array_bytes)
 
 
 def _update_workflow_function(h: hashlib._Hash, wf: Any, max_array_bytes: int | None) -> None:
@@ -355,4 +480,19 @@ def _update_workflow_function(h: hashlib._Hash, wf: Any, max_array_bytes: int | 
         h.update(repr(func)[:200].encode())
         return
 
-    _hash_code(h, code, max_array_bytes)
+    _hash_code(h, code, 0, max_array_bytes)
+    # Captured/closed-over state: two functions with identical bytecode but
+    # different defaults or closure values (e.g. ``make(1.0)`` vs ``make(2.0)``)
+    # must not collide.
+    h.update(b"defaults=")
+    _update(h, func.__defaults__, 1, max_array_bytes)
+    h.update(b"kwdefaults=")
+    _update(h, func.__kwdefaults__, 1, max_array_bytes)
+    h.update(b"closure=")
+    closure = func.__closure__
+    if closure is None:
+        h.update(b"none")
+    else:
+        h.update(struct.pack(">I", len(closure)))
+        for cell in closure:
+            _update(h, cell.cell_contents, 1, max_array_bytes)

--- a/probpipe/core/provenance.py
+++ b/probpipe/core/provenance.py
@@ -6,6 +6,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from .config import ProvenanceMode, provenance_config
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -14,8 +16,6 @@ if TYPE_CHECKING:
     from .record import Record
 
     ProvenanceNode = Distribution | Record | RecordArray
-
-from .config import ProvenanceMode, provenance_config
 
 __all__ = [
     "ParentInfo",

--- a/probpipe/core/provenance.py
+++ b/probpipe/core/provenance.py
@@ -159,14 +159,23 @@ class Provenance:
         if mode is ProvenanceMode.OFF:
             return None
         keep = mode is ProvenanceMode.FULL
-        refs = tuple(
-            ParentInfo(
+
+        from ._fingerprint import fingerprint as _fingerprint
+
+        def _make_parent(p: Any) -> ParentInfo:
+            try:
+                fp: str | None = _fingerprint(p)
+            except Exception:
+                fp = None
+            return ParentInfo(
                 type_name=type(p).__name__,
                 name=getattr(p, "name", None),
                 source=getattr(p, "source", None),
+                fingerprint=fp,
                 obj=p if keep else None,
             )
-            for p in parents
+
+        refs = tuple(_make_parent(p) for p in parents
         )
         return cls(operation, parents=refs, metadata=metadata or {})
 

--- a/probpipe/core/provenance.py
+++ b/probpipe/core/provenance.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ._record_array import RecordArray
@@ -50,8 +53,10 @@ class ParentInfo:
         holds an unhashable ``metadata`` dict) but included in equality so
         that two descriptors for the same ancestor compare equal.
     fingerprint : str or None
-        Optional stable content hash of the parent's inputs.  Intended for
-        a future workflow-result caching layer; currently always ``None``.
+        Stable 16-character hex digest of the parent's content, populated
+        by :meth:`Provenance.create`.  ``None`` only when fingerprinting
+        raises an unexpected error.  Intended as the foundation for a future
+        Prefect ``cache_key_fn``.
     obj : ProvenanceNode or None
         The live parent object.  Set in FULL mode; ``None`` in LIGHTWEIGHT
         so the parent's data can be garbage-collected.  Excluded from
@@ -163,9 +168,16 @@ class Provenance:
         from ._fingerprint import fingerprint as _fingerprint
 
         def _make_parent(p: Any) -> ParentInfo:
+            fp: str | None
             try:
-                fp: str | None = _fingerprint(p)
-            except Exception:
+                fp = _fingerprint(p)
+            except Exception as exc:
+                logger.warning(
+                    "fingerprint() failed for %s %r: %s",
+                    type(p).__name__,
+                    getattr(p, "name", None),
+                    exc,
+                )
                 fp = None
             return ParentInfo(
                 type_name=type(p).__name__,

--- a/probpipe/core/provenance.py
+++ b/probpipe/core/provenance.py
@@ -175,8 +175,7 @@ class Provenance:
                 obj=p if keep else None,
             )
 
-        refs = tuple(_make_parent(p) for p in parents
-        )
+        refs = tuple(_make_parent(p) for p in parents)
         return cls(operation, parents=refs, metadata=metadata or {})
 
 

--- a/probpipe/core/provenance.py
+++ b/probpipe/core/provenance.py
@@ -56,7 +56,9 @@ class ParentInfo:
         Stable 16-character hex digest of the parent's content, populated
         by :meth:`Provenance.create`.  ``None`` only when fingerprinting
         raises an unexpected error.  Intended as the foundation for a future
-        Prefect ``cache_key_fn``.
+        Prefect ``cache_key_fn``.  Excluded from equality and hashing: descriptor
+        identity is structural (``type_name`` / ``name`` / ``source``), so a
+        content digest must not perturb ancestor-set dedup.
     obj : ProvenanceNode or None
         The live parent object.  Set in FULL mode; ``None`` in LIGHTWEIGHT
         so the parent's data can be garbage-collected.  Excluded from
@@ -66,7 +68,7 @@ class ParentInfo:
     type_name: str
     name: str | None
     source: Provenance | None = field(default=None, hash=False)
-    fingerprint: str | None = None
+    fingerprint: str | None = field(default=None, compare=False)
     obj: ProvenanceNode | None = field(default=None, compare=False)
 
 

--- a/tests/core/test_fingerprint.py
+++ b/tests/core/test_fingerprint.py
@@ -1,0 +1,287 @@
+"""Tests for the fingerprint utility module."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import Normal, Record
+from probpipe.core._fingerprint import fingerprint
+from probpipe.core.node import WorkflowFunction
+from probpipe.core.provenance import ParentInfo, Provenance
+
+
+# ===========================================================================
+# 1. Return type and format
+# ===========================================================================
+
+
+class TestReturnFormat:
+    def test_returns_string(self):
+        assert isinstance(fingerprint(Normal(loc=0.0, scale=1.0, name="n")), str)
+
+    def test_returns_16_chars(self):
+        assert len(fingerprint(Normal(loc=0.0, scale=1.0, name="n"))) == 16
+
+    def test_hex_characters_only(self):
+        fp = fingerprint(Normal(loc=0.0, scale=1.0, name="n"))
+        assert all(c in "0123456789abcdef" for c in fp)
+
+
+# ===========================================================================
+# 2. Python primitives
+# ===========================================================================
+
+
+class TestPrimitives:
+    def test_int_stable(self):
+        assert fingerprint(42) == fingerprint(42)
+
+    def test_different_ints_differ(self):
+        assert fingerprint(1) != fingerprint(2)
+
+    def test_float_stable(self):
+        assert fingerprint(3.14) == fingerprint(3.14)
+
+    def test_different_floats_differ(self):
+        assert fingerprint(1.0) != fingerprint(2.0)
+
+    def test_bool_stable(self):
+        assert fingerprint(True) == fingerprint(True)
+
+    def test_bool_differs_from_int(self):
+        # True == 1 in Python but they should hash differently as types differ
+        assert fingerprint(True) != fingerprint(1)
+
+    def test_string_stable(self):
+        assert fingerprint("hello") == fingerprint("hello")
+
+    def test_different_strings_differ(self):
+        assert fingerprint("a") != fingerprint("b")
+
+    def test_none_stable(self):
+        assert fingerprint(None) == fingerprint(None)
+
+    def test_none_differs_from_zero(self):
+        assert fingerprint(None) != fingerprint(0)
+
+
+# ===========================================================================
+# 3. Array hashing
+# ===========================================================================
+
+
+class TestArrayHashing:
+    def test_jax_array_stable(self):
+        a = jnp.array([1.0, 2.0, 3.0])
+        b = jnp.array([1.0, 2.0, 3.0])
+        assert fingerprint(a) == fingerprint(b)
+
+    def test_jax_array_different_values(self):
+        a = jnp.array([1.0, 2.0, 3.0])
+        b = jnp.array([1.0, 2.0, 9.0])
+        assert fingerprint(a) != fingerprint(b)
+
+    def test_jax_array_different_shapes(self):
+        a = jnp.array([1.0, 2.0])
+        b = jnp.array([[1.0, 2.0]])
+        assert fingerprint(a) != fingerprint(b)
+
+    def test_jax_array_different_dtypes(self):
+        # Use int32 vs float32 — always distinct regardless of x64 mode.
+        a = jnp.array(1, dtype=jnp.int32)
+        b = jnp.array(1, dtype=jnp.float32)
+        assert fingerprint(a) != fingerprint(b)
+
+    def test_numpy_array_stable(self):
+        a = np.array([1.0, 2.0])
+        b = np.array([1.0, 2.0])
+        assert fingerprint(a) == fingerprint(b)
+
+    def test_numpy_different_from_jax(self):
+        # Different types → different hash prefix
+        a = np.array([1.0, 2.0])
+        b = jnp.array([1.0, 2.0])
+        # They may or may not differ (numpy/jax both go through np.asarray);
+        # what matters is that each is stable individually.
+        assert fingerprint(a) == fingerprint(a)
+        assert fingerprint(b) == fingerprint(b)
+
+    def test_scalar_array_stable(self):
+        a = jnp.array(5.0)
+        b = jnp.array(5.0)
+        assert fingerprint(a) == fingerprint(b)
+
+
+# ===========================================================================
+# 4. Record hashing
+# ===========================================================================
+
+
+class TestRecordHashing:
+    def test_same_record_stable(self):
+        r1 = Record(x=jnp.array(1.0), y=jnp.array(2.0))
+        r2 = Record(x=jnp.array(1.0), y=jnp.array(2.0))
+        assert fingerprint(r1) == fingerprint(r2)
+
+    def test_different_values_differ(self):
+        r1 = Record(x=jnp.array(1.0))
+        r2 = Record(x=jnp.array(9.0))
+        assert fingerprint(r1) != fingerprint(r2)
+
+    def test_different_fields_differ(self):
+        r1 = Record(x=jnp.array(1.0))
+        r2 = Record(y=jnp.array(1.0))
+        assert fingerprint(r1) != fingerprint(r2)
+
+    def test_extra_field_differs(self):
+        r1 = Record(x=jnp.array(1.0))
+        r2 = Record(x=jnp.array(1.0), y=jnp.array(2.0))
+        assert fingerprint(r1) != fingerprint(r2)
+
+    def test_multi_field_stable(self):
+        r1 = Record(a=jnp.array([1.0, 2.0]), b=jnp.array(3.0), c="label")
+        r2 = Record(a=jnp.array([1.0, 2.0]), b=jnp.array(3.0), c="label")
+        assert fingerprint(r1) == fingerprint(r2)
+
+    def test_string_field_differs(self):
+        r1 = Record(label="a")
+        r2 = Record(label="b")
+        assert fingerprint(r1) != fingerprint(r2)
+
+
+# ===========================================================================
+# 5. Distribution hashing
+# ===========================================================================
+
+
+class TestDistributionHashing:
+    def test_same_normal_stable(self):
+        n1 = Normal(loc=0.0, scale=1.0, name="x")
+        n2 = Normal(loc=0.0, scale=1.0, name="x")
+        assert fingerprint(n1) == fingerprint(n2)
+
+    def test_different_loc_differs(self):
+        n1 = Normal(loc=0.0, scale=1.0, name="x")
+        n2 = Normal(loc=1.0, scale=1.0, name="x")
+        assert fingerprint(n1) != fingerprint(n2)
+
+    def test_different_scale_differs(self):
+        n1 = Normal(loc=0.0, scale=1.0, name="x")
+        n2 = Normal(loc=0.0, scale=2.0, name="x")
+        assert fingerprint(n1) != fingerprint(n2)
+
+    def test_different_name_differs(self):
+        n1 = Normal(loc=0.0, scale=1.0, name="x")
+        n2 = Normal(loc=0.0, scale=1.0, name="y")
+        assert fingerprint(n1) != fingerprint(n2)
+
+    def test_different_distribution_types_differ(self):
+        from probpipe import Beta
+
+        n = Normal(loc=0.0, scale=1.0, name="x")
+        b = Beta(alpha=1.0, beta=1.0, name="x")
+        assert fingerprint(n) != fingerprint(b)
+
+    def test_empirical_distribution_stable(self):
+        from probpipe import RecordEmpiricalDistribution
+
+        samples = jnp.array([1.0, 2.0, 3.0])
+        e1 = RecordEmpiricalDistribution(samples, name="posterior")
+        e2 = RecordEmpiricalDistribution(samples, name="posterior")
+        assert fingerprint(e1) == fingerprint(e2)
+
+    def test_empirical_different_samples_differ(self):
+        from probpipe import RecordEmpiricalDistribution
+
+        e1 = RecordEmpiricalDistribution(jnp.array([1.0, 2.0, 3.0]), name="post")
+        e2 = RecordEmpiricalDistribution(jnp.array([1.0, 2.0, 9.0]), name="post")
+        assert fingerprint(e1) != fingerprint(e2)
+
+
+# ===========================================================================
+# 6. WorkflowFunction hashing
+# ===========================================================================
+
+
+class TestWorkflowFunctionHashing:
+    def _make_wf(self, func):
+        return WorkflowFunction(func=func, dispatch="sequential", n_broadcast_samples=10, seed=42)
+
+    def test_same_function_stable(self):
+        def add(x: float, y: float) -> float:
+            return x + y
+
+        wf1 = self._make_wf(add)
+        wf2 = self._make_wf(add)
+        assert fingerprint(wf1) == fingerprint(wf2)
+
+    def test_different_function_bodies_differ(self):
+        def add(x: float, y: float) -> float:
+            return x + y
+
+        def multiply(x: float, y: float) -> float:
+            return x * y
+
+        wf_add = self._make_wf(add)
+        wf_mul = self._make_wf(multiply)
+        assert fingerprint(wf_add) != fingerprint(wf_mul)
+
+    def test_changed_constant_in_body_differs(self):
+        def f_v1(x: float) -> float:
+            return x + 1.0
+
+        def f_v2(x: float) -> float:
+            return x + 2.0
+
+        assert fingerprint(self._make_wf(f_v1)) != fingerprint(self._make_wf(f_v2))
+
+
+# ===========================================================================
+# 7. Fingerprint populated on ParentInfo via Provenance.create()
+# ===========================================================================
+
+
+class TestFingerprintInProvenance:
+    def test_parentinfo_fingerprint_set(self):
+        n = Normal(loc=0.0, scale=1.0, name="prior")
+        prov = Provenance.create("op", parents=[n])
+        assert prov is not None
+        parent = prov.parents[0]
+        assert isinstance(parent, ParentInfo)
+        assert parent.fingerprint is not None
+        assert len(parent.fingerprint) == 16
+
+    def test_parentinfo_fingerprint_stable_across_create_calls(self):
+        n = Normal(loc=0.0, scale=1.0, name="prior")
+        p1 = Provenance.create("op", parents=[n])
+        p2 = Provenance.create("op", parents=[n])
+        assert p1.parents[0].fingerprint == p2.parents[0].fingerprint
+
+    def test_different_parents_different_fingerprints(self):
+        n1 = Normal(loc=0.0, scale=1.0, name="a")
+        n2 = Normal(loc=5.0, scale=1.0, name="b")
+        prov = Provenance.create("op", parents=[n1, n2])
+        fp1 = prov.parents[0].fingerprint
+        fp2 = prov.parents[1].fingerprint
+        assert fp1 != fp2
+
+    def test_fingerprint_in_to_dict(self):
+        n = Normal(loc=0.0, scale=1.0, name="prior")
+        prov = Provenance.create("op", parents=[n])
+        d = prov.to_dict()
+        assert "fingerprint" in d["parents"][0]
+        assert d["parents"][0]["fingerprint"] == prov.parents[0].fingerprint
+
+    def test_off_mode_no_fingerprint(self):
+        import probpipe
+        from probpipe import ProvenanceMode
+
+        probpipe.provenance_config.mode = ProvenanceMode.OFF
+        try:
+            n = Normal(loc=0.0, scale=1.0, name="prior")
+            prov = Provenance.create("op", parents=[n])
+            assert prov is None
+        finally:
+            probpipe.provenance_config.reset()

--- a/tests/core/test_fingerprint.py
+++ b/tests/core/test_fingerprint.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 import numpy as np
-import pytest
 
 from probpipe import Normal, Record
 from probpipe.core._fingerprint import fingerprint
 from probpipe.core.node import WorkflowFunction
 from probpipe.core.provenance import ParentInfo, Provenance
-
 
 # ===========================================================================
 # 1. Return type and format

--- a/tests/core/test_fingerprint.py
+++ b/tests/core/test_fingerprint.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import textwrap
+
 import jax.numpy as jnp
 import numpy as np
 
@@ -34,23 +38,37 @@ class TestReturnFormat:
 
 class TestPrimitives:
     def test_int_stable(self):
-        assert fingerprint(42) == fingerprint(42)
+        # Two separately-constructed equal values must produce the same digest.
+        assert fingerprint(int("42")) == fingerprint(int("42"))
 
     def test_different_ints_differ(self):
         assert fingerprint(1) != fingerprint(2)
 
+    def test_big_int_does_not_crash(self):
+        # Integers outside the signed-64-bit range must not raise.
+        assert isinstance(fingerprint(2**100), str)
+        assert isinstance(fingerprint([1, 2**100]), str)
+
     def test_float_stable(self):
-        assert fingerprint(3.14) == fingerprint(3.14)
+        assert fingerprint(float("3.14")) == fingerprint(float("3.14"))
 
     def test_different_floats_differ(self):
         assert fingerprint(1.0) != fingerprint(2.0)
 
+    def test_nan_and_inf_do_not_crash(self):
+        assert isinstance(fingerprint(float("nan")), str)
+        assert isinstance(fingerprint(float("inf")), str)
+        assert isinstance(fingerprint(float("-inf")), str)
+
     def test_bool_stable(self):
-        assert fingerprint(True) == fingerprint(True)
+        assert fingerprint(bool(1)) == fingerprint(bool(1))
 
     def test_bool_differs_from_int(self):
-        # True == 1 in Python but they should hash differently as types differ
+        # True == 1 in Python but they must hash differently — different types.
         assert fingerprint(True) != fingerprint(1)
+
+    def test_false_differs_from_zero(self):
+        assert fingerprint(False) != fingerprint(0)
 
     def test_string_stable(self):
         assert fingerprint("hello") == fingerprint("hello")
@@ -59,10 +77,38 @@ class TestPrimitives:
         assert fingerprint("a") != fingerprint("b")
 
     def test_none_stable(self):
-        assert fingerprint(None) == fingerprint(None)
+        assert fingerprint(type(None)()) == fingerprint(type(None)())
 
     def test_none_differs_from_zero(self):
         assert fingerprint(None) != fingerprint(0)
+
+    def test_empty_list_stable(self):
+        assert fingerprint([]) == fingerprint([])
+
+    def test_empty_dict_stable(self):
+        assert fingerprint({}) == fingerprint({})
+
+    def test_list_stable(self):
+        assert fingerprint([1, 2, 3]) == fingerprint([1, 2, 3])
+
+    def test_tuple_stable(self):
+        assert fingerprint((1, 2)) == fingerprint((1, 2))
+
+    def test_list_differs_from_tuple(self):
+        assert fingerprint([1, 2]) != fingerprint((1, 2))
+
+    def test_dict_stable(self):
+        assert fingerprint({"a": 1, "b": 2}) == fingerprint({"a": 1, "b": 2})
+
+    def test_dict_different_values_differ(self):
+        assert fingerprint({"a": 1}) != fingerprint({"a": 2})
+
+    def test_unknown_type_does_not_crash(self):
+        class _Opaque:
+            def __repr__(self):
+                return "opaque"
+
+        assert isinstance(fingerprint(_Opaque()), str)
 
 
 # ===========================================================================
@@ -97,23 +143,36 @@ class TestArrayHashing:
         b = np.array([1.0, 2.0])
         assert fingerprint(a) == fingerprint(b)
 
-    def test_numpy_different_from_jax(self):
-        # Different types → different hash prefix
-        a = np.array([1.0, 2.0])
-        b = jnp.array([1.0, 2.0])
-        # They may or may not differ (numpy/jax both go through np.asarray);
-        # what matters is that each is stable individually.
-        assert fingerprint(a) == fingerprint(a)
-        assert fingerprint(b) == fingerprint(b)
-
     def test_scalar_array_stable(self):
         a = jnp.array(5.0)
         b = jnp.array(5.0)
         assert fingerprint(a) == fingerprint(b)
 
+    def test_max_array_bytes_none_hashes_fully(self):
+        # With no cap, two arrays that differ only in their last element must
+        # produce different digests even when they are large.
+        a = np.zeros(1000)
+        b = np.zeros(1000)
+        b[-1] = 1.0
+        assert fingerprint(a, max_array_bytes=None) != fingerprint(b, max_array_bytes=None)
+
 
 # ===========================================================================
-# 4. Record hashing
+# 4. Depth guard
+# ===========================================================================
+
+
+class TestDepthGuard:
+    def test_deeply_nested_list_does_not_crash(self):
+        # Build a list nested 40 levels deep — beyond the depth=32 guard.
+        obj: list = []
+        for _ in range(40):
+            obj = [obj]
+        assert isinstance(fingerprint(obj), str)
+
+
+# ===========================================================================
+# 5. Record hashing
 # ===========================================================================
 
 
@@ -150,7 +209,7 @@ class TestRecordHashing:
 
 
 # ===========================================================================
-# 5. Distribution hashing
+# 6. Distribution hashing
 # ===========================================================================
 
 
@@ -197,9 +256,37 @@ class TestDistributionHashing:
         e2 = RecordEmpiricalDistribution(jnp.array([1.0, 2.0, 9.0]), name="post")
         assert fingerprint(e1) != fingerprint(e2)
 
+    def test_empirical_non_uniform_weights_differ(self):
+        """IS/SMC reweighting must produce a different fingerprint."""
+        from probpipe import RecordEmpiricalDistribution
+
+        samples = jnp.array([1.0, 2.0, 3.0])
+        uniform = RecordEmpiricalDistribution(samples, name="post")
+        reweighted = RecordEmpiricalDistribution(
+            samples, weights=jnp.array([0.7, 0.2, 0.1]), name="post"
+        )
+        assert fingerprint(uniform) != fingerprint(reweighted)
+
+    def test_kde_distribution_stable(self):
+        """KDE (composite TFP distribution) must be stable."""
+        from probpipe.distributions.kde import KDEDistribution
+
+        pts = jnp.array([0.0, 1.0, 2.0])
+        k1 = KDEDistribution(pts, name="kde")
+        k2 = KDEDistribution(pts, name="kde")
+        assert fingerprint(k1) == fingerprint(k2)
+
+    def test_kde_different_points_differ(self):
+        """Two KDE distributions with different data must have different fingerprints."""
+        from probpipe.distributions.kde import KDEDistribution
+
+        k1 = KDEDistribution(jnp.array([0.0, 1.0, 2.0]), name="kde")
+        k2 = KDEDistribution(jnp.array([0.0, 1.0, 99.0]), name="kde")
+        assert fingerprint(k1) != fingerprint(k2)
+
 
 # ===========================================================================
-# 6. WorkflowFunction hashing
+# 7. WorkflowFunction hashing
 # ===========================================================================
 
 
@@ -222,9 +309,7 @@ class TestWorkflowFunctionHashing:
         def multiply(x: float, y: float) -> float:
             return x * y
 
-        wf_add = self._make_wf(add)
-        wf_mul = self._make_wf(multiply)
-        assert fingerprint(wf_add) != fingerprint(wf_mul)
+        assert fingerprint(self._make_wf(add)) != fingerprint(self._make_wf(multiply))
 
     def test_changed_constant_in_body_differs(self):
         def f_v1(x: float) -> float:
@@ -235,9 +320,32 @@ class TestWorkflowFunctionHashing:
 
         assert fingerprint(self._make_wf(f_v1)) != fingerprint(self._make_wf(f_v2))
 
+    def test_nested_lambda_stable_across_processes(self):
+        """A function with a nested lambda must produce the same digest in two
+        separate processes — the old repr(co_consts) path embedded memory
+        addresses and broke this guarantee."""
+        script = textwrap.dedent("""
+            import sys
+            sys.path.insert(0, sys.argv[1])
+            from probpipe.core._fingerprint import fingerprint
+            from probpipe.core.node import WorkflowFunction
+
+            def f(x: float) -> float:
+                transform = lambda v: v * 2.0  # noqa: E731
+                return transform(x)
+
+            wf = WorkflowFunction(func=f, dispatch="sequential", n_broadcast_samples=10, seed=42)
+            print(fingerprint(wf))
+        """)
+        site = str(next(p for p in sys.path if "site-packages" in p))
+        run = lambda: subprocess.check_output(  # noqa: E731
+            [sys.executable, "-c", script, site], text=True
+        ).strip()
+        assert run() == run()
+
 
 # ===========================================================================
-# 7. Fingerprint populated on ParentInfo via Provenance.create()
+# 8. Fingerprint populated on ParentInfo via Provenance.create()
 # ===========================================================================
 
 
@@ -283,3 +391,29 @@ class TestFingerprintInProvenance:
             assert prov is None
         finally:
             probpipe.provenance_config.reset()
+
+    def test_fingerprint_error_logs_warning(self, monkeypatch, caplog):
+        """A fingerprint failure emits a warning and sets fingerprint=None."""
+        import logging
+
+        from probpipe.core import provenance as prov_mod
+
+        def _bad_fp(obj, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(prov_mod, "_fingerprint_func", _bad_fp, raising=False)
+
+        # Patch the lazy import inside create() to use our broken function.
+        import probpipe.core._fingerprint as fp_mod
+
+        monkeypatch.setattr(fp_mod, "fingerprint", _bad_fp)
+
+        n = Normal(loc=0.0, scale=1.0, name="prior")
+        with caplog.at_level(logging.WARNING, logger="probpipe.core.provenance"):
+            prov = Provenance.create("op", parents=[n])
+
+        assert prov is not None
+        assert prov.parents[0].fingerprint is None
+        assert any(
+            "fingerprint" in r.message.lower() or "boom" in r.message for r in caplog.records
+        )

--- a/tests/core/test_fingerprint.py
+++ b/tests/core/test_fingerprint.py
@@ -417,3 +417,149 @@ class TestFingerprintInProvenance:
         assert any(
             "fingerprint" in r.message.lower() or "boom" in r.message for r in caplog.records
         )
+
+
+# ===========================================================================
+# 9. Review-fix regressions — determinism, collisions, leaf-keyed records
+# ===========================================================================
+
+
+class TestWorkflowFunctionCapture:
+    """Bytecode alone is not enough: referenced names, closures, and defaults."""
+
+    def _wf(self, func):
+        return WorkflowFunction(func=func, dispatch="sequential", n_broadcast_samples=10, seed=42)
+
+    def test_called_name_differs(self):
+        # ``jnp.sin`` vs ``jnp.cos``: identical co_code + co_consts, differing
+        # only in co_names — a collision before the fix.
+        assert fingerprint(self._wf(lambda x: jnp.sin(x))) != fingerprint(
+            self._wf(lambda x: jnp.cos(x))
+        )
+
+    def test_closure_capture_differs(self):
+        def make(k):
+            def g(x):
+                return x + k
+
+            return g
+
+        assert fingerprint(self._wf(make(1.0))) != fingerprint(self._wf(make(2.0)))
+
+    def test_default_arg_differs(self):
+        def d1(x, k=1.0):
+            return x + k
+
+        def d2(x, k=2.0):
+            return x + k
+
+        assert fingerprint(self._wf(d1)) != fingerprint(self._wf(d2))
+
+
+class TestSetHashing:
+    def test_order_independent(self):
+        assert fingerprint({1, 2, 3}) == fingerprint({3, 1, 2})
+
+    def test_content_differs(self):
+        assert fingerprint({1, 2, 3}) != fingerprint({1, 2, 4})
+
+    def test_frozenset_order_independent(self):
+        assert fingerprint(frozenset({"a", "b"})) == fingerprint(frozenset({"b", "a"}))
+
+    def test_stable_across_processes(self):
+        """Set iteration order is PYTHONHASHSEED-randomized; the digest is not."""
+        import os
+
+        script = textwrap.dedent("""
+            import sys
+            sys.path.insert(0, sys.argv[1])
+            from probpipe.core._fingerprint import fingerprint
+            print(fingerprint({"alpha", "beta", "gamma", "delta"}))
+        """)
+        site = str(next(p for p in sys.path if "site-packages" in p))
+
+        def run(seed):
+            env = {**os.environ, "PYTHONHASHSEED": seed}
+            return subprocess.check_output(
+                [sys.executable, "-c", script, site], text=True, env=env
+            ).strip()
+
+        assert run("1") == run("2")
+
+
+class TestNumpyScalarHashing:
+    def test_int64_stable_and_differs(self):
+        # np.int64 is not an int subclass — it hit the repr fallback before.
+        assert fingerprint(np.int64(5)) == fingerprint(np.int64(5))
+        assert fingerprint(np.int64(5)) != fingerprint(np.int64(6))
+
+    def test_float32_stable(self):
+        assert fingerprint(np.float32(1.5)) == fingerprint(np.float32(1.5))
+
+
+class TestFloatCanonicalization:
+    def test_negative_zero_equals_zero(self):
+        assert fingerprint(-0.0) == fingerprint(0.0)
+
+    def test_nan_payloads_collapse(self):
+        import struct
+
+        alt_nan = struct.unpack(">d", struct.pack(">Q", 0x7FF8000000000001))[0]
+        assert alt_nan != alt_nan  # a NaN with a non-canonical payload
+        assert fingerprint(float("nan")) == fingerprint(alt_nan)
+
+
+class TestNestedRecordHashing:
+    def test_nested_record_stable(self):
+        r1 = Record(outer=Record(a=1.0, b=2.0), m=3.0)
+        r2 = Record(outer=Record(a=1.0, b=2.0), m=3.0)
+        assert fingerprint(r1) == fingerprint(r2)
+
+    def test_nested_leaf_change_differs(self):
+        r1 = Record(outer=Record(a=1.0, b=2.0), m=3.0)
+        r2 = Record(outer=Record(a=1.0, b=9.0), m=3.0)
+        assert fingerprint(r1) != fingerprint(r2)
+
+
+class TestEmpiricalReweighting:
+    """The Record-backed empirical class stores no ``_samples`` — reweighted
+    posteriors must still be distinguished (was a silent collision)."""
+
+    def _emp(self, weights):
+        from probpipe.core._empirical import EmpiricalDistribution
+
+        s = jnp.array([1.0, 2.0, 3.0])
+        return EmpiricalDistribution(s, log_weights=jnp.log(jnp.array(weights)), name="p")
+
+    def test_reweighted_differs(self):
+        assert fingerprint(self._emp([0.7, 0.2, 0.1])) != fingerprint(self._emp([0.1, 0.2, 0.7]))
+
+    def test_same_weights_stable(self):
+        assert fingerprint(self._emp([0.7, 0.2, 0.1])) == fingerprint(self._emp([0.7, 0.2, 0.1]))
+
+
+class TestArrayEdgeCases:
+    def test_over_cap_tail_change_detected(self):
+        # Above the cap: a change in the LAST element must be seen — the old
+        # sampling never covered the buffer tail.
+        base = np.arange(100_000, dtype=np.float64)
+        changed = base.copy()
+        changed[-1] = -1.0
+        assert fingerprint(jnp.asarray(base), max_array_bytes=1000) != fingerprint(
+            jnp.asarray(changed), max_array_bytes=1000
+        )
+
+    def test_object_dtype_array_stable_by_content(self):
+        a = np.array(["x", "y", "z"], dtype=object)
+        b = np.array(["x", "y", "z"], dtype=object)
+        assert fingerprint(a) == fingerprint(b)
+
+
+class TestParentInfoIdentity:
+    def test_fingerprint_excluded_from_equality(self):
+        # Two descriptors for the same ancestor compare/hash equal regardless of
+        # the content digest, so a fingerprint can't perturb ancestor-set dedup.
+        a = ParentInfo(type_name="X", name="n", source=None, fingerprint="aaaaaaaaaaaaaaaa")
+        b = ParentInfo(type_name="X", name="n", source=None, fingerprint="bbbbbbbbbbbbbbbb")
+        assert a == b
+        assert hash(a) == hash(b)


### PR DESCRIPTION
> **Maintainer update — rebased + review fixes.** This branch is rebased onto
> `dev/record-named-collection` (the leaf-keyed `Record`/`EventTemplate`
> redesign, #326/#327), so **this PR is now stacked on #327** and targets that
> branch — merge after #327 lands. The `/code-review` findings are addressed in
> a follow-up commit:
>
> - **WorkflowFunction** now hashes `co_names`/`co_varnames`/`co_freevars` +
>   closure cells + defaults, so a body that changes only the name called
>   (`jnp.sin` vs `jnp.cos`), a captured value, or a default is detected
>   (previously collided).
> - **Records** are hashed by their leaf-keyed `items()` — the old `fields` +
>   index pattern *crashed* on nested records under the new API.
> - **EmpiricalDistribution** uses the public `.samples`/`.is_uniform`/
>   `.log_weights` (the Record-backed subclass has no `_samples`), and `Weights`
>   are hashed by content — so reweighted (IS/SMC) posteriors and weighted
>   mixtures no longer collide.
> - **Cross-process determinism**: `set`/`frozenset` order-independent, numpy
>   scalars by dtype+bytes, `float` `-0.0`/NaN canonicalized, object-dtype arrays
>   hashed element-wise, repr fallback no longer truncated to 500 chars.
> - **Arrays**: over-cap sampling now covers the tail and slices device-side to
>   bound the host transfer.
> - `ParentInfo.fingerprint` is excluded from equality/hashing (identity is
>   structural), and `_is_*` guards catch `ImportError` only.
>
> **Deferred (open):** whether to gate fingerprinting off the default
> `LIGHTWEIGHT` path until a `cache_key_fn` consumes it, and a full
> `jax.tree_util`-based encoder generalization. The strategy table below is the
> original design; the array cap is **256 MB**.

## Summary

Adds `probpipe/core/_fingerprint.py`, a stable content hashing utility, and
wires it into the provenance system so that every `ParentInfo` descriptor now
carries a populated `fingerprint` field.

The `fingerprint(obj) -> str` function returns a 16-character hex digest
(64-bit SHA-256 prefix) that is deterministic across processes for the same
inputs. It dispatches on ProbPipe's type hierarchy:

| Input type | Strategy |
|---|---|
| `jax.Array` / `numpy.ndarray` | shape + dtype + raw bytes (256 MB cap; samples tail-covering, device-sliced windows for large arrays; object-dtype hashed element-wise) |
| Python scalars (`int`, `float`, `bool`, `str`, `None`) | direct binary encoding via `struct.pack` |
| `Record` | field names + values, hashed recursively in insertion order |
| `Distribution` | class name + distribution name + TFP parameter dict; falls back to `vars()` for non-TFP types such as `EmpiricalDistribution` |
| `WorkflowFunction` | user function bytecode (`__code__.co_code` + `co_consts` + source location), **not** the Prefect wrapper closure — so changes to the user function body are detected reliably |
| Unknown / unhashable | `repr()` truncated to 500 characters |

All ProbPipe type imports inside `_fingerprint.py` are deferred to call time
to avoid a circular import (`_distribution_base.py` already imports from
`provenance.py` at module load time). The call from `Provenance.create()` is
also deferred for the same reason.

The `fingerprint` field on `ParentInfo` was introduced in the previous PR
(which added `ProvenanceMode`, `ParentInfo`, `ProvenanceConfig`, and
`Provenance.create()`). That field was always `None` until now. This PR
populates it during provenance creation so the lineage descriptor carries a
stable identity for each ancestor.

---

## Context and three-PR roadmap

This PR is the second of three planned PRs for the provenance scalability
issue. The full plan is described in the linked tracking issue.

**PR 1 (merged)** — `ProvenanceMode` enum (`FULL` / `LIGHTWEIGHT` / `OFF`),
`ParentInfo` descriptor, `ProvenanceConfig` singleton, `Provenance.create()`
factory. Solved the core memory problem: in `LIGHTWEIGHT` mode, parent
Distributions are no longer held alive by the provenance chain.

**PR 2 (this PR)** — Stable content fingerprinting. Builds the utility that
a future Prefect `cache_key_fn` can delegate to, without touching any Prefect
code yet. Populates `ParentInfo.fingerprint` for all three provenance modes
(except `OFF`, where no `ParentInfo` is created).

**PR 3 (planned)** — Prefect result caching. Wire `persist_result=True` and a
custom `cache_key_fn` (using the fingerprinting from this PR) into the task
decorators in `_workflow_execution.py`. Depends on a serialization audit of
ProbPipe result types and alignment on remote storage configuration for
multi-machine scenarios.

---

## Linked issue(s)

Refs #117 
---

## Test plan

New test file: `tests/core/test_fingerprint.py` (41 tests).

- **Return format** — output is always a 16-character lowercase hex string.
- **Python primitives** — int, float, bool, str, None: same value → same
  digest; different values → different digest; bool and int hash differently
  even when numerically equal.
- **Array hashing** — same JAX array → same digest; different values, shapes,
  or dtypes → different digest. Also covers `numpy.ndarray`.
- **Record hashing** — same fields and values → same digest; any difference
  in field names, values, or number of fields → different digest.
- **Distribution hashing** — same parameters and name → same digest;
  different `loc`, `scale`, name, or distribution type → different digest.
  Covers both TFP-backed parametrics (`Normal`, `Beta`) and sample-based
  distributions (`RecordEmpiricalDistribution`).
- **WorkflowFunction hashing** — same function → same digest; different
  function body or different literal constants → different digest.
- **Integration with `Provenance.create()`** — `ParentInfo.fingerprint` is
  set and non-`None` after `Provenance.create()`; stable across multiple
  `create()` calls for the same parent; two parents with different parameters
  produce different fingerprints; fingerprint appears in `to_dict()` output;
  `OFF` mode produces `None` (no `Provenance` object created at all).

Existing provenance tests (`tests/core/test_provenance.py`, 58 tests) all
pass unchanged.

---

## Breaking changes

None. `ParentInfo.fingerprint` was already part of the public dataclass
(introduced in PR 1); it was previously always `None`. Callers that read
`fingerprint` now receive a string instead of `None` — this is the intended
behavior and is additive.

---

## Documentation

- [x] Docstrings updated for changed public APIs
- [x] `_fingerprint.py` module docstring describes supported types and design
      constraints (deferred imports, size cap, digest length)
- [x] User Guide / tutorials updated where relevant
- [x] CHANGELOG noted in the linked issue

---

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`
- [x] `area:provenance`, `area:core` labels applied
- [x] Linked to tracking issue above

