### PR TITLE
refactor(core): extract shared registry-resolution helpers

### DIFF
--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -216,6 +216,98 @@ def _to_jax_array(value: Any) -> jax.Array:
 
 
 # ---------------------------------------------------------------------------
+# Leaf resolvers: registry-first, duck-typing fallback
+# ---------------------------------------------------------------------------
+#
+# Every numeric gate asks one of a few questions about a leaf — is it numeric?
+# what is its shape / dtype? materialise it to numpy — and each resolves the
+# same way: the registered backend's hook if the leaf's type is registered,
+# else the numpy-protocol duck path. These helpers hold that one resolution
+# (mirroring ``_to_jax_array`` for ``to_jax``) so each question's duck fallback
+# lives in one place and cannot drift between call sites.
+
+# Numeric Python scalars. A bare scalar leaf is normalised to a 0-d
+# ``jax.Array`` at ``NumericRecord`` construction, but it still counts as
+# numeric everywhere the raw value is inspected.
+_NUMERIC_SCALARS = (bool, int, float, complex, np.integer, np.floating, np.bool_)
+
+
+def _is_numeric_leaf(value: Any) -> bool:
+    """Whether *value* is a numeric leaf — the shared numeric predicate.
+
+    Registry-first: a registered container answers through its ``is_numeric``
+    hook; a numeric Python scalar counts; everything else duck-types on a
+    numeric ``dtype`` / ``shape``. Strings, object arrays, and opaque types are
+    not numeric. Every "is this leaf numeric?" site shares this one decision,
+    so promotion, ``_full_array_shape_or_none``, and spec validation cannot
+    drift apart on what counts.
+    """
+    if isinstance(value, (str, bytes)):
+        return False
+    if isinstance(value, _NUMERIC_SCALARS):
+        return True
+    backend = array_backend_for(value)
+    if backend is not None:
+        return backend.is_numeric(value)
+    from .event_template import _is_numeric_dtype
+
+    return hasattr(value, "dtype") and hasattr(value, "shape") and _is_numeric_dtype(value.dtype)
+
+
+def _event_shape_of(value: Any) -> tuple[int, ...]:
+    """The numeric leaf's event shape — registry ``event_shape``, else ``.shape``.
+
+    Reads container metadata only, never the values. A scalar reports ``()``.
+    Assumes *value* is numeric (see :func:`_is_numeric_leaf`).
+    """
+    backend = array_backend_for(value)
+    if backend is not None:
+        return tuple(backend.event_shape(value))
+    return tuple(getattr(value, "shape", ()))
+
+
+def _numpy_dtype_of(value: Any) -> np.dtype | None:
+    """The leaf's single numpy dtype, or ``None`` when it has none.
+
+    Registry-first (``None`` for a heterogeneous container with no single
+    dtype); else the value's own ``.dtype``, else the numpy dtype of a
+    materialised copy. Reads metadata only except on that last fallback.
+    """
+    backend = array_backend_for(value)
+    if backend is not None:
+        return backend.numpy_dtype(value)
+    nd = getattr(value, "dtype", None)
+    if nd is None:
+        nd = np.asarray(value).dtype
+    return nd
+
+
+def _to_numpy_array(value: Any) -> np.ndarray:
+    """Materialise a numeric leaf to numpy on its native basis.
+
+    The registered backend's ``to_numpy`` (native dtype and full precision)
+    when *value*'s type is registered, else ``np.asarray`` — the basis
+    :func:`fingerprint` hashes on and ``Record.__eq__`` compares. The numpy
+    counterpart of :func:`_to_jax_array`.
+    """
+    backend = array_backend_for(value)
+    if backend is not None:
+        return np.asarray(backend.to_numpy(value))
+    return np.asarray(value)
+
+
+def _metadata_of(value: Any) -> Any:
+    """The leaf's identity-bearing container metadata, or ``None``.
+
+    A registered backend's ``metadata`` (an ``xarray`` array's dims / coords /
+    attrs, a ``pandas`` object's index / columns); ``None`` for a bare array or
+    an unregistered leaf, whose identity is its values alone.
+    """
+    backend = array_backend_for(value)
+    return backend.metadata(value) if backend is not None else None
+
+
+# ---------------------------------------------------------------------------
 # Built-in registrations (gated on import availability)
 # ---------------------------------------------------------------------------
 #

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -83,6 +83,43 @@ def _safe_numpy_dtype(dtype: Any) -> np.dtype | None:
         return None
 
 
