### PR TITLE
feat(core): pandas nullable/masked numeric columns are numeric leaves (NA -> NaN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,12 +175,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   boundary), and content-fingerprinted everywhere at once. `fingerprint()`
   hashes native containers by type + materialised values + identity metadata
   instead of falling to the process-dependent `repr` tier. A pandas
-  nullable / masked *numeric* column (`Int64`, `Float64`, `boolean`) is a
-  first-class numeric leaf. It is stored verbatim, so its validity mask stays
-  intact at rest. At the compute boundary it converts to `float64` with each
-  NA encoded as `NaN` — the only missing-value form `jax` offers — so missing
-  data round-trips as `NaN`. Integer and boolean columns therefore promote to
-  float. The generic duck-typing gate still rejects a *bare*
+  nullable / masked *numeric* column (`Int64`, `Float64`, `boolean`, Sparse /
+  pyarrow numerics) is a first-class numeric leaf. It is stored verbatim, so
+  its validity mask stays intact at rest. At the compute boundary it converts
+  to its columns' common dense dtype with each NA encoded as `NaN` — the only
+  missing-value form `jax` offers — so missing data round-trips as `NaN`. That
+  dtype keeps a nullable float at its own width and a complex column complex
+  (`Sparse[complex128]` → `complex128`); a nullable integer / boolean promotes
+  to `float64` (no integer `NaN`). The generic duck-typing gate still rejects
+  a *bare*
   extension dtype (it is not a dense numpy dtype); the pandas backend
   recognises its own masked dtypes. Non-numeric extension dtypes (categorical /
   string / datetime) are not numeric and leave the container a plain `Record`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,12 +176,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hashes native containers by type + materialised values + identity metadata
   instead of falling to the process-dependent `repr` tier. A pandas
   nullable / masked *numeric* column (`Int64`, `Float64`, `boolean`) is a
-  first-class numeric leaf: it is stored verbatim so its validity mask is
-  intact at rest, and converted through `float64` with each NA encoded as
-  `NaN` at the compute boundary — the only missing-value form `jax` offers —
-  so missing data round-trips as `NaN` (integer / boolean columns therefore
-  promote to float). The generic duck-typing gate still rejects a *bare*
-  extension dtype (it is not a dense numpy dtype); the pandas backend is what
+  first-class numeric leaf. It is stored verbatim, so its validity mask stays
+  intact at rest. At the compute boundary it converts to `float64` with each
+  NA encoded as `NaN` — the only missing-value form `jax` offers — so missing
+  data round-trips as `NaN`. Integer and boolean columns therefore promote to
+  float. The generic duck-typing gate still rejects a *bare*
+  extension dtype (it is not a dense numpy dtype); the pandas backend
   recognises its own masked dtypes. Non-numeric extension dtypes (categorical /
   string / datetime) are not numeric and leave the container a plain `Record`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,9 +175,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   boundary), and content-fingerprinted everywhere at once. `fingerprint()`
   hashes native containers by type + materialised values + identity metadata
   instead of falling to the process-dependent `repr` tier. A pandas
