### PR TITLE
chore(diagnostics): clean up view and typing style

### DIFF
--- a/probpipe/diagnostics/_ppc_spc.py
+++ b/probpipe/diagnostics/_ppc_spc.py
@@ -32,8 +32,9 @@ ProbPipe diagnostic summaries and run metadata are written under::
 from __future__ import annotations
 
 import json
+from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
-from typing import Any, Callable, Sequence
+from typing import Any
 
 import numpy as np
 import xarray as xr

--- a/probpipe/diagnostics/_view_base.py
+++ b/probpipe/diagnostics/_view_base.py
@@ -245,7 +245,7 @@ class DiagnosticRunView(DatasetView):
     This class is generic. It does not know whether the run is PPC, LOO, etc.
     """
 
-    __slots__ = ("name", "_tree")
+    __slots__ = ("name",)
 
     def __init__(self, name: str, tree: Any | None) -> None:
         super().__init__(tree)


### PR DESCRIPTION
## Summary

Applies two small diagnostics style cleanups from review: imports `Callable` and `Sequence` from `collections.abc`, and removes the redundant `_tree` slot redeclaration from `DiagnosticRunView`.

## Linked issue(s)

Refs #316

## Test plan

- `pytest -o addopts='' tests/diagnostics/test_ppc_spc.py tests/diagnostics/test_view_base.py tests/diagnostics/test_views.py`
- `pytest -o addopts='' tests/diagnostics`

## Breaking changes

None.

## Documentation

- [ ] Docstrings updated for changed public APIs
- [ ] User Guide / tutorials updated where relevant
- [ ] CHANGELOG (or release-notes entry) noted in the linked issue

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>` (e.g. `refactor(core): ...`, `feat(inference): ...`)
- [x] At least one `area:*` label applied
- [x] Linked to an issue above — or N/A for a small standalone fix (see CONTRIBUTING.md)