### PR TITLE
ci(lint): harden ruff-version parse against quoted/reformatted rev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,14 @@ jobs:
         run: |
           set -euo pipefail
           # Single source of truth for the pin lives in the pre-commit config.
+          # The rev regex tolerates an optional surrounding quote and leading
+          # `v` so a reformatted `rev: "v0.15.16"` still parses; `|| true`
+          # swallows a no-match grep exit (pipefail would otherwise abort the
+          # pipeline here) so the `test -n` below stays the single, clear
+          # "can't parse the pin" failure.
           ver=$(grep -A2 'astral-sh/ruff-pre-commit' .pre-commit-config.yaml \
-                  | sed -nE 's/^[[:space:]]*rev:[[:space:]]*v?([0-9][0-9.]*).*/\1/p' | head -1)
+                  | sed -nE 's/^[[:space:]]*rev:[[:space:]]*["'\'']?v?([0-9][0-9.]*).*/\1/p' \
+                  | head -1 || true)
           test -n "$ver"   # fail loudly if the rev can't be parsed
           echo "ruff=$ver" >> "$GITHUB_OUTPUT"
           echo "Resolved ruff $ver from .pre-commit-config.yaml"


### PR DESCRIPTION
Refs the prob-pipe-benchmark infrastructure review.

## Summary

The `lint` job derives the Ruff version from `.pre-commit-config.yaml` (the single source of truth). The parser was brittle in two ways:

- The rev regex required the version to begin immediately after an optional `v`, so a reformatted `rev: "v0.15.16"` (quoting is valid YAML, and editors / `pre-commit autoupdate` can introduce it) parsed to empty and failed the step.
- Under `set -euo pipefail`, a no-match `grep` exits 1, which aborts the `ver=$(...)` assignment before the `test -n "$ver"` guard can emit its intended "can't parse the pin" message.

## Change

- Tolerate an optional surrounding quote in the sed regex (`["']?v?`).
- Route a no-match through `|| true` so `test -n "$ver"` remains the single, clear failure point.

No behavior change for the current config: the step still resolves `0.15.16`.

## Test plan

- Hardened pipeline resolves `0.15.16` against the committed `.pre-commit-config.yaml`.
- Quoted (`"v0.15.16"`), single-quoted, and `# comment`-suffixed revs all resolve `0.15.16`.
- A no-match config yields empty `ver` and fails cleanly at `test -n` (not an opaque pipefail abort).