+# dtype.kind codes for numeric arrays: b=bool, i=int, u=uint, f=float, c=complex.
+_NUMERIC_KINDS = frozenset("biufc")
+
+
+def _is_numeric_dtype(dtype: Any) -> bool:
+    """Whether *dtype* is a numeric dtype — the shared numeric-gate predicate.
+
+    Covers the standard numpy kinds (bool, int, uint, float, complex) plus
+    the ml_dtypes extension types JAX registers (``bfloat16``, the
+    ``float8_*`` family, ``int4`` / ``uint4``), which numpy reports as kind
+    ``"V"``. A dtype that is **not** ``numpy.dtype``-coercible — a pandas
+    extension / masked dtype such as ``Int64Dtype`` — is **not** numeric on
+    this generic (duck-typing) path: it is not a dense numpy dtype, so a bare
+    value carrying one is not treated as a plain numeric array. A registered
+    :class:`~probpipe.ArrayBackend` may still recognise its own masked dtypes
+    and convert them: the built-in pandas backend accepts nullable numeric
+    columns, encoding each NA as ``NaN`` at the compute boundary. So this
+    predicate governs only the duck path, not the registry. Structured
+    (record) dtypes are likewise not numeric.
+    Every place that decides "is this array numeric?" — template inference,
+    spec validation, and the ``NumericRecord`` / ``NumericRecordArray`` leaf
+    gates — routes through this predicate so the sites cannot drift apart.
+    """
+    try:
+        np_dtype = np.dtype(dtype)
+    except (TypeError, ValueError):
+        # ``np.dtype`` raises ``TypeError`` for a pandas extension / masked
+        # dtype and ``ValueError`` for an object it cannot interpret at all
+        # (e.g. a mock). Either way it is not a dense numpy dtype, so not
+        # numeric.
+        return False
+    kind = np_dtype.kind
+    if kind in _NUMERIC_KINDS:
+        return True
+    return kind == "V" and jnp.issubdtype(np_dtype, jnp.number)
+
+
 @dataclass(frozen=True)
 class ArrayBackend:
     """Recognition and conversion hooks for one native array-container type.
@@ -249,8 +286,6 @@ def _is_numeric_leaf(value: Any) -> bool:
     backend = array_backend_for(value)
     if backend is not None:
         return backend.is_numeric(value)
-    from .event_template import _is_numeric_dtype
-
     return hasattr(value, "dtype") and hasattr(value, "shape") and _is_numeric_dtype(value.dtype)
 
 
@@ -326,8 +361,6 @@ def _register_xarray() -> None:
     except ImportError:
         return
 
-    from .event_template import _is_numeric_dtype
-
     def _metadata(da: xr.DataArray) -> Any:
         # Everything that distinguishes the container beyond its values: the
         # named dims, each coord's values, free-form attrs, and the name.
@@ -376,8 +409,6 @@ def _register_pandas() -> None:
         import pandas as pd
     except ImportError:
         return
-
-    from .event_template import _is_numeric_dtype
 
     def _is_nullable_numeric(dtype: Any) -> bool:
         # A masked / extension *numeric* dtype: numeric, but with a validity

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -20,14 +20,14 @@ import numpy as np
 
 from .._weights import Weights
 from ..custom_types import Array
-from ._array_backend import _to_jax_array
+from ._array_backend import _is_numeric_dtype, _to_jax_array
 from ._distribution_base import Distribution
 from ._empirical import (
     EmpiricalDistribution,
     RecordEmpiricalDistribution,
 )
 from ._record_array import RecordArray
-from .event_template import EventTemplate, _full_array_shape_or_none, _is_numeric_dtype
+from .event_template import EventTemplate, _full_array_shape_or_none
 from .protocols import (
     SupportsLogProb,
     SupportsMean,

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -216,8 +216,7 @@ def _numeric_container_to_numpy(obj: Any) -> _np.ndarray | None:
     ``None``. Materialisation is the documented cost of fingerprinting a
     lazy / disk-backed leaf.
     """
