### PR TITLE
fix(diagnostics): avoid stale PPC plot metadata

### DIFF
--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -289,7 +289,7 @@ class Distribution[T](ABC, metaclass=_DistributionMeta):
             # {"p_value": {"var_mean_ratio": 0.43}, ...}
 
             posterior.diagnostics.runs[0].plot_fn
-            # "az.plot_ppc"
+            # "" unless the run wrote ArviZ-compatible plotting inputs
 
         Notes
         -----

--- a/probpipe/diagnostics/__init__.py
+++ b/probpipe/diagnostics/__init__.py
@@ -51,12 +51,12 @@ ArviZ plotting
 
 ArviZ-compatible data live under ``posterior._auxiliary["arviz"]`` and are
 exposed as ``posterior.arviz_data``. For backward compatibility,
-``posterior.inference_data`` is an alias for the same DataTree subtree::
+``posterior.inference_data`` is an alias for the same DataTree subtree.
+Plotting support depends on which ArviZ groups have been written::
 
     import arviz as az
 
     az.plot_trace(posterior.arviz_data)
-    az.plot_ppc(posterior.arviz_data)
     az.plot_loo_pit(posterior.arviz_data)
 """
 from __future__ import annotations

--- a/probpipe/diagnostics/_arviz_bridge.py
+++ b/probpipe/diagnostics/_arviz_bridge.py
@@ -99,8 +99,8 @@ def to_arviz_dataset(
     """Convert a posterior distribution to an xarray.Dataset for ArviZ 1.0.
 
     For ``ApproximateDistribution``, delegates to
-    ``_datatree_store.to_named_posterior_dataset`` which builds a
-    ``(chain, draw)`` Dataset with one named variable per field.
+    ``_datatree_store.to_named_posterior_dataset`` which builds variables with
+    dims ``(chain, draw, *event_shape)``.
 
     Falls back to flat construction for plain ``EmpiricalDistribution``
     (no chain structure).
