### PR TITLE
Add two useful agent skills

### DIFF
--- a/.claude/skills/criticize-design/SKILL.md
+++ b/.claude/skills/criticize-design/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: criticize-design
+description: Critically interview the user about a plan or design until every design-significant branch reaches shared understanding. Use when the user wants to stress-test a plan, clarify an uncertain idea, compare real alternatives, expose edge cases, or be grilled before implementation.
+allowed-tools: Read Grep Glob Bash(gh *) Bash(git *) Agent
+---
+
+# Establish the frame
+
+- Identify the decision being designed, its scope, its constraints, and what would count as complete.
+- Default to discussion-only and read-only work. Do not edit code, documentation, issue trackers, or external systems unless the user explicitly asks.
+- Read repository instructions, design principles, relevant documentation, code, issues, and change history when they can answer a question or constrain the design.
+- Build a decision tree in dependency order. Maintain a decision ledger with each branch marked `unresolved`, `provisional`, `accepted`, or `rejected`, plus its rationale and downstream dependencies.
+
+# Resolve the tree
+
+- Work through one unresolved branch at a time, starting with the branch that constrains the most downstream decisions.
+- If code, documentation, or other available evidence can answer a question, investigate it instead of asking the user.
+- Separate design decisions from implementation trivia. Grill only choices with meaningful semantic, user-facing, architectural, operational, or irreversible consequences; defer naming and local mechanics unless they affect the design.
+- For every user-facing or high-risk decision, test the proposal with a concrete API example or scenario. Include random, batched, failure, or boundary cases only when they materially probe the contract.
+- If a branch reveals new design-significant sub-branches, add them explicitly to the decision tree before continuing. Do not hide them inside the parent branch or claim completion early.
+
+For each question, provide a recommendation:
+
+- If there is one clearly optimal solution for the current constraints, present that solution and ask for approval.
+- If there are genuinely competitive solutions, present only options at the **same level**. Explain each approach, its advantages and disadvantages, the core difference, which option you recommend for the current context, and when another option would win.
+- Never invent an inferior alternative merely to create a comparison.
+- Ask one question at a time and wait for feedback before advancing.
+
+# Challenge responsibly
+
+- Check every proposal against the project's stated philosophy, domain language, public contracts, and current direction. Surface contradictions directly and offer a concrete resolution when possible.
+- Be persistent, not tedious. Apply Occam's razor, stay concise, and avoid over-design or excessive criticism.
+- Mark scope-expanding or hard-to-reverse discoveries as major decisions. Do not silently fold them into a smaller accepted branch.
+- Treat tentative language such as "for now", "provisionally", or "let's start with this" as `provisional`, not `accepted`.
+- When the user asks for status, report accepted, provisional, and unresolved branches separately, then resume from the next dependency.
+- When a user's description is vague, first try to understand it using the most plausible explanation. If that fails, use the Socratic method: asking until the user to clarify the vague concept or acknowledge this thought is self-contradictory.
+
+# Close the session
+
+Before saying the design is complete, audit at least:
+
+- public API and mathematical/domain meaning;
+- lifecycle, mutability, and ownership;
+- randomness, batching, correlation, and jointness where relevant;
+- failure behavior and diagnostics;
+- provenance, persistence, and extension boundaries;
+- dependencies, migration, non-goals, and implementation order;
+- contradictions and every provisional or unresolved decision.
+
+Do not claim completion while a design-significant sub-branch remains hidden or unresolved. End with a self-contained summary of accepted decisions, provisional decisions, unresolved questions, rationale, consequences, and recommended next steps. If the user asked for an implementation-ready design, include representative public API examples and explicit boundaries.