-    from ._array_backend import array_backend_for
-    from .event_template import _is_numeric_dtype
+    from ._array_backend import _is_numeric_dtype, array_backend_for
 
     backend = array_backend_for(obj)
     if backend is not None:

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -179,10 +179,9 @@ def _update(h: hashlib._Hash, obj: Any, depth: int, max_array_bytes: int | None)
         h.update(type(obj).__qualname__.encode())
         h.update(b":")
         _update_array(h, content, max_array_bytes)
-        from ._array_backend import array_backend_for
+        from ._array_backend import _metadata_of
 
-        backend = array_backend_for(obj)
-        metadata = backend.metadata(obj) if backend is not None else None
+        metadata = _metadata_of(obj)
         if metadata is not None:
             h.update(b":meta:")
             _update(h, metadata, depth + 1, max_array_bytes)

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -27,42 +27,20 @@ import jax.numpy as jnp
 import numpy as np
 
 from ..custom_types import Array, ArrayLike
-from ._array_backend import _to_jax_array, array_backend_for
-from .event_template import EventTemplate, NumericEventTemplate, _is_numeric_dtype
+from ._array_backend import (
+    _NUMERIC_SCALARS,
+    _event_shape_of,
+    _is_numeric_leaf,
+    _numpy_dtype_of,
+    _to_jax_array,
+)
+from .event_template import EventTemplate, NumericEventTemplate
 from .named_tree import _PATH_SEP, _check_no_path_sep, _unflatten_paths
 from .record import Record
 
+# ``_is_numeric_leaf`` is defined in ``_array_backend`` (the shared leaf
+# resolvers) and re-exported here, its historical home.
 __all__ = ["NumericRecord", "_is_numeric_leaf"]
-
-
-# Scalar types accepted as numeric leaves. ``bool`` is intentionally
-# included: JAX treats it as dtype ``bool_`` and numpy arrays of bools
-# participate in arithmetic as 0/1.
-_NUMERIC_SCALARS = (bool, int, float, complex, np.integer, np.floating, np.bool_)
-
-
-def _is_numeric_leaf(val: Any) -> bool:
-    """True if *val* is a numeric array, numeric container, or numeric scalar.
-
-    Resolution is registry-first: a value whose type has a registered
-    :class:`~probpipe.ArrayBackend` answers through its ``is_numeric`` hook
-    (so e.g. a ``pandas.DataFrame`` counts iff every column is numeric);
-    everything else duck-types on a numeric ``dtype`` / ``shape``. Rejects
-    object-dtype arrays, string-like scalars, and opaque types. Dtype
-    numericness is decided by the shared ``_is_numeric_dtype`` predicate, so
-    this gate, ``NumericRecordArray._validate_fields``, and template
-    inference agree on what counts as numeric.
-    """
-    if isinstance(val, (str, bytes)):
-        return False
-    if isinstance(val, _NUMERIC_SCALARS):
-        return True
-    backend = array_backend_for(val)
-    if backend is not None:
-        return backend.is_numeric(val)
-    if hasattr(val, "dtype") and hasattr(val, "shape"):
-        return _is_numeric_dtype(val.dtype)
-    return False
 
 
 class NumericRecord(Record):
@@ -252,9 +230,7 @@ class NumericRecord(Record):
             if isinstance(val, NumericRecord):
                 total += val.vector_size
             else:
-                backend = array_backend_for(val)
-                shape = backend.event_shape(val) if backend is not None else val.shape
-                total += int(prod(shape))
+                total += int(prod(_event_shape_of(val)))
         object.__setattr__(self, "_vector_size", total)
         # The set-once converted-leaf cache backing the compute boundary.
         # Mutable by design (an internal memo, not value state); shallow
@@ -472,11 +448,7 @@ class NumericRecord(Record):
     # Multi-field raises ``TypeError`` (loud, not silent).
     @property
     def shape(self) -> tuple[int, ...]:
-        leaf = self._tree[self._single_numeric_field()]
-        backend = array_backend_for(leaf)
-        if backend is not None:
-            return tuple(backend.event_shape(leaf))
-        return tuple(getattr(leaf, "shape", ()))
+        return _event_shape_of(self._tree[self._single_numeric_field()])
 
     @property
     def dtype(self):