-  nullable / masked dtype (`Int64Dtype` etc.) is **not** treated as numeric
-  (it is not a dense numpy dtype), so a frame using one stays a plain `Record`
-  rather than promoting into a form `jax` cannot hold.
+  nullable / masked *numeric* column (`Int64`, `Float64`, `boolean`) is a
+  first-class numeric leaf: it is stored verbatim so its validity mask is
+  intact at rest, and converted through `float64` with each NA encoded as
+  `NaN` at the compute boundary — the only missing-value form `jax` offers —
+  so missing data round-trips as `NaN` (integer / boolean columns therefore
+  promote to float). The generic duck-typing gate still rejects a *bare*
+  extension dtype (it is not a dense numpy dtype); the pandas backend is what
+  recognises its own masked dtypes. Non-numeric extension dtypes (categorical /
+  string / datetime) are not numeric and leave the container a plain `Record`.
 
 - **`Record` / `NumericRecord` construction is name-first, and all-numeric
   records auto-promote (#338, breaking).** The constructors are now

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -35,8 +35,8 @@ for two reasons. The first is to expose their identity-bearing metadata (an
 columns) through the ``metadata`` hook. The second, for pandas, is to handle
 nullable / masked numeric columns (``Int64``, ``Float64``, ``boolean``). The
 generic duck path cannot see those columns as numeric, but the pandas backend
-accepts them and converts through ``float64``, encoding each NA as ``NaN``. Bare
-``numpy`` / ``jax`` arrays stay unregistered — the duck path covers them and
+accepts them, encoding each NA as ``NaN`` in the columns' common dense dtype.
+Bare ``numpy`` / ``jax`` arrays stay unregistered — the duck path covers them and
 they carry no metadata beyond their values.
 
 Batch stacking hooks (a per-backend native ``stack`` / ``element``) are
@@ -296,23 +296,45 @@ def _register_pandas() -> None:
         # numeric dtype (generic gate), or a nullable numeric one (NA -> NaN).
         return _is_numeric_dtype(dtype) or _is_nullable_numeric(dtype)
 
+    def _dense_dtype(dtypes: Any) -> np.dtype | None:
+        # The single dense numpy dtype a Series / DataFrame of these column
+        # dtypes densifies to (via to_numpy / to_jax), or None when a column has
+        # no dense numpy dtype. A masked numeric column has no dense numpy view
+        # and must hold NA as NaN, so it contributes a float: a nullable float
+        # keeps its own width (Float32 -> float32), a nullable integer / boolean
+        # promotes to float64. Every other column contributes its own dtype. The
+        # result is their common promotion, so a complex column yields complex128
+        # rather than being truncated to float.
+        contribs: list[np.dtype] = []
+        for d in dtypes:
+            if _is_nullable_numeric(d):
+                nd = getattr(d, "numpy_dtype", None)
+                if nd is not None and np.issubdtype(nd, np.floating):
+                    contribs.append(np.dtype(nd))
+                else:
+                    contribs.append(np.dtype("float64"))
+            else:
+                nd = _safe_numpy_dtype(d)
+                if nd is None:
+                    return None
+                contribs.append(nd)
+        return np.result_type(*contribs) if contribs else None
+
     def _dense(obj: Any, dtypes: Any) -> np.ndarray:
-        # Any masked column forces the whole result through float64, encoding
-        # each NA as NaN; otherwise the native numpy view is used unchanged.
+        # A masked column has no dense numpy view; converting with an explicit
+        # target dtype encodes each NA as NaN and keeps complex columns complex
+        # (see _dense_dtype). Otherwise the native numpy view is used unchanged.
         if any(_is_nullable_numeric(d) for d in dtypes):
-            return obj.to_numpy(dtype="float64", na_value=np.nan)
+            return obj.to_numpy(dtype=_dense_dtype(dtypes), na_value=np.nan)
         return obj.to_numpy()
 
     def _series_metadata(s: pd.Series) -> Any:
         return {"index": np.asarray(s.index), "name": s.name}
 
     def _series_numpy_dtype(s: pd.Series) -> np.dtype | None:
-        # A nullable column converts through float64 (see _dense), so float64
-        # is the leaf's dtype — not the masked dtype, which has no dense numpy
-        # form. This depends on the dtype, not on whether NAs are present.
-        if _is_nullable_numeric(s.dtype):
-            return np.dtype("float64")
-        return _safe_numpy_dtype(s.dtype)
+        # Report the single dense dtype the series densifies to (see
+        # _dense_dtype), so numpy_dtype matches what to_numpy / to_jax produce.
+        return _dense_dtype((s.dtype,))
 
     register_array_backend(
         pd.Series,
@@ -331,19 +353,9 @@ def _register_pandas() -> None:
         return len(dtypes) > 0 and all(_column_numeric(d) for d in dtypes)
 
     def _frame_numpy_dtype(df: pd.DataFrame) -> np.dtype | None:
-        # A masked / nullable numeric column has no dense numpy view, so the
-        # whole frame converts through float64 (NA -> NaN). Otherwise a numeric
-        # frame densifies (to_numpy / to_jax) to one dense array whose dtype is
-        # its columns' common promotion — e.g. int64 + float64 -> float64 — so
-        # report that rather than None. ``None`` only when a column has no dense
-        # numpy dtype (a non-numpy, non-nullable extension column).
-        dtypes = df.dtypes
-        if any(_is_nullable_numeric(d) for d in dtypes):
-            return np.dtype("float64")
-        numpy_dtypes = [_safe_numpy_dtype(d) for d in dtypes]
-        if not numpy_dtypes or any(nd is None for nd in numpy_dtypes):
-            return None
-        return np.result_type(*numpy_dtypes)
+        # Report the single dense dtype the frame densifies to (see
+        # _dense_dtype), so numpy_dtype matches what to_numpy / to_jax produce.
+        return _dense_dtype(df.dtypes)
 
     def _frame_metadata(df: pd.DataFrame) -> Any:
         return {

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -268,14 +268,17 @@ def _register_pandas() -> None:
     metadata without materialising values.
 
     Nullable / masked numeric columns (``Int64``, ``Float64``, ``boolean``,
-    pyarrow numerics) are accepted as numeric even though the generic gate
-    rejects their dtype: such a column has no dense numpy view, so the whole
-    container converts through ``float64`` with each NA encoded as ``NaN`` —
-    the only missing-value representation ``jax`` offers. The native leaf is
-    stored verbatim, so the validity mask survives at rest; NA becomes NaN
-    only at the compute boundary. Integer / boolean columns therefore promote
-    to float. Categorical / string / datetime extension dtypes are not numeric
-    and leave the container a plain ``Record``. No-op without pandas.
+    pyarrow / Sparse numerics) are accepted as numeric even though the generic
+    gate rejects their dtype: such a column has no dense numpy view, so the
+    container converts to its columns' **common dense dtype** (see
+    ``_dense_dtype``) with each NA encoded as ``NaN`` — the only missing-value
+    representation ``jax`` offers. That common dtype keeps a nullable float at
+    its own width (``Float32 -> float32``) and a complex column complex
+    (``Sparse[complex128] -> complex128``); a nullable integer / boolean
+    promotes to ``float64`` (no integer NaN). The native leaf is stored
+    verbatim, so the validity mask survives at rest; NA becomes NaN only at the
+    compute boundary. Categorical / string / datetime extension dtypes are not
+    numeric and leave the container a plain ``Record``. No-op without pandas.
     """
     try:
         import pandas as pd
@@ -296,23 +299,36 @@ def _register_pandas() -> None:
         # numeric dtype (generic gate), or a nullable numeric one (NA -> NaN).
         return _is_numeric_dtype(dtype) or _is_nullable_numeric(dtype)
 
+    def _extension_dense_dtype(dtype: Any) -> np.dtype | None:
+        # The underlying dense numpy dtype of a masked / extension numeric
+        # dtype: pandas masked dtypes expose it as ``.numpy_dtype``, a
+        # ``SparseDtype`` as ``.subtype``. ``None`` if neither is readable.
+        for attr in ("numpy_dtype", "subtype"):
+            nd = getattr(dtype, attr, None)
+            if nd is not None:
+                try:
+                    return np.dtype(nd)
+                except (TypeError, ValueError):
+                    pass
+        return None
+
     def _dense_dtype(dtypes: Any) -> np.dtype | None:
         # The single dense numpy dtype a Series / DataFrame of these column
         # dtypes densifies to (via to_numpy / to_jax), or None when a column has
-        # no dense numpy dtype. A masked numeric column has no dense numpy view
-        # and must hold NA as NaN, so it contributes a float: a nullable float
-        # keeps its own width (Float32 -> float32), a nullable integer / boolean
-        # promotes to float64. Every other column contributes its own dtype. The
-        # result is their common promotion, so a complex column yields complex128
-        # rather than being truncated to float.
+        # no dense numpy dtype. A masked / extension numeric column has no dense
+        # numpy view and must hold NA as NaN, so it contributes its underlying
+        # dense dtype when that already holds NaN — a float or complex, kept at
+        # its own width (Float32 -> float32, Sparse[complex128] -> complex128) —
+        # and float64 otherwise (integer / boolean have no NaN). Every other
+        # column contributes its own dtype. The result is their common
+        # promotion, so a complex column is never truncated to float.
         contribs: list[np.dtype] = []
         for d in dtypes:
             if _is_nullable_numeric(d):
-                nd = getattr(d, "numpy_dtype", None)
-                if nd is not None and np.issubdtype(nd, np.floating):
-                    contribs.append(np.dtype(nd))
-                else:
-                    contribs.append(np.dtype("float64"))
+                sub = _extension_dense_dtype(d)
+                contribs.append(
+                    sub if sub is not None and sub.kind in "fc" else np.dtype("float64")
+                )
             else:
                 nd = _safe_numpy_dtype(d)
                 if nd is None:

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -314,14 +314,14 @@ def _register_pandas() -> None:
 
     def _dense_dtype(dtypes: Any) -> np.dtype | None:
         # The single dense numpy dtype a Series / DataFrame of these column
-        # dtypes densifies to (via to_numpy / to_jax), or None when a column has
-        # no dense numpy dtype. A masked / extension numeric column has no dense
-        # numpy view and must hold NA as NaN, so it contributes its underlying
-        # dense dtype when that already holds NaN — a float or complex, kept at
-        # its own width (Float32 -> float32, Sparse[complex128] -> complex128) —
-        # and float64 otherwise (integer / boolean have no NaN). Every other
-        # column contributes its own dtype. The result is their common
-        # promotion, so a complex column is never truncated to float.
+        # dtypes densifies to, or None when a column has no dense numpy dtype.
+        # A masked / extension numeric column has no dense numpy view and must
+        # hold NA as NaN. It contributes its underlying dtype when that already
+        # holds NaN, so a nullable float keeps its width and a complex column
+        # stays complex; an integer or boolean underlying promotes to float64
+        # instead. Every other column contributes its own dtype, and the result
+        # is their common promotion, so a complex column is never truncated to a
+        # float.
         contribs: list[np.dtype] = []
         for d in dtypes:
             if _is_nullable_numeric(d):

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -28,10 +28,15 @@ conversion cache, batch stacking, and ``fingerprint()`` — resolves
 new array type recognised, validated, promoted, converted, and fingerprinted
 everywhere at once.
 
-Built-in registration: ``pandas.DataFrame`` (the ``.dtypes``-but-no-``.dtype``
-shape the duck path misses). ``numpy`` / ``jax`` arrays, ``xarray.DataArray``,
-and ``pandas.Series`` are deliberately unregistered — the duck path covers
-them.
+Built-in registrations: ``xarray.DataArray`` and ``pandas.Series`` /
+``pandas.DataFrame``. They are registered (not left to the duck path) both to
+expose their identity-bearing metadata — dims / coords / attrs / name, or
+index / columns — through the ``metadata`` hook, and, for pandas, to handle
+nullable / masked numeric columns (``Int64``, ``Float64``, ``boolean``): the
+generic duck path cannot see those as numeric, but the pandas backend accepts
+them and converts through ``float64``, encoding each NA as ``NaN``. Bare
+``numpy`` / ``jax`` arrays stay unregistered — the duck path covers them and
+they carry no metadata beyond their values.
 
 Batch stacking hooks (a per-backend native ``stack`` / ``element``) are
 expected to join this registry with the batch-axis rework; the keyword-only
@@ -259,7 +264,17 @@ def _register_pandas() -> None:
     A ``Series`` speaks the numpy protocol but carries an index and name; a
     ``DataFrame`` additionally has no single ``.dtype`` (per-column ``.dtypes``
     the duck path cannot read). Both answer shape / dtype / numericness from
-    metadata without materialising values. No-op without pandas.
+    metadata without materialising values.
+
+    Nullable / masked numeric columns (``Int64``, ``Float64``, ``boolean``,
+    pyarrow numerics) are accepted as numeric even though the generic gate
+    rejects their dtype: such a column has no dense numpy view, so the whole
+    container converts through ``float64`` with each NA encoded as ``NaN`` —
+    the only missing-value representation ``jax`` offers. The native leaf is
+    stored verbatim, so the validity mask survives at rest; NA becomes NaN
+    only at the compute boundary. Integer / boolean columns therefore promote
+    to float. Categorical / string / datetime extension dtypes are not numeric
+    and leave the container a plain ``Record``. No-op without pandas.
     """
     try:
         import pandas as pd
@@ -268,32 +283,63 @@ def _register_pandas() -> None:
 
     from .event_template import _is_numeric_dtype
 
+    def _is_nullable_numeric(dtype: Any) -> bool:
+        # A masked / extension *numeric* dtype: numeric, but with a validity
+        # mask and no dense numpy view. Excludes categorical / string /
+        # datetime, which are extension dtypes yet not numeric.
+        is_ext = pd.api.types.is_extension_array_dtype(dtype)
+        return is_ext and pd.api.types.is_numeric_dtype(dtype)
+
+    def _column_numeric(dtype: Any) -> bool:
+        # A column ProbPipe can turn into a dense numeric array: a plain numpy
+        # numeric dtype (generic gate), or a nullable numeric one (NA -> NaN).
+        return _is_numeric_dtype(dtype) or _is_nullable_numeric(dtype)
+
+    def _dense(obj: Any, dtypes: Any) -> np.ndarray:
+        # Any masked column forces the whole result through float64, encoding
+        # each NA as NaN; otherwise the native numpy view is used unchanged.
+        if any(_is_nullable_numeric(d) for d in dtypes):
+            return obj.to_numpy(dtype="float64", na_value=np.nan)
+        return obj.to_numpy()
+
     def _series_metadata(s: pd.Series) -> Any:
         return {"index": np.asarray(s.index), "name": s.name}
+
+    def _series_numpy_dtype(s: pd.Series) -> np.dtype | None:
+        # A nullable column converts through float64 (see _dense), so that —
+        # not the masked dtype, which has no dense numpy form — is the leaf's
+        # dtype. This depends on the dtype, not on whether NAs are present.
+        if _is_nullable_numeric(s.dtype):
+            return np.dtype("float64")
+        return _safe_numpy_dtype(s.dtype)
 
     register_array_backend(
         pd.Series,
         ArrayBackend(
             event_shape=lambda s: tuple(s.shape),
-            numpy_dtype=lambda s: _safe_numpy_dtype(s.dtype),
-            is_numeric=lambda s: _is_numeric_dtype(s.dtype),
-            to_jax=lambda s: jnp.asarray(s.to_numpy()),
-            to_numpy=lambda s: s.to_numpy(),
+            numpy_dtype=_series_numpy_dtype,
+            is_numeric=lambda s: _column_numeric(s.dtype),
+            to_jax=lambda s: jnp.asarray(_dense(s, (s.dtype,))),
+            to_numpy=lambda s: _dense(s, (s.dtype,)),
             metadata=_series_metadata,
         ),
     )
 
     def _frame_is_numeric(df: pd.DataFrame) -> bool:
         dtypes = df.dtypes
-        return len(dtypes) > 0 and all(_is_numeric_dtype(d) for d in dtypes)
+        return len(dtypes) > 0 and all(_column_numeric(d) for d in dtypes)
 
     def _frame_numpy_dtype(df: pd.DataFrame) -> np.dtype | None:
-        # A numeric frame densifies (to_numpy / to_jax) to one dense array whose
-        # dtype is its columns' common promotion — e.g. int64 + float64 ->
-        # float64 — so report that for an all-numeric frame rather than None.
-        # ``None`` only when a column has no dense numpy dtype (a non-numpy /
-        # extension column), so no single dense dtype exists.
-        numpy_dtypes = [_safe_numpy_dtype(d) for d in df.dtypes]
+        # A masked / nullable numeric column has no dense numpy view, so the
+        # whole frame converts through float64 (NA -> NaN). Otherwise a numeric
+        # frame densifies (to_numpy / to_jax) to one dense array whose dtype is
+        # its columns' common promotion — e.g. int64 + float64 -> float64 — so
+        # report that rather than None. ``None`` only when a column has no dense
+        # numpy dtype (a non-numpy, non-nullable extension column).
+        dtypes = df.dtypes
+        if any(_is_nullable_numeric(d) for d in dtypes):
+            return np.dtype("float64")
+        numpy_dtypes = [_safe_numpy_dtype(d) for d in dtypes]
         if not numpy_dtypes or any(nd is None for nd in numpy_dtypes):
             return None
         return np.result_type(*numpy_dtypes)
@@ -311,8 +357,8 @@ def _register_pandas() -> None:
             event_shape=lambda df: tuple(df.shape),
             numpy_dtype=_frame_numpy_dtype,
             is_numeric=_frame_is_numeric,
-            to_jax=lambda df: jnp.asarray(df.to_numpy()),
-            to_numpy=lambda df: df.to_numpy(),
+            to_jax=lambda df: jnp.asarray(_dense(df, df.dtypes)),
+            to_numpy=lambda df: _dense(df, df.dtypes),
             metadata=_frame_metadata,
         ),
     )

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -29,12 +29,13 @@ new array type recognised, validated, promoted, converted, and fingerprinted
 everywhere at once.
 
 Built-in registrations: ``xarray.DataArray`` and ``pandas.Series`` /
