### PR TITLE
fix(core): classify ml_dtypes arrays (bfloat16, float8, int4) as numeric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # dev/** covers stacked PRs (a PR based on another PR's dev/ branch),
+    # which would otherwise get no CI until the base merges and the PR
+    # retargets to main.
+    branches: [main, "dev/**"]
 
 # Cancel superseded runs on PR pushes (saves CI minutes during iteration).
 # Pushes to main keep running — never cancel work that gates the merged history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,12 +290,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `dtype.kind`, under which the ml_dtypes extension types JAX registers
   report `"V"` (void) — so a bfloat16 array failed `ArraySpec.is_valid`,
   inferred as an `OpaqueSpec`, and was rejected as a `NumericRecord` /
-  `NumericRecordArray` leaf. All gates (template inference, spec
-  validation, the record-layer leaf checks, and the `Design` marginals
-  probe) now route through one shared predicate that also admits
-  ml_dtypes numerics; structured (record) dtypes remain non-numeric. The
-  internal `_NUMERIC_DTYPE_KINDS` constant is removed in favor of the
-  shared predicate.
+  `NumericRecordArray` leaf. All five gates (template inference, spec
+  validation, the two record-layer leaf checks, the broadcast-template
+  builder, and the `Design` marginals probe) now route through one shared
+  predicate that also admits ml_dtypes numerics; structured (record)
+  dtypes remain non-numeric. The internal `_NUMERIC_DTYPE_KINDS` constant
+  is removed in favor of the shared predicate.
 
 - **Core container indexing and nested reductions.** `DistributionArray`
   integer indexing now raises `IndexError` for positive overflow and negatives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **ml_dtypes arrays (bfloat16, float8, int4) now classify as numeric