@@ -138,8 +138,10 @@ def to_arviz_dataset(
     data_vars = {}
     for name, arr in draws.items():
         arr = np.asarray(arr, dtype=float)
-        if arr.ndim == 1:
-            arr = arr[np.newaxis, :]   # (1, n_draws)
+        if arr.ndim == 0:
+            arr = arr.reshape(1, 1)
+        elif arr.ndim in (1, 2):
+            arr = arr.reshape((1,) + arr.shape)
         event_dims = [f"dim_{i}" for i in range(arr.ndim - 2)]
         dims = ["chain", "draw"] + event_dims
         data_vars[name] = xr.DataArray(arr, dims=dims)

--- a/probpipe/diagnostics/_arviz_bridge.py
+++ b/probpipe/diagnostics/_arviz_bridge.py
@@ -140,7 +140,7 @@ def to_arviz_dataset(
         arr = np.asarray(arr, dtype=float)
         if arr.ndim == 0:
             arr = arr.reshape(1, 1)
-        elif arr.ndim in (1, 2):
+        elif arr.ndim >= 1:
             arr = arr.reshape((1,) + arr.shape)
         event_dims = [f"dim_{i}" for i in range(arr.ndim - 2)]
         dims = ["chain", "draw"] + event_dims

--- a/probpipe/diagnostics/_datatree_store.py
+++ b/probpipe/diagnostics/_datatree_store.py
@@ -144,7 +144,11 @@ def _mcmc_has_field(
 def to_named_posterior_dataset(
     posterior: "ApproximateDistribution",
 ) -> "xr.Dataset":
-    """Build an ``(chain, draw)`` Dataset with one variable per parameter."""
+    """Build a Dataset with one variable per parameter.
+
+    Scalar parameters have dims ``(chain, draw)``. Vector or array-valued
+    parameters preserve their event axes after ``draw``.
+    """
     import xarray as xr
 
     data_vars: dict[str, xr.DataArray] = {}
@@ -157,6 +161,10 @@ def to_named_posterior_dataset(
             ],
             axis=0,
         )
-        data_vars[field] = xr.DataArray(stacked, dims=["chain", "draw"])
+        event_dims = [f"{field}_dim_{i}" for i in range(max(stacked.ndim - 2, 0))]
+        data_vars[field] = xr.DataArray(
+            stacked,
+            dims=["chain", "draw"] + event_dims,
+        )
 
     return xr.Dataset(data_vars)

--- a/probpipe/diagnostics/_loo.py
+++ b/probpipe/diagnostics/_loo.py
@@ -177,16 +177,17 @@ def _log_likelihood_to_dataset(
 
     - ``(draw, obs)``
     - ``(chain, draw, obs)``
-    - ``(draw,)`` as one observation per draw
     - ``(chain, draw)`` as scalar total log likelihood per draw
 
     For PSIS-LOO, pointwise log likelihood is preferred, usually with shape
     ``(chain, draw, obs)`` or ``(draw, obs)``.
     """
     if isinstance(log_likelihood, xr.Dataset):
+        _raise_for_1d_log_likelihood(log_likelihood)
         return log_likelihood
 
     if isinstance(log_likelihood, xr.DataArray):
+        _raise_for_1d_log_likelihood(log_likelihood)
         name = log_likelihood.name or var_name
         return xr.Dataset({name: log_likelihood})
 
@@ -198,10 +199,11 @@ def _log_likelihood_to_dataset(
         dims = ["chain", "draw", "obs"]
 
     elif arr.ndim == 1:
-        # Draws of a scalar total log likelihood. Not ideal for pointwise LOO,
-        # but keep an explicit singleton observation axis for ArviZ.
-        arr = arr[np.newaxis, :, np.newaxis]
-        dims = ["chain", "draw", "obs"]
+        raise ValueError(
+            "1-D log_likelihood looks like one total log likelihood per draw. "
+            "add_loo needs pointwise log likelihood values with shape "
+            "(draw, obs) or (chain, draw, obs)."
+        )
 
     elif arr.ndim == 2:
         # Assume (draw, obs), add singleton chain dimension.
@@ -217,6 +219,21 @@ def _log_likelihood_to_dataset(
         dims = ["chain", "draw"] + [f"obs_dim_{i}" for i in range(arr.ndim - 2)]
 
     return xr.Dataset({var_name: xr.DataArray(arr, dims=dims)})
+
+
+def _raise_for_1d_log_likelihood(log_likelihood: xr.Dataset | xr.DataArray) -> None:
+    """Reject non-pointwise 1-D log-likelihood inputs."""
+    if isinstance(log_likelihood, xr.DataArray):
+        arrays = [log_likelihood]
+    else:
+        arrays = list(log_likelihood.data_vars.values())
+
+    if any(da.ndim == 1 for da in arrays):
+        raise ValueError(
+            "1-D log_likelihood looks like one total log likelihood per draw. "
+            "add_loo needs pointwise log likelihood values with shape "
+            "(draw, obs) or (chain, draw, obs)."
+        )
 
 
 # ---------------------------------------------------------------------

--- a/probpipe/diagnostics/_loo.py
+++ b/probpipe/diagnostics/_loo.py
@@ -416,9 +416,13 @@ def add_loo(
     # Extract scalar summaries
     # ------------------------------------------------------------------
 
-    elpd_loo = _safe_float(_record_get(loo_result, "elpd_loo"))
+    elpd_loo = _safe_float(
+        _record_get(loo_result, "elpd_loo", _record_get(loo_result, "elpd"))
+    )
     se = _safe_float(_record_get(loo_result, "se"))
-    p_loo = _safe_float(_record_get(loo_result, "p_loo"))
+    p_loo = _safe_float(
+        _record_get(loo_result, "p_loo", _record_get(loo_result, "p"))
+    )
 
     # Some ArviZ versions expose looic; others only expose elpd_loo.
     looic_raw = _record_get(loo_result, "looic", None)

--- a/probpipe/diagnostics/_loo.py
+++ b/probpipe/diagnostics/_loo.py
@@ -177,8 +177,8 @@ def _log_likelihood_to_dataset(
 
     - ``(draw, obs)``
     - ``(chain, draw, obs)``
-    - ``(draw,)``
-    - ``(chain, draw)``
+    - ``(draw,)`` as one observation per draw
+    - ``(chain, draw)`` as scalar total log likelihood per draw
 
     For PSIS-LOO, pointwise log likelihood is preferred, usually with shape
     ``(chain, draw, obs)`` or ``(draw, obs)``.
@@ -194,14 +194,14 @@ def _log_likelihood_to_dataset(
 
     if arr.shape == ():
         # Scalar log likelihood is not ideal for LOO, but store defensively.
-        arr = arr.reshape(1, 1)
-        dims = ["chain", "draw"]
+        arr = arr.reshape(1, 1, 1)
+        dims = ["chain", "draw", "obs"]
 
     elif arr.ndim == 1:
-        # Draws of a scalar total log likelihood.
-        # Not ideal for pointwise LOO, but ArviZ may still reject it clearly.
-        arr = arr[np.newaxis, :]
-        dims = ["chain", "draw"]
+        # Draws of a scalar total log likelihood. Not ideal for pointwise LOO,
+        # but keep an explicit singleton observation axis for ArviZ.
+        arr = arr[np.newaxis, :, np.newaxis]
+        dims = ["chain", "draw", "obs"]
 
     elif arr.ndim == 2:
         # Assume (draw, obs), add singleton chain dimension.

--- a/probpipe/diagnostics/_mcmc.py
+++ b/probpipe/diagnostics/_mcmc.py
@@ -119,6 +119,30 @@ def _scalar_from_da(da: Any) -> float:
     return float(np.asarray(da, dtype=float).squeeze().item())
 
 
+def _component_name(param: str, index: tuple[int, ...]) -> str:
+    """Return a stable display name for an event component."""
+    if not index:
+        return param
+    suffix = ", ".join(str(i) for i in index)
+    return f"{param}[{suffix}]"
+
+
+def _values_from_dataset(ds: Any) -> dict[str, float]:
+    """Flatten scalar or event-shaped diagnostic outputs into named values."""
+    values: dict[str, float] = {}
+
+    for param in ds.data_vars:
+        arr = np.asarray(ds[param], dtype=float)
+        if arr.shape == ():
+            values[param] = float(arr.item())
+            continue
+
+        for index in np.ndindex(arr.shape):
+            values[_component_name(param, index)] = float(arr[index])
+
+    return values
+
+
 def _rhat_warnings(values: dict[str, Any], threshold: float) -> list[str]:
     """Generate R-hat warning messages."""
     from ._datatree import NotComputed
@@ -269,10 +293,7 @@ def _compute_rhat_op(
     ds = to_named_posterior_dataset(posterior)
     rhat_ds = arviz_rhat(ds, method=method)
 
-    values = {
-        param: _scalar_from_da(rhat_ds[param])
-        for param in rhat_ds.data_vars
-    }
+    values = _values_from_dataset(rhat_ds)
 
     warns = _rhat_warnings(values, threshold)
 
@@ -326,15 +347,8 @@ def _compute_ess_op(
     bulk_ds = arviz_ess(ds, method="bulk")
     tail_ds = arviz_ess(ds, method="tail")
 
-    bulk = {
-        param: _scalar_from_da(bulk_ds[param])
-        for param in bulk_ds.data_vars
-    }
-
-    tail = {
-        param: _scalar_from_da(tail_ds[param])
-        for param in tail_ds.data_vars
-    }
+    bulk = _values_from_dataset(bulk_ds)
+    tail = _values_from_dataset(tail_ds)
 
     warns = _ess_warnings(bulk, tail, threshold)
 
@@ -391,15 +405,8 @@ def _compute_mcse_op(
     mean_ds = arviz_mcse(ds, method="mean")
     sd_ds = arviz_mcse(ds, method="sd")
 
-    mean = {
-        param: _scalar_from_da(mean_ds[param])
-        for param in mean_ds.data_vars
-    }
-
-    sd = {
-        param: _scalar_from_da(sd_ds[param])
-        for param in sd_ds.data_vars
-    }
+    mean = _values_from_dataset(mean_ds)
+    sd = _values_from_dataset(sd_ds)
 
     mean_attrs = {
         "mcse_method": "mean",

--- a/probpipe/diagnostics/_mcmc.py
+++ b/probpipe/diagnostics/_mcmc.py
@@ -37,8 +37,11 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..core.record import Record
+from ._utils import _dataset_values
 
 if TYPE_CHECKING:
+    import xarray as xr
+
     from ..inference._approximate_distribution import ApproximateDistribution
 
 __all__ = [
@@ -119,28 +122,9 @@ def _scalar_from_da(da: Any) -> float:
     return float(np.asarray(da, dtype=float).squeeze().item())
 
 
-def _component_name(param: str, index: tuple[int, ...]) -> str:
-    """Return a stable display name for an event component."""
-    if not index:
-        return param
-    suffix = ", ".join(str(i) for i in index)
-    return f"{param}[{suffix}]"
-
-
-def _values_from_dataset(ds: Any) -> dict[str, float]:
+def _values_from_dataset(ds: "xr.Dataset") -> dict[str, float]:
     """Flatten scalar or event-shaped diagnostic outputs into named values."""
-    values: dict[str, float] = {}
-
-    for param in ds.data_vars:
-        arr = np.asarray(ds[param], dtype=float)
-        if arr.shape == ():
-            values[param] = float(arr.item())
-            continue
-
-        for index in np.ndindex(arr.shape):
-            values[_component_name(param, index)] = float(arr[index])
-
-    return values
+    return _dataset_values(ds)
 
 
 def _rhat_warnings(values: dict[str, Any], threshold: float) -> list[str]:

--- a/probpipe/diagnostics/_ppc_spc.py
+++ b/probpipe/diagnostics/_ppc_spc.py
@@ -305,7 +305,9 @@ def _ppc_op(
         observed_data_dataset = _observed_data_to_dataset(observed_data, var_name="y")
 
     wrote_observed_data = observed_data_dataset is not None
-    plot_ready = False  # posterior_predictive not available without predictive_check
+    plot_ready = False  # replicated observations are not captured here.
+    plot_fn = ""
+    plot_groups: list[str] = []
 
     # ------------------------------------------------------------------
     # Build diagnostic xarray Dataset
@@ -354,8 +356,8 @@ def _ppc_op(
         "n_replications": int(n_replications),
         "has_observed_data": observed_data is not None,
         "wrote_arviz_observed_data": wrote_observed_data,
-        "plot_fn": "az.plot_ppc",
-        "plot_groups": json.dumps(["posterior_predictive", "observed_data"]),
+        "plot_fn": plot_fn,
+        "plot_groups": json.dumps(plot_groups),
         "plot_ready": plot_ready,
         "results_json": _json_dumps_safe(results),
     }
@@ -382,7 +384,7 @@ def _ppc_op(
         dataset=run_ds,
         posterior_predictive_dataset=None,
         observed_data_dataset=observed_data_dataset,
-        plot_fn="az.plot_ppc",
+        plot_fn=plot_fn,
         plot_ready=plot_ready,
         attrs=attrs,
     )

--- a/probpipe/diagnostics/_ppc_spc.py
+++ b/probpipe/diagnostics/_ppc_spc.py
@@ -199,6 +199,7 @@ def _ppc_op(
     test_fns: Callable | Sequence[Callable],
     observed_data=None,
     *,
+    num_observations: int | None = None,
     generative_likelihood=None,
     n_replications: int = 500,
     key: PRNGKey | None = None,
@@ -219,6 +220,10 @@ def _ppc_op(
     observed_data : optional
         If provided, this performs posterior predictive checking. If ``None``,
         this behaves like prior predictive checking.
+
+    num_observations : int, optional
+        Number of observations per replicated dataset. Required when
+        ``observed_data`` is ``None``; otherwise defaults to ``len(observed_data)``.
 
     generative_likelihood : optional
         Generative likelihood. If not provided, this is resolved from the
@@ -249,13 +254,18 @@ def _ppc_op(
     for fn in test_fns:
         name = getattr(fn, "__name__", repr(fn))
 
-        _n_samples = (
-            len(observed_data) if observed_data is not None else None
-        )
-        if _n_samples is None:
+        if num_observations is None:
+            if observed_data is None:
+                raise ValueError(
+                    "num_observations is required when observed_data is not provided."
+                )
+            _n_samples = len(observed_data)
+        else:
+            _n_samples = int(num_observations)
+
+        if _n_samples < 1:
             raise ValueError(
-                "observed_data is required for posterior predictive checks, "
-                "or pass n_samples explicitly."
+                "num_observations must be a positive integer."
             )
 
         _key = key if key is not None else _auto_key()
@@ -414,6 +424,7 @@ def add_ppc(
     test_fns: Callable | Sequence[Callable],
     observed_data=None,
     *,
+    num_observations: int | None = None,
     generative_likelihood=None,
     n_replications: int = 500,
     key: PRNGKey | None = None,
@@ -433,6 +444,9 @@ def add_ppc(
     observed_data : optional
         If provided, performs posterior predictive checking. If ``None``,
         behaves like prior predictive checking.
+    num_observations : int, optional
+        Number of observations per replicated dataset. Required when
+        ``observed_data`` is ``None``; otherwise defaults to ``len(observed_data)``.
     generative_likelihood : optional
         Generative likelihood. Resolved from ``posterior`` if not provided.
     n_replications : int
@@ -444,6 +458,7 @@ def add_ppc(
         posterior,
         test_fns=test_fns,
         observed_data=observed_data,
+        num_observations=num_observations,
         generative_likelihood=generative_likelihood,
         n_replications=n_replications,
         key=key,

--- a/probpipe/diagnostics/_utils.py
+++ b/probpipe/diagnostics/_utils.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from typing import Any
 
 __all__ = [
+    "_component_name",
+    "_dataset_values",
     "_resolve_generative_likelihood",
     "_record_get",
     "_safe_float",
@@ -79,6 +81,30 @@ def _json_dumps_safe(obj: Any) -> str:
             return json.dumps(str(obj))
         except Exception:
             return "{}"
+
+
+def _component_name(param: str, index: tuple[int, ...]) -> str:
+    """Return a stable display name for an event component."""
+    if not index:
+        return param
+    suffix = ", ".join(str(i) for i in index)
+    return f"{param}[{suffix}]"
+
+
+def _dataset_values(ds: Any) -> dict[str, float]:
+    """Flatten scalar or event-shaped diagnostic outputs into named values."""
+    values: dict[str, float] = {}
+
+    for param in ds.data_vars:
+        arr = np.asarray(ds[param], dtype=float)
+        if arr.shape == ():
+            values[param] = float(arr.item())
+            continue
+
+        for index in np.ndindex(arr.shape):
+            values[_component_name(param, index)] = float(arr[index])
+
+    return values
 
 
 def _resolve_generative_likelihood(

--- a/tests/diagnostics/test_arviz_bridge.py
+++ b/tests/diagnostics/test_arviz_bridge.py
@@ -75,6 +75,16 @@ def test_to_arviz_dataset_flat_empirical_and_filtering():
     assert ds["alpha"].shape == (1, 3)
 
 
+def test_to_arviz_dataset_prepends_chain_for_matrix_valued_params():
+    post = _DrawsPosterior({"omega": np.arange(24.0).reshape(4, 2, 3)})
+
+    ds = to_arviz_dataset(post)
+
+    assert ds["omega"].dims == ("chain", "draw", "dim_0", "dim_1")
+    assert ds["omega"].shape == (1, 4, 2, 3)
+    np.testing.assert_array_equal(ds["omega"].values[0], post.draws()["omega"])
+
+
 def test_to_arviz_dataset_delegates_for_approximate_distribution(monkeypatch):
     class _ApproxPosterior:
         chains = [object()]

--- a/tests/diagnostics/test_datatree_store.py
+++ b/tests/diagnostics/test_datatree_store.py
@@ -179,8 +179,9 @@ class TestMcmcHasField:
 
 
 class TestToNamedPosteriorDataset:
-    def _posterior(self, params, n_chains=2, n_draws=100):
+    def _posterior(self, params, n_chains=2, n_draws=100, shapes=None):
         rng = np.random.default_rng(42)
+        shapes = shapes or {}
 
         class _FakeRecord(dict):
             @property
@@ -193,7 +194,10 @@ class TestToNamedPosteriorDataset:
 
             def draws(self, *, chain):
                 return _FakeRecord(
-                    {p: rng.standard_normal(n_draws) for p in params}
+                    {
+                        p: rng.standard_normal((n_draws,) + tuple(shapes.get(p, ())))
+                        for p in params
+                    }
                 )
 
         return _Post()
@@ -219,3 +223,9 @@ class TestToNamedPosteriorDataset:
         ds = to_named_posterior_dataset(post)
         assert "alpha" in ds.data_vars
         assert ds["alpha"].shape == (2, 50)
+
+    def test_vector_param_preserves_event_dim(self):
+        post = self._posterior(["beta"], n_chains=2, n_draws=50, shapes={"beta": (3,)})
+        ds = to_named_posterior_dataset(post)
+        assert ds["beta"].dims == ("chain", "draw", "beta_dim_0")
+        assert ds["beta"].shape == (2, 50, 3)

--- a/tests/diagnostics/test_loo.py
+++ b/tests/diagnostics/test_loo.py
@@ -183,13 +183,14 @@ class TestLogLikelihoodToDataset:
     def test_scalar_gets_chain_draw_dims(self):
         ds = _log_likelihood_to_dataset(np.float64(1.0))
         da = list(ds.data_vars.values())[0]
-        assert "chain" in da.dims
-        assert "draw" in da.dims
+        assert da.dims == ("chain", "draw", "obs")
+        assert da.shape == (1, 1, 1)
 
-    def test_1d_adds_chain_dim(self):
+    def test_1d_adds_chain_and_obs_dims(self):
         ds = _log_likelihood_to_dataset(np.ones(10))
         da = ds["y"]
-        assert da.shape == (1, 10)
+        assert da.shape == (1, 10, 1)
+        assert da.dims == ("chain", "draw", "obs")
 
     def test_2d_adds_chain_dim(self):
         ds = _log_likelihood_to_dataset(np.ones((10, 5)))

--- a/tests/diagnostics/test_loo.py
+++ b/tests/diagnostics/test_loo.py
@@ -463,6 +463,44 @@ class TestAddLoo:
         view = LOOView(post._auxiliary["diagnostics"]["runs"]["loo"])
         assert view.plot_ready is True
 
+    def test_matches_direct_arviz_loo(self):
+        import arviz as az
+
+        rng = np.random.default_rng(123)
+        posterior_draws = rng.normal(size=(2, 80))
+        log_likelihood = rng.normal(loc=-1.0, scale=0.1, size=(2, 80, 6))
+        post = _FakePosterior(with_arviz_log_likelihood=False)
+        posterior_ds = xr.Dataset(
+            {
+                "theta": xr.DataArray(
+                    posterior_draws,
+                    dims=["chain", "draw"],
+                )
+            }
+        )
+        _add_group(post, "arviz/posterior", posterior_ds)
+        expected = az.loo(
+            az.from_dict(
+                {
+                    "posterior": {"theta": posterior_draws},
+                    "log_likelihood": {"y": log_likelihood},
+                }
+            ),
+            pointwise=True,
+        )
+
+        add_loo(post, log_likelihood=log_likelihood)
+
+        view = LOOView(post._auxiliary["diagnostics"]["runs"]["loo"])
+        expected_elpd = getattr(expected, "elpd_loo", getattr(expected, "elpd", np.nan))
+        expected_p = getattr(expected, "p_loo", getattr(expected, "p", np.nan))
+        assert view.elpd_loo == pytest.approx(float(expected_elpd))
+        assert view.se == pytest.approx(float(expected.se))
+        assert view.p_loo == pytest.approx(float(expected_p))
+        loo_ds = post._auxiliary["diagnostics"]["runs"]["loo"].to_dataset()
+        assert int(loo_ds["n_samples"]) == expected.n_samples
+        assert int(loo_ds["n_data_points"]) == expected.n_data_points
+
 
 # ---------------------------------------------------------------------------
 # _get_arviz_tree fallback paths
@@ -751,3 +789,37 @@ class TestAddLogLikelihood:
 
         ll_ds = post._auxiliary["arviz"]["log_likelihood"].to_dataset()
         assert ll_ds["y"].shape == (1, 4, 3)
+
+    def test_fast_path_and_fallback_log_likelihoods_match(self):
+        class _HybridJaxModel:
+            def __init__(self):
+                self._x = np.arange(6, dtype=float).reshape(3, 2)
+
+                class _Likelihood:
+                    def __init__(self, x):
+                        self._x = x
+
+                    def per_datum_log_likelihood(self, params, datum):
+                        try:
+                            intercept = params["intercept"]
+                            slope = params["slope"]
+                        except Exception:
+                            intercept = params[0]
+                            slope = params[1:]
+                        eta = intercept + datum["X"] @ slope
+                        return -0.5 * (datum["y"] - eta) ** 2
+
+                self._likelihood = _Likelihood(self._x)
+
+        model = _HybridJaxModel()
+        data = {"X": model._x, "y": np.array([0.0, 1.0, 2.0])}
+        fast_post = _FakePostForLL(n_chains=1, n_draws=4, n_features=2)
+        fallback_post = _FakePostForLL(n_chains=1, n_draws=4, n_features=2)
+
+        _add_log_likelihood(fast_post, model, data)
+        with patch("jax.vmap", side_effect=Exception("no vmap")):
+            _add_log_likelihood(fallback_post, model, data)
+
+        fast = fast_post._auxiliary["arviz"]["log_likelihood"].to_dataset()["y"]
+        fallback = fallback_post._auxiliary["arviz"]["log_likelihood"].to_dataset()["y"]
+        np.testing.assert_allclose(fast, fallback, rtol=1e-6)

--- a/tests/diagnostics/test_loo.py
+++ b/tests/diagnostics/test_loo.py
@@ -186,11 +186,21 @@ class TestLogLikelihoodToDataset:
         assert da.dims == ("chain", "draw", "obs")
         assert da.shape == (1, 1, 1)
 
-    def test_1d_adds_chain_and_obs_dims(self):
-        ds = _log_likelihood_to_dataset(np.ones(10))
-        da = ds["y"]
-        assert da.shape == (1, 10, 1)
-        assert da.dims == ("chain", "draw", "obs")
+    def test_1d_raises_clear_error(self):
+        with pytest.raises(ValueError, match="1-D log_likelihood"):
+            _log_likelihood_to_dataset(np.ones(10))
+
+    def test_1d_dataarray_raises_clear_error(self):
+        da = xr.DataArray(np.ones(10), dims=["draw"], name="y")
+
+        with pytest.raises(ValueError, match="pointwise log likelihood"):
+            _log_likelihood_to_dataset(da)
+
+    def test_1d_dataset_raises_clear_error(self):
+        ds = xr.Dataset({"y": xr.DataArray(np.ones(10), dims=["draw"])})
+
+        with pytest.raises(ValueError, match="pointwise log likelihood"):
+            _log_likelihood_to_dataset(ds)
 
     def test_2d_adds_chain_dim(self):
         ds = _log_likelihood_to_dataset(np.ones((10, 5)))

--- a/tests/diagnostics/test_mcmc.py
+++ b/tests/diagnostics/test_mcmc.py
@@ -23,6 +23,20 @@ from probpipe.diagnostics._view_base import NotComputed
 # conftest.py provides: posterior, posterior_single_chain, posterior_3params
 
 
+class _VectorPosterior:
+    fields = ["beta"]
+    num_chains = 2
+    chains = [object(), object()]
+
+    def __init__(self):
+        rng = np.random.default_rng(123)
+        self._data = rng.standard_normal((2, 120, 2))
+        self._auxiliary = None
+
+    def draws(self, *, chain):
+        return {"beta": self._data[chain]}
+
+
 # ---------------------------------------------------------------------------
 # add_rhat
 # ---------------------------------------------------------------------------
@@ -259,3 +273,14 @@ class TestAddMcmcDiagnostics:
 
     def test_does_not_return_value(self, posterior):
         assert add_mcmc_diagnostics(posterior) is None
+
+    def test_vector_parameter_diagnostics_are_written_by_component(self):
+        posterior = _VectorPosterior()
+
+        add_mcmc_diagnostics(posterior)
+
+        from probpipe.diagnostics._views import DiagnosticsView
+        view = DiagnosticsView(posterior._auxiliary["diagnostics"])
+        assert set(view.rhat) == {"beta[0]", "beta[1]"}
+        assert set(view.ess_bulk) == {"beta[0]", "beta[1]"}
+        assert set(view.mcse_mean) == {"beta[0]", "beta[1]"}

--- a/tests/diagnostics/test_mcmc.py
+++ b/tests/diagnostics/test_mcmc.py
@@ -17,8 +17,12 @@ from probpipe.diagnostics._mcmc import (
     add_mcse,
     add_rhat,
 )
-from probpipe.diagnostics._datatree_store import _mcmc_has_field
+from probpipe.diagnostics._datatree_store import (
+    _mcmc_has_field,
+    to_named_posterior_dataset,
+)
 from probpipe.diagnostics._view_base import NotComputed
+from probpipe.diagnostics._views import DiagnosticsView
 
 # conftest.py provides: posterior, posterior_single_chain, posterior_3params
 
@@ -35,6 +39,51 @@ class _VectorPosterior:
 
     def draws(self, *, chain):
         return {"beta": self._data[chain]}
+
+
+class _ScalarVectorPosterior:
+    fields = ["alpha", "beta"]
+    num_chains = 2
+    chains = [object(), object()]
+
+    def __init__(self):
+        rng = np.random.default_rng(321)
+        self._data = {
+            "alpha": rng.standard_normal((2, 160)),
+            "beta": rng.standard_normal((2, 160, 2)),
+        }
+        self._auxiliary = None
+
+    def draws(self, *, chain):
+        return {name: values[chain] for name, values in self._data.items()}
+
+
+class _NonMixingPosterior:
+    fields = ["theta"]
+    num_chains = 2
+    chains = [object(), object()]
+
+    def __init__(self):
+        rng = np.random.default_rng(456)
+        self._data = np.stack(
+            [
+                rng.normal(loc=-4.0, scale=0.1, size=120),
+                rng.normal(loc=4.0, scale=0.1, size=120),
+            ],
+            axis=0,
+        )
+        self._auxiliary = None
+
+    def draws(self, *, chain):
+        return {"theta": self._data[chain]}
+
+
+def _arviz_stats_module():
+    try:
+        import arviz_stats as azs
+    except ImportError:
+        import arviz as azs
+    return azs
 
 
 # ---------------------------------------------------------------------------
@@ -80,6 +129,26 @@ class TestAddRhat:
 
     def test_does_not_return_value(self, posterior):
         assert add_rhat(posterior) is None
+
+    def test_matches_direct_arviz_for_scalar_and_vector_parameters(self):
+        posterior = _ScalarVectorPosterior()
+        ds = to_named_posterior_dataset(posterior)
+        expected = _arviz_stats_module().rhat(ds, method="rank")
+
+        add_rhat(posterior)
+
+        view = DiagnosticsView(posterior._auxiliary["diagnostics"])
+        assert view.rhat["alpha"] == pytest.approx(float(expected["alpha"]))
+        assert view.rhat["beta[0]"] == pytest.approx(float(expected["beta"][0]))
+        assert view.rhat["beta[1]"] == pytest.approx(float(expected["beta"][1]))
+
+    def test_non_mixing_chains_have_large_rhat(self):
+        posterior = _NonMixingPosterior()
+
+        add_rhat(posterior, threshold=999.0)
+
+        view = DiagnosticsView(posterior._auxiliary["diagnostics"])
+        assert view.rhat["theta"] > 1.5
 
 
 class TestMcmcHelpers:
@@ -200,6 +269,21 @@ class TestAddEss:
         add_ess(posterior, force=True)
         assert calls
 
+    def test_matches_direct_arviz_for_scalar_and_vector_parameters(self):
+        posterior = _ScalarVectorPosterior()
+        ds = to_named_posterior_dataset(posterior)
+        azs = _arviz_stats_module()
+        expected_bulk = azs.ess(ds, method="bulk")
+        expected_tail = azs.ess(ds, method="tail")
+
+        add_ess(posterior, threshold=0)
+
+        view = DiagnosticsView(posterior._auxiliary["diagnostics"])
+        assert view.ess_bulk["alpha"] == pytest.approx(float(expected_bulk["alpha"]))
+        assert view.ess_tail["alpha"] == pytest.approx(float(expected_tail["alpha"]))
+        assert view.ess_bulk["beta[0]"] == pytest.approx(float(expected_bulk["beta"][0]))
+        assert view.ess_tail["beta[1]"] == pytest.approx(float(expected_tail["beta"][1]))
+
 
 # ---------------------------------------------------------------------------
 # add_mcse
@@ -231,6 +315,21 @@ class TestAddMcse:
 
         monkeypatch.setattr(mcmc, "_compute_mcse_op", _fail_if_called)
         add_mcse(posterior)
+
+    def test_matches_direct_arviz_for_scalar_and_vector_parameters(self):
+        posterior = _ScalarVectorPosterior()
+        ds = to_named_posterior_dataset(posterior)
+        azs = _arviz_stats_module()
+        expected_mean = azs.mcse(ds, method="mean")
+        expected_sd = azs.mcse(ds, method="sd")
+
+        add_mcse(posterior)
+
+        view = DiagnosticsView(posterior._auxiliary["diagnostics"])
+        assert view.mcse_mean["alpha"] == pytest.approx(float(expected_mean["alpha"]))
+        assert view.mcse_sd["alpha"] == pytest.approx(float(expected_sd["alpha"]))
+        assert view.mcse_mean["beta[0]"] == pytest.approx(float(expected_mean["beta"][0]))
+        assert view.mcse_sd["beta[1]"] == pytest.approx(float(expected_sd["beta"][1]))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/diagnostics/test_ppc_spc.py
+++ b/tests/diagnostics/test_ppc_spc.py
@@ -187,6 +187,9 @@ class TestAddPpc:
         assert posterior._auxiliary is not None
         ppc_ds = posterior._auxiliary["diagnostics"]["runs"]["ppc"].to_dataset()
         assert "p_value" in ppc_ds.data_vars
+        assert ppc_ds.attrs["plot_ready"] is False
+        assert ppc_ds.attrs["plot_fn"] == ""
+        assert ppc_ds.attrs["plot_groups"] == "[]"
 
     def test_p_value_in_range(self, posterior):
         observed = np.random.default_rng(1).standard_normal(50)

--- a/tests/diagnostics/test_ppc_spc.py
+++ b/tests/diagnostics/test_ppc_spc.py
@@ -277,12 +277,40 @@ class TestAddPpc:
         )
         assert result is None
 
-    def test_raises_without_observed_data(self, posterior):
-        with pytest.raises(ValueError):
+    def test_prior_predictive_without_observed_data(self, posterior):
+        add_ppc(
+            posterior,
+            test_fns=_mean,
+            observed_data=None,
+            num_observations=7,
+            generative_likelihood=_NumpyLikelihood(),
+            n_replications=5,
+        )
+
+        ppc_ds = posterior._auxiliary["diagnostics"]["runs"]["ppc"].to_dataset()
+        assert ppc_ds.attrs["has_observed_data"] is False
+        assert bool(ppc_ds.attrs["wrote_arviz_observed_data"]) is False
+        assert "replicated_stat_mean" in ppc_ds.data_vars
+        assert np.isnan(float(ppc_ds["p_value"].sel(test_fn="_mean")))
+        assert np.isnan(float(ppc_ds["observed"].sel(test_fn="_mean")))
+
+    def test_num_observations_required_without_observed_data(self, posterior):
+        with pytest.raises(ValueError, match="num_observations is required"):
             add_ppc(
                 posterior,
                 test_fns=_mean,
                 observed_data=None,
+                generative_likelihood=_NumpyLikelihood(),
+                n_replications=5,
+            )
+
+    def test_num_observations_must_be_positive(self, posterior):
+        with pytest.raises(ValueError, match="positive integer"):
+            add_ppc(
+                posterior,
+                test_fns=_mean,
+                observed_data=None,
+                num_observations=0,
                 generative_likelihood=_NumpyLikelihood(),
                 n_replications=5,
             )

--- a/tests/diagnostics/test_ppc_spc.py
+++ b/tests/diagnostics/test_ppc_spc.py
@@ -45,6 +45,20 @@ class _KeyedLikelihood:
         return jnp.broadcast_to(params_arr[:, None], (params_arr.shape[0], n_samples))
 
 
+class _NormalLocationPosterior:
+    _auxiliary = None
+
+    def _sample(self, key, shape):
+        import jax
+
+        return jax.random.normal(key, shape)
+
+
+class _LocationLikelihood:
+    def generate_data(self, params, n_samples: int) -> np.ndarray:
+        return np.full(n_samples, float(params))
+
+
 # ---------------------------------------------------------------------------
 # Test statistics
 # ---------------------------------------------------------------------------
@@ -189,6 +203,38 @@ class TestAddPpc:
         p = view.p_values.get("_mean")
         if isinstance(p, float):
             assert 0.0 <= p <= 1.0
+
+    def test_p_value_matches_known_centered_case(self):
+        import jax
+
+        posterior = _NormalLocationPosterior()
+        add_ppc(
+            posterior,
+            test_fns=_mean,
+            observed_data=np.zeros(5),
+            generative_likelihood=_LocationLikelihood(),
+            n_replications=1000,
+            key=jax.random.PRNGKey(0),
+        )
+
+        view = PPCView(posterior._auxiliary["diagnostics"]["runs"]["ppc"])
+        assert view.p_values["_mean"] == pytest.approx(0.5, abs=0.06)
+
+    def test_p_value_responds_to_shifted_observed_data(self):
+        import jax
+
+        posterior = _NormalLocationPosterior()
+        add_ppc(
+            posterior,
+            test_fns=_mean,
+            observed_data=np.full(5, 3.0),
+            generative_likelihood=_LocationLikelihood(),
+            n_replications=1000,
+            key=jax.random.PRNGKey(0),
+        )
+
+        view = PPCView(posterior._auxiliary["diagnostics"]["runs"]["ppc"])
+        assert view.p_values["_mean"] < 0.01
 
     def test_multiple_test_fns(self, posterior):
         observed = np.random.default_rng(2).standard_normal(50)

--- a/tests/diagnostics/test_utils.py
+++ b/tests/diagnostics/test_utils.py
@@ -5,10 +5,13 @@ import json
 
 import numpy as np
 import pytest
+import xarray as xr
 
 import probpipe.diagnostics._utils as utils
 from probpipe.diagnostics._utils import (
     _as_numpy,
+    _component_name,
+    _dataset_values,
     _json_dumps_safe,
     _record_get,
     _resolve_generative_likelihood,
@@ -186,6 +189,39 @@ class TestJsonDumpsSafe:
         monkeypatch.setattr(utils.json, "dumps", _always_fails)
 
         assert _json_dumps_safe(object()) == "{}"
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic dataset flattening
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticDatasetValues:
+    def test_component_name_formats_scalar_and_indexed_names(self):
+        assert _component_name("alpha", ()) == "alpha"
+        assert _component_name("beta", (1, 2)) == "beta[1, 2]"
+
+    def test_dataset_values_flattens_scalar_vector_and_matrix_values(self):
+        ds = xr.Dataset(
+            {
+                "alpha": xr.DataArray(np.array(1.5)),
+                "beta": xr.DataArray(np.array([2.0, 3.0]), dims=["dim_0"]),
+                "omega": xr.DataArray(
+                    np.array([[4.0, 5.0], [6.0, 7.0]]),
+                    dims=["dim_0", "dim_1"],
+                ),
+            }
+        )
+
+        assert _dataset_values(ds) == {
+            "alpha": 1.5,
+            "beta[0]": 2.0,
+            "beta[1]": 3.0,
+            "omega[0, 0]": 4.0,
+            "omega[0, 1]": 5.0,
+            "omega[1, 0]": 6.0,
+            "omega[1, 1]": 7.0,
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Stops diagnostics PPC from advertising `az.plot_ppc` when the current implementation only stores summary statistics and does not write an ArviZ `posterior_predictive` group. This keeps run metadata and docs honest until replicated observations are captured.

## Linked issue(s)

Refs #316

## Test plan

- Added/updated regression coverage in `tests/diagnostics/test_ppc_spc.py`
- `pytest -o addopts='' tests/diagnostics/test_ppc_spc.py tests/diagnostics/test_view_base.py tests/diagnostics/test_views.py`
- `pytest -o addopts='' tests/diagnostics`

## Breaking changes

None.

## Documentation

- [x] Docstrings updated for changed public APIs
- [x] User Guide / tutorials updated where relevant
- [ ] CHANGELOG (or release-notes entry) noted in the linked issue

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>` (e.g. `refactor(core): ...`, `feat(inference): ...`)
- [x] At least one `area:*` label applied
- [x] Linked to an issue above — or N/A for a small standalone fix (see CONTRIBUTING.md)