-``pandas.DataFrame``. They are registered (not left to the duck path) both to
-expose their identity-bearing metadata — dims / coords / attrs / name, or
-index / columns — through the ``metadata`` hook, and, for pandas, to handle
-nullable / masked numeric columns (``Int64``, ``Float64``, ``boolean``): the
-generic duck path cannot see those as numeric, but the pandas backend accepts
-them and converts through ``float64``, encoding each NA as ``NaN``. Bare
+``pandas.DataFrame``. They are registered rather than left to the duck path
+for two reasons. The first is to expose their identity-bearing metadata (an
+``xarray`` array's dims / coords / attrs / name, a ``pandas`` object's index /
+columns) through the ``metadata`` hook. The second, for pandas, is to handle
+nullable / masked numeric columns (``Int64``, ``Float64``, ``boolean``). The
+generic duck path cannot see those columns as numeric, but the pandas backend
+accepts them and converts through ``float64``, encoding each NA as ``NaN``. Bare
 ``numpy`` / ``jax`` arrays stay unregistered — the duck path covers them and
 they carry no metadata beyond their values.
 
@@ -306,9 +307,9 @@ def _register_pandas() -> None:
         return {"index": np.asarray(s.index), "name": s.name}
 
     def _series_numpy_dtype(s: pd.Series) -> np.dtype | None:
