### PR TITLE
fix(core): harden container edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Core container indexing and nested reductions.** `DistributionArray`
+  integer indexing now raises `IndexError` for positive overflow and negatives
+  past the axis bounds, while 0-d arrays accept only empty-tuple indexing.
+  `NumericRecordArray.mean()` and `.var()` now recurse through nested numeric
+  record fields instead of treating nested records as arrays.
+
 - **Linear-algebra and Gaussian-conditioning edge cases on the algebra bug-fix
   branch.** `RootLinOp.diag()` now squares diagonal roots; `CholeskyLinOp`
   keeps lower-root (`L @ L.T`) and upper-root (`U.T @ U`) representations

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -447,6 +447,12 @@ class DistributionArray[T](Distribution[T]):
         ``shape=batch_shape`` object array.
         """
         bshape = self._batch_shape
+        if not bshape:
+            if key == ():
+                if self._backend is not None:
+                    return self._backend.cell(0)
+                return self._components[0]
+            raise IndexError("too many indices for 0-d DistributionArray")
         # Normalise the key to a tuple, one entry per leading axis.
         if isinstance(key, tuple):
             if len(key) > len(bshape):
@@ -460,11 +466,22 @@ class DistributionArray[T](Distribution[T]):
 
         # Fast path: all axes addressed by int (or int-like). Compute
         # the flat index directly; no object-array materialisation.
-        # ``np.ravel_multi_index`` rejects negative indices, so wrap
-        # them into the positive range first (``dists[-1]`` is a
-        # common pattern — e.g. "last posterior in an iterate output").
+        # ``np.ravel_multi_index`` rejects negative indices, so normalize
+        # valid Python-style negatives first. Positive overflow and
+        # negatives past the axis bounds must still raise ``IndexError``.
         if all(isinstance(k, (int, np.integer)) or hasattr(k, "__index__") for k in key_tuple):
-            indices = tuple(int(k) % dim for k, dim in zip(key_tuple, bshape))
+            indices = []
+            for axis, (k, dim) in enumerate(zip(key_tuple, bshape)):
+                idx = int(k)
+                if idx < 0:
+                    idx += dim
+                if idx < 0 or idx >= dim:
+                    raise IndexError(
+                        f"DistributionArray index {int(k)} is out of bounds "
+                        f"for axis {axis} with size {dim}"
+                    )
+                indices.append(idx)
+            indices = tuple(indices)
             flat = int(np.ravel_multi_index(indices, bshape))
             if self._backend is not None:
                 return self._backend.cell(flat)

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -549,7 +549,26 @@ class NumericRecordArray(RecordArray):
     ) -> NumericRecordArray | Any:
         """Apply a reduction function over a batch axis."""
         new_batch = self._batch_shape[:axis] + self._batch_shape[axis + 1 :]
-        fields = {name: fn(self._tree[name], axis) for name in self._tree}
+
+        def _reduce_value(value: Any, spec: Any) -> Any:
+            if isinstance(value, NumericRecordArray):
+                return value._reduce(fn, axis)
+            if isinstance(value, Record):
+                if not isinstance(spec, EventTemplate):
+                    return fn(value, axis)
+                fields = {
+                    name: _reduce_value(child, spec.children[name])
+                    for name, child in value.children.items()
+                }
+                if not new_batch:
+                    return NumericRecord(fields)
+                return NumericRecordArray(fields, batch_shape=new_batch, template=spec)
+            return fn(value, axis)
+
+        fields = {
+            name: _reduce_value(value, self._template.children[name])
+            for name, value in self._tree.items()
+        }
         if not new_batch:
             return NumericRecord(fields)
         return NumericRecordArray(fields, batch_shape=new_batch, template=self._template)

--- a/tests/core/test_distribution_array.py
+++ b/tests/core/test_distribution_array.py
@@ -65,6 +65,36 @@ class TestConstruction:
         assert da[-1] is comps[3]
         assert da[-2] is comps[2]
 
+    def test_integer_index_out_of_bounds_raises(self):
+        comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
+        da = _make_distribution_array(comps)
+        with pytest.raises(IndexError, match="out of bounds"):
+            _ = da[3]
+        with pytest.raises(IndexError, match="out of bounds"):
+            _ = da[100]
+        with pytest.raises(IndexError, match="out of bounds"):
+            _ = da[-4]
+
+    def test_multidim_integer_index_out_of_bounds_raises(self):
+        from probpipe import DistributionArray
+
+        da = DistributionArray.from_batched_params(
+            Normal,
+            batch_shape=(2, 3),
+            loc=jnp.arange(6.0).reshape(2, 3),
+            scale=1.0,
+            name="g",
+        )
+        assert float(da[-1, -1].loc) == 5.0
+        with pytest.raises(IndexError, match="axis 0"):
+            _ = da[2, 0]
+        with pytest.raises(IndexError, match="axis 1"):
+            _ = da[0, 3]
+        with pytest.raises(IndexError, match="axis 0"):
+            _ = da[-3, 0]
+        with pytest.raises(IndexError, match="axis 1"):
+            _ = da[0, -4]
+
     def test_iter_yields_components(self):
         comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
         da = _make_distribution_array(comps)
@@ -243,6 +273,26 @@ class TestContainerSurface:
         with pytest.raises(TypeError, match="0-d"):
             len(da)
         assert da.size == 1
+
+    def test_zero_d_indexing_matches_numpy(self):
+        """A 0-d array accepts the empty-tuple index, not integer axes."""
+        from probpipe import DistributionArray
+        from probpipe import MultivariateNormal as _MVN
+
+        da = DistributionArray.from_batched_params(
+            _MVN,
+            batch_shape=(),
+            loc=jnp.zeros(3),
+            cov=jnp.eye(3),
+            name="m",
+        )
+        assert isinstance(da[()], _MVN)
+        with pytest.raises(IndexError, match="0-d"):
+            _ = da[0]
+        with pytest.raises(IndexError, match="0-d"):
+            _ = da[-1]
+        with pytest.raises(IndexError, match="0-d"):
+            _ = da[:]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -886,12 +886,7 @@ class TestFromVectorRoundTripBatched:
         assert v.batch_shape == (2, 3)
         assert isinstance(v.at_path("nested"), NumericRecordArray)
         assert v["nested/b"].shape == (2, 3, 2)
-        # NOTE: assert via the vector round-trip, not ``from_vector(...) == v``.
-        # RecordArray.__eq__ is currently broken for a nested *Array field (it
-        # calls jnp.array_equal on the nested array, which raises, then falls
-        # back to an identity check). Tracked in #235 (batch-records PR); once
-        # that is fixed, simplify to ``tpl.from_vector(tpl.to_vector(v)) == v``.
-        assert jnp.array_equal(tpl.to_vector(v), flat)
+        assert tpl.from_vector(tpl.to_vector(v)) == v
 
 
 class TestFromVectorErrors:

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -445,6 +445,95 @@ class TestNumericRecordArrayReductions:
         assert isinstance(m, NumericRecord)
         np.testing.assert_allclose(m["x"], 5.5)
 
+    def test_mean_nested_records(self):
+        tpl = EventTemplate(outer=EventTemplate(a=(), b=(2,)), m=())
+        flat = jnp.asarray(
+            [
+                [0.0, 0.0, 1.0, 10.0],
+                [1.0, 1.0, 2.0, 11.0],
+                [2.0, 2.0, 3.0, 12.0],
+            ]
+        )
+        nra = tpl.from_vector(flat)
+        m = nra.mean(axis=0)
+        assert isinstance(m, NumericRecord)
+        assert isinstance(m.at_path("outer"), NumericRecord)
+        np.testing.assert_allclose(m["outer/a"], 1.0)
+        np.testing.assert_allclose(m["outer/b"], [1.0, 2.0])
+        np.testing.assert_allclose(m["m"], 11.0)
+
+    def test_var_nested_records(self):
+        tpl = EventTemplate(outer=EventTemplate(a=(), b=(2,)), m=())
+        flat = jnp.asarray(
+            [
+                [0.0, 0.0, 1.0, 10.0],
+                [1.0, 1.0, 2.0, 11.0],
+                [2.0, 2.0, 3.0, 12.0],
+            ]
+        )
+        nra = tpl.from_vector(flat)
+        v = nra.var(axis=0)
+        assert isinstance(v, NumericRecord)
+        assert isinstance(v.at_path("outer"), NumericRecord)
+        np.testing.assert_allclose(v["outer/a"], 2.0 / 3.0)
+        np.testing.assert_allclose(v["outer/b"], [2.0 / 3.0, 2.0 / 3.0])
+        np.testing.assert_allclose(v["m"], 2.0 / 3.0)
+
+    def test_reduce_plain_nested_record_field(self):
+        tpl = EventTemplate(outer=EventTemplate(a=(), b=(2,)), m=())
+        inner = Record(
+            a=jnp.asarray([0.0, 1.0, 2.0]),
+            b=jnp.asarray([[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]]),
+        )
+        nra = NumericRecordArray(
+            {"outer": inner, "m": jnp.asarray([10.0, 11.0, 12.0])},
+            batch_shape=(3,),
+            template=tpl,
+        )
+
+        m = nra.mean(axis=0)
+        assert isinstance(m, NumericRecord)
+        assert isinstance(m.at_path("outer"), NumericRecord)
+        np.testing.assert_allclose(m["outer/a"], 1.0)
+        np.testing.assert_allclose(m["outer/b"], [1.0, 2.0])
+        np.testing.assert_allclose(m["m"], 11.0)
+
+        v = nra.var(axis=0)
+        assert isinstance(v, NumericRecord)
+        assert isinstance(v.at_path("outer"), NumericRecord)
+        np.testing.assert_allclose(v["outer/a"], 2.0 / 3.0)
+        np.testing.assert_allclose(v["outer/b"], [2.0 / 3.0, 2.0 / 3.0])
+        np.testing.assert_allclose(v["m"], 2.0 / 3.0)
+
+    def test_mean_nested_records_multidim_batch(self):
+        tpl = EventTemplate(outer=EventTemplate(a=()), m=())
+        flat = jnp.arange(12.0).reshape(2, 3, tpl.vector_size)
+        nra = tpl.from_vector(flat)
+        m = nra.mean(axis=0)
+        assert isinstance(m, NumericRecordArray)
+        assert isinstance(m.at_path("outer"), NumericRecordArray)
+        assert m.batch_shape == (3,)
+        assert m.at_path("outer").batch_shape == (3,)
+        np.testing.assert_allclose(m["outer/a"], [3.0, 5.0, 7.0])
+        np.testing.assert_allclose(m["m"], [4.0, 6.0, 8.0])
+
+    def test_reduce_plain_nested_record_field_multidim_batch(self):
+        tpl = EventTemplate(outer=EventTemplate(a=()), m=())
+        inner = Record(a=jnp.arange(6.0).reshape(2, 3))
+        nra = NumericRecordArray(
+            {"outer": inner, "m": jnp.arange(6.0).reshape(2, 3) + 10.0},
+            batch_shape=(2, 3),
+            template=tpl,
+        )
+
+        m = nra.mean(axis=0)
+        assert isinstance(m, NumericRecordArray)
+        assert isinstance(m.at_path("outer"), NumericRecordArray)
+        assert m.batch_shape == (3,)
+        assert m.at_path("outer").batch_shape == (3,)
+        np.testing.assert_allclose(m["outer/a"], [1.5, 2.5, 3.5])
+        np.testing.assert_allclose(m["m"], [11.5, 12.5, 13.5])
+
 
 # ---------------------------------------------------------------------------
 # JAX PyTree


### PR DESCRIPTION
## Summary

Fixes two core container bugs with a deliberately small diff:

- `DistributionArray` integer indexing now follows NumPy/JAX-style bounds semantics: valid negative indices wrap per axis, while positive overflow and excessive negative indices raise `IndexError` with axis/size context. A 0-d `DistributionArray` accepts `da[()]` and rejects axis indexing.
- `NumericRecordArray.mean()` and `.var()` now recurse through nested numeric record fields instead of passing nested record containers directly to JAX reductions. This covers both canonical nested `NumericRecordArray` fields and accepted plain `Record` nested fields whose leaves carry the batch shape.

## Root cause

The `DistributionArray.__getitem__` integer fast path used modulo-style wrapping, so out-of-bounds integer keys could silently select a valid component. `NumericRecordArray._reduce()` treated nested record containers as ordinary array leaves, which broke reductions for nested numeric records.

## User impact

Indexing errors are now surfaced instead of silently wrapping to the wrong distribution component, and nested numeric record batches can be reduced structurally with `mean()` / `var()`.

## Linked issue(s)

N/A — small standalone bug fix.

## Test plan

- `uv run --frozen pytest -s -p no:xdist -o "addopts=" tests/core/test_distribution_array.py tests/core/test_record_array.py tests/core/test_event_template.py -x -v` — 278 passed.
- `uv run --frozen ruff check probpipe/core/_distribution_array.py probpipe/core/_record_array.py tests/core/test_distribution_array.py tests/core/test_record_array.py tests/core/test_event_template.py` — passed.
- `uv run --frozen ruff format --check probpipe/core/_distribution_array.py probpipe/core/_record_array.py tests/core/test_distribution_array.py tests/core/test_record_array.py tests/core/test_event_template.py` — passed.

## Breaking changes

None.

## Documentation

- [x] CHANGELOG updated for the fixed behavior.

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`.
- [x] Linked to an issue above, or marked N/A for a small standalone fix.