### PR TITLE
chore: sync uv.lock requires-dist specifier for mkdocs-jupyter

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3573,7 +3573,7 @@ requires-dist = [
     { name = "jupyter", marker = "extra == 'dev'" },
     { name = "matplotlib", marker = "extra == 'pymc'" },
     { name = "matplotlib", marker = "extra == 'viz'" },
-    { name = "mkdocs-jupyter", marker = "extra == 'docs'", specifier = ">=0.25.1,<0.26" },
+    { name = "mkdocs-jupyter", marker = "extra == 'docs'", specifier = "<0.26" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'" },
     { name = "nbformat", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary

`uv.lock`'s `requires-dist` entry for `mkdocs-jupyter` read `>=0.25.1,<0.26`, while `pyproject.toml` declares `mkdocs-jupyter<0.26`. Because the lock file's recorded specifier didn't match the project metadata, any `uv run` (or `uv sync`) would rewrite that line back to `<0.26`, producing recurring uncommitted churn in the working tree.

This regenerates the lock with `uv lock` against the current `pyproject.toml`. The only change is the one `requires-dist` specifier line — no package versions or resolutions changed (`uv lock --check` passes on the result).

## Changes

- `uv.lock`: `mkdocs-jupyter` requires-dist specifier `>=0.25.1,<0.26` → `<0.26`, matching `pyproject.toml`.