-        # A nullable column converts through float64 (see _dense), so that —
-        # not the masked dtype, which has no dense numpy form — is the leaf's
-        # dtype. This depends on the dtype, not on whether NAs are present.
+        # A nullable column converts through float64 (see _dense), so float64
+        # is the leaf's dtype — not the masked dtype, which has no dense numpy
+        # form. This depends on the dtype, not on whether NAs are present.
         if _is_nullable_numeric(s.dtype):
             return np.dtype("float64")
         return _safe_numpy_dtype(s.dtype)

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -414,11 +414,14 @@ def _is_numeric_dtype(dtype: Any) -> bool:
     the ml_dtypes extension types JAX registers (``bfloat16``, the
     ``float8_*`` family, ``int4`` / ``uint4``), which numpy reports as kind
     ``"V"``. A dtype that is **not** ``numpy.dtype``-coercible — a pandas
-    extension / masked dtype such as ``Int64Dtype`` — is **not** numeric
-    here: it reports a numpy ``kind`` but is not a dense numpy dtype, so a
-    container using it is not a plain numeric array (it carries NA / masking
-    semantics ``jax`` cannot represent) and must not promote to a
-    ``NumericRecord``. Structured (record) dtypes are likewise not numeric.
+    extension / masked dtype such as ``Int64Dtype`` — is **not** numeric on
+    this generic (duck-typing) path: it is not a dense numpy dtype, so a bare
+    value carrying one is not treated as a plain numeric array. A registered
+    :class:`~probpipe.ArrayBackend` may still recognise its own masked dtypes
+    and convert them — the built-in pandas backend accepts nullable numeric
+    columns and encodes each NA as ``NaN`` at the compute boundary — so this
+    predicate governs only the duck path, not the registry. Structured
+    (record) dtypes are likewise not numeric.
     Every place that decides "is this array numeric?" — template inference,
     spec validation, and the ``NumericRecord`` / ``NumericRecordArray`` leaf
     gates — routes through this predicate so the sites cannot drift apart.

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -418,8 +418,8 @@ def _is_numeric_dtype(dtype: Any) -> bool:
     this generic (duck-typing) path: it is not a dense numpy dtype, so a bare
     value carrying one is not treated as a plain numeric array. A registered
     :class:`~probpipe.ArrayBackend` may still recognise its own masked dtypes
