### PR TITLE
test(inference): NUTS-vs-analytic-reference + SGLD-bias validation suite (#301)

### DIFF
--- a/tests/inference/conftest.py
+++ b/tests/inference/conftest.py
@@ -1,0 +1,70 @@
+"""Shared fixtures for inference-method validation (issue #301).
+
+A conjugate Gaussian linear model with a *closed-form* posterior — the trusted
+reference an inference method is validated against by the suite in
+``test_validation_suite.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import pytest
+import tensorflow_probability.substrates.jax.glm as tfp_glm
+
+from probpipe import GLMLikelihood, MultivariateNormal, SimpleModel, condition_on
+from probpipe.custom_types import Array
+from probpipe.inference._approximate_distribution import ApproximateDistribution
+from probpipe.validation import Reference
+
+
+@dataclass(frozen=True)
+class ConjugateLinearModel:
+    """A conjugate Gaussian linear model and its exact analytic posterior."""
+
+    model: SimpleModel
+    design: Array  # X, shape (n, p)
+    data: Array  # response y, shape (n,)
+    reference: Reference  # exact posterior N(mN, SN)
+
+
+@pytest.fixture(scope="session")
+def conjugate_linear_model() -> ConjugateLinearModel:
+    """``y ~ N(Xβ, 1)`` with prior ``β ~ N(0, τ²I)`` — posterior is exactly Gaussian.
+
+    With unit noise the posterior is ``N(mN, SN)``, ``SN = (τ⁻²I + XᵀX)⁻¹``,
+    ``mN = SN Xᵀy``, giving a closed-form reference to validate inference against.
+    """
+    n, p, tau2 = 60, 3, 4.0
+    k_x, k_beta, k_y = jax.random.split(jax.random.PRNGKey(0), 3)
+    x = jax.random.normal(k_x, (n, p))
+    beta_star = jax.random.normal(k_beta, (p,)) * jnp.sqrt(tau2)
+    y = x @ beta_star + jax.random.normal(k_y, (n,))
+    likelihood = GLMLikelihood(tfp_glm.Normal(), x=x, fit_intercept=False)
+    model = SimpleModel(
+        MultivariateNormal(loc=jnp.zeros(p), cov=tau2 * jnp.eye(p), name="beta"), likelihood
+    )
+    cov = jnp.linalg.inv(jnp.eye(p) / tau2 + x.T @ x)
+    mean = cov @ (x.T @ y)
+    return ConjugateLinearModel(
+        model=model, design=x, data=y, reference=Reference.from_moments(mean=mean, cov=cov)
+    )
+
+
+@pytest.fixture(scope="session")
+def conjugate_nuts_posterior(
+    conjugate_linear_model: ConjugateLinearModel,
+) -> ApproximateDistribution:
+    """A well-mixed NUTS fit of the conjugate model — the method under validation."""
+    m = conjugate_linear_model
+    return condition_on(
+        m.model,
+        m.data,
+        method="blackjax_nuts",
+        num_results=3000,
+        num_warmup=1500,
+        num_chains=2,
+        random_seed=0,
+    )

--- a/tests/inference/conftest.py
+++ b/tests/inference/conftest.py
@@ -97,15 +97,17 @@ class BetaBernoulliModel:
 
 @pytest.fixture(scope="session")
 def beta_bernoulli_model() -> BetaBernoulliModel:
-    """Beta(2, 2) prior + Bernoulli likelihood, k=3 of n=17 → posterior Beta(5, 16).
+    """Beta(1, 1) prior + Bernoulli likelihood, k=2 of n=13 → posterior Beta(3, 12).
 
-    A conjugate but **non-Gaussian** target (skew ≈ 0.5, bounded on [0, 1], well
-    inside the boundaries), so validating inference here checks that good behavior
-    is not an artifact of Gaussianity. The data are fixed (deterministic success
-    count) so the posterior never pins against 0/1. The exact posterior is sampled
-    directly to give a draws reference for the distributional metrics.
+    A conjugate but markedly **non-Gaussian** target (skew ≈ 0.7, bounded on
+    [0, 1], mode ≈ 0.15 so safely inside the boundaries) — chosen far enough from
+    Gaussian that a *moment-matched* Gaussian is itself rejected by the
+    distributional metrics (see the negative control in the suite), so validating
+    inference here genuinely checks behavior beyond the Gaussian case. The data
+    are fixed (deterministic success count) so the posterior never pins against
+    0/1, and the exact posterior is sampled directly to give a draws reference.
     """
-    alpha, beta, k, n = 2.0, 2.0, 3, 17
+    alpha, beta, k, n = 1.0, 1.0, 2, 13
     data = jnp.concatenate([jnp.ones(k), jnp.zeros(n - k)])
     post_alpha, post_beta = alpha + k, beta + (n - k)
     mean = post_alpha / (post_alpha + post_beta)

--- a/tests/inference/conftest.py
+++ b/tests/inference/conftest.py
@@ -12,12 +12,15 @@ from dataclasses import dataclass
 import jax
 import jax.numpy as jnp
 import pytest
+import tensorflow_probability.substrates.jax as tfp
 import tensorflow_probability.substrates.jax.glm as tfp_glm
 
-from probpipe import GLMLikelihood, MultivariateNormal, SimpleModel, condition_on
+from probpipe import Beta, GLMLikelihood, MultivariateNormal, SimpleModel, condition_on
 from probpipe.custom_types import Array
 from probpipe.inference._approximate_distribution import ApproximateDistribution
 from probpipe.validation import Reference
+
+tfd = tfp.distributions
 
 
 @dataclass(frozen=True)
@@ -65,6 +68,67 @@ def conjugate_nuts_posterior(
         method="blackjax_nuts",
         num_results=3000,
         num_warmup=1500,
+        num_chains=2,
+        random_seed=0,
+    )
+
+
+class _BernoulliLikelihood:
+    """Bernoulli likelihood with the success probability as the parameter.
+
+    Conjugate to a Beta prior (unlike :class:`GLMLikelihood`, a logit-linear
+    model), so the posterior is Beta in closed form.
+    """
+
+    def log_likelihood(self, params, data):
+        theta = jnp.reshape(jnp.asarray(params), ())
+        return jnp.sum(tfd.Bernoulli(probs=theta).log_prob(jnp.asarray(data)))
+
+
+@dataclass(frozen=True)
+class BetaBernoulliModel:
+    """A Beta-Bernoulli conjugate model with its exact (skewed) Beta posterior."""
+
+    model: SimpleModel
+    data: Array  # 0/1 responses
+    reference: Reference  # exact Beta(α+k, β+n−k) posterior — moments and draws
+    posterior_skewness: float  # > 0 ⇒ the reference is genuinely non-Gaussian
+
+
+@pytest.fixture(scope="session")
+def beta_bernoulli_model() -> BetaBernoulliModel:
+    """Beta(2, 2) prior + Bernoulli likelihood, k=3 of n=17 → posterior Beta(5, 16).
+
+    A conjugate but **non-Gaussian** target (skew ≈ 0.5, bounded on [0, 1], well
+    inside the boundaries), so validating inference here checks that good behavior
+    is not an artifact of Gaussianity. The data are fixed (deterministic success
+    count) so the posterior never pins against 0/1. The exact posterior is sampled
+    directly to give a draws reference for the distributional metrics.
+    """
+    alpha, beta, k, n = 2.0, 2.0, 3, 17
+    data = jnp.concatenate([jnp.ones(k), jnp.zeros(n - k)])
+    post_alpha, post_beta = alpha + k, beta + (n - k)
+    mean = post_alpha / (post_alpha + post_beta)
+    var = mean * (1.0 - mean) / (post_alpha + post_beta + 1.0)
+    draws = jax.random.beta(jax.random.PRNGKey(99), post_alpha, post_beta, (5000,))[:, None]
+    skew = float(jnp.mean((draws[:, 0] - mean) ** 3) / var**1.5)
+    reference = Reference.from_moments(mean=jnp.array([mean]), cov=jnp.array([[var]]), draws=draws)
+    model = SimpleModel(Beta(alpha, beta, name="theta"), _BernoulliLikelihood())
+    return BetaBernoulliModel(model=model, data=data, reference=reference, posterior_skewness=skew)
+
+
+@pytest.fixture(scope="session")
+def beta_bernoulli_nuts_posterior(
+    beta_bernoulli_model: BetaBernoulliModel,
+) -> ApproximateDistribution:
+    """A NUTS fit of the constrained, skewed Beta-Bernoulli posterior."""
+    m = beta_bernoulli_model
+    return condition_on(
+        m.model,
+        m.data,
+        method="blackjax_nuts",
+        num_results=2000,
+        num_warmup=1000,
         num_chains=2,
         random_seed=0,
     )

--- a/tests/inference/test_validation_suite.py
+++ b/tests/inference/test_validation_suite.py
@@ -1,0 +1,49 @@
+"""Dogfood the validation metrics on real fits (issue #301).
+
+NUTS recovers the conjugate model's closed-form posterior (closing #301's
+acceptance: a method reproduces the analytic reference within measured
+tolerances); vanilla fixed-step ``blackjax_sgld`` exhibits the covariance bias
+that #304's calibration is meant to remove. Tolerances are measured across
+seeds 0–2 per STYLE_GUIDE §8.6.
+"""
+
+from __future__ import annotations
+
+from probpipe import condition_on
+from probpipe.core.record import Record
+from probpipe.validation import relative_cov_error, score_posterior
+
+
+class TestNUTSReproducesReference:
+    def test_moment_metrics_within_tolerance(
+        self, conjugate_linear_model, conjugate_nuts_posterior
+    ):
+        # score_posterior on an analytic (moments-only) reference scores the moment
+        # metrics and skips the sample/score ones. Measured across seeds 0–2:
+        # relative_cov_error ∈ [0.04, 0.08], standardized_mean_error ∈ [0.007, 0.021].
+        card = score_posterior(conjugate_nuts_posterior, conjugate_linear_model.reference)
+        assert {"ksd", "mmd", "sliced_wasserstein"}.isdisjoint(card)  # no draws/score_fn
+        assert float(card["relative_cov_error"]) < 0.15
+        assert float(card["standardized_mean_error"]) < 0.1
+
+
+class TestSGLDCovarianceBias:
+    def test_sgld_overdisperses_vs_nuts(self, conjugate_linear_model, conjugate_nuts_posterior):
+        m = conjugate_linear_model
+        sgld = condition_on(
+            m.model,
+            Record(X=m.design, y=m.data),
+            method="blackjax_sgld",
+            batch_size=20,
+            num_results=5000,
+            num_warmup=2000,
+            step_size=1e-3,
+            random_seed=0,
+        )
+        rce_nuts = float(relative_cov_error(conjugate_nuts_posterior, m.reference))
+        rce_sgld = float(relative_cov_error(sgld, m.reference))
+        # Vanilla fixed-step SGLD mis-estimates the posterior covariance. Measured
+        # across seeds 0–2: SGLD rce ∈ [0.18, 0.35] vs NUTS [0.04, 0.08], a 2.7–6×
+        # gap — the bias #304's calibration must remove.
+        assert rce_sgld > 2.0 * rce_nuts
+        assert rce_sgld > 0.12

--- a/tests/inference/test_validation_suite.py
+++ b/tests/inference/test_validation_suite.py
@@ -9,6 +9,9 @@ seeds 0–2 per STYLE_GUIDE §8.6.
 
 from __future__ import annotations
 
+import jax
+import jax.numpy as jnp
+
 from probpipe import condition_on
 from probpipe.core.record import Record
 from probpipe.validation import relative_cov_error, score_posterior
@@ -54,15 +57,23 @@ class TestNUTSReproducesNonGaussianReference:
         self, beta_bernoulli_model, beta_bernoulli_nuts_posterior
     ):
         m = beta_bernoulli_model