--- a/.claude/skills/criticize-with-docs/ADR-FORMAT.md
+++ b/.claude/skills/criticize-with-docs/ADR-FORMAT.md
@@ -1,0 +1,53 @@
+# ADR Format
+
+Use this profile only after the ADR decision gate in `SKILL.md` passes. Follow the repository's existing ADR/RFC location, naming, and status conventions. Do not create an ADR directory or impose numbered filenames merely because no convention exists; obtain user approval for a new convention first.
+
+Common conventions include `docs/adr/0001-slug.md`, `docs/architecture/decisions/`, RFCs, or repository-specific design records. Prefer the established one.
+
+## Template
+
+```md
+---
+status: proposed
+---
+
+# Represent probability kernels with ConditionalDistribution
+
+ProbPipe represents a probability kernel as a `ConditionalDistribution` carrying separate given and event templates, rather than as a `Distribution` with missing inputs. This keeps unconditional laws distinct from families of laws and lets the ordinary operation layer expose conditioning, sampling, and log-probability without inventing backend-specific model methods.
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs will not need all of them.
+
+- **Status** (`proposed | accepted | deprecated | superseded`) — required when the repository distinguishes tentative from accepted decisions; follow its syntax
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+If the repository uses sequential numbering, scan its established ADR location for the highest existing number and increment it. Otherwise follow the repository's naming convention.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+Do not mark an ADR `accepted` merely because the user accepted a branch during an exploratory session. Keep major changes `proposed` when they still require team, meeting, or maintainer approval.
+
+### What qualifies
+
+- **Architectural shape.** "ConditionalDistribution is a sibling of Distribution, not a subclass." "Batch axes are represented separately from one event's structure."
+- **Integration patterns between layers.** "Estimator adapters return ordinary Function or ConditionalDistribution terms instead of exposing estimator-shaped prediction methods."
+- **Technology choices that carry lock-in.** "The differentiable numeric boundary is JAX-native, while non-JAX execution is isolated behind dispatch." Record only choices whose replacement would reshape public contracts or a substantial part of the implementation.
+- **Boundary and scope decisions.** "EventTemplate owns event schema; concrete distributions must not keep a second authoritative copy." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "A RandomMeasure is preserved by default and marginalized only through an explicit operation." Record decisions a future contributor might otherwise simplify back into an incorrect automatic behavior.
+- **Constraints not visible in one code path.** "The core package cannot import estimator or inference subpackages because the dependency graph must remain acyclic." "Related stochastic views must co-sample without using a global draw cache."
+- **Rejected alternatives when the rejection is non-obvious.** If the team considered treating a probability kernel as a partially initialized Distribution and rejected it to preserve mathematical meaning and capability checks, record that rationale so the same conflation is not proposed again without new evidence.

--- a/.claude/skills/criticize-with-docs/CONTEXT-FORMAT.md
+++ b/.claude/skills/criticize-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,83 @@
+# Domain Context Format
+
+Use this profile only when the repository already uses `CONTEXT.md`/`CONTEXT-MAP.md` or the user explicitly approves creating that form. Prefer the repository's native design-document format otherwise. Do not create or modify context files without write authorization.
+
+## Structure
+
+The following is just an example.
+
+```md
+# Probabilistic Workflow Semantics
+
+This context defines the mathematical objects that cross ProbPipe's public operation boundary and the language used to distinguish their structure, randomness, and multiplicity.
+
+## Language
+
+**Event**:
+One value drawn from a probability distribution, with structure described by an EventTemplate.
+_Avoid_: Sample, record
+
+**Conditional Distribution**:
+A probability kernel that maps a given value to a Distribution over its event.
+_Avoid_: Model, callable distribution
+
+**Batch**:
+A collection of objects along named multiplicity axes, distinct from one structured or joint event.
+_Avoid_: Event shape, joint distribution
+
+## Relationships
+
+- A **Distribution** has exactly one **EventTemplate** describing each draw
+- A **Conditional Distribution** produces a **Distribution** when all given fields are bound
+- A **Computation** lifts over a **Batch** or **Distribution** when its declared parameter expects one element or value
+
+## Example dialogue (optional)
+
+> **Contributor:** "If a Computation receives a Distribution where it expects a value, does the result become a Conditional Distribution?"
+> **Maintainer:** "No. The Computation samples and lifts to a pushforward Distribution; a Conditional Distribution is specifically a kernel with an unbound given side."
+
+## Flagged ambiguities
+
+- "batch" was used for both a collection of separate laws and one joint array-valued event — resolved: **Batch** describes multiplicity; `event_template` describes one event.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's domain or mathematical language.** General programming concepts (timeouts, error types, utility patterns) do not belong merely because the project uses them.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Use an example dialogue only when it clarifies a real ambiguity.** Do not force business-style dialogue into mathematical, scientific, or library documentation.
+- **Record decision status outside definitions.** A term definition should describe the accepted language; provisional terminology belongs in flagged ambiguities or a working draft.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Core Value Model](./probpipe/core/CONTEXT.md) — defines EventTemplate, Record, Batch, identity, and provenance
+- [Distribution Algebra](./probpipe/distributions/CONTEXT.md) — defines probability measures, kernels, capabilities, and composition
+- [Inference Backends](./probpipe/inference/CONTEXT.md) — adapts inference methods to produce ordinary ProbPipe distributions
+
+## Relationships
+
+- **Core Value Model → Distribution Algebra**: distributions use EventTemplate for event schemas and Batch for collections of laws
+- **Distribution Algebra → Inference Backends**: inference methods consume capability-bearing distributions and return distributions with provenance
+- **Inference Backends → Core Value Model**: backend results cross the public boundary as tracked Records, Batches, or distribution-like terms
+```
+
+When this profile is selected, infer the existing structure:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, do not create one unless the user explicitly approves this profile and location
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.claude/skills/criticize-with-docs/SKILL.md
+++ b/.claude/skills/criticize-with-docs/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: criticize-with-docs
+description: Extend a design criticizing session with repository-aware documentation discovery, terminology checks, decision status, and controlled documentation updates. Use when the user wants to stress-test a plan against existing code and documented intent, create a private working draft, or keep canonical design documentation aligned as decisions are accepted.
+allowed-tools: Read Grep Glob Bash(gh *) Bash(git *) Agent
+---
+
+# Apply the core criticizing workflow
+
+Use the `criticize-design` skill. Apply its decision tree, ledger, one-question-at-a-time rule, evidence gathering, option quality bar, scenario testing, and closure audit. This skill only adds documentation routing and recording rules.
+
+# Choose the documentation mode
+
+Infer the least expansive mode authorized by the user's request:
+
+- **Discussion-only** — maintain the decision ledger in the conversation and make no file changes. Use this by default when the user asks only to discuss, review, or stress-test.
+- **Working draft** — write to a user-approved draft location. Preserve `provisional` and `accepted` status explicitly. Use local-only or ignored storage when the user requests a private draft.
+- **Canonical update** — update the repository's authoritative tracked documentation, but only when the user explicitly asks for documentation changes.
+
+If the mode is unclear, continue read-only and ask only before the first write. Never promote a provisional decision into canonical documentation as accepted.
+
+# Discover the repository's documentation system
+
+Before recording anything:
+
+1. Read repository instructions and documentation guidance such as `AGENTS.md`, `CONTRIBUTING.md`, and the README.
+2. Discover existing design authorities and navigation: design references, RFCs, ADRs, architecture docs, API contracts, issue-based proposals, `CONTEXT.md`, or `CONTEXT-MAP.md`.
+3. Identify which source describes the current implementation, which describes the target state, and which is merely a proposal.
+4. Follow the repository's existing location, structure, terminology, and status conventions. Do not create `CONTEXT.md`, `CONTEXT-MAP.md`, or `docs/adr/` merely because they are absent.
+5. If more than one document could be authoritative, surface the ambiguity and recommend one source of truth before writing.
+
+# Classify conflicts before resolving them
+
+When code, documentation, and the proposed design disagree, classify the mismatch before asking what to change:
+
+- current-code defect;
+- stale documentation;
+- intentional target design ahead of implementation;
+- new proposal beyond the current target;
+- terminology mismatch without behavioral disagreement.
+
+Do not call target-ahead-of-code documentation stale. State which layer each claim belongs to and preserve deliberate differences.
+
+# Sharpen language and scenarios
+
+- Challenge terminology against the repository's glossary or canonical design language when one exists.
+- When language is vague or overloaded, propose a precise canonical term and identify aliases or meanings to avoid.
+- Stress-test domain relationships and public contracts with concrete scenarios and edge cases.
+- Cross-reference user claims with code and documentation. Surface contradictions with evidence rather than deference.
+- Keep domain language separate from implementation names when the distinction matters.
+
+# Record decisions without churn
+
+- Record accepted decisions after a coherent decision cluster, not after every sentence.
+- Keep provisional decisions visibly provisional in working drafts; omit them from accepted canonical contracts unless the repository has a proposed/open-points convention.
+- Preserve rationale, rejected same-level alternatives, consequences, boundaries, and open points only when they help future readers understand the decision.
+- Keep implementation facts in implementation-facing docs and domain/mathematical meaning in design-facing docs.
+- Update navigation, cross-references, or supersession markers when the repository's conventions require them.
+- Reconcile the updated document against the decision ledger before finishing.
+
+# Route to an appropriate document profile
+
+- **Repository-native design or API document — default.** Follow the existing format, such as Contract/Rationale/Open points, RFC sections, or API reference conventions.
+- **Domain glossary/context document.** Use only when the repository already uses `CONTEXT.md`/`CONTEXT-MAP.md` or the user explicitly chooses that form. Then read and follow [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+- **ADR.** Offer or create one only when the decision is hard to reverse, surprising without context, and the result of a genuine trade-off. Then read and follow [ADR-FORMAT.md](./ADR-FORMAT.md) together with repository conventions.
+- **Private or meeting draft.** Use a user-approved path, label status clearly, and keep it out of tracked documentation when requested.
+
+# Close the documentation session
+
+Report the documentation mode, files changed, decisions recorded, provisional/open decisions, conflicts found, and validation performed. Do not claim the canonical docs are aligned until the written result has been checked against the final decision ledger and repository navigation.


### PR DESCRIPTION
This PR makes no changes to the code or infrastructure. It simply adds two agent skills to assist in the design.

- `criticize-design`: Used in the early design phase to help clarify concepts and make critical suggestions.
- `criticize-with-docs`: Use this when a relatively clear design has been developed and it is necessary to track long workflows to prevent task objectives from drifting.

You can use `criticize-with-docs` by default, but it consumes more tokens.