-    and convert them — the built-in pandas backend accepts nullable numeric
-    columns and encodes each NA as ``NaN`` at the compute boundary — so this
+    and convert them: the built-in pandas backend accepts nullable numeric
+    columns, encoding each NA as ``NaN`` at the compute boundary. So this
     predicate governs only the duck path, not the registry. Structured
     (record) dtypes are likewise not numeric.
     Every place that decides "is this array numeric?" — template inference,

--- a/tests/core/test_array_backend.py
+++ b/tests/core/test_array_backend.py
@@ -568,10 +568,12 @@ class TestGenericGateRejectsExtensionDtype:
 
 class TestNullableNumericMissingData:
     """pandas nullable / masked numeric columns (``Int64``, ``Float64``,
-    ``boolean``) are first-class numeric leaves: stored verbatim (mask intact
-    at rest) and converted to jax through ``float64`` with each NA encoded as
-    ``NaN`` at the compute boundary — the only missing-value representation
-    jax offers.
+    ``boolean``, Sparse / pyarrow numerics) are first-class numeric leaves:
+    stored verbatim (mask intact at rest) and converted to jax at the compute
+    boundary through the columns' common dense dtype, with each NA encoded as
+    ``NaN`` — the only missing-value representation jax offers. That dtype keeps
+    a nullable float at its own width and a complex column complex; a nullable
+    integer / boolean promotes to ``float64``.
     """
 
     def test_nullable_frame_promotes(self):