-        # The reference is genuinely non-Gaussian (a right-skewed Beta posterior),
-        # so good behavior here cannot be coming from Gaussianity alone.
-        assert m.posterior_skewness > 0.3  # Gaussian skewness is 0; measured ≈ 0.54
-        # The reference carries draws, so score_posterior also runs the sample-based
-        # distances — small mmd / sliced_W confirm NUTS captures the skewed *shape*,
-        # not just the moments. Measured across seeds 0–2: rce ≤ 0.11, sme ≤ 0.06,
-        # mmd ≤ 0.001, sliced_W ≤ 0.008.
-        card = score_posterior(beta_bernoulli_nuts_posterior, m.reference)
-        assert float(card["relative_cov_error"]) < 0.2
-        assert float(card["standardized_mean_error"]) < 0.15
-        assert float(card["mmd"]) < 0.01
-        assert float(card["sliced_wasserstein"]) < 0.02
+        # The reference is markedly non-Gaussian — a right-skewed Beta posterior.
+        assert m.posterior_skewness > 0.5  # Gaussian skewness is 0; measured ≈ 0.7
+        # NUTS captures the shape: the distributional metrics sit near the sampling
+        # floor. Measured across seeds 0–2: mmd ≤ 0.001, sliced_W ≤ 0.009.
+        nuts = score_posterior(beta_bernoulli_nuts_posterior, m.reference)
+        assert float(nuts["mmd"]) < 0.004
+        assert float(nuts["sliced_wasserstein"]) < 0.014
+        assert float(nuts["relative_cov_error"]) < 0.2
+
+        # Negative control: a Gaussian with the *same mean and variance* matches the
+        # moments (small relative_cov_error) yet is rejected by mmd — proving the
+        # metric actually sees the skew, so NUTS passing above is meaningful and not
+        # an artifact of Beta(3,12) being ~Gaussian. Measured: Gaussian mmd ≈ 0.011,
+        # well above NUTS's 0.004 bound (≈13× the NUTS value).
+        mean = m.reference.mean
+        sd = jnp.sqrt(jnp.diag(m.reference.cov))
+        gaussian = mean + sd * jax.random.normal(jax.random.PRNGKey(7), (5000, mean.shape[0]))
+        control = score_posterior(gaussian, m.reference)
+        assert float(control["relative_cov_error"]) < 0.05  # moments match
+        assert float(control["mmd"]) > 0.004  # but the non-Gaussian shape is rejected