@@ -487,11 +459,7 @@ class NumericRecord(Record):
         array-like forwards its own ``.dtype``. A leaf that exposes no single
         dtype yields ``None`` rather than a stand-in.
         """
-        leaf = self._tree[self._single_numeric_field()]
-        backend = array_backend_for(leaf)
-        if backend is not None:
-            return backend.numpy_dtype(leaf)
-        return getattr(leaf, "dtype", None)
+        return _numpy_dtype_of(self._tree[self._single_numeric_field()])
 
     @property
     def ndim(self) -> int:

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -17,13 +17,12 @@ import jax.numpy as jnp
 import numpy as np
 
 from ..custom_types import Array
-from ._array_backend import _to_jax_array
+from ._array_backend import _is_numeric_dtype, _to_jax_array
 from .event_template import (
     ArraySpec,
     EventTemplate,
     NumericEventTemplate,
     _full_array_shape_or_none,
-    _is_numeric_dtype,
 )
 from .record import Record
 from .tracked import auto_name

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -64,7 +64,6 @@ from dataclasses import dataclass
 from math import prod
 from typing import Any
 
-import jax.numpy as jnp
 import numpy as np
 import numpy.typing as npt
 
@@ -394,43 +393,6 @@ def _all_numeric(specs: Iterable[Any]) -> bool:
     (``__init__`` rejects the latter).
     """
     return all(isinstance(s, tuple) or _is_numeric_spec(s) for s in specs)
-
-
-# dtype.kind codes for numeric arrays: b=bool, i=int, u=uint, f=float, c=complex.
-_NUMERIC_KINDS = frozenset("biufc")
-
-
-def _is_numeric_dtype(dtype: Any) -> bool:
-    """Whether *dtype* is a numeric dtype — the shared numeric-gate predicate.
-
-    Covers the standard numpy kinds (bool, int, uint, float, complex) plus
-    the ml_dtypes extension types JAX registers (``bfloat16``, the
-    ``float8_*`` family, ``int4`` / ``uint4``), which numpy reports as kind
-    ``"V"``. A dtype that is **not** ``numpy.dtype``-coercible — a pandas
-    extension / masked dtype such as ``Int64Dtype`` — is **not** numeric on
-    this generic (duck-typing) path: it is not a dense numpy dtype, so a bare
-    value carrying one is not treated as a plain numeric array. A registered
-    :class:`~probpipe.ArrayBackend` may still recognise its own masked dtypes
-    and convert them: the built-in pandas backend accepts nullable numeric
-    columns, encoding each NA as ``NaN`` at the compute boundary. So this
-    predicate governs only the duck path, not the registry. Structured
-    (record) dtypes are likewise not numeric.
-    Every place that decides "is this array numeric?" — template inference,
-    spec validation, and the ``NumericRecord`` / ``NumericRecordArray`` leaf
-    gates — routes through this predicate so the sites cannot drift apart.
-    """
-    try:
-        np_dtype = np.dtype(dtype)
-    except (TypeError, ValueError):
-        # ``np.dtype`` raises ``TypeError`` for a pandas extension / masked
-        # dtype and ``ValueError`` for an object it cannot interpret at all
-        # (e.g. a mock). Either way it is not a dense numpy dtype, so not
-        # numeric.
-        return False
-    kind = np_dtype.kind
-    if kind in _NUMERIC_KINDS:
-        return True
-    return kind == "V" and jnp.issubdtype(np_dtype, jnp.number)
 
 
 def _full_array_shape_or_none(val: Any) -> tuple[int, ...] | None:

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -68,7 +68,7 @@ import jax.numpy as jnp
 import numpy as np
 import numpy.typing as npt
 
