### PR TITLE
docs(diagnostics): add follow-up API docs and notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gains a `weights=` argument so weighted particles flow through to the
   `ApproximateDistribution` without resampling.
 
+- **`probpipe.diagnostics` posterior diagnostics subsystem.** Adds in-place
+  mutator operations `add_rhat`, `add_ess`, `add_mcse`,
+  `add_mcmc_diagnostics`, `add_ppc`, and `add_loo`; structured
+  `posterior.diagnostics` views (`DiagnosticsView`, `MCMCView`, `PPCView`, and
+  `LOOView`); and ArviZ-compatible interop through `posterior.arviz_data`.
+
 - **`probpipe.validation` posterior-vs-reference comparison metrics.** A
   dependency-light scoring layer for validating inference methods against a
   trusted reference: `Reference` (a container for analytic / long-NUTS /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -382,6 +382,8 @@ probpipe/
 ├── record/         # Record-adjacent constructions: parameter-sweep Designs
 ├── modeling/       # Model wrappers (SimpleModel, StanModel, PyMCModel, likelihoods)
 ├── inference/      # Inference methods + registry (BlackJAX, TFP, nutpie, RWMH)
+├── validation/     # Reference metrics, SBC, and interval coverage checks
+├── diagnostics/    # Posterior diagnostics, ArviZ interop, and diagnostic views
 ├── converters/     # Distribution conversion registry
 ├── linalg/         # Linear algebra for random functions
 ├── custom_types.py # Array, PRNGKey, ArrayLike type aliases
@@ -395,6 +397,12 @@ a leading underscore (`_simple.py`, `_blackjax_rwmh.py`).  The package
 `probpipe` or from subpackage `__init__` modules, never from
 underscore modules directly.  See `probpipe/__init__.py` for the
 full public API surface.
+
+The diagnostics accessor is the one documented package-graph edge from
+`core/` back to a feature subpackage: `Distribution.diagnostics` lazily imports
+`probpipe.diagnostics.views.DiagnosticsView` only when the accessor is read.
+Keep this edge lazy so importing `probpipe.core` does not import the diagnostics
+subpackage or its optional ArviZ-facing dependencies.
 
 ### Distributions: `probpipe-core` and `probpipe`
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -544,6 +544,8 @@ converters/   (imports core/, distributions/, custom_types)
      ↑
 modeling/     (imports core/, inference/, converters/, custom_types)
 inference/    (imports core/, custom_types)
+validation/   (imports core/, inference/, custom_types)
+diagnostics/  (imports core/, inference/, validation/, custom_types)
 ```
 
 ### Rules
@@ -561,6 +563,11 @@ inference/    (imports core/, custom_types)
 6. **`inference/`** must never import from `modeling/` or `converters/`.
 7. **`modeling/`** may import from `inference/` (for MCMC result types)
    and from `converters/` (for auto-conversion in conditioning).
+8. **`validation/`** may import from `core/`, `inference/`, and
+   `custom_types`.
+9. **`diagnostics/`** may import from `core/`, `inference/`, `validation/`,
+   and `custom_types`; it must not become a dependency of those packages except
+   for the documented lazy accessor edge below.
 
 > **Exceptions** (intentional reverse edges):
 >
@@ -569,6 +576,8 @@ inference/    (imports core/, custom_types)
 > - `inference/` → `distributions/` (lazy imports: prior-type dispatch on
 >   distribution classes in `_blackjax_ess`, `bijector_for` constraint
 >   reparameterization in `_bayesflow_posteriors`)
+> - `core/` → `diagnostics.views` (lazy import inside
+>   `Distribution.diagnostics` to construct the read-only diagnostics accessor)
 >
 > These use lazy (in-function) imports to avoid circular imports at
 > module load time.  Do not add new reverse edges without discussion.

--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -1,0 +1,43 @@
+# Diagnostics
+
+Utilities for attaching Bayesian diagnostics to fitted posteriors in place.
+The public diagnostic operations mutate `posterior._auxiliary` and return
+`None`; users normally read the results back through `posterior.diagnostics`.
+ArviZ-compatible data are exposed through `posterior.arviz_data`.
+
+## MCMC diagnostics
+
+Use these operations to compute convergence and Monte Carlo accuracy summaries
+for a fitted posterior.
+
+::: probpipe.diagnostics.add_rhat
+
+::: probpipe.diagnostics.add_ess
+
+::: probpipe.diagnostics.add_mcse
+
+::: probpipe.diagnostics.add_mcmc_diagnostics
+
+## Predictive and LOO diagnostics
+
+::: probpipe.diagnostics.add_ppc
+
+::: probpipe.diagnostics.add_loo
+
+## Diagnostic views
+
+`posterior.diagnostics` returns a structured view over the diagnostics subtree.
+The concrete views expose MCMC, posterior predictive check, and LOO results
+without requiring users to traverse `_auxiliary` directly.
+
+::: probpipe.diagnostics.DiagnosticsView
+
+::: probpipe.diagnostics.MCMCView
+
+::: probpipe.diagnostics.PPCView
+
+::: probpipe.diagnostics.LOOView
+
+::: probpipe.diagnostics.DiagnosticRunView
+
+::: probpipe.diagnostics.NotComputed

--- a/docs/user_guide/12_diagnostics_workflow.ipynb
+++ b/docs/user_guide/12_diagnostics_workflow.ipynb
@@ -8,7 +8,7 @@
     "# Diagnostics workflow in ProbPipe\n",
     "\n",
     "This notebook is a walkthrough of the current diagnostics design.\n",
-    "It shows the API shape we are proposing for the 0.2.0 beta: fit a posterior,\n",
+    "It shows the diagnostics API shipped for the 0.2.0 beta: fit a posterior,\n",
     "attach diagnostics in place, then inspect results through `posterior.diagnostics`.\n",
     "\n",
     "The public workflow should stay small:\n",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - Random functions: api/distributions/random_functions.md
     - Records and data: api/records.md
     - Modeling and inference: api/inference.md
+    - Diagnostics: api/diagnostics.md
     - Validation: api/validation.md
     - Workflows and orchestration: api/workflows.md
     - Constraints and bijectors: api/constraints.md

--- a/tests/diagnostics/test_mcmc.py
+++ b/tests/diagnostics/test_mcmc.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 import numpy as np
 import pytest
 
 import probpipe.diagnostics._mcmc as mcmc
 from probpipe.core.record import Record
-from probpipe.diagnostics._datatree_store import (
-    _mcmc_has_field,
-    to_named_posterior_dataset,
-)
+from probpipe.diagnostics._datatree_store import _mcmc_has_field
 from probpipe.diagnostics._mcmc import (
     _check_arviz,
     _emit_record_warnings,
@@ -24,6 +23,9 @@ from probpipe.diagnostics._mcmc import (
 )
 from probpipe.diagnostics._view_base import NotComputed
 from probpipe.diagnostics._views import DiagnosticsView
+
+if TYPE_CHECKING:
+    import xarray as xr
 
 # conftest.py provides: posterior, posterior_single_chain, posterior_3params
 
@@ -84,6 +86,24 @@ def _arviz_stats_module():
     return azs
 
 
+def _independent_arviz_posterior(posterior: Any) -> xr.Dataset:
+    import arviz as az
+
+    return az.from_dict(
+        {
+            "posterior": {
+                field: np.stack(
+                    [
+                        np.asarray(posterior.draws(chain=i)[field])
+                        for i in range(posterior.num_chains)
+                    ]
+                )
+                for field in posterior.fields
+            }
+        }
+    ).posterior
+
+
 # ---------------------------------------------------------------------------
 # add_rhat
 # ---------------------------------------------------------------------------
@@ -133,7 +153,7 @@ class TestAddRhat:
 
     def test_matches_direct_arviz_for_scalar_and_vector_parameters(self):
         posterior = _ScalarVectorPosterior()
-        ds = to_named_posterior_dataset(posterior)
+        ds = _independent_arviz_posterior(posterior)
         expected = _arviz_stats_module().rhat(ds, method="rank")
 
         add_rhat(posterior)
@@ -274,7 +294,7 @@ class TestAddEss:
 
     def test_matches_direct_arviz_for_scalar_and_vector_parameters(self):
         posterior = _ScalarVectorPosterior()
-        ds = to_named_posterior_dataset(posterior)
+        ds = _independent_arviz_posterior(posterior)
         azs = _arviz_stats_module()
         expected_bulk = azs.ess(ds, method="bulk")
         expected_tail = azs.ess(ds, method="tail")
@@ -322,7 +342,7 @@ class TestAddMcse:
 
     def test_matches_direct_arviz_for_scalar_and_vector_parameters(self):
         posterior = _ScalarVectorPosterior()
-        ds = to_named_posterior_dataset(posterior)
+        ds = _independent_arviz_posterior(posterior)
         azs = _arviz_stats_module()
         expected_mean = azs.mcse(ds, method="mean")
         expected_sd = azs.mcse(ds, method="sd")


### PR DESCRIPTION
## Summary

Adds the diagnostics API reference page and navigation entry, updates the diagnostics workflow wording for the shipped 0.2.0 beta API, records the diagnostics subsystem in the changelog, and documents the diagnostics package import-boundary exception. It also strengthens MCMC diagnostics tests by comparing R-hat, ESS, and MCSE against an independently constructed ArviZ posterior dataset.

## Linked issue(s)

N/A — small standalone docs/test follow-up.

## Test plan

- Existing tests touched: `tests/diagnostics/test_mcmc.py`
- Ran `uv run pytest tests/diagnostics/test_mcmc.py` — 29 passed, 35 warnings
- Ran `uv run mkdocs build --strict` — passed; emitted existing-style HTML div warnings during docs generation

## Breaking changes

None.

## Documentation

- [ ] Docstrings updated for changed public APIs
- [x] User Guide / tutorials updated where relevant
- [x] CHANGELOG (or release-notes entry) noted in the linked issue

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>` (e.g. `refactor(core): ...`, `feat(inference): ...`)
- [x] At least one `area:*` label applied
- [x] Linked to an issue above — or N/A for a small standalone fix (see CONTRIBUTING.md)