@@ -689,6 +691,31 @@ class TestNullableNumericMissingData:
         # Differing only in an imaginary part -> unequal and fingerprint-different.
         assert mk(3 + 4j) != mk(3 + 5j)
         assert fingerprint(mk(3 + 4j)) != fingerprint(mk(3 + 5j))
+
+    def test_sparse_complex_extension_preserves_imaginary(self):
+        # A Sparse[complex128] column is a complex *extension* dtype whose dense
+        # type is exposed as .subtype (not .numpy_dtype). It must densify to
+        # complex128, not float64 — the imaginary parts (and NA -> nan) survive.
+        sd = pd.SparseDtype("complex128", np.nan)
+        s = pd.Series([1 + 2j, np.nan, 3 + 4j], dtype=sd)
+        backend = array_backend_for(s)
+        assert backend.numpy_dtype(s) == np.dtype("complex128")
+        out = backend.to_numpy(s)
+        assert out.dtype == np.dtype("complex128")
+        assert out[0] == 1 + 2j and out[2] == 3 + 4j  # imaginary parts kept
+        assert np.isnan(out[1])  # NA -> nan
+
+    def test_sparse_complex_promotes_and_round_trips(self):
+        sd = pd.SparseDtype("complex128", np.nan)
+        r1 = Record("r", m=pd.Series([1 + 2j, 3 + 4j], dtype=sd))
+        r2 = Record("r", m=pd.Series([1 + 2j, 3 + 4j], dtype=sd))
+        assert type(r1) is NumericRecord
+        v = np.asarray(r1.to_vector())
+        assert np.issubdtype(v.dtype, np.complexfloating)
+        np.testing.assert_array_equal(v, [1 + 2j, 3 + 4j])
+        # equality/fingerprint see the imaginary parts
+        assert r1 == r2
+        assert r1 != Record("r", m=pd.Series([1 + 2j, 3 + 9j], dtype=sd))
 
 
 class TestNativeMetadataInIdentity:

--- a/tests/core/test_array_backend.py
+++ b/tests/core/test_array_backend.py
@@ -539,24 +539,14 @@ class TestRegisteredBackendIdentity:
         assert leaf.converted == 0
 
 