-from ._array_backend import array_backend_for
+from ._array_backend import _event_shape_of, _is_numeric_leaf, _numpy_dtype_of
 from .constraints import Constraint
 from .named_tree import (
     _PATH_SEP,
@@ -200,18 +200,11 @@ class ArraySpec(ValueSpec):
         if shape is None or shape != self.shape:
             return False
         if self.dtype is not None:
-            backend = array_backend_for(value)
-            if backend is not None:
-                # A registered container answers from metadata; ``None``
-                # means it has no single dtype (a heterogeneous frame), which
-                # cannot match a dtype-pinned spec.
-                actual = backend.numpy_dtype(value)
-                if actual is None:
-                    return False
-            else:
-                actual = getattr(value, "dtype", None)
-                if actual is None:
-                    actual = np.asarray(value).dtype
+            # ``None`` means the value has no single dtype (a heterogeneous
+            # frame), which cannot match a dtype-pinned spec.
+            actual = _numpy_dtype_of(value)
+            if actual is None:
+                return False
             # A same-kind cast (a widening promotion or a within-kind
             # narrowing) matches; a cross-kind cast (e.g. float where an int
             # dtype is declared) does not.
@@ -451,14 +444,7 @@ def _full_array_shape_or_none(val: Any) -> tuple[int, ...] | None:
     Strings, object arrays, Python lists/tuples, and any remaining value
     without a numeric ``dtype`` / ``shape`` report ``None``.
     """
-    if isinstance(val, (bool, int, float, complex, np.integer, np.floating, np.bool_)):
-        return ()
-    backend = array_backend_for(val)
-    if backend is not None:
-        return tuple(backend.event_shape(val)) if backend.is_numeric(val) else None
-    if hasattr(val, "shape") and hasattr(val, "dtype") and _is_numeric_dtype(val.dtype):
-        return tuple(val.shape)
-    return None
+    return _event_shape_of(val) if _is_numeric_leaf(val) else None
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -44,7 +44,7 @@ import jax
 import numpy as np
 
 from ..custom_types import ArrayLike
-from ._array_backend import array_backend_for
+from ._array_backend import _metadata_of, _numpy_dtype_of, _to_numpy_array, array_backend_for
 from .event_template import (
     EventTemplate,
     NumericEventTemplate,
@@ -90,33 +90,19 @@ def _derived_record_name(field_keys: Iterable[str]) -> str:
     return "record(" + ",".join(field_keys) + ")"
 
 
-def _leaf_to_numpy(leaf: Any) -> np.ndarray:
-    """Materialise a numeric leaf to numpy on its native basis (registry-first).
-
-    Uses the registered backend's ``to_numpy`` (native dtype and full
-    precision) when *leaf*'s type is registered, else ``np.asarray`` — the same
-    basis :func:`fingerprint` hashes on, so a value comparison built on it
-    agrees with the content fingerprint.
-    """
-    backend = array_backend_for(leaf)
-    if backend is not None:
-        return np.asarray(backend.to_numpy(leaf))
-    return np.asarray(leaf)
-
-
 def _leaf_values_equal(a: Any, b: Any) -> bool:
     """Whether two numeric leaves have equal values, on their native basis.
 
-    Both leaves materialise to numpy through the array-backend registry — the
-    same native, full-precision basis :func:`fingerprint` uses — rather than
+    Both leaves materialise to numpy through :func:`_to_numpy_array` — the same
+    native, full-precision basis :func:`fingerprint` uses — rather than
     converting to ``jax.Array`` first. So ``__eq__`` agrees with the content
     fingerprint instead of comparing at the lossy compute-boundary precision (a
     sub-``float32`` difference is not silently equated under JAX's default x32
     policy), and ``NaN`` positions compare equal (``equal_nan``) for floating
     data, so a record with a ``NaN`` leaf equals an independent copy of itself.
     """
-    a_np = _leaf_to_numpy(a)
-    b_np = _leaf_to_numpy(b)
+    a_np = _to_numpy_array(a)
+    b_np = _to_numpy_array(b)
     equal_nan = np.issubdtype(a_np.dtype, np.inexact) and np.issubdtype(b_np.dtype, np.inexact)
     return bool(np.array_equal(a_np, b_np, equal_nan=equal_nan))
 
@@ -134,10 +120,7 @@ def _leaf_metadata_key(leaf: Any) -> Any:
     Metadata is normally small; a rare oversized coordinate array is fully
     materialised only when such records are actually compared.
     """
-    backend = array_backend_for(leaf)
-    if backend is None:
-        return None
-    meta = backend.metadata(leaf)
+    meta = _metadata_of(leaf)
     if meta is None:
         return None
     from ._fingerprint import fingerprint
