### PR TITLE
feat(core): wire fingerprints into Prefect cache_key_fn for cross-run task caching

### DIFF
--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -40,7 +40,13 @@ from probpipe.core._array_backend import (
 from probpipe.core._distribution_array import DistributionArray
 from probpipe.core._numeric_record import NumericRecord
 from probpipe.core._record_array import NumericRecordArray, RecordArray
-from probpipe.core.config import ProvenanceMode, WorkflowKind, prefect_config, provenance_config
+from probpipe.core.config import (
+    CacheMode,
+    ProvenanceMode,
+    WorkflowKind,
+    prefect_config,
+    provenance_config,
+)
 from probpipe.core.constraints import (
     Constraint,
     boolean,
@@ -212,6 +218,7 @@ __all__ = [
     "BootstrapDistribution",
     "BootstrapReplicateDistribution",
     "BroadcastDistribution",
+    "CacheMode",
     "Categorical",
     "Cauchy",
     "ConditionallyIndependentLikelihood",

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -42,6 +42,7 @@ a 3.13 one for the same source.
 from __future__ import annotations
 
 import hashlib
+import importlib.metadata as _metadata
 import math
 import struct
 from typing import Any
@@ -49,7 +50,7 @@ from typing import Any
 import jax as _jax
 import numpy as _np
 
-__all__ = ["fingerprint"]
+__all__ = ["environment_salt", "fingerprint"]
 
 # JAX is a hard dependency of probpipe, so ``jax.Array`` is always importable.
 _JAX_ARRAY_TYPE = _jax.Array
@@ -92,6 +93,39 @@ def fingerprint(obj: Any, *, max_array_bytes: int | None = _DEFAULT_MAX_ARRAY_BY
     h = hashlib.sha256()
     _update(h, obj, depth=0, max_array_bytes=max_array_bytes)
     return h.hexdigest()[:16]
+
+
+def environment_salt() -> str:
+    """Return a stable string identifying the fingerprint-relevant environment.
+
+    :func:`fingerprint` hashes user bytecode and input *content*, but not the
+    surrounding runtime.  Folding this salt into a cache key ensures that an
+    environment change is a cache **miss** rather than a stale **hit** on an
+    otherwise-identical content digest.  It captures:
+
+    - the ProbPipe version,
+    - the JAX version, and
+    - the ``jax_enable_x64`` flag — it changes array dtypes, and therefore the
+      dtype recorded in every array fingerprint, so the same values under
+      ``x64=True`` and ``x64=False`` must key differently.
+
+    The Python minor version is not included explicitly: it changes the
+    ``WorkflowFunction`` bytecode digest (already part of the cache key), so a
+    Python upgrade already invalidates keys for the function component.
+
+    Returns
+    -------
+    str
+        A human-readable, deterministic salt such as
+        ``"probpipe=0.1.0;jax=0.4.38;x64=False"``.
+    """
+    try:
+        probpipe_version = _metadata.version("probpipe")
+    except _metadata.PackageNotFoundError:
+        probpipe_version = "unknown"
+    return (
+        f"probpipe={probpipe_version};jax={_jax.__version__};x64={bool(_jax.config.jax_enable_x64)}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/_workflow_execution.py
+++ b/probpipe/core/_workflow_execution.py
@@ -7,15 +7,20 @@ assemble inputs and interpret outputs outside this module.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from ._fingerprint import environment_salt, fingerprint
+
 try:
     from prefect import flow, task
+    from prefect.cache_policies import CacheKeyFnPolicy
 except ImportError:
     task = flow = None
+    CacheKeyFnPolicy = None
 
 WorkflowExecutionMode = Literal[
     "sequential",
@@ -33,6 +38,21 @@ class WorkflowExecutionConfig:
     max_workers: int | None = None
     name: str = "workflow"
     prefect_task_runner: Any | None = None
+    func_fingerprint: str | None = None
+    """Content fingerprint of the wrapped user function, or ``None``.
+
+    Populated only on the Prefect paths when caching is enabled; it identifies
+    the user-function body for the cache key so a change to the function
+    invalidates cached results even though the task wrapper source is
+    unchanged.  ``None`` disables caching for this execution.
+    """
+    cache_result_storage: Any | None = None
+    """Shared storage for persisted cache results and cache-key records.
+
+    ``None`` uses Prefect's local default (single-machine).  When set, it is
+    passed to both the task's ``result_storage`` and the cache policy's
+    ``key_storage`` so other workers see both the result and its key record.
+    """
 
 
 @dataclass(frozen=True)
@@ -72,6 +92,46 @@ def execute_many_threaded(request: WorkflowExecutionRequest) -> list[Any]:
         return list(pool.map(lambda kwargs: request.func(**kwargs), request.call_value_list))
 
 
+def _cache_task_options(execution: WorkflowExecutionConfig) -> dict[str, Any]:
+    """Return Prefect ``@task`` caching options for this execution.
+
+    Caching is active exactly when ``func_fingerprint`` is set — ``node.py``
+    populates it only on the Prefect paths under an opted-in ``CacheMode`` — so
+    an empty dict here means "no caching", leaving the task decorated exactly as
+    before.
+
+    The cache key combines three parts so a change to any of them is a cache
+    *miss* rather than a stale *hit*:
+
+    - the user-function fingerprint (detects a changed function body, which the
+      generic ``run_func`` wrapper source would otherwise hide),
+    - the environment salt (probpipe/jax versions + x64 flag), and
+    - a content fingerprint of the per-row inputs.
+
+    Prefect binds a ``**kwargs`` task's arguments as ``{"kwargs": {...}}``, and
+    ``fingerprint`` hashes dict keys order-independently, so the whole
+    ``parameters`` mapping is fingerprinted directly.
+    """
+    func_fp = execution.func_fingerprint
+    if func_fp is None:
+        return {}
+
+    salt = environment_salt()
+    storage = execution.cache_result_storage
+
+    def cache_key_fn(context: Any, parameters: dict[str, Any]) -> str:
+        material = f"{func_fp}|{salt}|{fingerprint(parameters)}"
+        return hashlib.sha256(material.encode()).hexdigest()
+
+    options: dict[str, Any] = {
+        "cache_policy": CacheKeyFnPolicy(cache_key_fn=cache_key_fn, key_storage=storage),
+        "persist_result": True,
+    }
+    if storage is not None:
+        options["result_storage"] = storage
+    return options
+
+
 def map_task(
     request: WorkflowExecutionRequest,
     *,
@@ -85,7 +145,10 @@ def map_task(
 
     func = request.func
 
-    @task(name=task_name or request.execution.name)
+    @task(
+        name=task_name or request.execution.name,
+        **_cache_task_options(request.execution),
+    )
     def run_func(**kwargs):
         return func(**kwargs)
 

--- a/probpipe/core/config.py
+++ b/probpipe/core/config.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 
 __all__ = [
+    "CacheMode",
     "PrefectConfig",
     "ProvenanceConfig",
     "ProvenanceMode",
@@ -115,6 +116,59 @@ def _auto_detect_task_runner() -> Any:
 
 
 # ---------------------------------------------------------------------------
+# CacheMode enum
+# ---------------------------------------------------------------------------
+
+
+class CacheMode(Enum):
+    """Controls whether Prefect task results are cached across runs.
+
+    Caching is opt-in and only takes effect when Prefect orchestration is
+    active (``WorkflowKind.TASK`` / ``FLOW``).
+
+    Members
+    -------
+    OFF
+        No caching.  Tasks always execute; behaviour is identical to not
+        configuring caching at all.  This is the default.
+    FINGERPRINT
+        Cache task results keyed by a stable content fingerprint of the user
+        function, its inputs, and the runtime environment.  A re-run with the
+        same function, inputs, and environment reuses the persisted result
+        instead of re-executing the task.
+    """
+
+    OFF = "off"
+    FINGERPRINT = "fingerprint"
+
+
+# ---------------------------------------------------------------------------
+# Environment-variable override for CacheMode
+# ---------------------------------------------------------------------------
+
+_CACHE_MODE_ENV_VAR = "PROBPIPE_CACHE_MODE"
+
+
+def _initial_cache_mode() -> CacheMode:
+    """Resolve the initial ``cache_mode`` from the environment.
+
+    Reads ``PROBPIPE_CACHE_MODE`` (case-insensitive).  Unset → ``OFF``.
+    Unknown values raise ``ValueError`` so deployment-config typos surface
+    loudly rather than silently disabling caching.
+    """
+    raw = os.environ.get(_CACHE_MODE_ENV_VAR)
+    if raw is None:
+        return CacheMode.OFF
+    try:
+        return CacheMode(raw.lower())
+    except ValueError as e:
+        valid = ", ".join(repr(m.value) for m in CacheMode)
+        raise ValueError(
+            f"{_CACHE_MODE_ENV_VAR}={raw!r} is not a valid CacheMode. Expected one of: {valid}."
+        ) from e
+
+
+# ---------------------------------------------------------------------------
 # PrefectConfig singleton
 # ---------------------------------------------------------------------------
 
@@ -140,6 +194,15 @@ class PrefectConfig:
         ``prefect-ray`` is installed, then ``DaskTaskRunner`` if
         ``prefect-dask`` is installed, otherwise Prefect's built-in
         default.
+    cache_mode : CacheMode
+        Cross-run task caching mode.  ``OFF`` (default) disables caching;
+        ``FINGERPRINT`` caches task results keyed by a content fingerprint.
+        Initial value comes from ``PROBPIPE_CACHE_MODE`` if set.  Only takes
+        effect under ``WorkflowKind.TASK`` / ``FLOW``.
+    cache_result_storage : object or None
+        Where cached results and cache-key records are stored.  ``None``
+        (default) uses Prefect's built-in local storage (single-machine only);
+        set a shared Prefect storage target to cache across workers/machines.
     """
 
     def __init__(self) -> None:
@@ -148,9 +211,11 @@ class PrefectConfig:
     # -- Public API ---------------------------------------------------------
 
     def reset(self) -> None:
-        """Restore all settings to defaults (re-reading the env var)."""
+        """Restore all settings to defaults (re-reading the env vars)."""
         self._workflow_kind: WorkflowKind = _initial_workflow_kind()
         self._task_runner: Any = None
+        self._cache_mode: CacheMode = _initial_cache_mode()
+        self._cache_result_storage: Any = None
 
     @property
     def workflow_kind(self) -> WorkflowKind:
@@ -186,6 +251,49 @@ class PrefectConfig:
         if self._task_runner is not None:
             return self._task_runner
         return _auto_detect_task_runner()
+
+    # -- Caching ------------------------------------------------------------
+
+    @property
+    def cache_mode(self) -> CacheMode:
+        """Current cross-run task caching mode (default ``OFF``)."""
+        return self._cache_mode
+
+    @cache_mode.setter
+    def cache_mode(self, value: CacheMode) -> None:
+        if not isinstance(value, CacheMode):
+            raise TypeError(
+                f"cache_mode must be a CacheMode enum member, got {type(value).__name__}"
+            )
+        self._cache_mode = value
+
+    @property
+    def caching_enabled(self) -> bool:
+        """Whether caching is active (``cache_mode`` is not ``OFF``)."""
+        return self._cache_mode is not CacheMode.OFF
+
+    @property
+    def cache_result_storage(self) -> Any:
+        """Storage target for persisted cache results and cache-key records.
+
+        ``None`` (default) uses Prefect's built-in local storage, which is
+        single-machine only.  Set a shared Prefect storage target to cache
+        across workers/machines; the same target is used for both the task's
+        ``result_storage`` and the cache policy's ``key_storage``.
+        """
+        return self._cache_result_storage
+
+    @cache_result_storage.setter
+    def cache_result_storage(self, value: Any) -> None:
+        self._cache_result_storage = value
+
+    def resolve_cache_storage(self) -> Any:
+        """Return the configured cache storage target, or ``None`` for local.
+
+        The value is passed to both Prefect's ``result_storage`` and the cache
+        policy's ``key_storage``.  ``None`` means use Prefect's local default.
+        """
+        return self._cache_result_storage
 
 
 # Module-level singleton

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -32,6 +32,7 @@ from . import (
     _workflow_result,
     _workflow_sweep,
 )
+from ._fingerprint import fingerprint
 from ._record_array import RecordArray
 from .provenance import Provenance
 
@@ -294,6 +295,7 @@ class WorkflowFunction(Node):
         self._key = jax.random.PRNGKey(seed)
         self._include_inputs = include_inputs
         self._resolved_dispatch: str | None = None  # cached auto-detection result
+        self._func_fingerprint: str | None = None  # cached fingerprint(self) for caching
 
         # bind = "construction-time inputs" (defaults/config). kwargs are also treated as bind.
         b = dict(bind or {})
@@ -332,6 +334,16 @@ class WorkflowFunction(Node):
 
         return kind
 
+    def _func_fingerprint_value(self) -> str:
+        """Return the wrapped user function's content fingerprint (memoized).
+
+        Stable for the instance's lifetime — the wrapped function, its defaults,
+        and its closure do not change — so it is computed once and cached.
+        """
+        if self._func_fingerprint is None:
+            self._func_fingerprint = fingerprint(self)
+        return self._func_fingerprint
+
     def _make_execution_config(
         self,
         *,
@@ -359,11 +371,23 @@ class WorkflowFunction(Node):
                 stacklevel=2,
             )
 
+        # Caching applies only on the Prefect paths and only when opted in.
+        # ``func_fingerprint`` carries the user-function identity down to the
+        # task wrapper so cache keying can detect body changes, and
+        # ``cache_result_storage`` is the shared target for both persisted
+        # results and cache-key records. Both stay ``None`` off the caching
+        # path, keeping the non-caching paths byte-identical to before.
+        caching = is_prefect and prefect_config.caching_enabled
+        func_fingerprint = self._func_fingerprint_value() if caching else None
+        cache_result_storage = prefect_config.resolve_cache_storage() if caching else None
+
         return _workflow_execution.WorkflowExecutionConfig(
             mode=mode,
             max_workers=self._max_workers if mode == "thread" else None,
             name=self._name,
             prefect_task_runner=(prefect_config.resolve_task_runner() if is_prefect else None),
+            func_fingerprint=func_fingerprint,
+            cache_result_storage=cache_result_storage,
         )
 
     def with_options(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,14 +8,16 @@ from probpipe import EmpiricalDistribution, ProvenanceMode
 
 
 @pytest.fixture(autouse=True)
-def _reset_provenance_config():
-    """Always restore provenance_config to defaults after each test.
+def _reset_global_config():
+    """Always restore provenance_config and prefect_config to defaults.
 
-    Under pytest-xdist, a test that sets the mode and raises before its own
-    cleanup would otherwise leak the mode into subsequent tests on that worker.
+    Under pytest-xdist, a test that sets a global (provenance mode, cache mode,
+    workflow kind) and raises before its own cleanup would otherwise leak that
+    setting into subsequent tests on that worker.
     """
     yield
     probpipe.provenance_config.reset()
+    probpipe.prefect_config.reset()
 
 
 @pytest.fixture

--- a/tests/core/test_caching.py
+++ b/tests/core/test_caching.py
@@ -1,0 +1,244 @@
+"""Tests for the Prefect fingerprint-caching layer.
+
+Covers:
+- Threading: the WorkflowFunction's content fingerprint and the shared cache
+  storage are attached to ``WorkflowExecutionConfig`` only on the Prefect paths
+  and only when caching is enabled.
+- Cache key: ``map_task`` builds a ``cache_key_fn`` from the function
+  fingerprint, the environment salt, and a content fingerprint of the inputs,
+  so a change to any of them is a miss; the key is order-independent and stable
+  across processes; storage is wired to both the task and the cache policy.
+- End-to-end: a real Prefect run confirms a re-run hits the cache (the user
+  function is not re-executed) while a changed input re-executes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+import probpipe
+from probpipe import CacheMode
+from probpipe.core._fingerprint import fingerprint
+from probpipe.core._workflow_execution import (
+    CacheKeyFnPolicy,
+    WorkflowExecutionConfig,
+    _cache_task_options,
+)
+from probpipe.core.node import WorkflowFunction
+
+prefect_required = pytest.mark.skipif(CacheKeyFnPolicy is None, reason="requires prefect")
+
+
+@pytest.fixture
+def caching_on():
+    """Enable FINGERPRINT caching for the test (autouse conftest resets after)."""
+    probpipe.prefect_config.cache_mode = CacheMode.FINGERPRINT
+    yield
+
+
+def _wf(func):
+    return WorkflowFunction(func=func, dispatch="sequential", seed=0)
+
+
+class TestExecutionConfigDefault:
+    def test_func_fingerprint_defaults_none(self):
+        cfg = WorkflowExecutionConfig(mode="sequential")
+        assert cfg.func_fingerprint is None
+
+
+class TestFuncFingerprintThreading:
+    def test_none_when_caching_off(self):
+        # Default cache_mode is OFF, so even a Prefect-mode config carries no
+        # fingerprint and the non-caching path is unchanged.
+        wf = _wf(lambda x: x)
+        cfg = wf._make_execution_config(mode="prefect_task")
+        assert cfg.func_fingerprint is None
+
+    def test_set_when_caching_on_and_prefect(self, caching_on):
+        def f(x):
+            return x + 1
+
+        wf = _wf(f)
+        cfg = wf._make_execution_config(mode="prefect_task")
+        assert cfg.func_fingerprint == fingerprint(wf)
+        assert isinstance(cfg.func_fingerprint, str)
+        assert len(cfg.func_fingerprint) == 16
+
+    def test_set_on_prefect_flow_mode(self, caching_on):
+        wf = _wf(lambda x: x)
+        cfg = wf._make_execution_config(mode="prefect_flow")
+        assert cfg.func_fingerprint == fingerprint(wf)
+
+    def test_none_for_non_prefect_mode_even_when_caching_on(self, caching_on):
+        # Caching only applies to Prefect execution; local dispatch never caches.
+        wf = _wf(lambda x: x)
+        assert wf._make_execution_config(mode="sequential").func_fingerprint is None
+        assert wf._make_execution_config(mode="thread").func_fingerprint is None
+
+    def test_distinguishes_function_bodies(self, caching_on):
+        # Two functions differing only in a literal constant must key differently,
+        # or a changed function body would silently reuse a stale cached result.
+        def f(x):
+            return x + 1
+
+        def g(x):
+            return x + 2
+
+        cfg_f = _wf(f)._make_execution_config(mode="prefect_task")
+        cfg_g = _wf(g)._make_execution_config(mode="prefect_task")
+        assert cfg_f.func_fingerprint != cfg_g.func_fingerprint
+
+    def test_memoized_stable_across_calls(self, caching_on):
+        wf = _wf(lambda x: x)
+        first = wf._make_execution_config(mode="prefect_task").func_fingerprint
+        second = wf._make_execution_config(mode="prefect_task").func_fingerprint
+        assert first is not None
+        assert first == second
+
+
+# ===========================================================================
+# Step 4: cache_key_fn + task options built in map_task
+# ===========================================================================
+
+
+def _cfg(func_fingerprint, storage=None):
+    return WorkflowExecutionConfig(
+        mode="prefect_task", func_fingerprint=func_fingerprint, cache_result_storage=storage
+    )
+
+
+def _key(func_fingerprint, parameters, storage=None):
+    """Extract and invoke the cache_key_fn that map_task would attach."""
+    options = _cache_task_options(_cfg(func_fingerprint, storage))
+    return options["cache_policy"].cache_key_fn(None, parameters)
+
+
+@prefect_required
+class TestCacheTaskOptions:
+    def test_empty_when_caching_off(self):
+        # func_fingerprint None (caching off) → no task options, task unchanged.
+        assert _cache_task_options(_cfg(None)) == {}
+
+    def test_options_present_when_caching_on(self):
+        options = _cache_task_options(_cfg("abc123abc123abc1"))
+        assert isinstance(options["cache_policy"], CacheKeyFnPolicy)
+        assert options["persist_result"] is True
+
+    def test_no_result_storage_when_storage_none(self):
+        options = _cache_task_options(_cfg("abc123abc123abc1", storage=None))
+        assert "result_storage" not in options
+        assert options["cache_policy"].key_storage is None
+
+    def test_storage_wired_to_both_surfaces(self):
+        # One config field must feed both result_storage (the task) and
+        # key_storage (the policy) or other workers miss on a shared store.
+        options = _cache_task_options(_cfg("abc123abc123abc1", storage="/tmp/cache_store"))
+        assert options["result_storage"] == "/tmp/cache_store"
+        assert options["cache_policy"].key_storage == "/tmp/cache_store"
+
+
+# Prefect binds a **kwargs task's arguments as {"kwargs": {...}}.
+PARAMS = {"kwargs": {"x": 3, "y": 4}}
+
+
+@prefect_required
+class TestCacheKey:
+    def test_deterministic_for_same_inputs(self):
+        assert _key("fp0000000000000a", PARAMS) == _key("fp0000000000000a", PARAMS)
+
+    def test_changes_with_inputs(self):
+        # A changed input must be a cache miss.
+        other = {"kwargs": {"x": 3, "y": 5}}
+        assert _key("fp0000000000000a", PARAMS) != _key("fp0000000000000a", other)
+
+    def test_order_independent_over_kwargs(self):
+        # Prefect returns kwargs unordered; the key must not depend on order.
+        a = {"kwargs": {"x": 3, "y": 4}}
+        b = {"kwargs": {"y": 4, "x": 3}}
+        assert _key("fp0000000000000a", a) == _key("fp0000000000000a", b)
+
+    def test_changes_with_func_fingerprint(self):
+        # A changed function body (different func fingerprint) must be a miss.
+        assert _key("fp0000000000000a", PARAMS) != _key("fp0000000000000b", PARAMS)
+
+    def test_changes_with_environment_salt(self, monkeypatch):
+        # An environment change (version bump / x64 toggle) must be a miss.
+        import probpipe.core._workflow_execution as we
+
+        monkeypatch.setattr(we, "environment_salt", lambda: "env=A")
+        key_a = _key("fp0000000000000a", PARAMS)
+        monkeypatch.setattr(we, "environment_salt", lambda: "env=B")
+        key_b = _key("fp0000000000000a", PARAMS)
+        assert key_a != key_b
+
+    def test_cross_process_deterministic(self):
+        # The key must be identical in a fresh process (no PYTHONHASHSEED / id
+        # leakage), or cross-machine caching never hits.
+        code = textwrap.dedent(
+            """
+            from probpipe.core._workflow_execution import WorkflowExecutionConfig, _cache_task_options
+            cfg = WorkflowExecutionConfig(mode="prefect_task", func_fingerprint="fp0000000000000a")
+            fn = _cache_task_options(cfg)["cache_policy"].cache_key_fn
+            print(fn(None, {"kwargs": {"x": 3, "y": 4}}))
+            """
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        ).stdout.strip()
+        assert out == _key("fp0000000000000a", PARAMS)
+
+
+# ===========================================================================
+# Step 4: end-to-end cache behavior through a real Prefect run (slow)
+# ===========================================================================
+
+
+@pytest.mark.prefect
+class TestCacheEndToEnd:
+    @pytest.fixture(autouse=True)
+    def _prefect_harness(self):
+        # In-process temporary Prefect server so caching persists to a clean,
+        # isolated store (mirrors tests/core/test_prefect_orchestration.py).
+        prefect_testing = pytest.importorskip("prefect.testing.utilities")
+        harness = prefect_testing.prefect_test_harness(server_startup_timeout=60)
+        try:
+            harness.__enter__()
+        except Exception as e:
+            pytest.skip(f"Prefect server unavailable: {e}")
+        try:
+            yield
+        finally:
+            harness.__exit__(None, None, None)
+
+    def test_rerun_hits_and_changed_input_misses(self, tmp_path):
+        counter = tmp_path / "exec_log.txt"
+        counter.write_text("")
+
+        def add_one(x):
+            with open(counter, "a") as fh:
+                fh.write("run\n")
+            return x + 1
+
+        from probpipe import WorkflowKind
+
+        wf = WorkflowFunction(
+            func=add_one, workflow_kind=WorkflowKind.TASK, dispatch="sequential", seed=0
+        )
+        probpipe.prefect_config.cache_mode = CacheMode.FINGERPRINT
+
+        def n_runs():
+            with open(counter) as fh:
+                return sum(1 for ln in fh if ln.strip())
+
+        wf(x=3)  # miss → runs
+        assert n_runs() == 1
+        wf(x=3)  # hit → skipped
+        assert n_runs() == 1
+        wf(x=4)  # different input → miss → runs
+        assert n_runs() == 2
+        wf(x=3)  # hit again → skipped
+        assert n_runs() == 2

--- a/tests/core/test_fingerprint.py
+++ b/tests/core/test_fingerprint.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from probpipe import Normal, Record
-from probpipe.core._fingerprint import fingerprint
+from probpipe.core._fingerprint import environment_salt, fingerprint
 from probpipe.core.node import WorkflowFunction
 from probpipe.core.provenance import ParentInfo, Provenance
 
@@ -582,3 +582,48 @@ class TestParentInfoIdentity:
         b = ParentInfo(type_name="X", name="n", provenance=None, fingerprint="bbbbbbbbbbbbbbbb")
         assert a == b
         assert hash(a) == hash(b)
+
+
+# ===========================================================================
+# Environment salt (folded into the cache key so env drift is a cache miss)
+# ===========================================================================
+
+
+class TestEnvironmentSalt:
+    def test_returns_string(self):
+        assert isinstance(environment_salt(), str)
+
+    def test_deterministic(self):
+        # Same environment → identical salt across calls.
+        assert environment_salt() == environment_salt()
+
+    def test_contains_all_components(self):
+        salt = environment_salt()
+        assert "probpipe=" in salt
+        assert "jax=" in salt
+        assert "x64=" in salt
+
+    def test_reflects_real_jax_version(self):
+        # Compared against an independent read of jax.__version__, so this fails
+        # if the salt hard-coded or dropped the version rather than reading it.
+        import jax
+
+        assert f"jax={jax.__version__}" in environment_salt()
+
+    def test_x64_flag_changes_salt(self):
+        # The load-bearing property: toggling jax_enable_x64 must change the salt
+        # (same code + inputs under x64 on/off produce different array dtypes, so
+        # they must key differently). Restored in finally to avoid leaking state.
+        import jax
+
+        original = jax.config.jax_enable_x64
+        try:
+            jax.config.update("jax_enable_x64", False)
+            salt_false = environment_salt()
+            jax.config.update("jax_enable_x64", True)
+            salt_true = environment_salt()
+        finally:
+            jax.config.update("jax_enable_x64", original)
+        assert salt_false != salt_true
+        assert "x64=False" in salt_false
+        assert "x64=True" in salt_true

--- a/tests/core/test_prefect_config.py
+++ b/tests/core/test_prefect_config.py
@@ -9,6 +9,8 @@ Exercises:
 - Strict WorkflowFunction / Module workflow_kind validation
 - Module inherits global config
 - PROBPIPE_WORKFLOW_KIND environment-variable override
+- CacheMode enum, cache_mode / cache_result_storage settings, and the
+  PROBPIPE_CACHE_MODE environment-variable override
 """
 
 from __future__ import annotations
@@ -20,10 +22,13 @@ import types
 import pytest
 
 from probpipe.core.config import (
+    _CACHE_MODE_ENV_VAR,
     _WORKFLOW_KIND_ENV_VAR,
+    CacheMode,
     PrefectConfig,
     WorkflowKind,
     _auto_detect_task_runner,
+    _initial_cache_mode,
     prefect_config,
 )
 
@@ -501,3 +506,180 @@ class TestEnvVarOverride:
         pc.workflow_kind = WorkflowKind.OFF
         pc.reset()
         assert pc.workflow_kind is WorkflowKind.TASK
+
+
+# ---------------------------------------------------------------------------
+# CacheMode enum
+# ---------------------------------------------------------------------------
+
+
+class TestCacheModeEnum:
+    """Verify the enum has the expected members and values."""
+
+    def test_members(self):
+        assert set(CacheMode) == {CacheMode.OFF, CacheMode.FINGERPRINT}
+
+    def test_values(self):
+        assert CacheMode.OFF.value == "off"
+        assert CacheMode.FINGERPRINT.value == "fingerprint"
+
+    def test_construct_from_string(self):
+        assert CacheMode("off") is CacheMode.OFF
+        assert CacheMode("fingerprint") is CacheMode.FINGERPRINT
+
+    def test_invalid_string_raises(self):
+        with pytest.raises(ValueError):
+            CacheMode("banana")
+
+
+# ---------------------------------------------------------------------------
+# cache_mode / caching_enabled / cache_result_storage on PrefectConfig
+# ---------------------------------------------------------------------------
+
+
+class TestCacheModeDefaults:
+    """Verify default values and reset behavior for the caching settings."""
+
+    def test_default_cache_mode_is_off(self, monkeypatch):
+        monkeypatch.delenv(_CACHE_MODE_ENV_VAR, raising=False)
+        pc = PrefectConfig()
+        assert pc.cache_mode is CacheMode.OFF
+
+    def test_default_caching_disabled(self, monkeypatch):
+        monkeypatch.delenv(_CACHE_MODE_ENV_VAR, raising=False)
+        pc = PrefectConfig()
+        assert pc.caching_enabled is False
+
+    def test_default_cache_result_storage_is_none(self):
+        pc = PrefectConfig()
+        assert pc.cache_result_storage is None
+
+    def test_reset_restores_defaults(self, monkeypatch):
+        monkeypatch.delenv(_CACHE_MODE_ENV_VAR, raising=False)
+        pc = PrefectConfig()
+        pc.cache_mode = CacheMode.FINGERPRINT
+        pc.cache_result_storage = "s3://bucket"
+        pc.reset()
+        assert pc.cache_mode is CacheMode.OFF
+        assert pc.cache_result_storage is None
+
+
+class TestCachingEnabled:
+    """caching_enabled tracks cache_mode both ways."""
+
+    def test_off_is_disabled(self):
+        pc = PrefectConfig()
+        pc.cache_mode = CacheMode.OFF
+        assert pc.caching_enabled is False
+
+    def test_fingerprint_is_enabled(self):
+        pc = PrefectConfig()
+        pc.cache_mode = CacheMode.FINGERPRINT
+        assert pc.caching_enabled is True
+
+
+class TestCacheModeValidation:
+    """The cache_mode setter rejects non-enum values."""
+
+    def test_rejects_string(self):
+        pc = PrefectConfig()
+        with pytest.raises(TypeError, match="CacheMode enum member"):
+            pc.cache_mode = "fingerprint"
+
+    def test_rejects_none(self):
+        pc = PrefectConfig()
+        with pytest.raises(TypeError, match="CacheMode enum member"):
+            pc.cache_mode = None
+
+    def test_rejects_int(self):
+        pc = PrefectConfig()
+        with pytest.raises(TypeError, match="CacheMode enum member"):
+            pc.cache_mode = 1
+
+    def test_accepts_enum(self):
+        pc = PrefectConfig()
+        for mode in CacheMode:
+            pc.cache_mode = mode
+            assert pc.cache_mode is mode
+
+
+class TestCacheResultStorage:
+    """cache_result_storage stores and resolves an opaque target."""
+
+    def test_setter_stores_value(self):
+        pc = PrefectConfig()
+        sentinel = object()
+        pc.cache_result_storage = sentinel
+        assert pc.cache_result_storage is sentinel
+
+    def test_resolve_returns_configured_target(self):
+        pc = PrefectConfig()
+        sentinel = object()
+        pc.cache_result_storage = sentinel
+        assert pc.resolve_cache_storage() is sentinel
+
+    def test_resolve_defaults_to_none(self):
+        pc = PrefectConfig()
+        assert pc.resolve_cache_storage() is None
+
+
+# ---------------------------------------------------------------------------
+# PROBPIPE_CACHE_MODE environment variable
+# ---------------------------------------------------------------------------
+
+
+class TestCacheModeEnvVar:
+    """The ``PROBPIPE_CACHE_MODE`` env var sets the initial cache_mode."""
+
+    def test_unset_defaults_to_off(self, monkeypatch):
+        monkeypatch.delenv(_CACHE_MODE_ENV_VAR, raising=False)
+        assert _initial_cache_mode() is CacheMode.OFF
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("off", CacheMode.OFF),
+            ("fingerprint", CacheMode.FINGERPRINT),
+        ],
+    )
+    def test_valid_value_sets_initial_mode(self, monkeypatch, value, expected):
+        monkeypatch.setenv(_CACHE_MODE_ENV_VAR, value)
+        pc = PrefectConfig()
+        assert pc.cache_mode is expected
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv(_CACHE_MODE_ENV_VAR, "FingerPrint")
+        assert _initial_cache_mode() is CacheMode.FINGERPRINT
+
+    def test_invalid_value_raises(self, monkeypatch):
+        monkeypatch.setenv(_CACHE_MODE_ENV_VAR, "banana")
+        with pytest.raises(ValueError, match="PROBPIPE_CACHE_MODE"):
+            _initial_cache_mode()
+
+    def test_invalid_value_fails_at_import(self):
+        """A bad env var should fail loudly at ``import probpipe`` time."""
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "-c", "import probpipe"],
+            env={**os.environ, _CACHE_MODE_ENV_VAR: "banana"},
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "banana" in result.stderr
+        assert "PROBPIPE_CACHE_MODE" in result.stderr
+
+    def test_explicit_assignment_overrides_env(self, monkeypatch):
+        monkeypatch.setenv(_CACHE_MODE_ENV_VAR, "fingerprint")
+        pc = PrefectConfig()
+        assert pc.cache_mode is CacheMode.FINGERPRINT
+        pc.cache_mode = CacheMode.OFF
+        assert pc.cache_mode is CacheMode.OFF
+
+    def test_reset_re_reads_env(self, monkeypatch):
+        monkeypatch.setenv(_CACHE_MODE_ENV_VAR, "fingerprint")
+        pc = PrefectConfig()
+        pc.cache_mode = CacheMode.OFF
+        pc.reset()
+        assert pc.cache_mode is CacheMode.FINGERPRINT


### PR DESCRIPTION
> **Draft / WIP.** Steps 1–4 (below) are implemented, tested, and verified
> end-to-end. Step 5 (serialization audit + docs) and Step 6 (CHANGELOG + docs
> page) are still to come — opening now for early review of the core design.

## Summary

PR3 of the provenance/caching series (PR1 #244 `ProvenanceMode`, PR2 #318
`fingerprint()`). Adds **opt-in, cross-run Prefect task caching** keyed by
PR2's content fingerprints: a workflow step is skipped and its result reused
when the same computation — same user-function body, same inputs, same
environment — has already run, including across processes and machines.

Caching is **off by default**; nothing changes for existing users unless they
set `prefect_config.cache_mode = CacheMode.FINGERPRINT`.

Refs #117.

## Motivation

Today Prefect is used only as a parallel executor — the `@task` carries a
`name` and nothing else, so every re-run recomputes from scratch and a
mid-pipeline failure loses all progress. This PR turns on Prefect's result
caching, using a custom cache key that actually understands ProbPipe's types
(JAX arrays, `Record`s, distributions) and, critically, the user-function body
— which a source-hashing policy can't see through the generic `run_func`
wrapper.

## Design decisions (settled in plan review)

- **Opt-in, default OFF**, configured on `PrefectConfig` (caching is
  Prefect-only), mirroring `WorkflowKind`.
- **`CacheMode` enum**: `OFF` / `FINGERPRINT`.
- **No Record pickle fix** — already done: `Record`/`NumericRecord` define
  `__reduce__` (#336), pinned by `tests/core/test_record_serialization.py`.
  The serialization step is an audit, not new code.
- **No fingerprint gating** — fingerprints stay always-on in
  LIGHTWEIGHT/FULL as today, so there is **no breaking change** and no
  provenance-content↔caching-config coupling.
- **`cache_result_storage`** — one config field wired to **both** the task's
  `result_storage` and the cache policy's `key_storage` (a shared result store
  with local key records still misses on other workers). Default = Prefect
  local.
- **No TTL**; instead an **environment salt** (probpipe + jax versions +
  `jax_enable_x64`) is folded into the key, so env drift is a miss, not a
  stale hit.

## How the cache key is built

```
cache_key = sha256(func_fingerprint | environment_salt | fingerprint(inputs))
```

- `func_fingerprint` — computed once at the `WorkflowFunction` level (the only
  place `fingerprint()` can stably hash the user body) and threaded down via
  `WorkflowExecutionConfig`. Detects a changed function body.
- `environment_salt` — probpipe/jax versions + x64 flag. Detects env drift.
- `fingerprint(inputs)` — content hash of the per-row inputs. Empirically
  verified that Prefect binds a `**kwargs` task's args as `{"kwargs": {...}}`
  with **unordered** keys, so the whole mapping is fingerprinted and
  `fingerprint()`'s key-sorting makes the result order-independent.

## Changes

**`probpipe/core/config.py`**
- `CacheMode` enum (`OFF` / `FINGERPRINT`), next to `WorkflowKind`.
- `PrefectConfig.cache_mode` (type-checked setter), `caching_enabled`,
  `cache_result_storage` + `resolve_cache_storage()`, and a
  `PROBPIPE_CACHE_MODE` env var with an `_initial_cache_mode()` resolver
  (env-var parity with `PROBPIPE_WORKFLOW_KIND`).
- `CacheMode` added to `__all__`.

**`probpipe/core/_fingerprint.py`**
- `environment_salt()` — stable `probpipe=…;jax=…;x64=…` string.

**`probpipe/core/node.py`**
- `_func_fingerprint_value()` (memoized `fingerprint(self)`).
- `_make_execution_config` attaches `func_fingerprint` and
  `cache_result_storage` to the config **only** on the Prefect paths and
  **only** when caching is enabled; otherwise both stay `None` and the config
  is byte-identical to before.

**`probpipe/core/_workflow_execution.py`**
- `WorkflowExecutionConfig` gains `func_fingerprint` and
  `cache_result_storage`.
- `_cache_task_options()` builds the `cache_key_fn`, `persist_result=True`, and
  storage; `map_task` applies them. Returns `{}` when caching is off, leaving
  the task decorator unchanged.

**`probpipe/__init__.py`** — export `CacheMode`.

**`tests/conftest.py`** — the autouse config-reset now also resets
`prefect_config` (prevents the new `cache_mode` global leaking between tests
under xdist).

## Test plan

New `tests/core/test_caching.py` plus additions to `test_prefect_config.py`
and `test_fingerprint.py`:

- **Config** — `CacheMode` enum, defaults, type-checked setter,
  `caching_enabled` both ways, storage store/resolve, full
  `PROBPIPE_CACHE_MODE` env-var parity (incl. bad-value-crashes-at-import
  subprocess test).
- **Environment salt** — components present, reflects real jax version, and
  **toggling `jax_enable_x64` changes the salt** (restored in `finally`).
- **Threading** — `func_fingerprint`/storage set only on Prefect paths when
  caching on; `None` otherwise; memoized; two different function bodies →
  different fingerprints.
- **Cache key** — deterministic, order-independent, changes with inputs / func
  fingerprint / env salt, identical across a **subprocess**, storage wired to
  both surfaces.
- **End-to-end** (marked `prefect`, uses `prefect_test_harness`) — a real
  Prefect run confirms a re-run **hits** the cache (user function not
  re-executed) while a changed input **misses**.

Verified manually as well: caching OFF → 4 executions, ON → 2, over the same
call sequence.

Pre-existing, unrelated to this PR (confirmed identical on `main` in a clean
worktree): the `test_output_values_correct` JAX-tracer failures and the
NumericRecord/vmap broadcast failures under the local env.

## Still to do (before marking ready)

- [ ] **Step 5** — serialization audit: confirm persisted result types
  (`EmpiricalDistribution`, `Record`/`NumericRecord` incl. aux round-trip,
  `RecordArray`, TFP families) reload correctly; document JAX-x64 /
  Python-version key caveats.
- [ ] **Step 6** — CHANGELOG entry (Added: `CacheMode`, `cache_mode`,
  `cache_result_storage`, `PROBPIPE_CACHE_MODE`, env-salted keys) + a caching
  docs page.

## Note for reviewers

During review I found commit `15679eb` (Jul 13, "preserve backend aux across a
NumericRecord pickle round-trip") appears to **already fix** the `NumericRecord`
aux-loss caveat raised in plan review — so the "aux is dropped on reload"
acceptance criterion looks stale. Step 5's audit will confirm aux round-trips
faithfully; flagging in case that changes anyone's expectations.

## Breaking changes

None. Caching is opt-in and off by default; fingerprinting behavior is
unchanged (gating was dropped), so no public field changes.

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`
- [x] Opt-in, default-OFF; OFF path byte-identical to before
- [ ] CHANGELOG entry (Step 6)
- [ ] Docs page (Step 6)
- [x] `area:core` label
- [x] Linked to tracking issue