-class TestNullableDtypeNotNumeric:
-    """pandas nullable / masked dtypes report a numpy kind but are not
-    np.dtype-coercible; a frame using them must stay a plain Record rather
-    than promoting into a form jax cannot hold (which crashed on
-    dtype / is_valid / to_vector). Regression for the review-round finding.
+class TestGenericGateRejectsExtensionDtype:
+    """The generic numeric gate (``_is_numeric_dtype``, the duck path) stays
+    strict: a pandas extension / masked dtype is not ``np.dtype``-coercible,
+    so a *bare* value carrying one is not numeric there. The pandas backend
+    handles its own masked dtypes separately (see
+    :class:`TestNullableNumericMissingData`) — conservative duck path, backend
+    that knows its own types.
     """
-
-    def test_nullable_frame_does_not_promote(self):
-        df = pd.DataFrame({"a": pd.array([1, 2], dtype="Int64")})
-        r = Record("r", m=df)
-        assert type(r) is Record  # not NumericRecord
-        assert not isinstance(r.event_template, NumericEventTemplate)
-
-    def test_numpy_backed_frame_still_promotes(self):
-        df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
-        r = Record("r", m=df)
-        assert type(r) is NumericRecord
-        np.testing.assert_allclose(r.to_vector(), [1.0, 3.0, 2.0, 4.0])
 
     def test_is_numeric_dtype_rejects_extension_dtype(self):
         from probpipe.core.event_template import _is_numeric_dtype
@@ -574,6 +564,86 @@ class TestNullableDtypeNotNumeric:
 
         assert _is_numeric_dtype(MagicMock()) is False
         assert _full_array_shape_or_none(MagicMock()) is None
+
+
+class TestNullableNumericMissingData:
+    """pandas nullable / masked numeric columns (``Int64``, ``Float64``,
+    ``boolean``) are first-class numeric leaves: stored verbatim (mask intact
+    at rest) and converted to jax through ``float64`` with each NA encoded as
+    ``NaN`` at the compute boundary — the only missing-value representation
+    jax offers.
+    """
+
+    def test_nullable_frame_promotes(self):
+        df = pd.DataFrame({"a": pd.array([1, 2], dtype="Int64")})
+        r = Record("r", m=df)
+        assert type(r) is NumericRecord
+        assert isinstance(r.event_template, NumericEventTemplate)
+
+    def test_na_encoded_as_nan_at_boundary(self):
+        df = pd.DataFrame({"a": pd.array([1, None, 3], dtype="Int64")})
+        v = np.asarray(Record("r", m=df).to_vector())
+        assert v[0] == 1.0 and v[2] == 3.0
+        assert np.isnan(v[1])
+
+    def test_mask_preserved_at_rest(self):
+        # Native storage keeps the pandas object verbatim: the validity mask
+        # survives construction. NA -> NaN happens only at the jax boundary,
+        # never at rest.
+        df = pd.DataFrame({"a": pd.array([1, None], dtype="Int64")})
+        stored = Record("r", m=df)["m"]
+        assert isinstance(stored, pd.DataFrame)
+        assert stored["a"].isna().tolist() == [False, True]
+
+    def test_series_nullable_promotes_and_converts(self):
+        s = pd.Series(pd.array([1.5, None, 3.0], dtype="Float64"), name="x")
+        r = Record("r", m=s)
+        assert type(r) is NumericRecord
+        v = np.asarray(r.to_vector())
+        assert v[0] == 1.5 and v[2] == 3.0 and np.isnan(v[1])
+
+    def test_boolean_nullable_converts_to_float(self):
+        s = pd.Series(pd.array([True, None, False], dtype="boolean"))
+        v = np.asarray(Record("r", m=s).to_vector())
+        np.testing.assert_array_equal(np.isnan(v), [False, True, False])
+        assert v[0] == 1.0 and v[2] == 0.0
+
+    def test_mixed_nullable_and_plain_columns(self):
+        df = pd.DataFrame({"a": pd.array([1, None], dtype="Int64"), "b": [3.0, 4.0]})
+        r = Record("r", m=df)
+        assert type(r) is NumericRecord
+        v = np.asarray(r.to_vector())  # row-major flatten: [1, 3, nan, 4]
+        np.testing.assert_array_equal(np.isnan(v), [False, False, True, False])
+
+    def test_numpy_dtype_is_float64_for_nullable(self):
+        df = pd.DataFrame({"a": pd.array([1, 2], dtype="Int64")})
+        assert array_backend_for(df).numpy_dtype(df) == np.dtype("float64")
+        s = pd.Series(pd.array([1, 2], dtype="Int64"))
+        assert array_backend_for(s).numpy_dtype(s) == np.dtype("float64")
+
+    def test_complete_nullable_still_converts_through_float(self):
+        # No missing values, but a nullable integer dtype still promotes to
+        # floating point: the leaf dtype is predictable from the dtype, not
+        # from whether NAs happen to be present. (Float width follows jax's
+        # x64 config; the backend numpy_dtype is float64 either way, checked
+        # in test_numpy_dtype_is_float64_for_nullable.)
+        df = pd.DataFrame({"a": pd.array([1, 2, 3], dtype="Int64")})
+        v = np.asarray(Record("r", m=df).to_vector())
+        assert np.issubdtype(v.dtype, np.floating)
+
+    def test_categorical_and_string_stay_opaque(self):
+        # Non-numeric extension dtypes are not swept in: the container stays a
+        # plain Record.
+        cat = pd.DataFrame({"a": pd.Categorical([1, 2, 1])})
+        assert type(Record("r", m=cat)) is Record
+        text = pd.DataFrame({"a": pd.array(["a", "b"], dtype="string")})
+        assert type(Record("r", m=text)) is Record
+
+    def test_numpy_backed_frame_still_promotes(self):
+        df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        r = Record("r", m=df)
+        assert type(r) is NumericRecord
+        np.testing.assert_allclose(r.to_vector(), [1.0, 3.0, 2.0, 4.0])
 
 
 class TestNativeMetadataInIdentity:

--- a/tests/core/test_array_backend.py
+++ b/tests/core/test_array_backend.py
@@ -645,6 +645,51 @@ class TestNullableNumericMissingData:
         assert type(r) is NumericRecord
         np.testing.assert_allclose(r.to_vector(), [1.0, 3.0, 2.0, 4.0])
 
+    def test_nullable_beside_complex_preserves_imaginary(self):
+        # A nullable column beside a complex column must not truncate the
+        # imaginary parts: the frame densifies to the columns' common promotion
+        # (complex128), not float64. numpy_dtype reports the same dtype the
+        # conversion produces.
+        df = pd.DataFrame({"a": pd.array([1, None], dtype="Int64"), "b": [1 + 2j, 3 + 4j]})
+        backend = array_backend_for(df)
+        assert backend.numpy_dtype(df) == np.dtype("complex128")
+        out = backend.to_numpy(df)
+        assert out.dtype == np.dtype("complex128")
+        assert out[0, 1] == 1 + 2j and out[1, 1] == 3 + 4j  # imaginary parts kept
+        assert out[0, 0] == 1 + 0j and np.isnan(out[1, 0])  # NA -> nan
+
+    def test_nullable_beside_complex_promotes_and_vectorizes(self):
+        df = pd.DataFrame({"a": pd.array([1, 2], dtype="Int64"), "b": [1 + 2j, 3 + 4j]})
+        r = Record("r", m=df)
+        assert type(r) is NumericRecord
+        v = np.asarray(r.to_vector())
+        assert np.issubdtype(v.dtype, np.complexfloating)
+        # row-major flatten of [[1+0j, 1+2j], [2+0j, 3+4j]]
+        np.testing.assert_array_equal(v, [1 + 0j, 1 + 2j, 2 + 0j, 3 + 4j])
+
+    def test_nullable_float_keeps_its_own_width(self):
+        # A nullable float column contributes its own width, not a float64 floor.
+        f32 = pd.DataFrame({"a": pd.array([1.0, None], dtype="Float32")})
+        assert array_backend_for(f32).numpy_dtype(f32) == np.dtype("float32")
+        f64 = pd.DataFrame({"a": pd.array([1.0, None], dtype="Float64")})
+        assert array_backend_for(f64).numpy_dtype(f64) == np.dtype("float64")
+
+    def test_nullable_complex_equality_and_fingerprint(self):
+        from probpipe.core._fingerprint import fingerprint
+
+        def mk(imag):
+            return Record(
+                "r",
+                m=pd.DataFrame({"a": pd.array([1, None], dtype="Int64"), "b": [1 + 2j, imag]}),
+            )
+
+        # Identical (including the NA position) -> equal and fingerprint-equal.
+        assert mk(3 + 4j) == mk(3 + 4j)
+        assert fingerprint(mk(3 + 4j)) == fingerprint(mk(3 + 4j))
+        # Differing only in an imaginary part -> unequal and fingerprint-different.
+        assert mk(3 + 4j) != mk(3 + 5j)
+        assert fingerprint(mk(3 + 4j)) != fingerprint(mk(3 + 5j))
+
 
 class TestNativeMetadataInIdentity:
     """Option A: native-container metadata (coords / index) is part of a