@@ -154,13 +137,7 @@ def _canonical_dtype_str(leaf: Any) -> str:
     JAX would unify hash together, keeping :meth:`__hash__` a stable coarse
     key. ``"none"`` when the leaf has no single dense dtype.
     """
-    backend = array_backend_for(leaf)
-    if backend is not None:
-        nd = backend.numpy_dtype(leaf)
-    else:
-        nd = getattr(leaf, "dtype", None)
-        if nd is None:
-            nd = np.asarray(leaf).dtype
+    nd = _numpy_dtype_of(leaf)
     if nd is None:
         return "none"
     return str(jax.dtypes.canonicalize_dtype(np.dtype(nd)))

--- a/probpipe/record/design.py
+++ b/probpipe/record/design.py
@@ -22,8 +22,9 @@ from typing import Any
 import jax.numpy as jnp
 import numpy as np
 
+from ..core._array_backend import _is_numeric_dtype
 from ..core._record_array import RecordArray
-from ..core.event_template import EventTemplate, _is_numeric_dtype
+from ..core.event_template import EventTemplate
 
 __all__ = ["Design", "FullFactorialDesign"]
 

--- a/tests/core/test_array_backend.py
+++ b/tests/core/test_array_backend.py
@@ -549,7 +549,7 @@ class TestGenericGateRejectsExtensionDtype:
     """
 
     def test_is_numeric_dtype_rejects_extension_dtype(self):
-        from probpipe.core.event_template import _is_numeric_dtype
+        from probpipe.core._array_backend import _is_numeric_dtype
 
         assert not _is_numeric_dtype(pd.Int64Dtype())
         assert _is_numeric_dtype(np.dtype("int64"))
@@ -560,7 +560,8 @@ class TestGenericGateRejectsExtensionDtype:
         # return False, not propagate. (Regression for the stan-suite mock.)
         from unittest.mock import MagicMock
 
-        from probpipe.core.event_template import _full_array_shape_or_none, _is_numeric_dtype
+        from probpipe.core._array_backend import _is_numeric_dtype
+        from probpipe.core.event_template import _full_array_shape_or_none
 
         assert _is_numeric_dtype(MagicMock()) is False
         assert _full_array_shape_or_none(MagicMock()) is None

--- a/tests/core/test_numeric_record.py
+++ b/tests/core/test_numeric_record.py
@@ -146,19 +146,30 @@ class TestConstruction:
             assert nr["x"] is arr, f"failed for dtype {dt}"
 
     def test_numeric_dtype_predicate_shared(self):
-        """Every numeric gate — ``NumericRecord``, ``NumericRecordArray``,
-        template inference, the broadcast-template builder, and the ``Design``
-        marginals probe — must agree on which dtypes are numeric. Duplicated
-        literals would let the sites drift silently — this test pins down that
-        they consume the one shared predicate."""
-        from probpipe.core import _broadcast_distributions, _numeric_record, _record_array
+        """Every numeric gate must agree on what counts as numeric by consuming
+        a shared predicate rather than duplicating the logic. Two levels are
+        shared: the dtype-level ``_is_numeric_dtype`` (used directly where only
+        a dtype is in hand — ``NumericRecordArray``, the broadcast-template
+        builder, the ``Design`` marginals probe) and the leaf-level
+        ``_is_numeric_leaf`` (the registry-first resolver that wraps it,
+        consumed by ``NumericRecord`` and template inference)."""
+        from probpipe.core import (
+            _array_backend,
+            _broadcast_distributions,
+            _numeric_record,
+            _record_array,
+            event_template,
+        )
         from probpipe.core.event_template import _is_numeric_dtype
         from probpipe.record import design
 
-        assert _numeric_record._is_numeric_dtype is _is_numeric_dtype
+        # dtype-level predicate: consumed directly where only a dtype is checked
         assert _record_array._is_numeric_dtype is _is_numeric_dtype
         assert _broadcast_distributions._is_numeric_dtype is _is_numeric_dtype
         assert design._is_numeric_dtype is _is_numeric_dtype
+        # leaf-level predicate: one resolver shared by the record gate and inference
+        assert _numeric_record._is_numeric_leaf is _array_backend._is_numeric_leaf
+        assert event_template._is_numeric_leaf is _array_backend._is_numeric_leaf
 
     def test_bfloat16_leaf_accepted(self):
         # ml_dtypes numerics (kind "V") are numeric leaves.

--- a/tests/core/test_numeric_record.py
+++ b/tests/core/test_numeric_record.py
@@ -160,13 +160,13 @@ class TestConstruction:
             _record_array,
             event_template,
         )
-        from probpipe.core.event_template import _is_numeric_dtype
         from probpipe.record import design
 
