### PR TITLE
feat(core): term-spec hierarchy and declarations stored as specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Value specs are fingerprinted by declaration, not identity (#381).** The
+  spec hasher now covers `RecordSpec` and recurses into a stored declaration
+  (`DistributionSpec.event_spec`, `FunctionSpec.output_spec`), which is a spec
+  rather than a template. The generic hasher also routes any `ValueSpec` to it,
+  so a spec reached other than as a template leaf — bare, or inside a tuple,
+  list, or mapping — records its type and declaration fields instead of falling
+  through to identity hashing. Previously such a spec hashed weakly, so two
+  *equal* declarations produced different fingerprints and silently broke jit
+  cache keys and provenance.
+
 ### Added
 
 - **`TermSpec` — the term-spec sub-hierarchy, and declarations stored as specs
@@ -28,8 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   declaration is record-valued for now, since a `Distribution` exposes an
   `EventTemplate` and nothing that reports a term-valued draw kind, so a
   random-measure declaration is refused at construction rather than accepted
-  and always reported invalid. Fingerprinting recurses into declarations and
-  covers `RecordSpec`, so equal declarations hash equally.
+  and always reported invalid.
 
 - **First-class, tracked `Function` values (#368).** `Function` is now an
   immutable `Node` / `Tracked` / `Annotated` object with a construction-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,11 +205,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Renamed, for the storage rule (#381):** `FunctionSpec.output_template` is
   now **`output_spec`**, storing any `ValueSpec` or `None`, and
   `DistributionSpec.event_template` is now **`event_spec`**, storing a
-  `RecordSpec`. Both constructors still accept an `EventTemplate` and wrap it, so
-  existing positional and keyword construction from a template keeps working;
-  reads of the old attribute names do not. The names now carry their content:
-  `*_template` is always a record schema, `*_spec` a declaration of any kind —
-  which is why `RecordSpec.event_template` keeps its name.
+  `RecordSpec`. The names now carry their content: `*_template` is always a
+  record schema, `*_spec` a declaration of any kind — which is why
+  `RecordSpec.event_template` keeps its name.
+
+  To migrate: **positional** construction is unchanged, and both constructors
+  still accept an `EventTemplate` and wrap it, so `DistributionSpec(tau)` and
+  `FunctionSpec(tau, tau)` keep working. **Keyword** construction moves to the
+  new parameter name, and so does every **read** of the old attribute:
+
+  ```python
+  DistributionSpec(event_template=tau)    ->  DistributionSpec(event_spec=tau)
+  FunctionSpec(tau, output_template=tau)  ->  FunctionSpec(tau, output_spec=tau)
+  spec.event_template                     ->  spec.event_spec.event_template
+  ```
+
+  Each field is now declared at the type it *stores* — `event_spec: RecordSpec`,
+  `output_spec: ValueSpec | None` — with the wider template sugar carried by the
+  constructor signature, so a type checker and the generated API reference both
+  read the post-construction guarantee. `ArraySpec` follows the same split, its
+  `dtype` field declared as the `numpy.dtype` it stores rather than the
+  `DTypeLike` spellings it accepts.
 
 - **Function calls establish a new result identity and provenance boundary
   (#368, breaking).** Existing operations such as `condition_on` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bare `EventTemplate` is accepted as construction sugar wherever a record
   declaration is meant and normalised to `RecordSpec(template)`, so after
   construction the declared kind is simply the stored spec's class. This makes
-  `sample`'s draw kind and an operation's result kind a structural test rather
-  than an inference from a runtime value.
+  an operation's result kind a structural test rather than an inference from a
+  runtime value. A callable's `output_spec` accepts any kind; an *event*
+  declaration is record-valued for now, since a `Distribution` exposes an
+  `EventTemplate` and nothing that reports a term-valued draw kind, so a
+  random-measure declaration is refused at construction rather than accepted
+  and always reported invalid. Fingerprinting recurses into declarations and
+  covers `RecordSpec`, so equal declarations hash equally.
 
 - **First-class, tracked `Function` values (#368).** `Function` is now an
   immutable `Node` / `Tracked` / `Annotated` object with a construction-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   list, or mapping — records its type and declaration fields instead of falling
   through to identity hashing. Previously such a spec hashed weakly, so two
   *equal* declarations produced different fingerprints and silently broke jit
-  cache keys and provenance.
+  cache keys and provenance. Because a record declaration is now stored as a
+  `RecordSpec`, the digest of a template carrying a `DistributionSpec`, or a
+  `FunctionSpec` with a declared output, also changes value; fingerprints are
+  in-memory jit cache keys and provenance only, never persisted.
 
 ### Added
 
@@ -200,9 +203,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Renamed, for the storage rule (#381):** `FunctionSpec.output_template` is
-  now **`output_spec`**, stored as a `TermSpec | None`, and
-  `DistributionSpec.event_template` is now **`event_spec`**, stored as a
-  `TermSpec`. Both constructors still accept an `EventTemplate` and wrap it, so
+  now **`output_spec`**, storing any `ValueSpec` or `None`, and
+  `DistributionSpec.event_template` is now **`event_spec`**, storing a
+  `RecordSpec`. Both constructors still accept an `EventTemplate` and wrap it, so
   existing positional and keyword construction from a template keeps working;
   reads of the old attribute names do not. The names now carry their content:
   `*_template` is always a record schema, `*_spec` a declaration of any kind —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`TermSpec` — the term-spec sub-hierarchy, and declarations stored as specs
+  (#381).** `ValueSpec` now splits into *raw-value specs* (`ArraySpec`,
+  `OpaqueSpec`), which name no ProbPipe kind, and *term specs*, one per kind,
+  whose concrete class *is* the kind. `TermSpec(ValueSpec)` is the marker
+  `isinstance` reads; `is_valid` stays declared once on `ValueSpec`, so a term
+  spec is accepted anywhere a leaf is. New `RecordSpec` completes the four
+  corners beside `DistributionSpec`, `FunctionSpec`, and the conditional spec
+  to come, and `DistributionSpec` / `FunctionSpec` are reparented under
+  `TermSpec`.
+
+  A *declaration* — of an event or an output — is now **stored as a spec**: a
+  bare `EventTemplate` is accepted as construction sugar wherever a record
+  declaration is meant and normalised to `RecordSpec(template)`, so after
+  construction the declared kind is simply the stored spec's class. This makes
+  `sample`'s draw kind and an operation's result kind a structural test rather
+  than an inference from a runtime value.
+
 - **First-class, tracked `Function` values (#368).** `Function` is now an
   immutable `Node` / `Tracked` / `Annotated` object with a construction-time
   Python `signature`, optional authoritative `input_template` and
@@ -158,6 +175,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uniform everywhere.
 
 ### Changed
+
+- **Renamed, for the storage rule (#381):** `FunctionSpec.output_template` is
+  now **`output_spec`**, stored as a `TermSpec | None`, and
+  `DistributionSpec.event_template` is now **`event_spec`**, stored as a
+  `TermSpec`. Both constructors still accept an `EventTemplate` and wrap it, so
+  existing positional and keyword construction from a template keeps working;
+  reads of the old attribute names do not. The names now carry their content:
+  `*_template` is always a record schema, `*_spec` a declaration of any kind —
+  which is why `RecordSpec.event_template` keeps its name.
 
 - **Function calls establish a new result identity and provenance boundary
   (#368, breaking).** Existing operations such as `condition_on` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to come, and `DistributionSpec` / `FunctionSpec` are reparented under
   `TermSpec`.
 
+  An **output declaration** is any value specification, matching the model's
+  `Fun(σ, ρ)` with `ρ` a value specification: a callable may declare a term
+  result of any kind or a raw-value result, the latter typing the value the wrap
+  boundary places in a single-field `Record`. An **event** declaration is
+  narrower, record-valued, because `DistributionSpec.is_valid` checks it.
+
   A *declaration* — of an event or an output — is now **stored as a spec**: a
   bare `EventTemplate` is accepted as construction sugar wherever a record
   declaration is meant and normalised to `RecordSpec(template)`, so after
@@ -40,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   declaration is record-valued for now, since a `Distribution` exposes an
   `EventTemplate` and nothing that reports a term-valued draw kind, so a
   random-measure declaration is refused at construction rather than accepted
-  and always reported invalid.
+  and always reported invalid. `FunctionSpec` declares no check on its output,
+  so nothing there is expressible-but-unsatisfiable.
 
 - **First-class, tracked `Function` values (#368).** `Function` is now an
   immutable `Node` / `Tracked` / `Annotated` object with a construction-time

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -93,7 +93,7 @@ if it were user-guide reference text.
 | Abstraction | Canonical contract location |
 |---|---|
 | `NamedTree` (shared name-keyed tree substrate) | docstrings in `probpipe/core/named_tree.py`; #235 Chapter 1 |
-| `EventTemplate` / `NumericEventTemplate` / `ValueSpec` (`ArraySpec`·`OpaqueSpec`·`DistributionSpec`·`FunctionSpec`) | docstrings in `probpipe/core/event_template.py`; #235 Chapter 1 |
+| `EventTemplate` / `NumericEventTemplate` / `ValueSpec` (raw-value: `ArraySpec`·`OpaqueSpec`; `TermSpec`: `RecordSpec`·`DistributionSpec`·`FunctionSpec`) | docstrings in `probpipe/core/event_template.py`; #235 Chapter 1 |
 | `Record` / `NumericRecord` | docstrings in `probpipe/core/record.py`, `_numeric_record.py`; #235 Chapter 2 |
 | Batch types (`RecordArray`/`NumericRecordArray`/`DistributionArray` → `*Batch`) | docstrings in `_record_array.py`, `_distribution_array.py`; #235 Chapter 2 |
 | `Function` & ops (`sample`, `log_prob`, …) | docstrings in `core/node.py`, `core/ops.py`, `_workflow_result.py`; #235 Chapter 3 |

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -87,6 +87,8 @@ from probpipe.core.event_template import (
     FunctionSpec,
     NumericEventTemplate,
     OpaqueSpec,
+    RecordSpec,
+    TermSpec,
     ValueSpec,
 )
 from probpipe.core.named_tree import NamedTree
@@ -287,6 +289,7 @@ __all__ = [
     "RecordBootstrapReplicateDistribution",
     "RecordDistribution",
     "RecordEmpiricalDistribution",
+    "RecordSpec",
     "SequentialJointDistribution",
     "SimpleGenerativeModel",
     "SimpleModel",
@@ -305,8 +308,9 @@ __all__ = [
     "SupportsUnnormalizedLogProb",
     "SupportsVariance",
     "TFPDistribution",
-    "Tracked",
     # Transformed
+    "TermSpec",
+    "Tracked",
     "TransformedDistribution",
     "TruncatedNormal",
     "Uniform",

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -308,9 +308,9 @@ __all__ = [
     "SupportsUnnormalizedLogProb",
     "SupportsVariance",
     "TFPDistribution",
-    # Transformed
     "TermSpec",
     "Tracked",
+    # Transformed
     "TransformedDistribution",
     "TruncatedNormal",
     "Uniform",

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -383,21 +383,12 @@ def _update_value_spec(
     elif isinstance(spec, OpaqueSpec):
         _update(h, spec.meta, depth + 1, max_array_bytes, state)
     elif isinstance(spec, RecordSpec):
-        _update_event_template(
-            h,
-            spec.event_template,
-            depth + 1,
-            max_array_bytes,
-            state,
-        )
+        _update(h, spec.event_template, depth + 1, max_array_bytes, state)
     elif isinstance(spec, DistributionSpec):
-        _update_value_spec(h, spec.event_spec, depth + 1, max_array_bytes, state)
+        _update(h, spec.event_spec, depth + 1, max_array_bytes, state)
     elif isinstance(spec, FunctionSpec):
         _update(h, spec.input_template, depth + 1, max_array_bytes, state)
-        if spec.output_spec is None:
-            _update(h, None, depth + 1, max_array_bytes, state)
-        else:
-            _update_value_spec(h, spec.output_spec, depth + 1, max_array_bytes, state)
+        _update(h, spec.output_spec, depth + 1, max_array_bytes, state)
     else:
         _update_weak_identity(h, spec, state)
 

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -346,10 +346,7 @@ def _update_event_template(
     for name, spec in template.children.items():
         h.update(name.encode())
         h.update(b"=")
-        if _is_event_template(spec):
-            _update_event_template(h, spec, depth + 1, max_array_bytes, state)
-        else:
-            _update_value_spec(h, spec, depth + 1, max_array_bytes, state)
+        _update(h, spec, depth + 1, max_array_bytes, state)
         h.update(b";")
 
 

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -350,7 +350,13 @@ def _update_value_spec(
     state: _FingerprintState,
 ) -> None:
     """Hash a built-in ValueSpec by the declaration fields that define it."""
-    from .event_template import ArraySpec, DistributionSpec, FunctionSpec, OpaqueSpec
+    from .event_template import (
+        ArraySpec,
+        DistributionSpec,
+        FunctionSpec,
+        OpaqueSpec,
+        RecordSpec,
+    )
 
     spec_type = type(spec)
     h.update(b"spec:")
@@ -368,7 +374,7 @@ def _update_value_spec(
         _update_constraint(h, spec.support, depth + 1, max_array_bytes, state)
     elif isinstance(spec, OpaqueSpec):
         _update(h, spec.meta, depth + 1, max_array_bytes, state)
-    elif isinstance(spec, DistributionSpec):
+    elif isinstance(spec, RecordSpec):
         _update_event_template(
             h,
             spec.event_template,
@@ -376,9 +382,16 @@ def _update_value_spec(
             max_array_bytes,
             state,
         )
+    elif isinstance(spec, DistributionSpec):
+        # The event declaration is itself a spec, so recurse rather than
+        # hashing it as an opaque value.
+        _update_value_spec(h, spec.event_spec, depth + 1, max_array_bytes, state)
     elif isinstance(spec, FunctionSpec):
         _update(h, spec.input_template, depth + 1, max_array_bytes, state)
-        _update(h, spec.output_template, depth + 1, max_array_bytes, state)
+        if spec.output_spec is None:
+            _update(h, None, depth + 1, max_array_bytes, state)
+        else:
+            _update_value_spec(h, spec.output_spec, depth + 1, max_array_bytes, state)
     else:
         _update_weak_identity(h, spec, state)
 

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -167,6 +167,8 @@ def _update(
         _update_function(h, obj, max_array_bytes, state)
     elif _is_event_template(obj):
         _update_event_template(h, obj, depth, max_array_bytes, state)
+    elif _is_value_spec(obj):
+        _update_value_spec(h, obj, depth, max_array_bytes, state)
     elif _is_weights(obj):
         _update_weights(h, obj, depth, max_array_bytes, state)
     elif isinstance(obj, _np.generic):
@@ -318,6 +320,15 @@ def _is_event_template(obj: Any) -> bool:
         return False
 
 
+def _is_value_spec(obj: Any) -> bool:
+    try:
+        from .event_template import ValueSpec
+
+        return isinstance(obj, ValueSpec)
+    except ImportError:
+        return False
+
+
 def _update_event_template(
     h: hashlib._Hash,
     template: Any,
@@ -383,8 +394,6 @@ def _update_value_spec(
             state,
         )
     elif isinstance(spec, DistributionSpec):
-        # The event declaration is itself a spec, so recurse rather than
-        # hashing it as an opaque value.
         _update_value_spec(h, spec.event_spec, depth + 1, max_array_bytes, state)
     elif isinstance(spec, FunctionSpec):
         _update(h, spec.input_template, depth + 1, max_array_bytes, state)

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -306,11 +306,11 @@ class RecordSpec(TermSpec):
 
     ``event_template`` describes the record. ``RecordSpec(tau)`` and the template
     ``tau`` denote the same space but read differently, and that difference is
-    the point: the spec *names the kind* ``Record``, whereas an interior
-    :class:`EventTemplate` node contributes fields that are paths of the
-    enclosing template. So a declaration given as a bare template is stored as
-    ``RecordSpec(template)``, which is what makes a declared kind a stored class
-    rather than an inference.
+    the point. The spec *names the kind* ``Record``; an interior
+    :class:`EventTemplate` node instead contributes fields that are paths of the
+    enclosing template. A declaration given as a bare template is therefore
+    stored as ``RecordSpec(template)``, which is what makes a declared kind a
+    stored class rather than an inference.
 
     Record construction does not yet accept a ``RecordSpec`` leaf: a
     record-valued field materialises as an interior template node, so this spec
@@ -392,11 +392,11 @@ class DistributionSpec(TermSpec):
     declaration is always a spec and the declared draw kind is simply its
     class. A ``RecordSpec`` may also be passed directly.
 
-    The declaration is record-valued: a term-valued draw — a random measure —
-    is rejected here, because a ``Distribution`` exposes an ``EventTemplate``
-    and nothing that reports a term-valued draw kind, so such a declaration
-    could be written but never satisfied. Accepting it belongs with the
-    ``Distribution``-side support that makes it checkable.
+    The declaration is record-valued: a term-valued draw, a random measure say,
+    is rejected here. A ``Distribution`` exposes an ``EventTemplate`` and nothing
+    that reports a term-valued draw kind, so such a declaration could be written
+    but never satisfied. Accepting it belongs with the ``Distribution``-side
+    support that makes it checkable.
 
     Raises
     ------
@@ -455,9 +455,9 @@ class FunctionSpec(TermSpec):
     ``input_template`` is the :class:`EventTemplate` of the callable's input.
     ``output_spec`` is the *output declaration*: what the callable returns. A
     record output is declared by its :class:`EventTemplate`, which construction
-    normalises to ``RecordSpec(template)``; any other spec is stored as given,
-    so a :class:`TermSpec` declares a result that is itself a term of that kind
-    (a ``Function`` returning a ``Distribution``, say) and a raw-value spec
+    normalises to ``RecordSpec(template)``. Any other spec is stored as given, so
+    a :class:`TermSpec` declares a result that is itself a term of that kind — a
+    ``Function`` returning a ``Distribution``, say — and a raw-value spec
     declares a raw result. The stored declaration is therefore always a spec.
     Both sides default to ``None``, leaving that side unspecified, so a bare
     ``FunctionSpec()`` describes any callable. A specified side is written

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -38,10 +38,12 @@ contain lots of useful structure (e.g., shape and dtype for arrays), while
 others may expose no structure at all (e.g., an opaque Python object).
 The concrete specs are as follows:
 - :class:`ArraySpec`: describes a numeric array (shape, optional dtype/support)
-- :class:`DistributionSpec`: describes a ``Distribution``. Carries a sub-template
-  describing the structure of one sample from the distribution.
-- :class:`FunctionSpec`: describes a callable. Optionally carries sub-templates
-  for the structure of the function's inputs and outputs.
+- :class:`RecordSpec`: describes an embedded ``Record``. Carries the event
+  template of that record.
+- :class:`DistributionSpec`: describes a ``Distribution``. Carries the *event
+  declaration* of one draw from it, stored as a spec.
+- :class:`FunctionSpec`: describes a callable. Optionally carries the input
+  template and the *output declaration*, the latter stored as a spec.
 - :class:`OpaqueSpec`: fallback for any other object (no structure exposed).
 
 Numeric vs. Mixed
@@ -347,10 +349,17 @@ class RecordSpec(TermSpec):
 # whose class is the declared kind. An :class:`EventTemplate` is accepted as
 # construction-time sugar for the record case, mirroring the ``_FieldSpecInput``
 # sugar below, and is normalised by :func:`_to_declaration`.
-type _DeclInput = EventTemplate | TermSpec
+#
+# The output side of a callable admits any kind, since a ``FunctionSpec``
+# claims no check on it. An *event* declaration is record-only for now: a
+# ``Distribution`` exposes an ``EventTemplate`` and nothing that reports a
+# term-valued draw kind, so a term declaration would be expressible but never
+# satisfiable. Widening it belongs with the ``Distribution``-side support.
+type _OutputDecl = EventTemplate | TermSpec
+type _EventDecl = EventTemplate | RecordSpec
 
 
-def _to_declaration(decl: _DeclInput) -> TermSpec:
+def _to_declaration(decl: _OutputDecl) -> TermSpec:
     """Normalise a declaration input to the stored :class:`TermSpec`.
 
     A bare :class:`EventTemplate` means a record declaration and becomes
@@ -368,24 +377,30 @@ class DistributionSpec(TermSpec):
     """A term spec for a ``Distribution``.
 
     ``event_spec`` is the *event declaration*: what one draw from the
-    distribution is. A record draw is declared by its :class:`EventTemplate`,
-    which construction normalises to ``RecordSpec(template)``, so the stored
-    declaration is always a :class:`TermSpec` and the declared draw kind is
-    simply its class.
+    distribution is. It is declared by the draw's :class:`EventTemplate`, which
+    construction normalises to ``RecordSpec(template)``, so the stored
+    declaration is always a spec and the declared draw kind is simply its
+    class. A ``RecordSpec`` may also be passed directly.
+
+    The declaration is record-valued: a term-valued draw — a random measure —
+    is rejected here, because a ``Distribution`` exposes an ``EventTemplate``
+    and nothing that reports a term-valued draw kind, so such a declaration
+    could be written but never satisfied. Accepting it belongs with the
+    ``Distribution``-side support that makes it checkable.
 
     Raises
     ------
     TypeError
         If ``event_spec`` is neither an :class:`EventTemplate` nor a
-        :class:`TermSpec`.
+        :class:`RecordSpec`.
     """
 
-    event_spec: _DeclInput
+    event_spec: _EventDecl
 
     def __post_init__(self) -> None:
-        if not isinstance(self.event_spec, (EventTemplate, TermSpec)):
+        if not isinstance(self.event_spec, (EventTemplate, RecordSpec)):
             raise TypeError(
-                f"DistributionSpec.event_spec must be an EventTemplate or a TermSpec, "
+                f"DistributionSpec.event_spec must be an EventTemplate or a RecordSpec, "
                 f"got {type(self.event_spec).__name__}"
             )
         object.__setattr__(self, "event_spec", _to_declaration(self.event_spec))
@@ -402,19 +417,10 @@ class DistributionSpec(TermSpec):
         any *other* error raised while reading ``event_template`` signals a
         malfunctioning distribution and is left to propagate rather than being
         masked as invalid.
-
-        A declaration whose draws are themselves terms — a random measure, say
-        — is not certifiable here for the same reason: a ``Distribution``
-        exposes an ``EventTemplate`` and nothing that reports a term-valued
-        draw kind, so such a declaration returns ``False`` rather than a guess.
         """
         from ._distribution_base import Distribution
 
         if not isinstance(value, Distribution):
-            return False
-        if not isinstance(self.event_spec, RecordSpec):
-            # A term-valued draw declaration: nothing on ``Distribution``
-            # reports the draw kind yet, so the value cannot be certified.
             return False
         try:
             template = value.event_template
@@ -461,7 +467,7 @@ class FunctionSpec(TermSpec):
     """
 
     input_template: EventTemplate | None = None
-    output_spec: _DeclInput | None = None
+    output_spec: _OutputDecl | None = None
 
     def __post_init__(self) -> None:
         if self.input_template is not None and not isinstance(self.input_template, EventTemplate):

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -67,7 +67,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Hashable, Iterable, Mapping
 from dataclasses import dataclass
 from math import prod
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -163,7 +163,7 @@ class TermSpec(ValueSpec):
     """
 
 
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, init=False)
 class ArraySpec(ValueSpec):
     """A numeric-array value spec: an event ``shape`` plus optional metadata.
 
@@ -179,26 +179,33 @@ class ArraySpec(ValueSpec):
     """
 
     shape: tuple[int | str, ...]
-    # ``DTypeLike`` types the constructor *input* (a dtype instance, scalar
-    # type, or string); ``__post_init__`` normalises it, so the stored value
-    # is always ``np.dtype | None``.
-    dtype: npt.DTypeLike | None = None
-    support: Constraint | None = None
+    dtype: np.dtype | None
+    support: Constraint | None
 
-    def __post_init__(self) -> None:
-        shape = tuple(self.shape)
+    def __init__(
+        self,
+        shape: Iterable[int | str],
+        dtype: npt.DTypeLike | None = None,
+        support: Constraint | None = None,
+    ) -> None:
+        """Store the shape and metadata, normalising *shape* and *dtype*.
+
+        The fields are the *stored* types; the wider parameters here are the
+        accepted spellings, normalised away before assignment.
+        """
+        dimensions = tuple(shape)
         if not all(
-            (isinstance(d, int) and d >= 0) or (isinstance(d, str) and bool(d)) for d in shape
+            (isinstance(d, int) and d >= 0) or (isinstance(d, str) and bool(d)) for d in dimensions
         ):
             raise TypeError(
                 "ArraySpec.shape must contain only non-negative ints or non-empty "
-                f"symbolic dimension names, got {self.shape!r}"
+                f"symbolic dimension names, got {shape!r}"
             )
-        object.__setattr__(self, "shape", shape)
-        if self.dtype is not None:
-            object.__setattr__(self, "dtype", np.dtype(self.dtype))
-        if self.support is not None:
-            _require_hashable(self.support, context="ArraySpec.support")
+        if support is not None:
+            _require_hashable(support, context="ArraySpec.support")
+        object.__setattr__(self, "shape", dimensions)
+        object.__setattr__(self, "dtype", None if dtype is None else np.dtype(dtype))
+        object.__setattr__(self, "support", support)
 
     def __eq__(self, other: object) -> bool:
         # Mirror the dataclass-generated ``__eq__``: on a class mismatch,
@@ -353,10 +360,12 @@ class RecordSpec(TermSpec):
         return template == self.event_template
 
 
-# A *declaration* — of an event or of an output — is stored as a ``TermSpec``,
-# whose class is the declared kind. An :class:`EventTemplate` is accepted as
-# construction-time sugar for the record case, mirroring the ``_FieldSpecInput``
-# sugar below, and is normalised by :func:`_to_declaration`.
+# A *declaration* — of an event or of an output — is stored as a ``ValueSpec``.
+# An :class:`EventTemplate` is accepted as construction-time sugar for the record
+# case, mirroring the ``_FieldSpecInput`` sugar below, and is normalised to
+# ``RecordSpec(template)``. Of the stored specs only a ``TermSpec`` names a
+# ProbPipe kind, and it names it by its class; a raw-value spec declares a raw
+# value instead.
 #
 # An output declaration is any value specification, matching ``Fun(sigma, rho)``
 # with ``rho`` a value specification: a callable may return a term of any kind
@@ -382,7 +391,18 @@ def _to_declaration(decl: _OutputDecl) -> ValueSpec:
     return decl
 
 
-@dataclass(frozen=True)
+def _to_record_declaration(decl: _EventDecl) -> RecordSpec:
+    """:func:`_to_declaration` for a record-valued declaration.
+
+    Narrower in and narrower out: the record case is where the stored spec's
+    class is known statically, so a caller storing one needs no cast.
+    """
+    if isinstance(decl, EventTemplate):
+        return RecordSpec(decl)
+    return decl
+
+
+@dataclass(frozen=True, init=False)
 class DistributionSpec(TermSpec):
     """A term spec for a ``Distribution``.
 
@@ -405,17 +425,20 @@ class DistributionSpec(TermSpec):
         :class:`RecordSpec`.
     """
 
-    # ``_EventDecl`` types the constructor *input* (a template or a RecordSpec);
-    # ``__post_init__`` normalises it, so the stored value is always a RecordSpec.
-    event_spec: _EventDecl
+    event_spec: RecordSpec
 
-    def __post_init__(self) -> None:
-        if not isinstance(self.event_spec, (EventTemplate, RecordSpec)):
+    def __init__(self, event_spec: _EventDecl) -> None:
+        """Store *event_spec*, wrapping a bare :class:`EventTemplate`.
+
+        The field is the *stored* declaration; the wider ``_EventDecl`` here is
+        the construction sugar, and is normalised away before assignment.
+        """
+        if not isinstance(event_spec, (EventTemplate, RecordSpec)):
             raise TypeError(
                 f"DistributionSpec.event_spec must be an EventTemplate or a RecordSpec, "
-                f"got {type(self.event_spec).__name__}"
+                f"got {type(event_spec).__name__}"
             )
-        object.__setattr__(self, "event_spec", _to_declaration(self.event_spec))
+        object.__setattr__(self, "event_spec", _to_record_declaration(event_spec))
 
     def is_valid(self, value: Any) -> bool:
         """Whether *value* is a ``Distribution`` matching this event declaration.
@@ -445,10 +468,10 @@ class DistributionSpec(TermSpec):
             # error is a bug to surface, not a silent "invalid".
             return False
         # Normalised at construction, so the declaration is always a RecordSpec.
-        return template == cast(RecordSpec, self.event_spec).event_template
+        return template == self.event_spec.event_template
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class FunctionSpec(TermSpec):
     """A term spec for a callable, optionally typed by its input/output structure.
 
@@ -485,26 +508,33 @@ class FunctionSpec(TermSpec):
         :class:`ValueSpec`.
     """
 
-    input_template: EventTemplate | None = None
-    # ``_OutputDecl`` types the constructor *input*; ``__post_init__`` normalises a
-    # bare template, so the stored value is always a ValueSpec (or None).
-    output_spec: _OutputDecl | None = None
+    input_template: EventTemplate | None
+    output_spec: ValueSpec | None
 
-    def __post_init__(self) -> None:
-        if self.input_template is not None and not isinstance(self.input_template, EventTemplate):
+    def __init__(
+        self,
+        input_template: EventTemplate | None = None,
+        output_spec: _OutputDecl | None = None,
+    ) -> None:
+        """Store both sides, wrapping a bare :class:`EventTemplate` output.
+
+        The fields are the *stored* declarations; the wider ``_OutputDecl`` here
+        is the construction sugar, and is normalised away before assignment.
+        """
+        if input_template is not None and not isinstance(input_template, EventTemplate):
             raise TypeError(
                 f"FunctionSpec.input_template must be None or an EventTemplate, "
-                f"got {type(self.input_template).__name__}"
+                f"got {type(input_template).__name__}"
             )
-        if self.output_spec is not None and not isinstance(
-            self.output_spec, (EventTemplate, ValueSpec)
-        ):
+        if output_spec is not None and not isinstance(output_spec, (EventTemplate, ValueSpec)):
             raise TypeError(
                 f"FunctionSpec.output_spec must be None, an EventTemplate, "
-                f"or a ValueSpec, got {type(self.output_spec).__name__}"
+                f"or a ValueSpec, got {type(output_spec).__name__}"
             )
-        if self.output_spec is not None:
-            object.__setattr__(self, "output_spec", _to_declaration(self.output_spec))
+        object.__setattr__(self, "input_template", input_template)
+        object.__setattr__(
+            self, "output_spec", None if output_spec is None else _to_declaration(output_spec)
+        )
 
     def is_valid(self, value: Any) -> bool:
         """Whether *value* is a callable.

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -36,7 +36,10 @@ one. Every spec answers :meth:`ValueSpec.is_valid`, which checks whether a
 concrete value matches the spec. The specs for certain value types may
 contain lots of useful structure (e.g., shape and dtype for arrays), while
 others may expose no structure at all (e.g., an opaque Python object).
-The concrete specs are as follows:
+Specs come in two families. A **raw-value spec** describes a plain value that
+names no ProbPipe kind. A **term spec** describes a tracked term, one class per
+kind, and all of them subclass the :class:`TermSpec` marker; a declaration whose
+class is a term spec therefore names a kind. The concrete specs are as follows:
 - :class:`ArraySpec`: describes a numeric array (shape, optional dtype/support)
 - :class:`RecordSpec`: describes an embedded ``Record``. Carries the event
   template of that record.
@@ -64,7 +67,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Hashable, Iterable, Mapping
 from dataclasses import dataclass
 from math import prod
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -104,7 +107,7 @@ class ValueSpec(ABC):
 
     A ``ValueSpec`` describes what a single value looks like; the concrete
     specs (see the module docstring for the catalog) cover numeric arrays,
-    distributions, callables, and opaque Python objects. These are the
+    records, distributions, callables, and opaque Python objects. These are the
     leaves of an :class:`EventTemplate`.
 
     A spec carries no name: it becomes a *field* only when an
@@ -141,20 +144,22 @@ class TermSpec(ValueSpec):
     """A :class:`ValueSpec` marking a leaf whose value is a tracked term.
 
     A term spec is the subset of leaf specs whose value is itself a tracked
-    term — a ``Record``, ``Distribution``, ``ConditionalDistribution``, or
-    ``Function``. It subclasses :class:`ValueSpec` and adds no members of its
-    own: the concrete subclass (:class:`RecordSpec`, :class:`DistributionSpec`,
-    ``ConditionalDistributionSpec``, :class:`FunctionSpec`) *is* the kind, and
-    ``is_valid`` is inherited, not redeclared. ``ArraySpec`` and ``OpaqueSpec``,
-    the raw-value leaves, are not term specs. The marker is what
-    ``isinstance`` checks — a `Function`'s ``output_spec`` accepts a
-    ``TermSpec`` for a term-valued result, and the wrap boundary reads it to
-    coproject a raw result into the term it names.
+    term — a ``Record``, ``Distribution``, or ``Function``. It subclasses
+    :class:`ValueSpec` and adds no members of its own: the concrete subclass
+    (:class:`RecordSpec`, :class:`DistributionSpec`, :class:`FunctionSpec`)
+    *is* the kind, and ``is_valid`` is inherited, not redeclared. ``ArraySpec``
+    and ``OpaqueSpec``, the raw-value leaves, are not term specs.
 
-    Position fixes how a term spec is read. As a **leaf** of an
-    :class:`EventTemplate` it types a field holding such a term. Heading an
-    operation's output declaration it states that the result *is* a term of
-    that kind, rather than a raw value wrapped into a ``Record``.
+    The marker is what ``isinstance`` reads: a declaration whose class is a term
+    spec names a kind, which is how a :class:`FunctionSpec`'s ``output_spec``
+    declares that a callable returns a term rather than a raw value. (An
+    ``output_spec`` admits any :class:`ValueSpec`, so a raw-value declaration is
+    equally well formed; only a term spec names a kind.)
+
+    A term spec also types a field holding such a term, as a **leaf** of an
+    :class:`EventTemplate`. That leaf role is live for a ``Distribution`` or a
+    ``Function`` value; a record-valued field is currently an interior template
+    node instead, so :class:`RecordSpec` serves only as a declaration.
     """
 
 
@@ -297,17 +302,20 @@ class OpaqueSpec(ValueSpec):
 
 @dataclass(frozen=True)
 class RecordSpec(TermSpec):
-    """A term spec for an embedded ``Record``; mirrors :class:`DistributionSpec`
-    at the ``Rec`` corner.
+    """A term spec for a ``Record``, and the stored form of a record declaration.
 
-    ``event_template`` describes the record. ``RecordSpec(tau)`` and the
-    template ``tau`` denote the same space but read differently: the spec is a
-    leaf holding a tracked ``Record`` that keeps its own name and provenance,
-    whereas an interior :class:`EventTemplate` node contributes fields that are
-    paths of the enclosing template. Raw mappings are never leaves, so a
-    ``RecordSpec`` leaf is reached only for an already-tracked record or an
-    explicit declaration; at top level it declares a result that *is* a
-    ``Record``.
+    ``event_template`` describes the record. ``RecordSpec(tau)`` and the template
+    ``tau`` denote the same space but read differently, and that difference is
+    the point: the spec *names the kind* ``Record``, whereas an interior
+    :class:`EventTemplate` node contributes fields that are paths of the
+    enclosing template. So a declaration given as a bare template is stored as
+    ``RecordSpec(template)``, which is what makes a declared kind a stored class
+    rather than an inference.
+
+    Record construction does not yet accept a ``RecordSpec`` leaf: a
+    record-valued field materialises as an interior template node, so this spec
+    is reached as a declaration and not as a template leaf. ``is_valid`` is
+    written for the leaf role that a kind-directed wrap boundary will use.
 
     Raises
     ------
@@ -397,6 +405,8 @@ class DistributionSpec(TermSpec):
         :class:`RecordSpec`.
     """
 
+    # ``_EventDecl`` types the constructor *input* (a template or a RecordSpec);
+    # ``__post_init__`` normalises it, so the stored value is always a RecordSpec.
     event_spec: _EventDecl
 
     def __post_init__(self) -> None:
@@ -434,7 +444,8 @@ class DistributionSpec(TermSpec):
             # narrower catch than ``Exception`` on purpose: an unexpected
             # error is a bug to surface, not a silent "invalid".
             return False
-        return template == self.event_spec.event_template
+        # Normalised at construction, so the declaration is always a RecordSpec.
+        return template == cast(RecordSpec, self.event_spec).event_template
 
 
 @dataclass(frozen=True)
@@ -447,8 +458,9 @@ class FunctionSpec(TermSpec):
     normalises to ``RecordSpec(template)``; any other spec is stored as given,
     so a :class:`TermSpec` declares a result that is itself a term of that kind
     (a ``Function`` returning a ``Distribution``, say) and a raw-value spec
-    declares a raw result. The stored declaration is therefore always a spec. Both sides default to ``None``, leaving that side unspecified, so a
-    bare ``FunctionSpec()`` describes any callable. A specified side is written
+    declares a raw result. The stored declaration is therefore always a spec.
+    Both sides default to ``None``, leaving that side unspecified, so a bare
+    ``FunctionSpec()`` describes any callable. A specified side is written
     out — e.g. ``FunctionSpec(EventTemplate(x=()), EventTemplate(out=()))`` for
     ``f(x) -> out`` — so a function's field names are caller-chosen and
     meaningful, matching :class:`DistributionSpec`.
@@ -461,9 +473,9 @@ class FunctionSpec(TermSpec):
 
     Validity is callability alone: the value-layer specs stay callable-generic,
     so a ``FunctionSpec`` admits any callable (a lambda, a NumPy function, a
-    ``Function``) as a leaf value. It is the spec's identity as a
-    ``FunctionSpec``, not ``is_valid``, that tells the wrap boundary to
-    coproject a raw callable *result* into a ``Function`` term.
+    ``Function``) as a leaf value. Nothing about the output declaration is
+    checked here; it is read by the kind-directed wrap boundary, which will
+    place a raw callable result in a ``Function``.
 
     Raises
     ------
@@ -474,6 +486,8 @@ class FunctionSpec(TermSpec):
     """
 
     input_template: EventTemplate | None = None
+    # ``_OutputDecl`` types the constructor *input*; ``__post_init__`` normalises a
+    # bare template, so the stored value is always a ValueSpec (or None).
     output_spec: _OutputDecl | None = None
 
     def __post_init__(self) -> None:
@@ -804,7 +818,7 @@ class EventTemplate(NamedTree[ValueSpec]):
                 if not spec.is_numeric:
                     return False
                 continue
-            # Opaque / distribution / function leaf — not numeric.
+            # Opaque / record / distribution / function leaf — not numeric.
             return False
         return True
 
@@ -866,7 +880,7 @@ class EventTemplate(NamedTree[ValueSpec]):
                     # future change adds another ValueError path, narrow this
                     # catch so it can't mask an unrelated failure.
                     continue
-            # Opaque / distribution / function leaves are dropped.
+            # Opaque / record / distribution / function leaves are dropped.
         if not specs:
             dropped = tuple(
                 name
@@ -921,9 +935,10 @@ class EventTemplate(NamedTree[ValueSpec]):
         yet (e.g. at a workflow boundary); for a value you already hold, read
         its authoritative ``event_template`` directly. Inference is lossy — it
         cannot recover an :class:`ArraySpec`'s ``dtype`` / ``support``, an
-        :class:`OpaqueSpec`'s ``meta``, or a :class:`DistributionSpec` /
-        :class:`FunctionSpec`. A Python ``list`` / ``tuple`` leaf (no ``.shape``
-        / ``.dtype``) is treated as opaque even if it holds numbers; wrap it in
+        :class:`OpaqueSpec`'s ``meta``, or a :class:`RecordSpec` /
+        :class:`DistributionSpec` / :class:`FunctionSpec`. A Python ``list`` /
+        ``tuple`` leaf (no ``.shape`` / ``.dtype``) is treated as opaque even if
+        it holds numbers; wrap it in
         ``np.asarray`` / ``jnp.asarray`` first for a numeric leaf.
 
         Parameters
@@ -1024,7 +1039,7 @@ class NumericEventTemplate(EventTemplate):
                     f"{type(spec).__name__}; nested sub-templates must "
                     f"themselves be NumericEventTemplate."
                 )
-            # Any non-array leaf — OpaqueSpec, DistributionSpec, or FunctionSpec.
+            # Any non-array leaf — OpaqueSpec, RecordSpec, DistributionSpec, or FunctionSpec.
             raise TypeError(
                 f"NumericEventTemplate: field {name!r} is a {type(spec).__name__}; "
                 f"only ArraySpec leaves (or a nested NumericEventTemplate) are "

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -452,6 +452,12 @@ class FunctionSpec(TermSpec):
     ``f(x) -> out`` — so a function's field names are caller-chosen and
     meaningful, matching :class:`DistributionSpec`.
 
+    The output declaration is a kind, so it is a :class:`TermSpec` and not any
+    :class:`ValueSpec`. A raw-value result is declared as the single-field
+    template it wraps into, whose field name comes from the ``Function`` and so
+    cannot be supplied here; admitting a bare ``ArraySpec`` would store a
+    declaration that names no kind and has to be completed elsewhere.
+
     Validity is callability alone: the value-layer specs stay callable-generic,
     so a ``FunctionSpec`` admits any callable (a lambda, a NumPy function, a
     ``Function``) as a leaf value. It is the spec's identity as a

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -350,22 +350,24 @@ class RecordSpec(TermSpec):
 # construction-time sugar for the record case, mirroring the ``_FieldSpecInput``
 # sugar below, and is normalised by :func:`_to_declaration`.
 #
-# The output side of a callable admits any kind, since a ``FunctionSpec``
-# claims no check on it. An *event* declaration is record-only for now: a
+# An output declaration is any value specification, matching ``Fun(sigma, rho)``
+# with ``rho`` a value specification: a callable may return a term of any kind
+# or a raw value. A ``FunctionSpec`` claims no check on its output, so nothing
+# is declared that cannot be satisfied. An *event* declaration is narrower,
+# record-only for now, because ``DistributionSpec.is_valid`` does check: a
 # ``Distribution`` exposes an ``EventTemplate`` and nothing that reports a
 # term-valued draw kind, so a term declaration would be expressible but never
 # satisfiable. Widening it belongs with the ``Distribution``-side support.
-type _OutputDecl = EventTemplate | TermSpec
+type _OutputDecl = EventTemplate | ValueSpec
 type _EventDecl = EventTemplate | RecordSpec
 
 
-def _to_declaration(decl: _OutputDecl) -> TermSpec:
-    """Normalise a declaration input to the stored :class:`TermSpec`.
+def _to_declaration(decl: _OutputDecl) -> ValueSpec:
+    """Normalise a declaration input to the stored spec.
 
     A bare :class:`EventTemplate` means a record declaration and becomes
-    ``RecordSpec(template)``; an existing :class:`TermSpec` passes through. The
-    two forms denote the same space, so after construction only the spec
-    remains and the declared kind is its class.
+    ``RecordSpec(template)``; an existing spec passes through. The two forms
+    denote the same space, so after construction only a spec remains.
     """
     if isinstance(decl, EventTemplate):
         return RecordSpec(decl)
@@ -442,21 +444,20 @@ class FunctionSpec(TermSpec):
     ``input_template`` is the :class:`EventTemplate` of the callable's input.
     ``output_spec`` is the *output declaration*: what the callable returns. A
     record output is declared by its :class:`EventTemplate`, which construction
-    normalises to ``RecordSpec(template)``, and any other :class:`TermSpec`
-    declares a result that is itself a term of that kind (a ``Function``
-    returning a ``Distribution``, say). The stored declaration is therefore
-    always a :class:`TermSpec`, and the declared result kind is simply its
-    class. Both sides default to ``None``, leaving that side unspecified, so a
+    normalises to ``RecordSpec(template)``; any other spec is stored as given,
+    so a :class:`TermSpec` declares a result that is itself a term of that kind
+    (a ``Function`` returning a ``Distribution``, say) and a raw-value spec
+    declares a raw result. The stored declaration is therefore always a spec. Both sides default to ``None``, leaving that side unspecified, so a
     bare ``FunctionSpec()`` describes any callable. A specified side is written
     out — e.g. ``FunctionSpec(EventTemplate(x=()), EventTemplate(out=()))`` for
     ``f(x) -> out`` — so a function's field names are caller-chosen and
     meaningful, matching :class:`DistributionSpec`.
 
-    The output declaration is a kind, so it is a :class:`TermSpec` and not any
-    :class:`ValueSpec`. A raw-value result is declared as the single-field
-    template it wraps into, whose field name comes from the ``Function`` and so
-    cannot be supplied here; admitting a bare ``ArraySpec`` would store a
-    declaration that names no kind and has to be completed elsewhere.
+    The output declaration is any value specification, so a callable may
+    declare a raw-value result as well as a term: an ``ArraySpec`` output
+    declares one array. A term declaration names its kind by its class, while a
+    raw-value declaration types the value the wrap boundary then places in a
+    single-field ``Record``, keyed by the ``Function``'s name.
 
     Validity is callability alone: the value-layer specs stay callable-generic,
     so a ``FunctionSpec`` admits any callable (a lambda, a NumPy function, a
@@ -469,7 +470,7 @@ class FunctionSpec(TermSpec):
     TypeError
         If ``input_template`` is neither ``None`` nor an :class:`EventTemplate`,
         or ``output_spec`` is neither ``None``, an :class:`EventTemplate`, nor a
-        :class:`TermSpec`.
+        :class:`ValueSpec`.
     """
 
     input_template: EventTemplate | None = None
@@ -482,11 +483,11 @@ class FunctionSpec(TermSpec):
                 f"got {type(self.input_template).__name__}"
             )
         if self.output_spec is not None and not isinstance(
-            self.output_spec, (EventTemplate, TermSpec)
+            self.output_spec, (EventTemplate, ValueSpec)
         ):
             raise TypeError(
                 f"FunctionSpec.output_spec must be None, an EventTemplate, "
-                f"or a TermSpec, got {type(self.output_spec).__name__}"
+                f"or a ValueSpec, got {type(self.output_spec).__name__}"
             )
         if self.output_spec is not None:
             object.__setattr__(self, "output_spec", _to_declaration(self.output_spec))

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -145,7 +145,7 @@ class TermSpec(ValueSpec):
     ``ConditionalDistributionSpec``, :class:`FunctionSpec`) *is* the kind, and
     ``is_valid`` is inherited, not redeclared. ``ArraySpec`` and ``OpaqueSpec``,
     the raw-value leaves, are not term specs. The marker is what
-    ``isinstance`` checks — a `Function`'s ``output_template`` accepts a
+    ``isinstance`` checks — a `Function`'s ``output_spec`` accepts a
     ``TermSpec`` for a term-valued result, and the wrap boundary reads it to
     coproject a raw result into the term it names.
 
@@ -343,44 +343,78 @@ class RecordSpec(TermSpec):
         return template == self.event_template
 
 
+# A *declaration* — of an event or of an output — is stored as a ``TermSpec``,
+# whose class is the declared kind. An :class:`EventTemplate` is accepted as
+# construction-time sugar for the record case, mirroring the ``_FieldSpecInput``
+# sugar below, and is normalised by :func:`_to_declaration`.
+type _DeclInput = EventTemplate | TermSpec
+
+
+def _to_declaration(decl: _DeclInput) -> TermSpec:
+    """Normalise a declaration input to the stored :class:`TermSpec`.
+
+    A bare :class:`EventTemplate` means a record declaration and becomes
+    ``RecordSpec(template)``; an existing :class:`TermSpec` passes through. The
+    two forms denote the same space, so after construction only the spec
+    remains and the declared kind is its class.
+    """
+    if isinstance(decl, EventTemplate):
+        return RecordSpec(decl)
+    return decl
+
+
 @dataclass(frozen=True)
 class DistributionSpec(TermSpec):
     """A term spec for a ``Distribution``.
 
-    ``event_template`` is the :class:`EventTemplate` of one draw from that
-    distribution.
+    ``event_spec`` is the *event declaration*: what one draw from the
+    distribution is. A record draw is declared by its :class:`EventTemplate`,
+    which construction normalises to ``RecordSpec(template)``, so the stored
+    declaration is always a :class:`TermSpec` and the declared draw kind is
+    simply its class.
 
     Raises
     ------
     TypeError
-        If ``event_template`` is not an :class:`EventTemplate`.
+        If ``event_spec`` is neither an :class:`EventTemplate` nor a
+        :class:`TermSpec`.
     """
 
-    event_template: EventTemplate
+    event_spec: _DeclInput
 
     def __post_init__(self) -> None:
-        if not isinstance(self.event_template, EventTemplate):
+        if not isinstance(self.event_spec, (EventTemplate, TermSpec)):
             raise TypeError(
-                f"DistributionSpec.event_template must be an EventTemplate, "
-                f"got {type(self.event_template).__name__}"
+                f"DistributionSpec.event_spec must be an EventTemplate or a TermSpec, "
+                f"got {type(self.event_spec).__name__}"
             )
+        object.__setattr__(self, "event_spec", _to_declaration(self.event_spec))
 
     def is_valid(self, value: Any) -> bool:
-        """Whether *value* is a ``Distribution`` whose draws match ``event_template``.
+        """Whether *value* is a ``Distribution`` matching this event declaration.
 
         *value* must be a :class:`~probpipe.Distribution` whose own
-        ``event_template`` equals this spec's. A distribution that is not one,
-        or that legitimately exposes no template — no ``event_template``
-        attribute, or a template that cannot yet be derived — does not satisfy
-        the spec and returns ``False``. These are the only two "schema
-        unavailable" conditions treated as a non-match; any *other* error
-        raised while reading ``event_template`` signals a malfunctioning
-        distribution and is left to propagate rather than being masked as
-        invalid.
+        ``event_template`` equals the declared record template. A distribution
+        that is not one, or that legitimately exposes no template — no
+        ``event_template`` attribute, or a template that cannot yet be
+        derived — does not satisfy the spec and returns ``False``. These are
+        the only two "schema unavailable" conditions treated as a non-match;
+        any *other* error raised while reading ``event_template`` signals a
+        malfunctioning distribution and is left to propagate rather than being
+        masked as invalid.
+
+        A declaration whose draws are themselves terms — a random measure, say
+        — is not certifiable here for the same reason: a ``Distribution``
+        exposes an ``EventTemplate`` and nothing that reports a term-valued
+        draw kind, so such a declaration returns ``False`` rather than a guess.
         """
         from ._distribution_base import Distribution
 
         if not isinstance(value, Distribution):
+            return False
+        if not isinstance(self.event_spec, RecordSpec):
+            # A term-valued draw declaration: nothing on ``Distribution``
+            # reports the draw kind yet, so the value cannot be certified.
             return False
         try:
             template = value.event_template
@@ -392,7 +426,7 @@ class DistributionSpec(TermSpec):
             # narrower catch than ``Exception`` on purpose: an unexpected
             # error is a bug to surface, not a silent "invalid".
             return False
-        return template == self.event_template
+        return template == self.event_spec.event_template
 
 
 @dataclass(frozen=True)
@@ -400,12 +434,15 @@ class FunctionSpec(TermSpec):
     """A term spec for a callable, optionally typed by its input/output structure.
 
     ``input_template`` is the :class:`EventTemplate` of the callable's input.
-    ``output_template`` is its output: an :class:`EventTemplate` (a record
-    output) or any :class:`TermSpec` (a result that is itself a term, e.g. a
-    ``Function`` returning a ``Distribution``). Both default to ``None``,
-    leaving that side unspecified, so a bare ``FunctionSpec()`` describes any
-    callable. A specified side is written out — e.g.
-    ``FunctionSpec(EventTemplate(x=()), EventTemplate(out=()))`` for
+    ``output_spec`` is the *output declaration*: what the callable returns. A
+    record output is declared by its :class:`EventTemplate`, which construction
+    normalises to ``RecordSpec(template)``, and any other :class:`TermSpec`
+    declares a result that is itself a term of that kind (a ``Function``
+    returning a ``Distribution``, say). The stored declaration is therefore
+    always a :class:`TermSpec`, and the declared result kind is simply its
+    class. Both sides default to ``None``, leaving that side unspecified, so a
+    bare ``FunctionSpec()`` describes any callable. A specified side is written
+    out — e.g. ``FunctionSpec(EventTemplate(x=()), EventTemplate(out=()))`` for
     ``f(x) -> out`` — so a function's field names are caller-chosen and
     meaningful, matching :class:`DistributionSpec`.
 
@@ -419,12 +456,12 @@ class FunctionSpec(TermSpec):
     ------
     TypeError
         If ``input_template`` is neither ``None`` nor an :class:`EventTemplate`,
-        or ``output_template`` is neither ``None``, an :class:`EventTemplate`,
-        nor a :class:`TermSpec`.
+        or ``output_spec`` is neither ``None``, an :class:`EventTemplate`, nor a
+        :class:`TermSpec`.
     """
 
     input_template: EventTemplate | None = None
-    output_template: EventTemplate | TermSpec | None = None
+    output_spec: _DeclInput | None = None
 
     def __post_init__(self) -> None:
         if self.input_template is not None and not isinstance(self.input_template, EventTemplate):
@@ -432,19 +469,21 @@ class FunctionSpec(TermSpec):
                 f"FunctionSpec.input_template must be None or an EventTemplate, "
                 f"got {type(self.input_template).__name__}"
             )
-        if self.output_template is not None and not isinstance(
-            self.output_template, (EventTemplate, TermSpec)
+        if self.output_spec is not None and not isinstance(
+            self.output_spec, (EventTemplate, TermSpec)
         ):
             raise TypeError(
-                f"FunctionSpec.output_template must be None, an EventTemplate, "
-                f"or a TermSpec, got {type(self.output_template).__name__}"
+                f"FunctionSpec.output_spec must be None, an EventTemplate, "
+                f"or a TermSpec, got {type(self.output_spec).__name__}"
             )
+        if self.output_spec is not None:
+            object.__setattr__(self, "output_spec", _to_declaration(self.output_spec))
 
     def is_valid(self, value: Any) -> bool:
         """Whether *value* is a callable.
 
         The input/output structure of a bare callable cannot be inspected, so
-        validity is callability alone; ``input_template`` / ``output_template``
+        validity is callability alone; ``input_template`` / ``output_spec``
         document the intended signature but are not checked against the value.
         """
         return callable(value)

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -83,6 +83,8 @@ __all__ = [
     "FunctionSpec",
     "NumericEventTemplate",
     "OpaqueSpec",
+    "RecordSpec",
+    "TermSpec",
     "ValueSpec",
 ]
 
@@ -131,6 +133,27 @@ class ValueSpec(ABC):
             documents its own); it does not suppress an unexpected error from
             inspecting a malformed value, so a genuine bug still surfaces.
         """
+
+
+class TermSpec(ValueSpec):
+    """A :class:`ValueSpec` marking a leaf whose value is a tracked term.
+
+    A term spec is the subset of leaf specs whose value is itself a tracked
+    term — a ``Record``, ``Distribution``, ``ConditionalDistribution``, or
+    ``Function``. It subclasses :class:`ValueSpec` and adds no members of its
+    own: the concrete subclass (:class:`RecordSpec`, :class:`DistributionSpec`,
+    ``ConditionalDistributionSpec``, :class:`FunctionSpec`) *is* the kind, and
+    ``is_valid`` is inherited, not redeclared. ``ArraySpec`` and ``OpaqueSpec``,
+    the raw-value leaves, are not term specs. The marker is what
+    ``isinstance`` checks — a `Function`'s ``output_template`` accepts a
+    ``TermSpec`` for a term-valued result, and the wrap boundary reads it to
+    coproject a raw result into the term it names.
+
+    Position fixes how a term spec is read. As a **leaf** of an
+    :class:`EventTemplate` it types a field holding such a term. Heading an
+    operation's output declaration it states that the result *is* a term of
+    that kind, rather than a raw value wrapped into a ``Record``.
+    """
 
 
 @dataclass(frozen=True, eq=False)
@@ -271,8 +294,58 @@ class OpaqueSpec(ValueSpec):
 
 
 @dataclass(frozen=True)
-class DistributionSpec(ValueSpec):
-    """A value spec for a ``Distribution``.
+class RecordSpec(TermSpec):
+    """A term spec for an embedded ``Record``; mirrors :class:`DistributionSpec`
+    at the ``Rec`` corner.
+
+    ``event_template`` describes the record. ``RecordSpec(tau)`` and the
+    template ``tau`` denote the same space but read differently: the spec is a
+    leaf holding a tracked ``Record`` that keeps its own name and provenance,
+    whereas an interior :class:`EventTemplate` node contributes fields that are
+    paths of the enclosing template. Raw mappings are never leaves, so a
+    ``RecordSpec`` leaf is reached only for an already-tracked record or an
+    explicit declaration; at top level it declares a result that *is* a
+    ``Record``.
+
+    Raises
+    ------
+    TypeError
+        If ``event_template`` is not an :class:`EventTemplate`.
+    """
+
+    event_template: EventTemplate
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.event_template, EventTemplate):
+            raise TypeError(
+                f"RecordSpec.event_template must be an EventTemplate, "
+                f"got {type(self.event_template).__name__}"
+            )
+
+    def is_valid(self, value: Any) -> bool:
+        """Whether *value* is a ``Record`` whose template matches ``event_template``.
+
+        *value* must be a :class:`~probpipe.Record` whose own
+        ``event_template`` equals this spec's. Anything that is not a
+        ``Record``, or a ``Record`` whose template cannot be read, does not
+        satisfy the spec and returns ``False``; an unexpected error while
+        reading the template is left to propagate. Mirrors
+        :meth:`DistributionSpec.is_valid`.
+        """
+        from .record import Record
+
+        if not isinstance(value, Record):
+            return False
+        try:
+            template = value.event_template
+        except (AttributeError, TypeError):
+            return False
+        return template == self.event_template
+
+
+@dataclass(frozen=True)
+class DistributionSpec(TermSpec):
+    """A term spec for a ``Distribution``.
 
     ``event_template`` is the :class:`EventTemplate` of one draw from that
     distribution.
@@ -323,43 +396,49 @@ class DistributionSpec(ValueSpec):
 
 
 @dataclass(frozen=True)
-class FunctionSpec(ValueSpec):
-    """A value spec for a callable, optionally typed by its input/output structure.
+class FunctionSpec(TermSpec):
+    """A term spec for a callable, optionally typed by its input/output structure.
 
-    ``input_template`` / ``output_template`` are the :class:`EventTemplate`\\ s
-    of the callable's input and output, and each is optional (default
-    ``None``). A template describes a structured signature: its named fields
-    are the callable's inputs (or outputs), so
-    ``FunctionSpec(EventTemplate(x=(), y=(3,)), EventTemplate(out=()))`` types
-    ``f(x, y) -> out``. ``None`` means that side's structure is unspecified,
-    so a bare ``FunctionSpec()`` describes *any* callable — the natural spec
-    for a function of unknown or variable signature.
+    ``input_template`` is the :class:`EventTemplate` of the callable's input.
+    ``output_template`` is its output: an :class:`EventTemplate` (a record
+    output) or any :class:`TermSpec` (a result that is itself a term, e.g. a
+    ``Function`` returning a ``Distribution``). Both default to ``None``,
+    leaving that side unspecified, so a bare ``FunctionSpec()`` describes any
+    callable. A specified side is written out — e.g.
+    ``FunctionSpec(EventTemplate(x=()), EventTemplate(out=()))`` for
+    ``f(x) -> out`` — so a function's field names are caller-chosen and
+    meaningful, matching :class:`DistributionSpec`.
 
-    Each specified side must be an :class:`EventTemplate`; a single-field
-    signature is written out explicitly, e.g.
-    ``FunctionSpec(EventTemplate(x=()), EventTemplate(out=()))``, rather than
-    passed as a bare :class:`ValueSpec` — so a function's field names are
-    always caller-chosen and meaningful, not a fixed ``"input"`` / ``"output"``
-    placeholder. This matches :class:`DistributionSpec`, which likewise takes an
-    explicit template.
+    Validity is callability alone: the value-layer specs stay callable-generic,
+    so a ``FunctionSpec`` admits any callable (a lambda, a NumPy function, a
+    ``Function``) as a leaf value. It is the spec's identity as a
+    ``FunctionSpec``, not ``is_valid``, that tells the wrap boundary to
+    coproject a raw callable *result* into a ``Function`` term.
 
     Raises
     ------
     TypeError
-        If either side is not ``None`` or an :class:`EventTemplate`.
+        If ``input_template`` is neither ``None`` nor an :class:`EventTemplate`,
+        or ``output_template`` is neither ``None``, an :class:`EventTemplate`,
+        nor a :class:`TermSpec`.
     """
 
     input_template: EventTemplate | None = None
-    output_template: EventTemplate | None = None
+    output_template: EventTemplate | TermSpec | None = None
 
     def __post_init__(self) -> None:
-        for attr in ("input_template", "output_template"):
-            template = getattr(self, attr)
-            if template is not None and not isinstance(template, EventTemplate):
-                raise TypeError(
-                    f"FunctionSpec.{attr} must be None or an EventTemplate, "
-                    f"got {type(template).__name__}"
-                )
+        if self.input_template is not None and not isinstance(self.input_template, EventTemplate):
+            raise TypeError(
+                f"FunctionSpec.input_template must be None or an EventTemplate, "
+                f"got {type(self.input_template).__name__}"
+            )
+        if self.output_template is not None and not isinstance(
+            self.output_template, (EventTemplate, TermSpec)
+        ):
+            raise TypeError(
+                f"FunctionSpec.output_template must be None, an EventTemplate, "
+                f"or a TermSpec, got {type(self.output_template).__name__}"
+            )
 
     def is_valid(self, value: Any) -> bool:
         """Whether *value* is a callable.

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -593,7 +593,7 @@ class Record(NamedTree[Any], Tracked, Annotated):
         -----
         Inference is a lossy fallback (it cannot recover an ``ArraySpec``'s
         ``dtype`` / ``support``, an ``OpaqueSpec``'s ``meta``, or a
-        ``DistributionSpec`` / ``FunctionSpec``). The template rides in the
+        ``RecordSpec`` / ``DistributionSpec`` / ``FunctionSpec``). The template rides in the
         JAX pytree aux data, so a value reconstructed by ``tree_unflatten``
         carries this same template; unpickling instead infers a fresh
         template from the rebuilt data.

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -963,23 +963,20 @@ class TestFunctionSpecTemplatesRequired:
         assert spec.input_template is inp
         assert spec.output_spec == RecordSpec(out)
 
-    def test_bare_value_spec_rejected(self):
-        # The input side is a record schema, written out as an EventTemplate; a
-        # bare ValueSpec is not wrapped into one. The output side additionally
-        # accepts a TermSpec (a term-valued result), but a raw-value ValueSpec
-        # (ArraySpec / OpaqueSpec — not a TermSpec) is still rejected.
+    def test_bare_value_spec_rejected_on_the_input_side_only(self):
+        # The input side is a record schema, written out as an EventTemplate, so
+        # a bare ValueSpec is not wrapped into one. The output side is a
+        # declaration and accepts any value specification.
         with pytest.raises(TypeError, match="input_template must be None or an EventTemplate"):
             FunctionSpec(ArraySpec(()), EventTemplate(b=()))  # type: ignore[arg-type]
-        with pytest.raises(
-            TypeError, match="output_spec must be None, an EventTemplate, or a TermSpec"
-        ):
-            FunctionSpec(EventTemplate(a=()), OpaqueSpec())  # type: ignore[arg-type]
+
+        assert FunctionSpec(EventTemplate(a=()), OpaqueSpec()).output_spec == OpaqueSpec()
 
     def test_non_spec_rejected(self):
         with pytest.raises(TypeError, match="input_template must be None or an EventTemplate"):
             FunctionSpec((3,), EventTemplate(b=()))  # type: ignore[arg-type]
         with pytest.raises(
-            TypeError, match="output_spec must be None, an EventTemplate, or a TermSpec"
+            TypeError, match="output_spec must be None, an EventTemplate, or a ValueSpec"
         ):
             FunctionSpec(EventTemplate(a=()), "not a template")  # type: ignore[arg-type]
 
@@ -1448,6 +1445,17 @@ class TestTermSpecTaxonomy:
         assert type(FunctionSpec(tau, tau).output_spec) is RecordSpec
         assert type(FunctionSpec(tau, FunctionSpec()).output_spec) is FunctionSpec
 
+    def test_raw_value_output_declaration_is_stored_as_given(self):
+        """An output declaration is any value specification, as in Fun(sigma, rho).
+
+        A raw-value output declares the value itself; the wrap boundary is what
+        places it in a single-field record, keyed by the function's name, so no
+        field name is invented here.
+        """
+        tau = EventTemplate(x=())
+        for raw in (ArraySpec((3,)), OpaqueSpec(meta="m")):
+            assert FunctionSpec(tau, raw).output_spec is raw
+
     def test_unspecified_output_stays_none(self):
         """None means "unspecified" and is not wrapped into a record declaration."""
         assert FunctionSpec().output_spec is None
@@ -1508,9 +1516,14 @@ class TestFunctionSpecOutputWidening:
         fs2 = FunctionSpec(output_spec=RecordSpec(EventTemplate(y=())))
         assert isinstance(fs2.output_spec, RecordSpec)
 
-    def test_bad_output_rejected(self):
+    def test_raw_value_output_accepted(self):
+        # An output declaration is any value specification, so a raw-value spec
+        # declares a raw result rather than being rejected.
+        assert FunctionSpec(output_spec=ArraySpec(())).output_spec == ArraySpec(())
+
+    def test_non_spec_output_rejected(self):
         with pytest.raises(TypeError):
-            FunctionSpec(output_spec=ArraySpec(()))  # neither template nor term spec
+            FunctionSpec(output_spec=(3,))  # neither a template nor a spec
 
     def test_input_template_still_event_template_only(self):
         with pytest.raises(TypeError):

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -16,6 +16,7 @@ from probpipe.core.event_template import (
     FunctionSpec,
     NumericEventTemplate,
     OpaqueSpec,
+    RecordSpec,
     ValueSpec,
 )
 
@@ -554,8 +555,8 @@ class TestValueSpecs:
         for spec in (
             ArraySpec((3,)),
             OpaqueSpec(),
-            DistributionSpec(event_template=EventTemplate(x=())),
-            FunctionSpec(input_template=EventTemplate(x=()), output_template=EventTemplate(y=())),
+            DistributionSpec(event_spec=EventTemplate(x=())),
+            FunctionSpec(input_template=EventTemplate(x=()), output_spec=EventTemplate(y=())),
         ):
             with pytest.raises(FrozenInstanceError):
                 spec.shape = (1,)  # type: ignore[misc]
@@ -565,10 +566,8 @@ class TestValueSpecs:
         specs = {
             ArraySpec((3,)): 1,
             OpaqueSpec(): 2,
-            DistributionSpec(event_template=EventTemplate(x=())): 3,
-            FunctionSpec(
-                input_template=EventTemplate(x=()), output_template=EventTemplate(y=())
-            ): 4,
+            DistributionSpec(event_spec=EventTemplate(x=())): 3,
+            FunctionSpec(input_template=EventTemplate(x=()), output_spec=EventTemplate(y=())): 4,
         }
         assert len(specs) == 4
 
@@ -604,12 +603,12 @@ class TestValueSpecs:
         assert OpaqueSpec(meta="a") != OpaqueSpec(meta="b")
         # Distinct-but-equal templates, so this pins value equality (a
         # shared object would also pass under identity-based equality).
-        assert DistributionSpec(event_template=EventTemplate(x=())) == DistributionSpec(
-            event_template=EventTemplate(x=())
+        assert DistributionSpec(event_spec=EventTemplate(x=())) == DistributionSpec(
+            event_spec=EventTemplate(x=())
         )
         assert FunctionSpec(
-            input_template=EventTemplate(x=()), output_template=EventTemplate(y=())
-        ) == FunctionSpec(input_template=EventTemplate(x=()), output_template=EventTemplate(y=()))
+            input_template=EventTemplate(x=()), output_spec=EventTemplate(y=())
+        ) == FunctionSpec(input_template=EventTemplate(x=()), output_spec=EventTemplate(y=()))
 
     def test_array_and_opaque_specs_are_distinct(self):
         assert ArraySpec(()) != OpaqueSpec()
@@ -641,7 +640,7 @@ class TestValueSpecs:
                 ArraySpec((2,), dtype=jnp.float32, support=positive),
             ),
             (OpaqueSpec(meta="a"), OpaqueSpec(meta="a")),
-            (DistributionSpec(event_template=inner_a), DistributionSpec(event_template=inner_b)),
+            (DistributionSpec(event_spec=inner_a), DistributionSpec(event_spec=inner_b)),
         ]
         for a, b in pairs:
             assert a == b
@@ -650,8 +649,8 @@ class TestValueSpecs:
     def test_distribution_and_function_spec_inequality(self):
         # Distinct-but-equal templates compare equal; different templates
         # do not (the equality is by value, not object identity).
-        assert DistributionSpec(event_template=EventTemplate(x=())) != DistributionSpec(
-            event_template=EventTemplate(y=())
+        assert DistributionSpec(event_spec=EventTemplate(x=())) != DistributionSpec(
+            event_spec=EventTemplate(y=())
         )
         assert FunctionSpec(EventTemplate(a=()), EventTemplate(b=())) != FunctionSpec(
             EventTemplate(a=()), EventTemplate(c=())
@@ -690,7 +689,7 @@ class TestValueSpecs:
         tpl = EventTemplate(
             x=ArraySpec((2,), dtype="float32"),
             label=OpaqueSpec(meta="tag"),
-            d=DistributionSpec(event_template=EventTemplate(a=())),
+            d=DistributionSpec(event_spec=EventTemplate(a=())),
             f=FunctionSpec(EventTemplate(inp=ArraySpec(())), EventTemplate(out=ArraySpec(()))),
         )
         restored = pickle.loads(pickle.dumps(tpl))
@@ -714,12 +713,12 @@ class TestValueSpecs:
         with pytest.raises(TypeError, match="symbolic dimension"):
             ArraySpec((dimension,))
 
-    def test_distribution_spec_requires_event_template(self):
-        with pytest.raises(TypeError, match="must be an EventTemplate"):
-            DistributionSpec(event_template=(3,))  # type: ignore[arg-type]
-        # Unlike FunctionSpec, a bare ValueSpec is not auto-wrapped here.
-        with pytest.raises(TypeError, match="must be an EventTemplate"):
-            DistributionSpec(event_template=ArraySpec(()))  # type: ignore[arg-type]
+    def test_distribution_spec_requires_record_declaration(self):
+        with pytest.raises(TypeError, match="must be an EventTemplate or a RecordSpec"):
+            DistributionSpec(event_spec=(3,))  # type: ignore[arg-type]
+        # A raw-value spec is not a declaration: it names no kind.
+        with pytest.raises(TypeError, match="must be an EventTemplate or a RecordSpec"):
+            DistributionSpec(event_spec=ArraySpec(()))  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -862,16 +861,16 @@ class TestDistributionSpecIsValid:
         from probpipe import Normal
 
         dist = Normal(name="x", loc=0.0, scale=1.0)
-        assert DistributionSpec(event_template=dist.event_template).is_valid(dist)
+        assert DistributionSpec(event_spec=dist.event_template).is_valid(dist)
 
     def test_template_mismatch_invalid(self):
         from probpipe import Normal
 
         dist = Normal(name="x", loc=0.0, scale=1.0)
-        assert not DistributionSpec(event_template=EventTemplate(y=())).is_valid(dist)
+        assert not DistributionSpec(event_spec=EventTemplate(y=())).is_valid(dist)
 
     def test_non_distribution_invalid(self):
-        spec = DistributionSpec(event_template=EventTemplate(x=()))
+        spec = DistributionSpec(event_spec=EventTemplate(x=()))
         assert not spec.is_valid(42)
         assert not spec.is_valid(EventTemplate(x=()))
 
@@ -884,7 +883,7 @@ class TestDistributionSpecIsValid:
             def __init__(self):
                 super().__init__(name="d")
 
-        spec = DistributionSpec(event_template=EventTemplate(x=()))
+        spec = DistributionSpec(event_spec=EventTemplate(x=()))
         assert not spec.is_valid(_NoTemplate())
 
     def test_distribution_with_none_template_invalid(self):
@@ -898,7 +897,7 @@ class TestDistributionSpecIsValid:
             def event_template(self):
                 return None
 
-        spec = DistributionSpec(event_template=EventTemplate(x=()))
+        spec = DistributionSpec(event_spec=EventTemplate(x=()))
         assert not spec.is_valid(_NoneTemplate())
 
     def test_type_error_template_is_not_a_match(self):
@@ -915,7 +914,7 @@ class TestDistributionSpecIsValid:
             def event_template(self):
                 raise TypeError("template not derivable")
 
-        spec = DistributionSpec(event_template=EventTemplate(x=()))
+        spec = DistributionSpec(event_spec=EventTemplate(x=()))
         assert not spec.is_valid(_NotDerivable())
 
     @pytest.mark.parametrize("error", [RuntimeError, ValueError, KeyError])
@@ -933,19 +932,19 @@ class TestDistributionSpecIsValid:
             def event_template(self):
                 raise error("boom")
 
-        spec = DistributionSpec(event_template=EventTemplate(x=()))
+        spec = DistributionSpec(event_spec=EventTemplate(x=()))
         with pytest.raises(error):
             spec.is_valid(_Broken())
 
 
 class TestFunctionSpecIsValid:
     def test_callable_valid(self):
-        spec = FunctionSpec(input_template=EventTemplate(a=()), output_template=EventTemplate(b=()))
+        spec = FunctionSpec(input_template=EventTemplate(a=()), output_spec=EventTemplate(b=()))
         assert spec.is_valid(lambda a: a)
         assert spec.is_valid(np.sin)
 
     def test_non_callable_invalid(self):
-        spec = FunctionSpec(input_template=EventTemplate(a=()), output_template=EventTemplate(b=()))
+        spec = FunctionSpec(input_template=EventTemplate(a=()), output_spec=EventTemplate(b=()))
         assert not spec.is_valid(3.0)
         assert not spec.is_valid("f")
 
@@ -956,11 +955,13 @@ class TestFunctionSpecIsValid:
 
 
 class TestFunctionSpecTemplatesRequired:
-    def test_explicit_templates_stored_as_is(self):
+    def test_explicit_sides_stored_per_the_storage_rule(self):
+        # The input side is a schema and is stored as given; the output side is
+        # a declaration, so a bare template is stored wrapped.
         inp, out = EventTemplate(a=()), EventTemplate(b=())
         spec = FunctionSpec(inp, out)
         assert spec.input_template is inp
-        assert spec.output_template is out
+        assert spec.output_spec == RecordSpec(out)
 
     def test_bare_value_spec_rejected(self):
         # The input side is a record schema, written out as an EventTemplate; a
@@ -970,7 +971,7 @@ class TestFunctionSpecTemplatesRequired:
         with pytest.raises(TypeError, match="input_template must be None or an EventTemplate"):
             FunctionSpec(ArraySpec(()), EventTemplate(b=()))  # type: ignore[arg-type]
         with pytest.raises(
-            TypeError, match="output_template must be None, an EventTemplate, or a TermSpec"
+            TypeError, match="output_spec must be None, an EventTemplate, or a TermSpec"
         ):
             FunctionSpec(EventTemplate(a=()), OpaqueSpec())  # type: ignore[arg-type]
 
@@ -978,7 +979,7 @@ class TestFunctionSpecTemplatesRequired:
         with pytest.raises(TypeError, match="input_template must be None or an EventTemplate"):
             FunctionSpec((3,), EventTemplate(b=()))  # type: ignore[arg-type]
         with pytest.raises(
-            TypeError, match="output_template must be None, an EventTemplate, or a TermSpec"
+            TypeError, match="output_spec must be None, an EventTemplate, or a TermSpec"
         ):
             FunctionSpec(EventTemplate(a=()), "not a template")  # type: ignore[arg-type]
 
@@ -992,15 +993,16 @@ class TestFunctionSpecOptionalTemplates:
     def test_bare_function_spec_is_any_callable(self):
         spec = FunctionSpec()
         assert spec.input_template is None
-        assert spec.output_template is None
+        assert spec.output_spec is None
         assert spec.is_valid(lambda x: x)
         assert spec.is_valid(np.sin)
         assert not spec.is_valid(3.0)
 
     def test_one_side_specified(self):
-        spec = FunctionSpec(output_template=EventTemplate(out=ArraySpec(())))
+        spec = FunctionSpec(output_spec=EventTemplate(out=ArraySpec(())))
         assert spec.input_template is None
-        assert spec.output_template == EventTemplate(out=ArraySpec(()))
+        # A record output is stored as its declaration (the storage rule).
+        assert spec.output_spec == RecordSpec(EventTemplate(out=ArraySpec(())))
 
     def test_none_specs_are_hashable_and_equal(self):
         assert FunctionSpec() == FunctionSpec()
@@ -1054,10 +1056,8 @@ class TestConstructionSpecs:
         assert tpl["label"] is spec
 
     def test_explicit_distribution_and_function_specs_accepted(self):
-        dspec = DistributionSpec(event_template=EventTemplate(x=()))
-        fspec = FunctionSpec(
-            input_template=EventTemplate(a=()), output_template=EventTemplate(b=())
-        )
+        dspec = DistributionSpec(event_spec=EventTemplate(x=()))
+        fspec = FunctionSpec(input_template=EventTemplate(a=()), output_spec=EventTemplate(b=()))
         tpl = EventTemplate(d=dspec, f=fspec)
         assert tpl["d"] is dspec
         assert tpl["f"] is fspec
@@ -1086,13 +1086,13 @@ class TestAutoPromotionSpecs:
         assert type(tpl) is EventTemplate
 
     def test_distribution_spec_blocks_promotion(self):
-        tpl = EventTemplate(x=(), d=DistributionSpec(event_template=EventTemplate(a=())))
+        tpl = EventTemplate(x=(), d=DistributionSpec(event_spec=EventTemplate(a=())))
         assert type(tpl) is EventTemplate
 
     def test_function_spec_blocks_promotion(self):
         tpl = EventTemplate(
             x=(),
-            f=FunctionSpec(input_template=EventTemplate(a=()), output_template=EventTemplate(b=())),
+            f=FunctionSpec(input_template=EventTemplate(a=()), output_spec=EventTemplate(b=())),
         )
         assert type(tpl) is EventTemplate
 
@@ -1102,15 +1102,13 @@ class TestAutoPromotionSpecs:
 
     def test_numeric_rejects_distribution_spec(self):
         with pytest.raises(TypeError, match="only ArraySpec"):
-            NumericEventTemplate(x=(), d=DistributionSpec(event_template=EventTemplate(a=())))
+            NumericEventTemplate(x=(), d=DistributionSpec(event_spec=EventTemplate(a=())))
 
     def test_numeric_rejects_function_spec(self):
         with pytest.raises(TypeError, match="only ArraySpec"):
             NumericEventTemplate(
                 x=(),
-                f=FunctionSpec(
-                    input_template=EventTemplate(a=()), output_template=EventTemplate(b=())
-                ),
+                f=FunctionSpec(input_template=EventTemplate(a=()), output_spec=EventTemplate(b=())),
             )
 
 
@@ -1141,11 +1139,11 @@ class TestShapeAccessorBackCompat:
 
 
 def _dist_spec() -> DistributionSpec:
-    return DistributionSpec(event_template=EventTemplate(a=()))
+    return DistributionSpec(event_spec=EventTemplate(a=()))
 
 
 def _func_spec() -> FunctionSpec:
-    return FunctionSpec(input_template=EventTemplate(a=()), output_template=EventTemplate(b=()))
+    return FunctionSpec(input_template=EventTemplate(a=()), output_spec=EventTemplate(b=()))
 
 
 class TestIsNumeric:
@@ -1386,7 +1384,7 @@ class TestTermSpecTaxonomy:
     """The term-spec sub-hierarchy: one spec per kind, all also ValueSpecs."""
 
     def test_term_specs_are_value_specs(self):
-        from probpipe.core.event_template import RecordSpec, TermSpec
+        from probpipe.core.event_template import TermSpec
 
         tau = EventTemplate(x=())
         for spec in (
@@ -1402,6 +1400,48 @@ class TestTermSpecTaxonomy:
 
         assert not isinstance(ArraySpec(()), TermSpec)
         assert not isinstance(OpaqueSpec(), TermSpec)
+
+    # --- the storage rule: a declaration is stored as a TermSpec ---
+
+    def test_event_template_declaration_wraps_to_record_spec(self):
+        """A bare EventTemplate is constructor sugar; the stored form is a spec."""
+        from probpipe.core.event_template import RecordSpec, TermSpec
+
+        tau = EventTemplate(x=())
+        assert DistributionSpec(tau).event_spec == RecordSpec(tau)
+        assert isinstance(DistributionSpec(tau).event_spec, TermSpec)
+        assert FunctionSpec(tau, tau).output_spec == RecordSpec(tau)
+        assert isinstance(FunctionSpec(tau, tau).output_spec, TermSpec)
+
+    def test_declaration_normalisation_is_idempotent(self):
+        """Passing the wrapped form gives the same spec as passing the template."""
+        from probpipe.core.event_template import RecordSpec
+
+        tau = EventTemplate(x=())
+        assert DistributionSpec(RecordSpec(tau)) == DistributionSpec(tau)
+        assert FunctionSpec(tau, RecordSpec(tau)) == FunctionSpec(tau, tau)
+
+    def test_term_valued_declaration_is_kept_not_wrapped(self):
+        """A term declaration names its own kind and passes through unchanged."""
+        tau = EventTemplate(x=())
+        inner = DistributionSpec(tau)
+        assert DistributionSpec(inner).event_spec is inner  # a random measure
+        assert FunctionSpec(tau, inner).output_spec is inner
+        assert FunctionSpec(tau, FunctionSpec()).output_spec == FunctionSpec()
+
+    def test_declared_kind_is_the_stored_spec_class(self):
+        """The declaration's class is the declared kind — a structural test."""
+        from probpipe.core.event_template import RecordSpec
+
+        tau = EventTemplate(x=())
+        assert type(DistributionSpec(tau).event_spec) is RecordSpec
+        assert type(DistributionSpec(DistributionSpec(tau)).event_spec) is DistributionSpec
+        assert type(FunctionSpec(tau, FunctionSpec()).output_spec) is FunctionSpec
+
+    def test_unspecified_output_stays_none(self):
+        """None means "unspecified" and is not wrapped into a record declaration."""
+        assert FunctionSpec().output_spec is None
+        assert FunctionSpec(EventTemplate(x=())).output_spec is None
 
     def test_event_template_is_not_a_spec(self):
         """The schema is the index; it is not itself a (value or term) spec."""
@@ -1442,9 +1482,11 @@ class TestFunctionSpecOutputWidening:
     """A FunctionSpec output may be a record schema or any term spec."""
 
     def test_event_template_output_still_accepted(self):
-        # backward compatible: the pre-existing EventTemplate output
-        fs = FunctionSpec(EventTemplate(x=()), EventTemplate(out=()))
-        assert isinstance(fs.output_template, EventTemplate)
+        # The pre-existing EventTemplate output is still accepted, now as
+        # construction sugar: it is stored as the record declaration.
+        tau = EventTemplate(out=())
+        fs = FunctionSpec(EventTemplate(x=()), tau)
+        assert fs.output_spec == RecordSpec(tau)
 
     def test_term_spec_output_accepted(self):
         # the widening: a function whose result is itself a term
@@ -1452,13 +1494,13 @@ class TestFunctionSpecOutputWidening:
 
         tau = EventTemplate(out=())
         fs = FunctionSpec(EventTemplate(x=()), DistributionSpec(tau))
-        assert fs.output_template == DistributionSpec(tau)
-        fs2 = FunctionSpec(output_template=RecordSpec(EventTemplate(y=())))
-        assert isinstance(fs2.output_template, RecordSpec)
+        assert fs.output_spec == DistributionSpec(tau)
+        fs2 = FunctionSpec(output_spec=RecordSpec(EventTemplate(y=())))
+        assert isinstance(fs2.output_spec, RecordSpec)
 
     def test_bad_output_rejected(self):
         with pytest.raises(TypeError):
-            FunctionSpec(output_template=ArraySpec(()))  # neither template nor term spec
+            FunctionSpec(output_spec=ArraySpec(()))  # neither template nor term spec
 
     def test_input_template_still_event_template_only(self):
         with pytest.raises(TypeError):

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -1421,21 +1421,31 @@ class TestTermSpecTaxonomy:
         assert DistributionSpec(RecordSpec(tau)) == DistributionSpec(tau)
         assert FunctionSpec(tau, RecordSpec(tau)) == FunctionSpec(tau, tau)
 
-    def test_term_valued_declaration_is_kept_not_wrapped(self):
-        """A term declaration names its own kind and passes through unchanged."""
+    def test_term_valued_output_is_kept_not_wrapped(self):
+        """A term output declaration names its own kind and passes through."""
         tau = EventTemplate(x=())
         inner = DistributionSpec(tau)
-        assert DistributionSpec(inner).event_spec is inner  # a random measure
         assert FunctionSpec(tau, inner).output_spec is inner
         assert FunctionSpec(tau, FunctionSpec()).output_spec == FunctionSpec()
 
+    def test_term_valued_event_declaration_is_rejected(self):
+        """An event declaration is record-valued: a term draw is not yet checkable.
+
+        A ``Distribution`` exposes an ``EventTemplate`` and nothing that reports
+        a term-valued draw kind, so a random-measure declaration could be
+        written but never satisfied. It is refused at construction rather than
+        accepted and always reported invalid.
+        """
+        tau = EventTemplate(x=())
+        for decl in (DistributionSpec(tau), FunctionSpec()):
+            with pytest.raises(TypeError, match="must be an EventTemplate or a RecordSpec"):
+                DistributionSpec(decl)  # type: ignore[arg-type]
+
     def test_declared_kind_is_the_stored_spec_class(self):
         """The declaration's class is the declared kind — a structural test."""
-        from probpipe.core.event_template import RecordSpec
-
         tau = EventTemplate(x=())
         assert type(DistributionSpec(tau).event_spec) is RecordSpec
-        assert type(DistributionSpec(DistributionSpec(tau)).event_spec) is DistributionSpec
+        assert type(FunctionSpec(tau, tau).output_spec) is RecordSpec
         assert type(FunctionSpec(tau, FunctionSpec()).output_spec) is FunctionSpec
 
     def test_unspecified_output_stays_none(self):

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -17,6 +17,7 @@ from probpipe.core.event_template import (
     NumericEventTemplate,
     OpaqueSpec,
     RecordSpec,
+    TermSpec,
     ValueSpec,
 )
 
@@ -555,6 +556,7 @@ class TestValueSpecs:
         for spec in (
             ArraySpec((3,)),
             OpaqueSpec(),
+            RecordSpec(EventTemplate(x=())),
             DistributionSpec(event_spec=EventTemplate(x=())),
             FunctionSpec(input_template=EventTemplate(x=()), output_spec=EventTemplate(y=())),
         ):
@@ -568,8 +570,9 @@ class TestValueSpecs:
             OpaqueSpec(): 2,
             DistributionSpec(event_spec=EventTemplate(x=())): 3,
             FunctionSpec(input_template=EventTemplate(x=()), output_spec=EventTemplate(y=())): 4,
+            RecordSpec(EventTemplate(x=())): 5,
         }
-        assert len(specs) == 4
+        assert len(specs) == 5
 
     def test_opaque_spec_rejects_unhashable_meta_at_construction(self):
         with pytest.raises(TypeError, match=r"OpaqueSpec\.meta must be hashable"):
@@ -691,6 +694,7 @@ class TestValueSpecs:
             label=OpaqueSpec(meta="tag"),
             d=DistributionSpec(event_spec=EventTemplate(a=())),
             f=FunctionSpec(EventTemplate(inp=ArraySpec(())), EventTemplate(out=ArraySpec(()))),
+            r=RecordSpec(EventTemplate(c=ArraySpec(()))),
         )
         restored = pickle.loads(pickle.dumps(tpl))
         assert restored == tpl
@@ -1086,6 +1090,10 @@ class TestAutoPromotionSpecs:
         tpl = EventTemplate(x=(), d=DistributionSpec(event_spec=EventTemplate(a=())))
         assert type(tpl) is EventTemplate
 
+    def test_record_spec_blocks_promotion(self):
+        tpl = EventTemplate(x=(), r=RecordSpec(EventTemplate(a=())))
+        assert type(tpl) is EventTemplate
+
     def test_function_spec_blocks_promotion(self):
         tpl = EventTemplate(
             x=(),
@@ -1100,6 +1108,10 @@ class TestAutoPromotionSpecs:
     def test_numeric_rejects_distribution_spec(self):
         with pytest.raises(TypeError, match="only ArraySpec"):
             NumericEventTemplate(x=(), d=DistributionSpec(event_spec=EventTemplate(a=())))
+
+    def test_numeric_rejects_record_spec(self):
+        with pytest.raises(TypeError, match="only ArraySpec"):
+            NumericEventTemplate(x=(), r=RecordSpec(EventTemplate(a=())))
 
     def test_numeric_rejects_function_spec(self):
         with pytest.raises(TypeError, match="only ArraySpec"):
@@ -1381,7 +1393,6 @@ class TestTermSpecTaxonomy:
     """The term-spec sub-hierarchy: one spec per kind, all also ValueSpecs."""
 
     def test_term_specs_are_value_specs(self):
-        from probpipe.core.event_template import TermSpec
 
         tau = EventTemplate(x=())
         for spec in (
@@ -1393,7 +1404,6 @@ class TestTermSpecTaxonomy:
             assert isinstance(spec, ValueSpec)  # sub-hierarchy: still a leaf spec
 
     def test_raw_value_specs_are_not_term_specs(self):
-        from probpipe.core.event_template import TermSpec
 
         assert not isinstance(ArraySpec(()), TermSpec)
         assert not isinstance(OpaqueSpec(), TermSpec)
@@ -1402,7 +1412,6 @@ class TestTermSpecTaxonomy:
 
     def test_event_template_declaration_wraps_to_record_spec(self):
         """A bare EventTemplate is constructor sugar; the stored form is a spec."""
-        from probpipe.core.event_template import RecordSpec, TermSpec
 
         tau = EventTemplate(x=())
         assert DistributionSpec(tau).event_spec == RecordSpec(tau)
@@ -1412,7 +1421,6 @@ class TestTermSpecTaxonomy:
 
     def test_declaration_normalisation_is_idempotent(self):
         """Passing the wrapped form gives the same spec as passing the template."""
-        from probpipe.core.event_template import RecordSpec
 
         tau = EventTemplate(x=())
         assert DistributionSpec(RecordSpec(tau)) == DistributionSpec(tau)
@@ -1463,31 +1471,51 @@ class TestTermSpecTaxonomy:
 
     def test_event_template_is_not_a_spec(self):
         """The schema is the index; it is not itself a (value or term) spec."""
-        from probpipe.core.event_template import TermSpec
 
         tau = EventTemplate(x=())
         assert not isinstance(tau, ValueSpec)
         assert not isinstance(tau, TermSpec)
 
-    def test_specs_are_frozen_hashable_by_value(self):
-        from probpipe.core.event_template import RecordSpec
+    def test_term_specs_compare_and_hash_by_value(self):
+        # Distinct-but-equal templates throughout, so this pins value equality
+        # rather than sharing one template object.
+        assert RecordSpec(EventTemplate(x=())) == RecordSpec(EventTemplate(x=()))
+        assert hash(RecordSpec(EventTemplate(x=()))) == hash(RecordSpec(EventTemplate(x=())))
 
+    def test_a_record_declaration_is_the_wrapped_template(self):
+        """The storage rule at the value level, not merely by class."""
         tau = EventTemplate(x=())
-        assert RecordSpec(tau) == RecordSpec(tau)
-        assert hash(RecordSpec(tau)) == hash(RecordSpec(EventTemplate(x=())))
-        # Same event template, different kinds: the concrete class distinguishes.
-        assert RecordSpec(tau) != DistributionSpec(tau)
+        assert DistributionSpec(tau).event_spec == RecordSpec(tau)
+        assert FunctionSpec(tau, tau).output_spec == RecordSpec(tau)
+
+    def test_term_spec_is_abstract_and_declares_no_is_valid(self):
+        """The hierarchy's headline claim: is_valid stays declared once."""
+        with pytest.raises(TypeError, match="abstract"):
+            TermSpec()  # type: ignore[abstract]
+        assert "is_valid" not in TermSpec.__dict__
+
+    def test_the_old_attribute_names_are_gone(self):
+        """The breaking half of the rename, which the CHANGELOG advertises."""
+        tau = EventTemplate(x=())
+        assert not hasattr(DistributionSpec(tau), "event_template")
+        assert not hasattr(FunctionSpec(tau, tau), "output_template")
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            DistributionSpec(event_template=tau)  # type: ignore[call-arg]
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            FunctionSpec(tau, output_template=tau)  # type: ignore[call-arg]
 
 
 class TestRecordSpec:
     def test_requires_event_template(self):
-        from probpipe.core.event_template import RecordSpec
 
         with pytest.raises(TypeError):
             RecordSpec(ArraySpec(()))  # not an EventTemplate
 
+    def test_requires_event_template_message(self):
+        with pytest.raises(TypeError, match="must be an EventTemplate"):
+            RecordSpec(ArraySpec(()))
+
     def test_is_valid_accepts_matching_record_only(self):
-        from probpipe.core.event_template import RecordSpec
 
         rec = Record("r", x=jnp.asarray(1.0))
         spec = RecordSpec(rec.event_template)
@@ -1495,43 +1523,52 @@ class TestRecordSpec:
         assert not spec.is_valid(jnp.asarray(1.0))  # not a Record
         assert not spec.is_valid(Record("r", y=jnp.asarray(1.0)))  # wrong template
 
+    # The two cases DistributionSpec.is_valid documents, mirrored here: a value
+    # that cannot present its schema is not a match, and any other error is a
+    # bug to surface rather than to report as invalid.
+
+    def test_is_valid_false_when_the_template_cannot_be_read(self):
+        class _Unreadable(Record):
+            @property
+            def event_template(self):
+                raise TypeError("template not derivable")
+
+        rec = _Unreadable("r", x=jnp.asarray(1.0))
+        assert not RecordSpec(EventTemplate(x=())).is_valid(rec)
+
+    def test_is_valid_propagates_an_unexpected_error(self):
+        class _Broken(Record):
+            @property
+            def event_template(self):
+                raise RuntimeError("malfunctioning record")
+
+        rec = _Broken("r", x=jnp.asarray(1.0))
+        with pytest.raises(RuntimeError, match="malfunctioning record"):
+            RecordSpec(EventTemplate(x=())).is_valid(rec)
+
 
 class TestFunctionSpecOutputWidening:
-    """A FunctionSpec output may be a record schema or any term spec."""
+    """An output declaration admits every kind, and raw values too.
 
-    def test_event_template_output_still_accepted(self):
-        # The pre-existing EventTemplate output is still accepted, now as
-        # construction sugar: it is stored as the record declaration.
-        tau = EventTemplate(out=())
-        fs = FunctionSpec(EventTemplate(x=()), tau)
-        assert fs.output_spec == RecordSpec(tau)
+    The record-output, non-spec-rejection, and callability cases are covered by
+    TestFunctionSpecTemplatesRequired and TestFunctionSpecOptionalTemplates; only
+    the widening itself lives here.
+    """
 
     def test_term_spec_output_accepted(self):
-        # the widening: a function whose result is itself a term
-        from probpipe.core.event_template import RecordSpec
-
         tau = EventTemplate(out=())
-        fs = FunctionSpec(EventTemplate(x=()), DistributionSpec(tau))
-        assert fs.output_spec == DistributionSpec(tau)
-        fs2 = FunctionSpec(output_spec=RecordSpec(EventTemplate(y=())))
-        assert isinstance(fs2.output_spec, RecordSpec)
-
-    def test_raw_value_output_accepted(self):
-        # An output declaration is any value specification, so a raw-value spec
-        # declares a raw result rather than being rejected.
-        assert FunctionSpec(output_spec=ArraySpec(())).output_spec == ArraySpec(())
-
-    def test_non_spec_output_rejected(self):
-        with pytest.raises(TypeError):
-            FunctionSpec(output_spec=(3,))  # neither a template nor a spec
+        assert FunctionSpec(EventTemplate(x=()), DistributionSpec(tau)).output_spec == (
+            DistributionSpec(tau)
+        )
+        assert isinstance(
+            FunctionSpec(output_spec=RecordSpec(EventTemplate(y=()))).output_spec, RecordSpec
+        )
 
     def test_input_template_still_event_template_only(self):
-        with pytest.raises(TypeError):
+        # The input side is a schema, so a spec is not accepted there even though
+        # the output side takes one.
+        with pytest.raises(TypeError, match="input_template must be None or an EventTemplate"):
             FunctionSpec(input_template=DistributionSpec(EventTemplate(x=())))
-
-    def test_is_valid_is_callable_generic(self):
-        # unchanged: the leaf role admits any callable, not only Functions
-        assert FunctionSpec().is_valid(lambda x: x)
 
 
 def test_public_exports():

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -1,7 +1,7 @@
 """Tests for probpipe.core.record.EventTemplate."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, get_type_hints
 
 import jax
 import jax.numpy as jnp
@@ -1408,7 +1408,7 @@ class TestTermSpecTaxonomy:
         assert not isinstance(ArraySpec(()), TermSpec)
         assert not isinstance(OpaqueSpec(), TermSpec)
 
-    # --- the storage rule: a declaration is stored as a TermSpec ---
+    # --- the storage rule: a declaration is stored as a ValueSpec ---
 
     def test_event_template_declaration_wraps_to_record_spec(self):
         """A bare EventTemplate is constructor sugar; the stored form is a spec."""
@@ -1425,6 +1425,33 @@ class TestTermSpecTaxonomy:
         tau = EventTemplate(x=())
         assert DistributionSpec(RecordSpec(tau)) == DistributionSpec(tau)
         assert FunctionSpec(tau, RecordSpec(tau)) == FunctionSpec(tau, tau)
+
+    def test_a_declaration_field_is_declared_at_the_type_it_stores(self):
+        """The annotation is the post-construction guarantee, not the input sugar.
+
+        The wider template spelling is carried by the constructor signature, so a
+        type checker and the generated API reference read the stored type. Pins
+        the split against a rewidening of the field annotations.
+        """
+        assert get_type_hints(DistributionSpec)["event_spec"] is RecordSpec
+        assert get_type_hints(FunctionSpec)["output_spec"] == ValueSpec | None
+        assert get_type_hints(ArraySpec)["dtype"] == np.dtype | None
+
+    def test_the_old_parameter_names_are_gone(self):
+        """Positional construction survives the rename; keyword construction does not.
+
+        The migration rule the CHANGELOG states: a keyword call moves to the new
+        parameter name, as does every read of the old attribute.
+        """
+        tau = EventTemplate(x=())
+        assert DistributionSpec(tau) == DistributionSpec(event_spec=tau)
+        assert FunctionSpec(tau, tau) == FunctionSpec(tau, output_spec=tau)
+        with pytest.raises(TypeError, match="event_template"):
+            DistributionSpec(event_template=tau)  # type: ignore[call-arg]
+        with pytest.raises(TypeError, match="output_template"):
+            FunctionSpec(tau, output_template=tau)  # type: ignore[call-arg]
+        assert not hasattr(DistributionSpec(tau), "event_template")
+        assert not hasattr(FunctionSpec(tau, tau), "output_template")
 
     def test_term_valued_output_is_kept_not_wrapped(self):
         """A term output declaration names its own kind and passes through."""

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -963,17 +963,23 @@ class TestFunctionSpecTemplatesRequired:
         assert spec.output_template is out
 
     def test_bare_value_spec_rejected(self):
-        # A single-field signature is written out as an EventTemplate; a bare
-        # ValueSpec is not wrapped into one.
+        # The input side is a record schema, written out as an EventTemplate; a
+        # bare ValueSpec is not wrapped into one. The output side additionally
+        # accepts a TermSpec (a term-valued result), but a raw-value ValueSpec
+        # (ArraySpec / OpaqueSpec — not a TermSpec) is still rejected.
         with pytest.raises(TypeError, match="input_template must be None or an EventTemplate"):
             FunctionSpec(ArraySpec(()), EventTemplate(b=()))  # type: ignore[arg-type]
-        with pytest.raises(TypeError, match="output_template must be None or an EventTemplate"):
+        with pytest.raises(
+            TypeError, match="output_template must be None, an EventTemplate, or a TermSpec"
+        ):
             FunctionSpec(EventTemplate(a=()), OpaqueSpec())  # type: ignore[arg-type]
 
     def test_non_spec_rejected(self):
         with pytest.raises(TypeError, match="input_template must be None or an EventTemplate"):
             FunctionSpec((3,), EventTemplate(b=()))  # type: ignore[arg-type]
-        with pytest.raises(TypeError, match="output_template must be None or an EventTemplate"):
+        with pytest.raises(
+            TypeError, match="output_template must be None, an EventTemplate, or a TermSpec"
+        ):
             FunctionSpec(EventTemplate(a=()), "not a template")  # type: ignore[arg-type]
 
 
@@ -1369,3 +1375,103 @@ class TestFromVectorErrors:
         tpl = EventTemplate(x=(), y=(3,))
         with pytest.raises(ValueError, match="vector_size"):
             NumericRecord.from_vector("nr", tpl, jnp.zeros(5))
+
+
+# ---------------------------------------------------------------------------
+# TermSpec taxonomy (RecordSpec / DistributionSpec / FunctionSpec)
+# ---------------------------------------------------------------------------
+
+
+class TestTermSpecTaxonomy:
+    """The term-spec sub-hierarchy: one spec per kind, all also ValueSpecs."""
+
+    def test_term_specs_are_value_specs(self):
+        from probpipe.core.event_template import RecordSpec, TermSpec
+
+        tau = EventTemplate(x=())
+        for spec in (
+            RecordSpec(tau),
+            DistributionSpec(tau),
+            FunctionSpec(),
+        ):
+            assert isinstance(spec, TermSpec)
+            assert isinstance(spec, ValueSpec)  # sub-hierarchy: still a leaf spec
+
+    def test_raw_value_specs_are_not_term_specs(self):
+        from probpipe.core.event_template import TermSpec
+
+        assert not isinstance(ArraySpec(()), TermSpec)
+        assert not isinstance(OpaqueSpec(), TermSpec)
+
+    def test_event_template_is_not_a_spec(self):
+        """The schema is the index; it is not itself a (value or term) spec."""
+        from probpipe.core.event_template import TermSpec
+
+        tau = EventTemplate(x=())
+        assert not isinstance(tau, ValueSpec)
+        assert not isinstance(tau, TermSpec)
+
+    def test_specs_are_frozen_hashable_by_value(self):
+        from probpipe.core.event_template import RecordSpec
+
+        tau = EventTemplate(x=())
+        assert RecordSpec(tau) == RecordSpec(tau)
+        assert hash(RecordSpec(tau)) == hash(RecordSpec(EventTemplate(x=())))
+        # Same event template, different kinds: the concrete class distinguishes.
+        assert RecordSpec(tau) != DistributionSpec(tau)
+
+
+class TestRecordSpec:
+    def test_requires_event_template(self):
+        from probpipe.core.event_template import RecordSpec
+
+        with pytest.raises(TypeError):
+            RecordSpec(ArraySpec(()))  # not an EventTemplate
+
+    def test_is_valid_accepts_matching_record_only(self):
+        from probpipe.core.event_template import RecordSpec
+
+        rec = Record("r", x=jnp.asarray(1.0))
+        spec = RecordSpec(rec.event_template)
+        assert spec.is_valid(rec)
+        assert not spec.is_valid(jnp.asarray(1.0))  # not a Record
+        assert not spec.is_valid(Record("r", y=jnp.asarray(1.0)))  # wrong template
+
+
+class TestFunctionSpecOutputWidening:
+    """A FunctionSpec output may be a record schema or any term spec."""
+
+    def test_event_template_output_still_accepted(self):
+        # backward compatible: the pre-existing EventTemplate output
+        fs = FunctionSpec(EventTemplate(x=()), EventTemplate(out=()))
+        assert isinstance(fs.output_template, EventTemplate)
+
+    def test_term_spec_output_accepted(self):
+        # the widening: a function whose result is itself a term
+        from probpipe.core.event_template import RecordSpec
+
+        tau = EventTemplate(out=())
+        fs = FunctionSpec(EventTemplate(x=()), DistributionSpec(tau))
+        assert fs.output_template == DistributionSpec(tau)
+        fs2 = FunctionSpec(output_template=RecordSpec(EventTemplate(y=())))
+        assert isinstance(fs2.output_template, RecordSpec)
+
+    def test_bad_output_rejected(self):
+        with pytest.raises(TypeError):
+            FunctionSpec(output_template=ArraySpec(()))  # neither template nor term spec
+
+    def test_input_template_still_event_template_only(self):
+        with pytest.raises(TypeError):
+            FunctionSpec(input_template=DistributionSpec(EventTemplate(x=())))
+
+    def test_is_valid_is_callable_generic(self):
+        # unchanged: the leaf role admits any callable, not only Functions
+        assert FunctionSpec().is_valid(lambda x: x)
+
+
+def test_public_exports():
+    import probpipe
+
+    for name in ("TermSpec", "RecordSpec"):
+        assert hasattr(probpipe, name), name
+        assert name in probpipe.__all__, name

--- a/tests/core/test_fingerprint.py
+++ b/tests/core/test_fingerprint.py
@@ -982,3 +982,40 @@ class TestValueSpecFingerprints:
 
     def test_unspecified_output_differs_from_a_declared_one(self, tau):
         assert self._fp(FunctionSpec(tau)) != self._fp(FunctionSpec(tau, tau))
+
+    # --- a spec is hashed by declaration wherever it appears, not by identity ---
+
+    @pytest.mark.parametrize(
+        "wrap",
+        [lambda sp: sp, lambda sp: (sp,), lambda sp: [sp], lambda sp: {"f": sp}],
+        ids=["bare", "in-tuple", "in-list", "in-dict"],
+    )
+    def test_spec_outside_a_template_is_still_hashed_by_declaration(self, wrap, tau):
+        """A spec reached other than as a template leaf must not hash by identity.
+
+        The generic hasher must route a `ValueSpec` to the spec hasher, which
+        records the object type and the declaration fields. Falling through to
+        identity hashing would make equal declarations hash differently and
+        silently break cache keys and provenance.
+        """
+        first, _ = _fingerprint_with_strength(wrap(RecordSpec(EventTemplate(x=()))))
+        second, weak = _fingerprint_with_strength(wrap(RecordSpec(EventTemplate(x=()))))
+
+        assert not weak
+        assert first == second
+
+    @pytest.mark.parametrize(
+        "wrap",
+        [lambda sp: sp, lambda sp: (sp,)],
+        ids=["bare", "in-tuple"],
+    )
+    def test_spec_type_is_recorded_outside_a_template(self, wrap, tau):
+        """Two specs that differ only in kind must not collide."""
+        assert (
+            _fingerprint_with_strength(wrap(RecordSpec(tau)))[0]
+            != _fingerprint_with_strength(wrap(DistributionSpec(tau)))[0]
+        )
+        assert (
+            _fingerprint_with_strength(wrap(ArraySpec(())))[0]
+            != _fingerprint_with_strength(wrap(OpaqueSpec()))[0]
+        )

--- a/tests/core/test_fingerprint.py
+++ b/tests/core/test_fingerprint.py
@@ -12,7 +12,16 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import EventTemplate, Normal, Record
+from probpipe import (
+    ArraySpec,
+    DistributionSpec,
+    EventTemplate,
+    FunctionSpec,
+    Normal,
+    OpaqueSpec,
+    Record,
+    RecordSpec,
+)
 from probpipe.core._fingerprint import (
     _fingerprint_with_strength,
     _update_function,
@@ -910,3 +919,66 @@ class TestNumericContainerHashing:
             return subprocess.check_output([sys.executable, "-c", script, site], text=True).strip()
 
         assert run() == run()
+
+
+class TestValueSpecFingerprints:
+    """Specs are hashed as template leaves, by declaration and not by identity.
+
+    A declaration is stored as a spec (`DistributionSpec.event_spec`,
+    `FunctionSpec.output_spec`), so the spec hasher must recurse into it. These
+    tests pin that: equal declarations must agree, distinct ones must not, and
+    every spec kind must be reachable — a spec the hasher does not know falls
+    back to identity hashing, which silently breaks cache keys and provenance.
+    """
+
+    @staticmethod
+    def _fp(spec):
+        """Fingerprint a spec in the position it is actually used: a leaf."""
+        return fingerprint(EventTemplate(field=spec))
+
+    @pytest.fixture
+    def tau(self):
+        return EventTemplate(x=())
+
+    def test_every_spec_kind_fingerprints(self, tau):
+        for spec in (
+            ArraySpec(()),
+            OpaqueSpec(),
+            RecordSpec(tau),
+            DistributionSpec(tau),
+            FunctionSpec(tau, tau),
+            FunctionSpec(),
+        ):
+            assert isinstance(self._fp(spec), str)
+
+    @pytest.mark.parametrize(
+        "make",
+        [
+            lambda t: RecordSpec(t),
+            lambda t: DistributionSpec(t),
+            lambda t: FunctionSpec(t, t),
+            lambda t: FunctionSpec(t, DistributionSpec(t)),
+        ],
+        ids=["record", "distribution", "function-record-out", "function-term-out"],
+    )
+    def test_equal_declarations_fingerprint_equal(self, make):
+        # Distinct-but-equal templates, so this pins declaration equality
+        # rather than object identity.
+        assert self._fp(make(EventTemplate(x=()))) == self._fp(make(EventTemplate(x=())))
+
+    def test_distinct_declarations_fingerprint_differently(self, tau):
+        other = EventTemplate(y=())
+        assert self._fp(RecordSpec(tau)) != self._fp(RecordSpec(other))
+        assert self._fp(DistributionSpec(tau)) != self._fp(DistributionSpec(other))
+        assert self._fp(FunctionSpec(tau, tau)) != self._fp(FunctionSpec(tau, other))
+
+    def test_declared_kind_changes_the_fingerprint(self, tau):
+        # The same space under different declared kinds must not collide: the
+        # declaration's class is the kind.
+        assert self._fp(RecordSpec(tau)) != self._fp(DistributionSpec(tau))
+        assert self._fp(FunctionSpec(tau, tau)) != self._fp(
+            FunctionSpec(tau, DistributionSpec(tau))
+        )
+
+    def test_unspecified_output_differs_from_a_declared_one(self, tau):
+        assert self._fp(FunctionSpec(tau)) != self._fp(FunctionSpec(tau, tau))

--- a/tests/core/test_fingerprint.py
+++ b/tests/core/test_fingerprint.py
@@ -21,6 +21,7 @@ from probpipe import (
     OpaqueSpec,
     Record,
     RecordSpec,
+    ValueSpec,
 )
 from probpipe.core._fingerprint import (
     _fingerprint_with_strength,
@@ -933,14 +934,22 @@ class TestValueSpecFingerprints:
 
     @staticmethod
     def _fp(spec):
-        """Fingerprint a spec in the position it is actually used: a leaf."""
-        return fingerprint(EventTemplate(field=spec))
+        """Fingerprint a spec as a template leaf, asserting it hashed strongly.
+
+        A spec the hasher does not know falls through to identity hashing, which
+        still returns a digest — so every comparison below would be meaningless
+        without this check.
+        """
+        digest, weak = _fingerprint_with_strength(EventTemplate(field=spec))
+        assert not weak, "spec hashed by identity, not by declaration"
+        return digest
 
     @pytest.fixture
     def tau(self):
         return EventTemplate(x=())
 
-    def test_every_spec_kind_fingerprints(self, tau):
+    def test_every_spec_kind_is_reachable_by_the_hasher(self, tau):
+        """Each kind hashes by declaration; none falls through to identity."""
         for spec in (
             ArraySpec(()),
             OpaqueSpec(),
@@ -949,7 +958,19 @@ class TestValueSpecFingerprints:
             FunctionSpec(tau, tau),
             FunctionSpec(),
         ):
-            assert isinstance(self._fp(spec), str)
+            _, weak = _fingerprint_with_strength(EventTemplate(field=spec))
+            assert not weak, f"{type(spec).__name__} hashed by identity"
+
+    def test_an_unknown_spec_kind_is_reported_weak(self, tau):
+        """The contract boundary: a spec the hasher does not know is not silently
+        treated as strong, so a future kind that skips the hasher is visible."""
+
+        class _UnknownSpec(ValueSpec):
+            def is_valid(self, value):
+                return True
+
+        _, weak = _fingerprint_with_strength(EventTemplate(field=_UnknownSpec()))
+        assert weak
 
     @pytest.mark.parametrize(
         "make",
@@ -983,6 +1004,22 @@ class TestValueSpecFingerprints:
     def test_unspecified_output_differs_from_a_declared_one(self, tau):
         assert self._fp(FunctionSpec(tau)) != self._fp(FunctionSpec(tau, tau))
 
+    def test_a_deep_declaration_chain_truncates_instead_of_recursing(self, tau):
+        """Declaration edges are hashed through the depth-guarded entry point.
+
+        An output declaration may itself be a FunctionSpec, so the chain is
+        unbounded; hashing it must degrade to the depth marker and report weak
+        rather than exhaust the interpreter stack. The spec is hashed directly:
+        nesting it in a template instead would recurse in ``EventTemplate``'s
+        own hash, which is a separate concern.
+        """
+        spec = FunctionSpec()
+        for _ in range(1000):
+            spec = FunctionSpec(tau, spec)
+
+        _, weak = _fingerprint_with_strength(spec)
+        assert weak
+
     # --- a spec is hashed by declaration wherever it appears, not by identity ---
 
     @pytest.mark.parametrize(
@@ -998,24 +1035,32 @@ class TestValueSpecFingerprints:
         identity hashing would make equal declarations hash differently and
         silently break cache keys and provenance.
         """
-        first, _ = _fingerprint_with_strength(wrap(RecordSpec(EventTemplate(x=()))))
-        second, weak = _fingerprint_with_strength(wrap(RecordSpec(EventTemplate(x=()))))
+        # Both specs are bound and alive simultaneously, so they cannot share an
+        # address: under identity hashing the digests would differ.
+        left = RecordSpec(EventTemplate(x=()))
+        right = RecordSpec(EventTemplate(x=()))
+        first, weak = _fingerprint_with_strength(wrap(left))
+        second, _ = _fingerprint_with_strength(wrap(right))
 
         assert not weak
         assert first == second
 
     @pytest.mark.parametrize(
         "wrap",
-        [lambda sp: sp, lambda sp: (sp,)],
-        ids=["bare", "in-tuple"],
+        [lambda sp: sp, lambda sp: (sp,), lambda sp: [sp], lambda sp: {"f": sp}],
+        ids=["bare", "in-tuple", "in-list", "in-dict"],
     )
-    def test_spec_type_is_recorded_outside_a_template(self, wrap, tau):
-        """Two specs that differ only in kind must not collide."""
-        assert (
-            _fingerprint_with_strength(wrap(RecordSpec(tau)))[0]
-            != _fingerprint_with_strength(wrap(DistributionSpec(tau)))[0]
-        )
-        assert (
-            _fingerprint_with_strength(wrap(ArraySpec(())))[0]
-            != _fingerprint_with_strength(wrap(OpaqueSpec()))[0]
-        )
+    def test_declaration_fields_are_recorded_outside_a_template(self, wrap):
+        """Two specs of the same kind differing only in their declaration.
+
+        Distinguishing *kinds* would not pin this: the identity fallback writes
+        the type name too, so it separates a RecordSpec from a DistributionSpec
+        on its own. Only reading the declaration fields separates these.
+        """
+        one = RecordSpec(EventTemplate(x=()))
+        other = RecordSpec(EventTemplate(y=()))
+        first, weak = _fingerprint_with_strength(wrap(one))
+        second, _ = _fingerprint_with_strength(wrap(other))
+
+        assert not weak
+        assert first != second

--- a/tests/core/test_first_class_function.py
+++ b/tests/core/test_first_class_function.py
@@ -530,7 +530,7 @@ class TestApplyContract:
         output_template = EventTemplate(
             learned=FunctionSpec(
                 input_template=learned.input_template,
-                output_template=learned.output_template,
+                output_spec=learned.output_template,
             )
         )
         wrapped = Function(


### PR DESCRIPTION
## Summary

The term-spec sub-hierarchy from #381, together with the declaration-storage rule it exists to support. This is **PR B** of the staging in #382 (A design docs · B this · C the wrap boundary · D `sample`).

The two were originally planned as separate PRs. They are folded here because the storage rule's normalisation *needs* `RecordSpec` — the class this PR introduces — so split apart, B would ship a `RecordSpec` with no consumer and B2 would immediately rename an attribute B had just widened. Landing them together also means one breaking change rather than two, and one coherent hierarchy per release rather than a half-applied convention.

## The hierarchy

`ValueSpec` splits into two families:

- **Raw-value specs** — `ArraySpec`, `OpaqueSpec` — type a plain value that names no ProbPipe kind.
- **Term specs** — one per kind, whose concrete class *is* the kind. `TermSpec(ValueSpec)` is the marker `isinstance` reads. New `RecordSpec` completes the four corners beside `DistributionSpec`, `FunctionSpec`, and the conditional spec still to come; `DistributionSpec` and `FunctionSpec` are reparented under `TermSpec`.

Because a tracked term is still one value that can occupy a leaf, a term spec *is* a value spec: `is_valid` stays declared once on `ValueSpec`, and anywhere a leaf is accepted a term spec is accepted unchanged.

## The storage rule

A **declaration** — of an event or of an output — is stored as a `ValueSpec`. A bare `EventTemplate` is accepted as construction sugar wherever a record declaration is meant, and is normalised to `RecordSpec(template)`, mirroring the existing `_FieldSpecInput` sugar in the same module. Of the stored specs only a `TermSpec` names a ProbPipe kind, and it names it by its class; a raw-value spec declares a raw value instead. After construction only the spec remains, so the declared kind is a **structural test** rather than an inference from a runtime value.

```python
DistributionSpec(EventTemplate(x=())).event_spec  # RecordSpec(...) — a record law
FunctionSpec(tau, tau).output_spec                # RecordSpec(...) — a record output
FunctionSpec(tau, FunctionSpec()).output_spec     # FunctionSpec    — returns a function
FunctionSpec(tau, DistributionSpec(tau))          # returns a Distribution
```

### Renames (breaking)

| Before | After | Stored as |
|---|---|---|
| `FunctionSpec.output_template` | **`output_spec`** | any `ValueSpec`, or `None` |
| `DistributionSpec.event_template` | **`event_spec`** | `RecordSpec` (see below) |

**Positional** construction is unchanged, and both constructors still accept an `EventTemplate` and wrap it, so `DistributionSpec(tau)` and `FunctionSpec(tau, tau)` keep working. **Keyword** construction moves to the new parameter name, as does every **read** of the old attribute:

```python
DistributionSpec(event_template=tau)    ->  DistributionSpec(event_spec=tau)
FunctionSpec(tau, output_template=tau)  ->  FunctionSpec(tau, output_spec=tau)
spec.event_template                     ->  spec.event_spec.event_template
```

There are no deprecation aliases: at `0.1.0` the only call sites outside the defining module are in its own test file, and an alias would preserve exactly the name the design rejects.

### Each field is declared at the type it stores

A field's annotation is the value it **holds**, not what the constructor accepts: `event_spec: RecordSpec` and `output_spec: ValueSpec | None`. The wider template spelling is carried by an explicit `__init__` (`dataclass(init=False)`, which keeps `eq`, `hash`, `repr`, and `dataclasses.replace`), so a type checker and the generated API reference both read the post-construction guarantee — and `is_valid` no longer casts its way back to it. `_to_record_declaration` is the narrow-in, narrow-out normaliser the record path needs, which retires the `cast` and its import rather than relocating it.

`ArraySpec` gets the same split, since it had the same mismatch: `dtype` is now declared as the `numpy.dtype` it stores rather than the `DTypeLike` spellings it accepts, and `shape` as the tuple rather than the iterable.

`RecordSpec.event_template` **keeps** its name. That is the naming rule, not an oversight: `*_template` is always a record schema, `*_spec` a declaration of any kind. Please don't apply the rename mechanically to it.

## What each declaration admits

`FunctionSpec.output_spec` accepts **any value specification**, matching the model's `Fun(σ, ρ)` with `ρ` a value specification and `E_Fun(σ,ρ) = Meas(E_σ, E_ρ)`: a callable may declare a term result of any kind, or a raw-value result that types the value the wrap boundary then places in a single-field `Record` keyed by the function's name. Nothing there is expressible-but-unsatisfiable, because the output side is unchecked — validity is callability alone.

An **event** declaration is narrower, and for a different reason: `DistributionSpec` takes an `EventTemplate` or a `RecordSpec` and **refuses a term-valued declaration**.

The reason is that a random measure could otherwise be *declared* but never *satisfied* — a `Distribution` exposes an `EventTemplate` and nothing that reports a term-valued draw kind — so `is_valid` would have to report "not implemented" as "invalid". That is exactly the conflation the two-partialities rule forbids (mathematically undefined versus computationally unavailable; design `III.5`'s error boundary). Refusing at construction removes the unsatisfiable state rather than choosing an answer about it, and puts the error where the declaration is written. Widening is non-breaking and belongs with the `Distribution`-side support that makes it checkable.

## `RecordSpec`'s leaf role is deferred

A `RecordSpec` is reached as a *declaration*, not as a template leaf: `Record` construction materialises a record-valued field into an interior template node, and `infer_from` does the same, so no in-tree route produces a `RecordSpec` leaf. The docstrings say so rather than describing the leaf role as live — `is_valid` is written for the leaf role a kind-directed wrap boundary will use, and that boundary is PR C.

## Fingerprinting

The stored declaration is a spec, not a template, so `_fingerprint.py` recurses into it and gains an explicit `RecordSpec` branch.

Chasing that surfaced a pre-existing defect worth its own note. The spec hasher records the object type and declaration fields, but the *generic* hasher had no `ValueSpec` branch, so a spec was routed there only as a template leaf. Reached any other way — bare, or inside a tuple, list, or mapping — it fell through to **identity** hashing, so two *equal* declarations produced different fingerprints and silently broke jit cache keys and provenance. `_update` now routes any `ValueSpec` to the spec hasher.

Deliberately **not** in this PR:

- `Tracked` → `TrackedTerm` and the `spec` slot on the tracked base, with the per-kind accessors becoming views. That touches nine files and has to absorb the scattered `self._event_template = …` assignments in `_empirical`, `_joint_empirical`, `_broadcast_distributions`, and `_record_distribution` — substrate work that should be revertable on its own.
- `Distribution` / `ConditionalDistribution` declarations accepting a `TermSpec`, and the batch classes. These depend on that slot.
- The wrap boundary and `sample` (PRs C/D), gated on the first-class `Function` (#368 / #380).

## Tests

`tests/core/test_event_template.py`: the renames throughout, plus tests for the storage rule — wrapping, idempotent normalisation, a term *output* declaration kept unwrapped, a term *event* declaration refused, the declared kind as the stored class, and `None` staying unspecified. Two tests that pinned the old store-as-given behaviour now assert the new contract. Two more pin the field split: that each declaration field's annotation resolves to the stored type (so a rewidening is caught), and that positional construction survives the rename while `event_template=` / `output_template=` raise.

`tests/core/test_fingerprint.py` gains `TestValueSpecFingerprints` (14 tests): every spec kind is reachable by the hasher, equal declarations agree while distinct declarations and distinct declared *kinds* do not, an unspecified output differs from a declared one, and a spec in each of the bare, in-tuple, in-list, and in-dict positions hashes strongly and stably. That class is what would have caught the two `AttributeError`s this PR briefly had after rebasing, and the identity-hashing defect above; both were verified to fail without their fixes.

**1020 pass** across every test module that touches these specs in `tests/core`, plus **114 pass** in `tests/inference` and `tests/modeling`. `ruff check` and `ruff format` clean at the pinned 0.15.16. `pyright` on `event_template.py` reports the same two pre-existing errors as before, both outside this diff's hunks — the change adds none and removes one `cast` suppression.

## Rebased

This branch is rebased onto `origin/main` (`f1987a4c`); it previously sat on the pre-`Function` merge base, which is why the two consumers above were invisible to it. Note one transient asymmetry until the follow-on lands: `FunctionSpec.output_spec` sits beside `Function.output_template`, which is a different attribute and is not renamed here.

Part of #381. Design reference: #382.