--- a/tests/inference/test_validation_suite.py
+++ b/tests/inference/test_validation_suite.py
@@ -47,3 +47,22 @@ class TestSGLDCovarianceBias:
         # gap — the bias #304's calibration must remove.
         assert rce_sgld > 2.0 * rce_nuts
         assert rce_sgld > 0.12
+
+
+class TestNUTSReproducesNonGaussianReference:
+    def test_recovers_skewed_beta_posterior(
+        self, beta_bernoulli_model, beta_bernoulli_nuts_posterior
+    ):
+        m = beta_bernoulli_model
+        # The reference is genuinely non-Gaussian (a right-skewed Beta posterior),
+        # so good behavior here cannot be coming from Gaussianity alone.
+        assert m.posterior_skewness > 0.3  # Gaussian skewness is 0; measured ≈ 0.54
+        # The reference carries draws, so score_posterior also runs the sample-based
+        # distances — small mmd / sliced_W confirm NUTS captures the skewed *shape*,
+        # not just the moments. Measured across seeds 0–2: rce ≤ 0.11, sme ≤ 0.06,
+        # mmd ≤ 0.001, sliced_W ≤ 0.008.
+        card = score_posterior(beta_bernoulli_nuts_posterior, m.reference)
+        assert float(card["relative_cov_error"]) < 0.2
+        assert float(card["standardized_mean_error"]) < 0.15
+        assert float(card["mmd"]) < 0.01
+        assert float(card["sliced_wasserstein"]) < 0.02