+  (#343).** The numeric-dtype gates previously keyed on numpy's
+  `dtype.kind`, under which the ml_dtypes extension types JAX registers
+  report `"V"` (void) — so a bfloat16 array failed `ArraySpec.is_valid`,
+  inferred as an `OpaqueSpec`, and was rejected as a `NumericRecord` /
+  `NumericRecordArray` leaf. All gates (template inference, spec
+  validation, the record-layer leaf checks, and the `Design` marginals
+  probe) now route through one shared predicate that also admits
+  ml_dtypes numerics; structured (record) dtypes remain non-numeric. The
+  internal `_NUMERIC_DTYPE_KINDS` constant is removed in favor of the
+  shared predicate.
+
 - **Core container indexing and nested reductions.** `DistributionArray`
   integer indexing now raises `IndexError` for positive overflow and negatives
   past the axis bounds, while 0-d arrays accept only empty-tuple indexing.

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -26,7 +26,7 @@ from ._empirical import (
     RecordEmpiricalDistribution,
 )
 from ._record_array import RecordArray
-from .event_template import EventTemplate
+from .event_template import EventTemplate, _is_numeric_dtype
 from .protocols import (
     SupportsLogProb,
     SupportsMean,
@@ -550,7 +550,7 @@ def _make_stack(
                     fields[fname] = arr.reshape(batch_shape + arr.shape[1:])
             tpl_spec: dict[str, Any] = {}
             for fname, v in fields.items():
-                if hasattr(v, "dtype") and getattr(v.dtype, "kind", None) in "biufc":
+                if hasattr(v, "dtype") and _is_numeric_dtype(v.dtype):
                     tpl_spec[fname] = tuple(v.shape[len(batch_shape) :])
                 else:
                     tpl_spec[fname] = None

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -41,21 +41,22 @@ import numpy as np
 
 from ..custom_types import ArrayLike
 from ._array_backend import aux_for
-from .event_template import EventTemplate, _check_no_path_sep, _PathSubtree, _unflatten_paths
+from .event_template import (
+    EventTemplate,
+    _check_no_path_sep,
+    _is_numeric_dtype,
+    _PathSubtree,
+    _unflatten_paths,
+)
 from .record import Record, _record_flatten
 
-__all__ = ["_NUMERIC_DTYPE_KINDS", "NumericRecord", "_is_numeric_leaf"]
+__all__ = ["NumericRecord", "_is_numeric_leaf"]
 
 
 # Scalar types accepted as numeric leaves. ``bool`` is intentionally
 # included: JAX treats it as dtype ``bool_`` and numpy arrays of bools
 # participate in arithmetic as 0/1.
 _NUMERIC_SCALARS = (bool, int, float, complex, np.integer, np.floating, np.bool_)
-
-# dtype.kind codes for numeric arrays: b=bool, i=int, u=uint, f=float,
-# c=complex. Shared with ``NumericRecordArray._validate_fields`` so the
-# two validation sites stay in lockstep.
-_NUMERIC_DTYPE_KINDS = frozenset("biufc")
 
 
 def _is_numeric_leaf(val: Any) -> bool:
@@ -64,24 +65,25 @@ def _is_numeric_leaf(val: Any) -> bool:
     Rejects object-dtype arrays, string-like scalars, and opaque types
     that don't expose ``dtype`` / ``shape``. ``pandas.DataFrame``-like
     types whose elements are numeric are accepted via their ``.dtypes``
-    summary.
+    summary. Dtype numericness is decided by the shared
+    ``_is_numeric_dtype`` predicate, so this gate,
+    ``NumericRecordArray._validate_fields``, and template inference agree
+    on what counts as numeric.
     """
     if isinstance(val, (str, bytes)):
         return False
     if isinstance(val, _NUMERIC_SCALARS):
         return True
     if hasattr(val, "dtype") and hasattr(val, "shape"):
-        kind = getattr(val.dtype, "kind", None)
-        return kind in _NUMERIC_DTYPE_KINDS
+        return _is_numeric_dtype(val.dtype)
     # ``pandas.DataFrame`` has ``.dtypes`` (per-column) but no ``.dtype``.
     # Accept when every column is numeric.
     dtypes = getattr(val, "dtypes", None)
     if dtypes is not None and hasattr(val, "shape"):
         try:
-            kinds = {getattr(d, "kind", None) for d in dtypes}
+            return len(dtypes) > 0 and all(_is_numeric_dtype(d) for d in dtypes)
         except TypeError:
             return False
-        return bool(kinds) and kinds.issubset(_NUMERIC_DTYPE_KINDS)
     return False
 
 

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -17,8 +17,8 @@ import jax.numpy as jnp
 import numpy as np
 
 from ..custom_types import Array
-from ._numeric_record import _NUMERIC_DTYPE_KINDS, NumericRecord
-from .event_template import ArraySpec, EventTemplate
+from ._numeric_record import NumericRecord
+from .event_template import ArraySpec, EventTemplate, _is_numeric_dtype
 from .record import Record
 
 __all__ = [
@@ -498,8 +498,7 @@ class NumericRecordArray(RecordArray):
                     f"NumericRecordArray: field {name!r} must be a "
                     f"numeric array, got {type(raw).__name__}"
                 )
-            kind = getattr(raw.dtype, "kind", None)
-            if kind not in _NUMERIC_DTYPE_KINDS:
+            if not _is_numeric_dtype(raw.dtype):
                 raise TypeError(
                     f"NumericRecordArray: field {name!r} has non-numeric dtype {raw.dtype!r}"
                 )

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -977,6 +977,23 @@ def _all_numeric(specs: Iterable[Any]) -> bool:
 _NUMERIC_KINDS = frozenset("biufc")
 
 
+def _is_numeric_dtype(dtype: Any) -> bool:
+    """Whether *dtype* is a numeric dtype — the shared numeric-gate predicate.
+
+    Covers the standard numpy kinds (bool, int, uint, float, complex) plus
+    the ml_dtypes extension types JAX registers (``bfloat16``, the
+    ``float8_*`` family, ``int4`` / ``uint4``), which numpy reports as kind
+    ``"V"``. Structured (record) dtypes are not numeric. Every place that
+    decides "is this array numeric?" — template inference, spec validation,
+    and the ``NumericRecord`` / ``NumericRecordArray`` leaf gates — routes
+    through this predicate so the sites cannot drift apart.
+    """
+    kind = getattr(dtype, "kind", None)
+    if kind in _NUMERIC_KINDS:
+        return True
+    return kind == "V" and jnp.issubdtype(dtype, jnp.number)
+
+
 def _full_array_shape_or_none(val: Any) -> tuple[int, ...] | None:
     """Return the shape of a numeric array-like value, or ``None``.
 
@@ -986,11 +1003,7 @@ def _full_array_shape_or_none(val: Any) -> tuple[int, ...] | None:
     """
     if isinstance(val, (bool, int, float, complex, np.integer, np.floating, np.bool_)):
         return ()
-    if (
-        hasattr(val, "shape")
-        and hasattr(val, "dtype")
-        and getattr(val.dtype, "kind", None) in _NUMERIC_KINDS
-    ):
+    if hasattr(val, "shape") and hasattr(val, "dtype") and _is_numeric_dtype(val.dtype):
         return tuple(val.shape)
     return None
 

--- a/probpipe/record/design.py
+++ b/probpipe/record/design.py
@@ -23,7 +23,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from ..core._record_array import RecordArray
-from ..core.event_template import EventTemplate
+from ..core.event_template import EventTemplate, _is_numeric_dtype
 
 __all__ = ["Design", "FullFactorialDesign"]
 
@@ -38,7 +38,7 @@ def _is_numeric_sequence(seq: Any) -> bool:
 
     Strings and byte sequences are rejected (they're iterable but
     categorical-valued). We probe via ``jnp.asarray`` and check the
-    resulting dtype's kind.
+    resulting dtype with the shared numeric-dtype predicate.
     """
     if isinstance(seq, (str, bytes)):
         return False
@@ -46,7 +46,7 @@ def _is_numeric_sequence(seq: Any) -> bool:
         arr = jnp.asarray(seq)
     except (TypeError, ValueError):
         return False
-    return arr.dtype.kind in "biufc"
+    return _is_numeric_dtype(arr.dtype)
 
 
 def _seq_to_column(

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -774,6 +774,21 @@ class TestMakeStack:
         np.testing.assert_allclose(out["a"], [0.0, 1.0, 2.0])
         np.testing.assert_array_equal(out["label"], ["row0", "row1", "row2"])
 
+    def test_bfloat16_field_inferred_numeric_not_opaque(self):
+        """The broadcast-template builder shares the numeric-dtype gate, so an
+        ml_dtypes (bfloat16) field stacks into an ArraySpec column rather than
+        being mislabeled opaque (#343)."""
+        from probpipe import Record, RecordArray
+        from probpipe.core._broadcast_distributions import _make_stack
+        from probpipe.core.event_template import ArraySpec, OpaqueSpec
+
+        records = [Record(x=jnp.ones(2, dtype=jnp.bfloat16), label=f"r{i}") for i in range(3)]
+        out = _make_stack(records, n=3, field_name="demo")
+        assert isinstance(out, RecordArray)
+        assert out["x"].dtype == jnp.bfloat16
+        assert out.template["x"] == ArraySpec((2,))  # numeric, not None/opaque
+        assert out.template["label"] == OpaqueSpec()
+
     def test_list_of_distributions_gives_distribution_array(self):
         from probpipe import DistributionArray, Normal
         from probpipe.core._broadcast_distributions import _make_stack

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -694,23 +694,21 @@ class TestArraySpecIsValid:
 
     def test_ml_dtypes_are_numeric(self):
         # bfloat16 / float8 report numpy kind "V" but are numeric JAX arrays;
-        # they satisfy ArraySpec (shape-only and dtype-pinned) and are
-        # rejected by OpaqueSpec.
+        # they satisfy ArraySpec (shape-only and dtype-pinned). infer_from
+        # therefore routes them to the array side (see the infer_from test).
         bf16 = jnp.ones(2, dtype=jnp.bfloat16)
         assert ArraySpec((2,)).is_valid(bf16)
         assert ArraySpec((2,), dtype=jnp.bfloat16).is_valid(bf16)
         assert not ArraySpec((2,), dtype=jnp.float32).is_valid(bf16)
-        assert not OpaqueSpec().is_valid(bf16)
         f8 = jnp.ones((), dtype=jnp.float8_e4m3fn)
         assert ArraySpec(()).is_valid(f8)
-        assert not OpaqueSpec().is_valid(f8)
 
     def test_structured_dtype_stays_non_numeric(self):
         # numpy structured dtypes are also kind "V" but are not numeric:
-        # they fail ArraySpec and fall to OpaqueSpec.
+        # they fail ArraySpec, so infer_from routes them to OpaqueSpec.
         rec = np.zeros(2, dtype=[("a", "f4")])
         assert not ArraySpec((2,)).is_valid(rec)
-        assert OpaqueSpec().is_valid(rec)
+        assert EventTemplate.infer_from({"r": rec})["r"] == OpaqueSpec()
 
     def test_infer_from_bfloat16_is_numeric(self):
         tpl = EventTemplate.infer_from({"x": jnp.ones((2, 3), dtype=jnp.bfloat16)})

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -692,6 +692,31 @@ class TestArraySpecIsValid:
         assert spec.is_valid(jnp.ones(2, dtype=jnp.float32))
         assert spec.is_valid(np.ones(2, dtype=np.int64))
 
+    def test_ml_dtypes_are_numeric(self):
+        # bfloat16 / float8 report numpy kind "V" but are numeric JAX arrays;
+        # they satisfy ArraySpec (shape-only and dtype-pinned) and are
+        # rejected by OpaqueSpec.
+        bf16 = jnp.ones(2, dtype=jnp.bfloat16)
+        assert ArraySpec((2,)).is_valid(bf16)
+        assert ArraySpec((2,), dtype=jnp.bfloat16).is_valid(bf16)
+        assert not ArraySpec((2,), dtype=jnp.float32).is_valid(bf16)
+        assert not OpaqueSpec().is_valid(bf16)
+        f8 = jnp.ones((), dtype=jnp.float8_e4m3fn)
+        assert ArraySpec(()).is_valid(f8)
+        assert not OpaqueSpec().is_valid(f8)
+
+    def test_structured_dtype_stays_non_numeric(self):
+        # numpy structured dtypes are also kind "V" but are not numeric:
+        # they fail ArraySpec and fall to OpaqueSpec.
+        rec = np.zeros(2, dtype=[("a", "f4")])
+        assert not ArraySpec((2,)).is_valid(rec)
+        assert OpaqueSpec().is_valid(rec)
+
+    def test_infer_from_bfloat16_is_numeric(self):
+        tpl = EventTemplate.infer_from({"x": jnp.ones((2, 3), dtype=jnp.bfloat16)})
+        assert isinstance(tpl, NumericEventTemplate)
+        assert tpl["x"] == ArraySpec((2, 3))
+
     def test_python_scalar_dtype_is_numpy_default(self):
         # A bare Python scalar reports the dtype ``np.asarray`` gives it.
         assert ArraySpec((), dtype=np.asarray(1.0).dtype).is_valid(1.0)

--- a/tests/core/test_numeric_record.py
+++ b/tests/core/test_numeric_record.py
@@ -137,19 +137,32 @@ class TestConstruction:
             nr = NumericRecord(x=arr)
             assert isinstance(nr["x"], jnp.ndarray), f"failed for dtype {dt}"
 
-    def test_numeric_dtype_kinds_shared_constant(self):
-        """``NumericRecord`` and ``NumericRecordArray`` must agree on
-        which dtype kinds are numeric. Duplicated literals would let
-        the two validation sites drift silently — this test pins down
-        that they consume the same frozenset."""
-        from probpipe.core._numeric_record import _NUMERIC_DTYPE_KINDS
+    def test_numeric_dtype_predicate_shared(self):
+        """Every numeric gate — ``NumericRecord``, ``NumericRecordArray``,
+        template inference, and the ``Design`` marginals probe — must agree
+        on which dtypes are numeric. Duplicated literals would let the
+        sites drift silently — this test pins down that they consume the
+        one shared predicate."""
+        from probpipe.core import _numeric_record, _record_array
+        from probpipe.core.event_template import _is_numeric_dtype
+        from probpipe.record import design
 
-        assert frozenset("biufc") == _NUMERIC_DTYPE_KINDS
-        # Import path is also the import path used by
-        # NumericRecordArray._validate_fields (see _record_array.py).
-        from probpipe.core import _record_array
+        assert _numeric_record._is_numeric_dtype is _is_numeric_dtype
+        assert _record_array._is_numeric_dtype is _is_numeric_dtype
+        assert design._is_numeric_dtype is _is_numeric_dtype
 
-        assert _record_array._NUMERIC_DTYPE_KINDS is _NUMERIC_DTYPE_KINDS
+    def test_bfloat16_leaf_accepted(self):
+        # ml_dtypes numerics (kind "V") are numeric leaves.
+        nr = NumericRecord(x=jnp.ones(3, dtype=jnp.bfloat16))
+        assert nr["x"].dtype == jnp.bfloat16
+
+    def test_bfloat16_vector_round_trip(self):
+        nr = NumericRecord(x=jnp.ones(3, dtype=jnp.bfloat16), y=jnp.zeros((), dtype=jnp.bfloat16))
+        tpl = nr.event_template
+        vec = tpl.to_vector(nr)
+        assert vec.shape == (4,)
+        assert vec.dtype == jnp.bfloat16
+        assert tpl.from_vector(vec) == nr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_numeric_record.py
+++ b/tests/core/test_numeric_record.py
@@ -139,16 +139,17 @@ class TestConstruction:
 
     def test_numeric_dtype_predicate_shared(self):
         """Every numeric gate — ``NumericRecord``, ``NumericRecordArray``,
-        template inference, and the ``Design`` marginals probe — must agree
-        on which dtypes are numeric. Duplicated literals would let the
-        sites drift silently — this test pins down that they consume the
-        one shared predicate."""
-        from probpipe.core import _numeric_record, _record_array
+        template inference, the broadcast-template builder, and the ``Design``
+        marginals probe — must agree on which dtypes are numeric. Duplicated
+        literals would let the sites drift silently — this test pins down that
+        they consume the one shared predicate."""
+        from probpipe.core import _broadcast_distributions, _numeric_record, _record_array
         from probpipe.core.event_template import _is_numeric_dtype
         from probpipe.record import design
 
         assert _numeric_record._is_numeric_dtype is _is_numeric_dtype
         assert _record_array._is_numeric_dtype is _is_numeric_dtype
+        assert _broadcast_distributions._is_numeric_dtype is _is_numeric_dtype
         assert design._is_numeric_dtype is _is_numeric_dtype
 
     def test_bfloat16_leaf_accepted(self):

--- a/tests/core/test_record_array.py
+++ b/tests/core/test_record_array.py
@@ -756,9 +756,9 @@ class TestNumericRecordArrayValidation:
 
     def test_rejects_numpy_object_dtype_batch(self):
         """Parallel regression for the _is_numeric_leaf object-dtype fix:
-        NumericRecordArray._validate_fields shares the same
-        _NUMERIC_DTYPE_KINDS set, so an object-dtype batched field
-        must be rejected up front (not left to blow up inside JAX)."""
+        NumericRecordArray._validate_fields shares the same numeric-dtype
+        predicate, so an object-dtype batched field must be rejected up
+        front (not left to blow up inside JAX)."""
         tpl = EventTemplate(x=())
         with pytest.raises(TypeError, match="non-numeric dtype"):
             NumericRecordArray(


### PR DESCRIPTION
# Summary

Closes #343. ml_dtypes arrays — `bfloat16`, the `float8_*` family, `int4`/`uint4` — now classify as **numeric** everywhere ProbPipe asks "is this array numeric?". Stacked on #337 (base branch `dev/value-spec-classes`), since the spec-validation gate it fixes is defined there.

## The bug

The numeric-dtype gates keyed on numpy's `dtype.kind in "biufc"`. The ml_dtypes extension types JAX registers report kind `"V"` (numpy void), so a perfectly ordinary JAX array fell on the wrong side of every gate:

```python
x = jnp.ones(2, dtype=jnp.bfloat16)
ArraySpec((2,)).is_valid(x)                      # was False — a numeric JAX array
ArraySpec((2,), dtype=jnp.bfloat16).is_valid(x)  # was False, even dtype-pinned
EventTemplate.infer_from({"x": x})               # inferred OpaqueSpec, template non-numeric
NumericRecord(x=x)                               # rejected the leaf
```

## The fix

One shared predicate, `_is_numeric_dtype` in `probpipe/core/event_template.py`: a dtype is numeric when its kind is one of `biufc`, or when its kind is `"V"` **and** `jnp.issubdtype(dtype, jnp.number)` holds — which is exactly the ml_dtypes numerics and excludes structured (record) dtypes. All five gates route through it:

| Gate | Site |
|---|---|
| Template inference + spec validation | `event_template._full_array_shape_or_none` (drives `infer_from`, `ArraySpec.is_valid`) |
| `NumericRecord` leaf check | `_numeric_record._is_numeric_leaf` (array and DataFrame-`dtypes` branches) |
| `NumericRecordArray` field validation | `_record_array._validate_fields` |
| Broadcast-template builder | `_broadcast_distributions._make_stack` |
| `Design` marginals probe | `record/design._is_numeric_sequence` |

The gates were previously kept in lockstep by duplicating a `frozenset("biufc")` literal with a "keep in sync" comment and a test pinning the copies to each other; the shared predicate replaces that, and the internal `_NUMERIC_DTYPE_KINDS` constant is removed. The lockstep test now pins all five modules to the one predicate.

## Behavior changes

- `ArraySpec.is_valid` / `OpaqueSpec.is_valid` put ml_dtypes arrays on the array side of the array/opaque split.
- `EventTemplate.infer_from` infers `ArraySpec` (and auto-promotes to `NumericEventTemplate`) for ml_dtypes leaves.
- `NumericRecord` / `NumericRecordArray` accept ml_dtypes leaves; `to_vector` / `from_vector` round-trip them at their native dtype.
- `Design` marginals given as sequences of ml_dtypes scalars materialise as numeric columns.
- Structured (`np.dtype([("a", "f4")])`) and object/string dtypes are unchanged: non-numeric.

## CI for stacked PRs

`ci.yml`'s `pull_request` trigger filtered on base `main` only, so a PR stacked on another PR's `dev/` branch got no CI at all until its base merged. The filter now also matches `dev/**` bases, which is what runs the checks on this PR.

## Tests

`tests/core/test_event_template.py` — bfloat16 and float8 through `ArraySpec.is_valid` (shape-only, dtype-pinned, and mismatched-dtype), `OpaqueSpec` rejection, `infer_from` promotion, and a structured-dtype guard (kind `"V"` but non-numeric). `tests/core/test_numeric_record.py` — bfloat16 leaf acceptance, a `to_vector`/`from_vector` round-trip at native dtype, and the rewritten shared-predicate lockstep pin across all four modules.

## Contract checklist (CONTRACTS.md)

- [x] Contract clear before coding (the numeric gate's meaning is stated on the shared predicate's docstring).
- [x] Changed contracts documented in docstrings (`_is_numeric_dtype`, `_is_numeric_leaf`).
- [x] Code obeys the documented contract; tests assert it (acceptance, rejection, round-trip, lockstep).
- [x] Variable names consistent with the canonical table.
- [x] CHANGELOG entry (Fixed).
- [x] `ruff format` and `ruff check` clean (CI-pinned 0.15.16).