-        # dtype-level predicate: consumed directly where only a dtype is checked
-        assert _record_array._is_numeric_dtype is _is_numeric_dtype
-        assert _broadcast_distributions._is_numeric_dtype is _is_numeric_dtype
-        assert design._is_numeric_dtype is _is_numeric_dtype
+        # dtype-level predicate (lives in _array_backend): imported directly from
+        # there wherever only a dtype is in hand
+        assert _record_array._is_numeric_dtype is _array_backend._is_numeric_dtype
+        assert _broadcast_distributions._is_numeric_dtype is _array_backend._is_numeric_dtype
+        assert design._is_numeric_dtype is _array_backend._is_numeric_dtype
         # leaf-level predicate: one resolver shared by the record gate and inference
         assert _numeric_record._is_numeric_leaf is _array_backend._is_numeric_leaf
         assert event_template._is_numeric_leaf is _array_backend._is_numeric_leaf


### PR DESCRIPTION
## Summary

Extracts the **registry-first, duck-typing-fallback** resolution into one shared helper per numeric question, so each fallback lives in a single place and can't drift between call sites. Only `to_jax` had such a helper (`_to_jax_array`); the rest were open-coded at ~12 sites.

Stacked on #362 (base `dev/native-form-missing-data`).

### Motivation

Every numeric gate asks one of a few questions about a leaf — *is it numeric? what's its shape / dtype? materialise it to numpy / metadata* — and each resolved the same way inline: the registered `ArrayBackend` hook if the type is registered, else the numpy-protocol duck path. Because the duck fallback was copied per site, they had **already drifted**:

- the numeric predicate was implemented **twice** — `_is_numeric_leaf` and, inline, inside `_full_array_shape_or_none`;
- the dtype fallback existed in **three forms** — `NumericRecord.dtype` used a bare `getattr(leaf, "dtype", None)`, while `_canonical_dtype_str` and `ArraySpec.is_valid` added an `np.asarray(...).dtype` fallback.

Both were harmless today (the leaf invariant guarantees a stored leaf has a real dtype), but they're latent bugs and make any change to the resolution contract a ~12-site edit kept in sync by hand.

### What this does

Adds, in `_array_backend.py` alongside `_to_jax_array`:

| Resolver | Question |
|---|---|
| `_is_numeric_leaf(v)` | is this a numeric leaf? |
| `_event_shape_of(v)` | its event shape (`()` for a scalar) |
| `_numpy_dtype_of(v)` | its single numpy dtype, or `None` |
| `_to_numpy_array(v)` | materialise to numpy (numpy twin of `_to_jax_array`) |
| `_metadata_of(v)` | its identity-bearing container metadata, or `None` |

`_NUMERIC_SCALARS` moves here too, as the single scalar-set definition. Call sites in `_numeric_record`, `event_template`, `record`, and `_fingerprint` now delegate.

### Two behaviours corrected (not just consolidated)

- `_full_array_shape_or_none` is now `_event_shape_of(v) if _is_numeric_leaf(v) else None` — the duplicated numeric decision is gone, so it and promotion can't disagree on what counts as numeric.
- `NumericRecord.dtype` shares `_numpy_dtype_of` with the other dtype sites, removing the bare-`getattr` drift.

Verified equivalent on scalars, registered numeric/non-numeric containers, duck arrays, and strings.

### Deliberately not touched

- **`Record.to_numpy()`** — its fallback returns non-numeric leaves *as-is* (avoids boxing an opaque object), a genuinely different contract from the numeric `_to_numpy_array`.
- **`_fingerprint._numeric_container_to_numpy`** — a tiered gate (returns `None` for bare arrays/scalars handled in earlier fingerprint tiers); only its metadata line moved to `_metadata_of`.
- **`__hash__` double lookup** — left as two resolver calls; `array_backend_for` is a dict probe + short MRO walk, so a special combined shape+dtype resolver wasn't worth bloating the one-per-hook API.

`_is_numeric_leaf` keeps its historical import path (re-exported from `_numeric_record`).

### Tests

Pure refactor; no behaviour change on valid leaves. Full `tests/core` (1772) plus distributions / converters / modeling / inference / diagnostics / validation (1784, 54 skipped) green. The shared-predicate regression test now asserts **both** shared predicates (the dtype-level `_is_numeric_dtype` and the leaf-level `_is_numeric_leaf`).