### PR DESCRIPTION
## Summary

The **final slice of #301** — the inference-method **validation suite** that
dogfoods PR 1's metrics on real fits and closes #301's acceptance ("NUTS
reproduces the analytic references within measured tolerances"). Test-only; no
source changes.

> **Stacked on #314 (PR 2).** Base is `dev/validation-sbc-coverage` so the diff
> shows only PR 3. Re-target to `main` once #314 merges; this must merge after it.

## What's in this PR

- **`tests/inference/conftest.py`** — two models with exact references:
  - a **conjugate Gaussian linear model** (`y ~ N(Xβ, 1)`, prior `β ~ N(0, τ²I)`)
    whose posterior is *exactly* Gaussian (`N(mN, SN)`, `SN = (τ⁻²I + XᵀX)⁻¹`,
    `mN = SN Xᵀy`), as a `Reference.from_moments`; plus a session-scoped NUTS fit.
  - a **Beta–Bernoulli model** (`k=2` of `n=13` → posterior `Beta(3, 12)`) — a
    conjugate but markedly **non-Gaussian** target (skew ≈ 0.7, bounded on
    `[0, 1]`), chosen far enough from Gaussian that even a *moment-matched*
    Gaussian is distinguishable. The exact posterior is sampled directly, so the
    reference carries *draws* too.
- **`tests/inference/test_validation_suite.py`**
  - **NUTS reproduces the analytic Gaussian reference** via `score_posterior` —
    `relative_cov_error < 0.15`, `standardized_mean_error < 0.1` (measured
    `0.04–0.08` / `0.007–0.021` across seeds 0–2). Closes the #301 acceptance.
  - **NUTS reproduces the non-Gaussian Beta reference** — moments *and* shape:
    with draws in the reference, `score_posterior` also runs `mmd`/`sliced_W`,
    which sit near the floor (`mmd ≤ 0.001`, `sliced_W ≤ 0.009`). A **negative
    control** in the same test confirms this isn't vacuous: a Gaussian with the
    *same mean and variance* matches the moments (`rce < 0.05`) yet is rejected by
    `mmd` (`≈ 0.011`, ~13× NUTS's) — so the metric genuinely sees the skew, and
    NUTS capturing it is meaningful rather than an artifact of near-Gaussianity.
  - **Vanilla `blackjax_sgld` shows its covariance bias** — `relative_cov_error`
    `2.7–6×` NUTS's against the same exact reference. The signal #304's
    calibration is meant to remove.

## Scope notes

- Covers both a **Gaussian** (conjugate linear) and a **non-Gaussian** (Beta–
  Bernoulli) analytic reference — the moment metrics on both, and the
  sample-based distances (`mmd`/`sliced_wasserstein`) on the skewed posterior via
  its exact draws. Deferred as plan nice-to-haves (not acceptance criteria): a
  logistic GLM fixture, and consolidating the duplicated per-file fixtures in
  `test_minibatch.py` / `test_blackjax_sgmcmc.py`.
- With this merged, #301's three acceptance criteria are all met (metric
  correctness — PR 1; NUTS reproduces the analytic reference — here; SBC uniform
  for NUTS — PR 2).

Part of #301.