### PR DESCRIPTION
## Summary

Makes pandas **nullable / masked numeric** columns (`Int64`, `Float64`, `boolean`, pyarrow numerics) first-class numeric leaves, so records carrying missing data promote to `NumericRecord` and flow through the numeric machinery. Missing values are encoded as `NaN` at the compute boundary — the only missing-value representation `jax` offers.

Base: **`main`** (originally stacked on #359, which has since merged).

### Motivation

Missing data is a common case for real datasets, and we want ProbPipe to handle it rather than force users to pre-clean or lose the numeric path. With the native-form-leaves work (now in `main`), a frame with an `Int64`/`Float64`/`boolean` column stayed a plain `Record`: the generic numeric gate `_is_numeric_dtype` rejects masked dtypes because they are not dense-numpy-coercible. That is the right default for a *bare* value on the duck-typing path, but the pandas backend can do better for its own types.

### Design

The change lives mainly in the pandas `ArrayBackend` hooks (`is_numeric`, `numpy_dtype`, `to_jax`, `to_numpy`) in `_array_backend.py`. It also **touches `event_template.py`**: a one-paragraph clarification to the `_is_numeric_dtype` docstring stating that the generic (duck-typing) gate stays strict while a registered backend may still recognise its own masked dtypes. Because every numeric gate resolves **registry-first**, promotion, `ArraySpec` inference, the compute boundary, and `fingerprint()` all pick the change up at once.

- **Recognition:** a column is nullable-numeric when `pd.api.types.is_extension_array_dtype(dtype) and is_numeric_dtype(dtype)` — admits `Int64`/`Float64`/`boolean`/pyarrow numerics, excludes categorical / string / datetime.
- **Conversion & dtype:** the container densifies to its columns' **common dense dtype** (`_dense_dtype`). A masked numeric column contributes a float — a nullable float keeps its own width (`Float32 → float32`), a nullable integer / boolean promotes to `float64` — and every other column contributes its own dtype; the result is their `np.result_type` promotion. So a mixed frame promotes correctly and a **complex column stays `complex128`** rather than being truncated to float. `numpy_dtype` reports exactly the dtype the conversion produces, and each NA is encoded as `NaN`.

The generic `_is_numeric_dtype` gate stays strict: a conservative duck path over a backend that knows its own types.

### Why this fits native storage

The nullable frame is **stored verbatim**, so its validity mask is intact at rest — `record["x"]` returns the pandas object with real `NA`s. `NA → NaN` happens *only* when converting to `jax`, where a mask cannot survive anyway. No information is lost until you actually compute.

### Semantic notes (inherent, not bugs)

- **Integer / boolean columns promote to float** — there is no integer `NaN`.
- **NA and a genuine `NaN` are indistinguishable once in `jax`** — at rest the mask is preserved; after conversion both read as `NaN`.

### Tests

`TestNullableNumericMissingData` — promotion; `NA → NaN` at the boundary; mask preserved at rest; `Series`/`DataFrame`; `boolean`/`Float64`; mixed nullable+plain columns; `numpy_dtype`; categorical/string stay opaque; and the **nullable+complex** cases (imaginary parts preserved, `numpy_dtype == complex128`, own-width nullable floats, and equality/fingerprint distinguishing imaginary parts while treating NA as equal). `TestGenericGateRejectsExtensionDtype` — the generic gate stays strict (incl. the `np.dtype` `ValueError` regression pin).

Full `tests/core` plus distributions / converters / modeling / inference / diagnostics / validation green.

### Also

Corrects a stale line in the `_array_backend` module docstring (`xarray.DataArray` / `pandas.Series` are registered, carrying `metadata` hooks). Includes a documentation-prose pass (parentheticals, sentence length, en/em-dashes) over the module docstring, the `_is_numeric_dtype` docstring, and the CHANGELOG entry.
