### PR TITLE
fix(core): co-sample aliased lifted arguments; lift record-valued laws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Aliased lifted arguments now co-sample (#388).** Within one lifted call, two
+  references to the same law denote one random variable, so they must come from
+  one draw. Passing the same `Distribution` to two arguments sampled it twice
+  instead, so `f(d, d)` approximated `f(X1, X2)` — a silently wrong answer, with
+  `difference(dist, dist)` returning a spread around zero rather than zero.
+
+  Arguments were already grouped by root ancestor, as the co-sampling contract
+  requires; the grouping was then discarded for plain distributions and honored
+  only for field views. Each group is now drawn **once**, from its root, with
+  every member taking its own value out of that draw. Two further cases follow
+  from the same change: a parent passed alongside its own view no longer raises
+  (it was projected as though the parent were a view), and an empirical passed
+  twice contributes **one** enumeration axis rather than a squared grid — over
+  three atoms, `f(e, e)` enumerates 3 points instead of 9, each weighted once
+  instead of squared.
+
+  Arguments with no common root are unaffected, down to the subkeys: a group of
+  one consumes exactly one key split, as before. Only calls that were already
+  returning wrong values change their output.
+
 - **Value specs are fingerprinted by declaration, not identity (#381).** The
   spec hasher now covers `RecordSpec` and recurses into a stored declaration
   (`DistributionSpec.event_spec`, `FunctionSpec.output_spec`), which is a spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The other: a record-valued empirical passed alongside a
   field view of itself. That group routes to sampling rather than enumeration,
-  and `RecordEmpiricalDistribution._sample` returns a single `Record` rather
-  than a batch of them, so there are no rows to index. That is a distribution-
+  where `RecordEmpiricalDistribution._sample` hands back a plain record batched
+  on its leaves rather than a record batch — deliberately, so a vmap'd caller
+  can flatten it — and the view half of the group has no rows to project from. That is a distribution-
   layer contract gap rather than a broadcast one.
 
 - **Value specs are fingerprinted by declaration, not identity (#381).** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passed twice. Explicit `dispatch="jax"` reports the usual not-traceable error
   when the wrapped function indexes a record.
 
+  **The joint those lifts produce also resamples.** `include_inputs=True` keeps
+  every input beside the output, and drawing from that joint gathers the same
+  rows from each, which is what keeps a drawn tuple paired. A record-shaped
+  component has fields rather than a shape, so handing it an array of rows raised
+  `TypeError: key must be str, tuple, or int`. Every component now goes through
+  one gather that reads the container it is given: an array indexes directly, a
+  list of per-row objects gathers positionally, and a record is rebuilt from its
+  gathered leaves. The rebuild is deliberate rather than a `jax.tree.map` — a
+  `RecordArray` stores its row count and a `Record` its event template, both in
+  pytree aux data, so mapping over the leaves alone would have produced a batch
+  quietly claiming the rows it started with. The same gather covers the output
+  side, where a vectorized broadcast over a record-returning function leaves the
+  output a batched `Record`. A single draw is unwrapped to one record rather than
+  a one-row batch, its field names intact.
+
   One shape is still unsupported: a record-valued empirical passed alongside a
   field view of itself. That group routes to sampling rather than enumeration,
   and `RecordEmpiricalDistribution._sample` returns a single `Record` rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,18 +30,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returning wrong values change their output.
 
 - **A record-valued law can be lifted.** Passing a record-valued
-  `Distribution` as an argument raised `TypeError: NumericRecordArray with 2
-  fields is not array-like`, because broadcast assembly read the row count from
-  the samples' `shape` — which a record batch refuses unless it holds exactly
-  one leaf. The count now comes from `batch_shape`, the one accessor that means
-  the same thing for every batched value. (Not `len`: on a `RecordArray` that is
-  the *field* count, which would have made `num_atoms` silently wrong.)
+  `Distribution` as an argument raised `TypeError: ... is not array-like`, from
+  two places that assumed every argument's samples were an array. Broadcast
+  assembly read the row count from the samples' `shape`, which a record batch
+  refuses unless it holds exactly one leaf; the count now comes from
+  `batch_shape`, the one accessor that means the same thing for every batched
+  value. (Not `len`: on a `RecordArray` that is the *field* count, which would
+  have made `num_atoms` silently wrong.) And enumeration stacked each
+  argument's per-row values with `jnp.stack`, which a `Record` row is not; those
+  now stack through `RecordArray.stack`.
 
-  This is what kept `f(d, d["x"])` — a parent alongside its own view, the
-  remaining co-sampling case above — from running end to end once its draws were
-  shared. A record-valued argument now lifts under `auto`, `sequential`, and
-  `thread` dispatch; explicit `dispatch="jax"` reports the usual
-  not-traceable error when the wrapped function indexes a record.
+  The first of those is what kept `f(d, d["x"])` — a parent alongside its own
+  view, the remaining co-sampling case above — from running end to end once its
+  draws were shared. Record-valued laws now lift under `auto`, `sequential`, and
+  `thread` dispatch, including record-valued empiricals, whether enumerated or
+  passed twice. Explicit `dispatch="jax"` reports the usual not-traceable error
+  when the wrapped function indexes a record.
+
+  One shape is still unsupported: a record-valued empirical passed alongside a
+  field view of itself. That group routes to sampling rather than enumeration,
+  and `RecordEmpiricalDistribution._sample` returns a single `Record` rather
+  than a batch of them, so there are no rows to index. That is a distribution-
+  layer contract gap rather than a broadcast one.
 
 - **Value specs are fingerprinted by declaration, not identity (#381).** The
   spec hasher now covers `RecordSpec` and recurses into a stored declaration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output a batched `Record`. A single draw is unwrapped to one record rather than
   a one-row batch, its field names intact.
 
-  One shape is still unsupported: a record-valued empirical passed alongside a
+  Two shapes are still unsupported. A record with **nested** fields cannot be
+  batched at all, since a record batch is keyed by its top-level children rather
+  than by leaf path, so lifting such a law is refused with a message naming the
+  argument rather than surfacing what the container said. That is #340, and a
+  strict `xfail` in the broadcast tests marks the case so it reports the day
+  record batches become leaf-keyed.
+
+  The other: a record-valued empirical passed alongside a
   field view of itself. That group routes to sampling rather than enumeration,
   and `RecordEmpiricalDistribution._sample` returns a single `Record` rather
   than a batch of them, so there are no rows to index. That is a distribution-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one consumes exactly one key split, as before. Only calls that were already
   returning wrong values change their output.
 
+- **A record-valued law can be lifted.** Passing a record-valued
+  `Distribution` as an argument raised `TypeError: NumericRecordArray with 2
+  fields is not array-like`, because broadcast assembly read the row count from
+  the samples' `shape` — which a record batch refuses unless it holds exactly
+  one leaf. The count now comes from `batch_shape`, the one accessor that means
+  the same thing for every batched value. (Not `len`: on a `RecordArray` that is
+  the *field* count, which would have made `num_atoms` silently wrong.)
+
+  This is what kept `f(d, d["x"])` — a parent alongside its own view, the
+  remaining co-sampling case above — from running end to end once its draws were
+  shared. A record-valued argument now lifts under `auto`, `sequential`, and
+  `thread` dispatch; explicit `dispatch="jax"` reports the usual
+  not-traceable error when the wrapped function indexes a record.
+
 - **Value specs are fingerprinted by declaration, not identity (#381).** The
   spec hasher now covers `RecordSpec` and recurses into a stored declaration
   (`DistributionSpec.event_spec`, `FunctionSpec.output_spec`), which is a spec

--- a/docs/user_guide/03_broadcasting.ipynb
+++ b/docs/user_guide/03_broadcasting.ipynb
@@ -212,7 +212,7 @@
    "source": [
     "## Multiple Distribution Arguments\n",
     "\n",
-    "When multiple arguments receive distributions, each is sampled independently per call. The i-th call uses the i-th sample from every distribution argument."
+    "When multiple arguments receive distributions, the i-th call uses the i-th sample from every distribution argument. Arguments that come from *different* distributions are sampled independently, so the calls draw from the product of their laws. Arguments that refer to the *same* distribution — the same object passed twice, or two field views of one joint law — instead share a single draw per call, so `f(d, d)` evaluates `f` on one realization rather than two."
    ]
   },
   {

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -886,6 +886,60 @@ def _make_stack(
 # ---------------------------------------------------------------------------
 
 
+def _record_rows(record: Record, rows: Any) -> Record:
+    """*record* with every leaf reduced to *rows*, its specification re-derived.
+
+    A record's pytree aux data carries its event template, whose shapes describe
+    the leaves it was built from, so ``jax.tree.map`` would rebuild a record
+    claiming the shapes it started with while holding gathered ones. Rebuilding by
+    path lets the template be re-derived from the leaves that survived.
+    """
+    paths = tuple(record.event_template.keys())
+    return type(record)(
+        record.name, {path: record[path][rows] for path in paths}, name_is_auto=True
+    )
+
+
+def _take_rows(component: Any, indices: Array) -> Any:
+    """Gather the rows *indices* of one batched component, keeping its container.
+
+    A component of a broadcast is batched along its leading axis, but what carries
+    that axis depends on what the component holds. An array is indexed directly. A
+    list holds one object per row and is gathered positionally. A record has fields
+    rather than a shape, so its leaves are gathered and the record rebuilt around
+    them — a ``RecordArray`` stating the row count it now holds, since that count
+    is stored rather than read off the leaves.
+    """
+    if isinstance(component, list):
+        return [component[int(i)] for i in indices]
+    if isinstance(component, RecordArray):
+        return type(component)(
+            {path: component[path][indices] for path in component.fields},
+            batch_shape=(indices.shape[0], *component.batch_shape[1:]),
+            template=component.template,
+        )
+    if isinstance(component, Record):
+        return _record_rows(component, indices)
+    return component[indices]
+
+
+def _one_row(component: Any) -> Any:
+    """One drawn row of a component, presented on its own.
+
+    ``sample_shape=()`` asks for a single draw rather than a batch of one, so the
+    row is unwrapped: a record of that row rather than a one-row batch of records,
+    and the object itself rather than a one-element list. Field names survive —
+    one draw of a record-valued component is a record, whatever its field count.
+    """
+    if isinstance(component, RecordArray):
+        return component[0]
+    if isinstance(component, Record):
+        return _record_rows(component, 0)
+    if isinstance(component, list):
+        return component[0]
+    return component[0] if hasattr(component, "__getitem__") else component
+
+
 class BroadcastDistribution(Distribution[dict], SupportsSampling):
     """Joint distribution over broadcast inputs and function output.
 
@@ -1014,25 +1068,22 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
     # -- joint sampling -----------------------------------------------------
 
     def _sample(self, key, sample_shape=()):
-        """Resample paired input–output tuples."""
+        """Resample paired input–output tuples.
+
+        Every component is batched along the same leading axis, so one set of
+        drawn rows is gathered from each — the inputs and the output alike, which
+        is what keeps a drawn tuple paired.
+        """
         n_draws = prod(sample_shape) if sample_shape else 1
         indices = self._w.choice(key, shape=(n_draws,))
 
-        result = {}
-        for arg_name in self._broadcast_args:
-            arr = self._input_samples[arg_name]
-            result[arg_name] = arr[indices]
-
-        # Output
-        if isinstance(self._output_samples, jnp.ndarray):
-            result["_output"] = self._output_samples[indices]
-        elif isinstance(self._output_samples, list):
-            result["_output"] = [self._output_samples[int(i)] for i in indices]
-        else:
-            result["_output"] = self._output_samples[indices]
+        result = {
+            name: _take_rows(self._input_samples[name], indices) for name in self._broadcast_args
+        }
+        result["_output"] = _take_rows(self._output_samples, indices)
 
         if sample_shape == ():
-            return jax.tree.map(lambda x: x[0] if hasattr(x, "__getitem__") else x, result)
+            return {name: _one_row(component) for name, component in result.items()}
         return result
 
     # -- marginalization ----------------------------------------------------

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -954,10 +954,19 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
         self._output_distributions = output_distributions
         self._output_template = output_template
 
-        # Determine n from first broadcast arg
+        # The row count, taken from the first broadcast arg. A record batch
+        # answers neither of the obvious questions the way one would hope: its
+        # ``len`` is the field count, and its ``shape`` raises unless it holds a
+        # single leaf — and raises a ``TypeError``, which ``hasattr`` propagates
+        # rather than swallowing. ``batch_shape`` is the one accessor that means
+        # the same thing for every batched value.
         first_key = next(iter(broadcast_args))
         first_arr = input_samples[first_key]
-        n = first_arr.shape[0] if hasattr(first_arr, "shape") else len(first_arr)
+        batch_shape = getattr(first_arr, "batch_shape", None)
+        if batch_shape:
+            n = batch_shape[0]
+        else:
+            n = first_arr.shape[0] if hasattr(first_arr, "shape") else len(first_arr)
         self._w = Weights(n=n, weights=weights, log_weights=log_weights)
         self._broadcast_args = list(broadcast_args)
         name, name_is_auto = auto_name(name, "broadcast")

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -913,8 +913,12 @@ def _take_rows(component: Any, indices: Array) -> Any:
     if isinstance(component, list):
         return [component[int(i)] for i in indices]
     if isinstance(component, RecordArray):
+        # Keyed by the template, which is leaf-keyed, rather than by ``fields``,
+        # which names the top-level children and is retained only for the
+        # migration. The two agree while a record batch is flat and will not once
+        # one can nest; ``_RecordMarginal`` peels a batch the same way.
         return type(component)(
-            {path: component[path][indices] for path in component.fields},
+            {path: component[path][indices] for path in component.template},
             batch_shape=(indices.shape[0], *component.batch_shape[1:]),
             template=component.template,
         )
@@ -968,10 +972,15 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
 
     Parameters
     ----------
-    input_samples : dict[str, Array]
-        ``{arg_name: (n, *event_shape)}`` for each broadcast argument.
-    output_samples : Array or list
-        ``(n, *event_shape)`` for array outputs, or a list of length *n*.
+    input_samples : dict[str, Array or RecordArray or list]
+        ``{arg_name: rows}`` for each broadcast argument, every value batched
+        over the same leading axis of length ``n``: an array of shape
+        ``(n, *event_shape)``, a record batch of ``batch_shape == (n,)`` for a
+        record-valued argument, or a list of ``n`` objects.
+    output_samples : Array, Record, or list
+        The outputs, batched over the same axis: ``(n, *event_shape)`` for array
+        outputs, a record whose leaves carry that axis for record-returning
+        functions, or a list of length *n*.
     weights : array-like, :class:`~probpipe.Weights`, or None
         Non-negative weights (normalized internally).  A pre-built
         :class:`~probpipe.Weights` object is also accepted.  Mutually

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -900,6 +900,26 @@ def _record_rows(record: Record, rows: Any) -> Record:
     )
 
 
+def _row_count(component: Any) -> int:
+    """How many rows one batched component holds.
+
+    Every component is batched along its leading axis, but what reports that
+    axis differs. An array has a ``shape`` and a list a ``len``. A record batch
+    has neither that means the right thing — its ``len`` is the *field* count and
+    its ``shape`` raises unless it holds a single leaf — so it reports
+    ``batch_shape``. A plain record batched on its leaves has no ``batch_shape``
+    either, which is the form ``RecordEmpiricalDistribution._sample`` returns, so
+    its rows are read off a leaf.
+    """
+    batch_shape = getattr(component, "batch_shape", None)
+    if batch_shape:
+        return batch_shape[0]
+    if isinstance(component, Record):
+        leaf = next(iter(component.values()))
+        return leaf.shape[0]
+    return component.shape[0] if hasattr(component, "shape") else len(component)
+
+
 def _take_rows(component: Any, indices: Array) -> Any:
     """Gather the rows *indices* of one batched component, keeping its container.
 
@@ -1017,19 +1037,8 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
         self._output_distributions = output_distributions
         self._output_template = output_template
 
-        # The row count, taken from the first broadcast arg. A record batch
-        # answers neither of the obvious questions the way one would hope: its
-        # ``len`` is the field count, and its ``shape`` raises unless it holds a
-        # single leaf — and raises a ``TypeError``, which ``hasattr`` propagates
-        # rather than swallowing. ``batch_shape`` is the one accessor that means
-        # the same thing for every batched value.
-        first_key = next(iter(broadcast_args))
-        first_arr = input_samples[first_key]
-        batch_shape = getattr(first_arr, "batch_shape", None)
-        if batch_shape:
-            n = batch_shape[0]
-        else:
-            n = first_arr.shape[0] if hasattr(first_arr, "shape") else len(first_arr)
+        # The row count, taken from the first broadcast arg.
+        n = _row_count(input_samples[next(iter(broadcast_args))])
         self._w = Weights(n=n, weights=weights, log_weights=log_weights)
         self._broadcast_args = list(broadcast_args)
         name, name_is_auto = auto_name(name, "broadcast")

--- a/probpipe/core/_workflow_distribution_broadcast.py
+++ b/probpipe/core/_workflow_distribution_broadcast.py
@@ -315,8 +315,12 @@ def _sample_broadcast_args(
     return sampled
 
 
-def _project_from_root(view: Any, drawn: Any) -> Array:
-    """A view's own draw, taken out of its root's joint draw."""
+def _project_from_root(view: Any, drawn: Any) -> Any:
+    """A view's own draw, taken out of its root's joint draw.
+
+    Not necessarily an array: a view of a field group projects the sub-record its
+    path names, so this returns whatever the root's draw holds there.
+    """
     if hasattr(view, "_extract"):
         return view._extract(drawn)
     projected = drawn

--- a/probpipe/core/_workflow_distribution_broadcast.py
+++ b/probpipe/core/_workflow_distribution_broadcast.py
@@ -520,17 +520,17 @@ def _stack_rows(rows: list[Any], *, arg_name: str) -> Any:
     from .record import Record
 
     if rows and isinstance(rows[0], Record):
-        try:
-            return RecordArray.stack(rows)
-        except TypeError as exc:
-            # ``stack`` reports what the container cannot do; the caller needs to
-            # hear which argument of theirs it was, and that the shape is the one
-            # a record batch does not represent yet rather than a mistake.
+        # Checked rather than caught: ``stack`` refuses a nested template, but it
+        # refuses other things too, and attributing every refusal to nesting
+        # would advise flattening a record that is already flat. A leaf path
+        # differs from a child name exactly when the record nests.
+        if tuple(rows[0].keys()) != rows[0].fields:
             raise TypeError(
                 f"lifting {arg_name!r} would batch a record with nested fields, which a record "
                 f"batch does not represent yet; flatten the law's fields, or pass the nested "
-                f"parts as separate arguments ({exc})"
-            ) from exc
+                f"parts as separate arguments"
+            )
+        return RecordArray.stack(rows)
     return jnp.stack(rows)
 
 

--- a/probpipe/core/_workflow_distribution_broadcast.py
+++ b/probpipe/core/_workflow_distribution_broadcast.py
@@ -449,7 +449,7 @@ def _broadcast_enumerate(
     results = _workflow_execution.execute_many(request)
 
     all_input_samples = {
-        ref.label: jnp.stack(
+        ref.label: _stack_rows(
             [_workflow_call.input_ref_value(call_values, ref) for call_values in call_value_list]
         )
         for ref in all_broadcast_args
@@ -505,6 +505,22 @@ def _broadcast_sample(
         broadcast_args=[ref.label for ref in broadcast_args],
         output_template=output_template,
     )
+
+
+def _stack_rows(rows: list[Any]) -> Any:
+    """Stack one argument's per-row values into a single batched value.
+
+    ``jnp.stack`` covers array-valued rows. A record-valued row is not an array
+    — a ``Record`` has fields, not a shape — so those stack through
+    ``RecordArray.stack``, giving a batch whose ``batch_shape`` is ``(n,)`` and
+    whose fields are the per-row leaves.
+    """
+    from ._record_array import RecordArray
+    from .record import Record
+
+    if rows and isinstance(rows[0], Record):
+        return RecordArray.stack(rows)
+    return jnp.stack(rows)
 
 
 def _index_sample(s: Any, i: int) -> Any:

--- a/probpipe/core/_workflow_distribution_broadcast.py
+++ b/probpipe/core/_workflow_distribution_broadcast.py
@@ -450,7 +450,8 @@ def _broadcast_enumerate(
 
     all_input_samples = {
         ref.label: _stack_rows(
-            [_workflow_call.input_ref_value(call_values, ref) for call_values in call_value_list]
+            [_workflow_call.input_ref_value(call_values, ref) for call_values in call_value_list],
+            arg_name=ref.label,
         )
         for ref in all_broadcast_args
     }
@@ -507,7 +508,7 @@ def _broadcast_sample(
     )
 
 
-def _stack_rows(rows: list[Any]) -> Any:
+def _stack_rows(rows: list[Any], *, arg_name: str) -> Any:
     """Stack one argument's per-row values into a single batched value.
 
     ``jnp.stack`` covers array-valued rows. A record-valued row is not an array
@@ -519,7 +520,17 @@ def _stack_rows(rows: list[Any]) -> Any:
     from .record import Record
 
     if rows and isinstance(rows[0], Record):
-        return RecordArray.stack(rows)
+        try:
+            return RecordArray.stack(rows)
+        except TypeError as exc:
+            # ``stack`` reports what the container cannot do; the caller needs to
+            # hear which argument of theirs it was, and that the shape is the one
+            # a record batch does not represent yet rather than a mistake.
+            raise TypeError(
+                f"lifting {arg_name!r} would batch a record with nested fields, which a record "
+                f"batch does not represent yet; flatten the law's fields, or pass the nested "
+                f"parts as separate arguments ({exc})"
+            ) from exc
     return jnp.stack(rows)
 
 

--- a/probpipe/core/_workflow_distribution_broadcast.py
+++ b/probpipe/core/_workflow_distribution_broadcast.py
@@ -24,7 +24,6 @@ except ImportError:
 
 from ..custom_types import Array, PRNGKey
 from . import _workflow_call, _workflow_execution, _workflow_plan
-from ._record_distribution import _RecordDistributionView
 from .config import WorkflowKind, prefect_config
 from .distribution import BroadcastDistribution, Distribution, EmpiricalDistribution
 from .event_template import EventTemplate
@@ -117,7 +116,7 @@ def execute_distribution_broadcast(
     broadcast_args = list(broadcast_args)
     _validate_n_broadcast_samples(n_broadcast_samples)
 
-    empirical_args, sample_args, product_size = _split_empirical_args(
+    empirical_groups, sample_args, product_size = _split_empirical_args(
         values=values,
         broadcast_args=broadcast_args,
         n_broadcast_samples=n_broadcast_samples,
@@ -126,9 +125,9 @@ def execute_distribution_broadcast(
     dispatch = resolve_dispatch(
         values,
         broadcast_args,
-        jax_supported=not empirical_args,
+        jax_supported=not empirical_groups,
     )
-    if requested_dispatch == "jax" and empirical_args:
+    if requested_dispatch == "jax" and empirical_groups:
         raise ValueError(
             "dispatch='jax' does not support exact empirical enumeration; "
             "use dispatch='auto', 'sequential', or 'thread' for this path."
@@ -136,11 +135,11 @@ def execute_distribution_broadcast(
 
     # Enumeration preserves exact empirical weights and must run in all row-wise
     # dispatch modes; otherwise cartesian-product semantics vary by dispatch.
-    if empirical_args:
+    if empirical_groups:
         result = _broadcast_enumerate(
             func=func,
             values=values,
-            empirical_args=empirical_args,
+            empirical_groups=empirical_groups,
             sample_args=sample_args,
             product_size=product_size,
             n_broadcast_samples=n_broadcast_samples,
@@ -214,30 +213,51 @@ def _split_empirical_args(
     broadcast_args: Sequence[_workflow_call.WorkflowInputRef],
     n_broadcast_samples: int,
 ) -> tuple[
-    dict[_workflow_call.WorkflowInputRef, EmpiricalDistribution],
+    tuple[tuple[EmpiricalDistribution, tuple[_workflow_call.WorkflowInputRef, ...]], ...],
     dict[_workflow_call.WorkflowInputRef, Distribution],
     int,
 ]:
-    candidates: list[tuple[_workflow_call.WorkflowInputRef, EmpiricalDistribution]] = []
-    sample_args: dict[_workflow_call.WorkflowInputRef, Distribution] = {}
-    for ref in broadcast_args:
-        dist = _workflow_call.input_ref_value(values, ref)
-        if isinstance(dist, EmpiricalDistribution) and dist.num_atoms <= n_broadcast_samples:
-            candidates.append((ref, dist))
-        else:
-            sample_args[ref] = dist
-    candidates.sort(key=lambda pair: pair[1].num_atoms)
+    """Split the broadcast arguments into enumerable empirical groups and the rest.
 
-    empirical_args: dict[_workflow_call.WorkflowInputRef, EmpiricalDistribution] = {}
+    A **co-sampling group** is enumerated or sampled as a unit, never split, so
+    the same empirical passed twice contributes one enumeration axis rather than
+    a squared grid. A group is enumerable when its root is an empirical small
+    enough to enumerate and every member *is* that root: a group holding a view
+    goes to the sampling path whole, which keeps a parent and its view on one
+    draw instead of enumerating one and sampling the other.
+
+    Groups are enumerated smallest-first while the running product fits the
+    budget; a group that does not fit falls through to sampling, where its
+    members still co-sample.
+    """
+    candidates: list[tuple[EmpiricalDistribution, tuple[_workflow_call.WorkflowInputRef, ...]]] = []
+    sample_args: dict[_workflow_call.WorkflowInputRef, Distribution] = {}
+    for root, arg_refs in _workflow_plan.group_by_root(values=values, refs=broadcast_args):
+        enumerable = (
+            isinstance(root, EmpiricalDistribution)
+            and root.num_atoms <= n_broadcast_samples
+            and all(_workflow_call.input_ref_value(values, ref) is root for ref in arg_refs)
+        )
+        if enumerable:
+            candidates.append((root, arg_refs))
+        else:
+            for ref in arg_refs:
+                sample_args[ref] = _workflow_call.input_ref_value(values, ref)
+    candidates.sort(key=lambda pair: pair[0].num_atoms)
+
+    empirical_groups: list[
+        tuple[EmpiricalDistribution, tuple[_workflow_call.WorkflowInputRef, ...]]
+    ] = []
     product_size = 1
-    for name, dist in candidates:
+    for dist, arg_refs in candidates:
         if product_size * dist.num_atoms <= n_broadcast_samples:
-            empirical_args[name] = dist
+            empirical_groups.append((dist, arg_refs))
             product_size *= dist.num_atoms
         else:
-            sample_args[name] = dist
+            for ref in arg_refs:
+                sample_args[ref] = dist
 
-    return empirical_args, sample_args, product_size
+    return tuple(empirical_groups), sample_args, product_size
 
 
 def _make_broadcast_provenance(
@@ -272,37 +292,37 @@ def _sample_broadcast_args(
     n: int,
     key: PRNGKey,
 ) -> dict[_workflow_call.WorkflowInputRef, Array]:
-    """Sample all broadcast arguments, handling view reconnection.
+    """Sample all broadcast arguments, one joint draw per co-sampling group.
 
-    Sibling views from the same parent distribution share one parent draw,
-    preserving cross-field correlation. Plain non-view distributions are
-    sampled independently per kwarg, even if the same object is passed under
-    multiple names.
+    Arguments are grouped by root ancestor, so the same distribution passed
+    twice, sibling views of one parent, and a parent passed alongside its own
+    view all fall in one group. Each group is drawn **once**, from its root, and
+    every member takes its own value out of that draw — the root itself whole, a
+    view through its field path. Dependence within a group therefore flows
+    through the wrapped function instead of being broken by independent
+    sampling, so ``f(d, d)`` approximates ``f(X, X)`` rather than ``f(X1, X2)``.
+
+    Groups with no common root are drawn from separate subkeys, which samples the
+    product of their laws.
     """
     sampled: dict[_workflow_call.WorkflowInputRef, Array] = {}
-    for arg_refs in _workflow_plan.group_by_parent(
-        values=values,
-        refs=broadcast_args,
-    ).values():
-        first = _workflow_call.input_ref_value(values, arg_refs[0])
-        if not isinstance(first, _RecordDistributionView):
-            for ref in arg_refs:
-                key, subkey = jax.random.split(key)
-                dist = _workflow_call.input_ref_value(values, ref)
-                sampled[ref] = dist._sample(subkey, (n,))
-            continue
+    for root, arg_refs in _workflow_plan.group_by_root(values=values, refs=broadcast_args):
         key, subkey = jax.random.split(key)
-        structured = first.parent._sample(subkey, (n,))
+        drawn = root._sample(subkey, (n,))
         for ref in arg_refs:
-            view = _workflow_call.input_ref_value(values, ref)
-            if hasattr(view, "_extract"):
-                sampled[ref] = view._extract(structured)
-            else:
-                val = structured
-                for k in getattr(view, "_key_path", (view.field,)):
-                    val = val[k]
-                sampled[ref] = val
+            member = _workflow_call.input_ref_value(values, ref)
+            sampled[ref] = drawn if member is root else _project_from_root(member, drawn)
     return sampled
+
+
+def _project_from_root(view: Any, drawn: Any) -> Array:
+    """A view's own draw, taken out of its root's joint draw."""
+    if hasattr(view, "_extract"):
+        return view._extract(drawn)
+    projected = drawn
+    for key_name in getattr(view, "_key_path", (view.field,)):
+        projected = projected[key_name]
+    return projected
 
 
 def _broadcast_jax(
@@ -364,7 +384,9 @@ def _broadcast_enumerate(
     *,
     func: Callable[..., Any],
     values: dict[str, Any],
-    empirical_args: dict[_workflow_call.WorkflowInputRef, EmpiricalDistribution],
+    empirical_groups: tuple[
+        tuple[EmpiricalDistribution, tuple[_workflow_call.WorkflowInputRef, ...]], ...
+    ],
     sample_args: dict[_workflow_call.WorkflowInputRef, Distribution],
     product_size: int,
     n_broadcast_samples: int,
@@ -375,10 +397,14 @@ def _broadcast_enumerate(
     ],
     output_template: EventTemplate | None,
 ) -> BroadcastDistribution:
-    """Enumerate empirical distributions and sample any remaining inputs."""
+    """Enumerate empirical distributions and sample any remaining inputs.
+
+    One axis of the cartesian product per co-sampling group, so every reference in
+    a group takes the same atom and contributes its weight once.
+    """
     key = get_key()
-    emp_names = list(empirical_args.keys())
-    emp_dists = [empirical_args[name] for name in emp_names]
+    emp_dists = [dist for dist, _refs in empirical_groups]
+    emp_refs = [arg_refs for _dist, arg_refs in empirical_groups]
 
     reps_per_combo = max(1, n_broadcast_samples // product_size) if sample_args else 1
     total = product_size * reps_per_combo
@@ -393,18 +419,20 @@ def _broadcast_enumerate(
     weights = []
     sample_idx = 0
 
-    all_broadcast_args = emp_names + sample_arg_names
+    all_broadcast_args = [ref for arg_refs in emp_refs for ref in arg_refs] + sample_arg_names
 
     for combo in cartesian_product(*(range(d.num_atoms) for d in emp_dists)):
         emp_weight = 1.0
-        for _ref, dist, i in zip(emp_names, emp_dists, combo):
+        for dist, i in zip(emp_dists, combo, strict=True):
             emp_weight *= float(dist.weights[i])
 
         for _ in range(reps_per_combo):
             replacements: dict[_workflow_call.WorkflowInputRef, Any] = {}
 
-            for ref, dist, i in zip(emp_names, emp_dists, combo):
-                replacements[ref] = _index_sample(dist.samples, i)
+            for dist, arg_refs, i in zip(emp_dists, emp_refs, combo, strict=True):
+                atom = _index_sample(dist.samples, i)
+                for ref in arg_refs:
+                    replacements[ref] = atom
 
             for ref in sample_args:
                 replacements[ref] = _index_sample(sampled[ref], sample_idx)

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -88,18 +88,30 @@ def build_broadcast_plan(
     )
 
 
-def group_by_parent(
+def group_by_root(
     *,
     values: Mapping[str, Any],
     refs: Sequence[_workflow_call.WorkflowInputRef],
-) -> dict[int, list[_workflow_call.WorkflowInputRef]]:
-    """Group input references by the identity of their source parent."""
-    groups: dict[int, list[_workflow_call.WorkflowInputRef]] = {}
+) -> list[tuple[Any, tuple[_workflow_call.WorkflowInputRef, ...]]]:
+    """Group input references by root ancestor, with the root of each group.
+
+    A value with no parent is its own root, so one group holds every reference
+    that denotes the same underlying random variable: the same distribution
+    passed twice, sibling views of one parent, and a parent passed alongside its
+    own view. References with no common root land in separate groups. Groups and
+    their members keep argument order, so the grouping is a deterministic
+    function of the call.
+
+    A root is found by a single ``parent`` lookup, which is exact for the view
+    types that exist: a view's parent is always a distribution, never another
+    view. A nested view type would need this walked transitively.
+    """
+    groups: dict[int, tuple[Any, list[_workflow_call.WorkflowInputRef]]] = {}
     for ref in refs:
         value = _workflow_call.input_ref_value(values, ref)
-        parent = getattr(value, "parent", value)
-        groups.setdefault(id(parent), []).append(ref)
-    return groups
+        root = getattr(value, "parent", value)
+        groups.setdefault(id(root), (root, []))[1].append(ref)
+    return [(root, tuple(group_refs)) for root, group_refs in groups.values()]
 
 
 def group_array_args_by_parent(
@@ -109,7 +121,7 @@ def group_array_args_by_parent(
 ) -> tuple[ArrayBroadcastGroup, ...]:
     """Build parent-identity groups for array-valued sweep arguments."""
     groups: list[ArrayBroadcastGroup] = []
-    for arg_refs in group_by_parent(values=values, refs=refs).values():
+    for _root, arg_refs in group_by_root(values=values, refs=refs):
         first = _workflow_call.input_ref_value(values, arg_refs[0])
         batch_shape = tuple(first.batch_shape)
         groups.append(

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -12,6 +12,7 @@ from probpipe import (
     ProductDistribution,
     Provenance,
     Record,
+    RecordArray,
     SupportsCovariance,
     SupportsLogProb,
     SupportsMean,
@@ -156,6 +157,82 @@ class TestBroadcastDistributionSampling:
         batch = bd._sample(key, (100,))
         # For each resampled pair, output should be 10x input
         np.testing.assert_allclose(batch["_output"], batch["x"] * 10, atol=1e-5)
+
+
+class TestResamplingARecordValuedComponent:
+    """A component may be record-shaped, which has fields rather than a shape."""
+
+    @staticmethod
+    def _paired(**controls):
+        """A batch of three rows whose record input determines the output."""
+        rows = [Record("r", x=jnp.array(float(i)), y=jnp.array(10.0 * i)) for i in range(1, 4)]
+        return BroadcastDistribution(
+            input_samples={"a": RecordArray.stack(rows)},
+            output_samples=jnp.array([10.0, 20.0, 30.0]),
+            weights=None,
+            broadcast_args=["a"],
+            **controls,
+        )
+
+    def test_a_record_valued_input_resamples(self, key):
+        batch = self._paired()._sample(key, (5,))
+
+        assert isinstance(batch["a"], RecordArray)
+        assert batch["a"].batch_shape == (5,)
+        assert batch["_output"].shape == (5,)
+
+    def test_the_drawn_rows_stay_paired(self, key):
+        """Every field and the output are gathered at the same rows, or not paired."""
+        batch = self._paired()._sample(key, (50,))
+
+        x, y = np.asarray(batch["a"]["x"]), np.asarray(batch["a"]["y"])
+        np.testing.assert_allclose(y, x * 10, atol=1e-5)
+        np.testing.assert_allclose(np.asarray(batch["_output"]), y, atol=1e-5)
+        assert set(x.tolist()) <= {1.0, 2.0, 3.0}
+
+    def test_the_resampled_batch_states_the_rows_it_holds(self, key):
+        """A RecordArray stores its row count, so a gather has to restate it.
+
+        Rebuilding through ``jax.tree.map`` would carry the count over from the
+        pytree aux data and claim three rows while holding five.
+        """
+        batch = self._paired()._sample(key, (5,))
+
+        assert batch["a"].batch_shape == (batch["a"]["x"].shape[0],)
+        assert all(spec.shape == () for spec in batch["a"].template.values())
+
+    def test_one_draw_is_a_record_rather_than_a_one_row_batch(self, key):
+        drawn = self._paired()._sample(key, ())
+
+        assert isinstance(drawn["a"], Record)
+        assert not isinstance(drawn["a"], RecordArray)
+        assert drawn["a"]["x"].shape == ()
+        np.testing.assert_allclose(
+            float(np.asarray(drawn["_output"])), float(np.asarray(drawn["a"]["y"])), atol=1e-5
+        )
+
+    def test_a_record_valued_output_resamples_too(self, key):
+        """The output side takes the same gather, and keeps its field names.
+
+        A vectorized broadcast over a record-returning function leaves the output
+        a batched ``Record``, whose ``[]`` addresses a field rather than a row.
+        """
+        bd = BroadcastDistribution(
+            input_samples={"a": jnp.array([1.0, 2.0, 3.0])},
+            output_samples=Record("o", z=jnp.array([10.0, 20.0, 30.0])),
+            weights=None,
+            broadcast_args=["a"],
+        )
+
+        batch = bd._sample(key, (5,))
+        assert batch["_output"]["z"].shape == (5,)
+        np.testing.assert_allclose(
+            np.asarray(batch["_output"]["z"]), np.asarray(batch["a"]) * 10, atol=1e-5
+        )
+
+        drawn = bd._sample(key, ())
+        assert drawn["_output"]["z"].shape == ()
+        assert drawn["_output"].event_template["z"].shape == ()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -15,6 +15,7 @@ from probpipe import (
     ProductDistribution,
     Record,
     RecordEmpiricalDistribution,
+    sample,
 )
 from probpipe.core import _workflow_call, _workflow_distribution_broadcast, _workflow_execution
 from probpipe.core.config import WorkflowKind
@@ -469,6 +470,39 @@ class TestCoSamplingThroughACall:
         np.testing.assert_array_equal(
             np.asarray(lifted(empirical).samples).ravel(), np.array([10.0, 20.0, 30.0])
         )
+
+    def test_a_record_valued_lift_can_be_resampled(self):
+        """The joint over a record-valued input is a distribution, so it samples.
+
+        Reading ``.samples`` goes through the output marginal and says nothing
+        about the joint: resampling gathers rows from every component, and a
+        record-valued input carries its rows in fields rather than along a shape.
+        """
+        empirical = RecordEmpiricalDistribution(
+            Record("r", x=jnp.array([1.0, 2.0, 3.0]), y=jnp.array([10.0, 20.0, 30.0])),
+            name="e",
+        )
+        lifted = Function(
+            func=lambda a: a["y"],
+            dispatch="sequential",
+            n_broadcast_samples=8,
+            seed=0,
+            include_inputs=True,
+        )
+
+        joint = lifted(empirical)
+        drawn = sample(joint, sample_shape=(6,))
+
+        # Every drawn row is one atom of the empirical, and the output is that
+        # atom's own ``y`` — the pairing a joint exists to preserve.
+        x, y = np.asarray(drawn["a/x"]), np.asarray(drawn["a/y"])
+        np.testing.assert_allclose(y, x * 10)
+        np.testing.assert_allclose(np.asarray(drawn["_output"]).ravel(), y)
+        assert set(x.tolist()) <= {1.0, 2.0, 3.0}
+
+        one = sample(joint)
+        assert np.asarray(one["a/x"]).shape == ()
+        np.testing.assert_allclose(float(np.asarray(one["_output"])), float(np.asarray(one["a/y"])))
 
     def test_a_record_valued_empirical_passed_twice_shares_its_atom(self):
         empirical = RecordEmpiricalDistribution(

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -504,6 +504,31 @@ class TestCoSamplingThroughACall:
         assert np.asarray(one["a/x"]).shape == ()
         np.testing.assert_allclose(float(np.asarray(one["_output"])), float(np.asarray(one["a/y"])))
 
+    def test_a_record_valued_empirical_bigger_than_the_budget_samples(self):
+        """Too many atoms to enumerate, so the group routes to sampling.
+
+        That path hands back a plain record batched on its leaves rather than a
+        record batch, which reports no ``batch_shape`` — the rows are on a leaf.
+        """
+        empirical = RecordEmpiricalDistribution(
+            Record("r", x=jnp.arange(10.0), y=jnp.arange(10.0) * 10), name="e"
+        )
+        lifted = Function(
+            func=lambda a: a["y"], dispatch="sequential", n_broadcast_samples=5, seed=0
+        )
+
+        result = lifted(empirical)
+        assert result.num_atoms == 5
+        assert np.asarray(result.samples).shape == (5,)
+
+    def test_a_flat_record_that_will_not_stack_is_not_blamed_on_nesting(self):
+        """``stack`` refuses more than nesting, and flattening cannot help here."""
+        rows = [Record("r", x=jnp.array(1.0), tag="a"), Record("r", x=jnp.array(2.0), tag="b")]
+
+        with pytest.raises(TypeError) as raised:
+            _workflow_distribution_broadcast._stack_rows(rows, arg_name="a")
+        assert "nested fields" not in str(raised.value)
+
     def test_a_nested_record_valued_law_is_refused_until_batches_nest(self):
         """A record batch is child-keyed, so it cannot hold a nested record yet.
 

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -13,6 +13,8 @@ from probpipe import (
     Function,
     Normal,
     ProductDistribution,
+    Record,
+    RecordEmpiricalDistribution,
 )
 from probpipe.core import _workflow_call, _workflow_distribution_broadcast, _workflow_execution
 from probpipe.core.config import WorkflowKind
@@ -384,6 +386,21 @@ class TestCoSamplingThroughACall:
             np.asarray(result.input_samples["a"]), np.asarray(result.input_samples["b"])
         )
 
+    def test_identical_but_distinct_laws_are_distinct_roots(self):
+        """A group is object identity, not structural equality.
+
+        Two separately constructed laws are two random variables however alike
+        their parameters and names, so they sample the product; only a shared
+        object is one variable.
+        """
+        first = Normal(loc=0.0, scale=1.0, name="x")
+        second = Normal(loc=0.0, scale=1.0, name="x")
+
+        assert not np.allclose(np.asarray(self._difference()(first, second).samples), 0.0)
+        np.testing.assert_array_equal(
+            np.asarray(self._difference()(first, first).samples), np.zeros(8)
+        )
+
     def test_unrelated_laws_still_sample_the_product(self):
         """The complementary case: independence must survive the fix."""
         result = self._difference()(
@@ -434,6 +451,38 @@ class TestCoSamplingThroughACall:
         )
 
         np.testing.assert_array_equal(np.asarray(lifted(joint, joint["x"]).samples), np.zeros(8))
+
+    def test_a_record_valued_empirical_enumerates(self):
+        """Enumerated rows stack per argument, and a record row is not an array.
+
+        Atoms of a record-valued empirical are ``Record``s, which ``jnp.stack``
+        cannot take; they stack through ``RecordArray.stack`` instead.
+        """
+        empirical = RecordEmpiricalDistribution(
+            Record("r", x=jnp.array([1.0, 2.0, 3.0]), y=jnp.array([10.0, 20.0, 30.0])),
+            name="e",
+        )
+        lifted = Function(
+            func=lambda a: a["y"], dispatch="sequential", n_broadcast_samples=8, seed=0
+        )
+
+        np.testing.assert_array_equal(
+            np.asarray(lifted(empirical).samples).ravel(), np.array([10.0, 20.0, 30.0])
+        )
+
+    def test_a_record_valued_empirical_passed_twice_shares_its_atom(self):
+        empirical = RecordEmpiricalDistribution(
+            Record("r", x=jnp.array([1.0, 2.0, 3.0]), y=jnp.array([10.0, 20.0, 30.0])),
+            name="e",
+        )
+        lifted = Function(
+            func=lambda a, b: a["y"] - b["y"],
+            dispatch="sequential",
+            n_broadcast_samples=8,
+            seed=0,
+        )
+
+        np.testing.assert_array_equal(np.asarray(lifted(empirical, empirical).samples), np.zeros(3))
 
     def test_an_aliased_empirical_counts_its_weight_once(self):
         """Weights are per group, so an alias does not square them."""

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -366,22 +366,29 @@ class TestCoSamplingThroughACall:
     def _difference(**controls):
         return Function(
             func=lambda a, b: a - b,
-            dispatch="sequential",
+            dispatch=controls.pop("dispatch", "sequential"),
             n_broadcast_samples=controls.pop("n_broadcast_samples", 8),
             seed=0,
             **controls,
         )
 
-    def test_a_law_passed_twice_approximates_f_of_one_variable(self):
-        """``f(d, d)`` is ``X - X``, not ``X1 - X2``."""
+    @pytest.mark.parametrize("dispatch", ["sequential", "jax"])
+    def test_a_law_passed_twice_approximates_f_of_one_variable(self, dispatch):
+        """``f(d, d)`` is ``X - X``, not ``X1 - X2``.
+
+        Both dispatches, because the grouping lives in the sampler all three
+        execution paths share: a divergence here would mean one backend silently
+        answering a different question from another.
+        """
         dist = Normal(loc=0.0, scale=1.0, name="x")
-        result = self._difference()(dist, dist)
+        result = self._difference(dispatch=dispatch)(dist, dist)
 
         np.testing.assert_array_equal(np.asarray(result.samples), np.zeros(8))
 
-    def test_include_inputs_reports_one_realization_under_both_names(self):
+    @pytest.mark.parametrize("dispatch", ["sequential", "jax"])
+    def test_include_inputs_reports_one_realization_under_both_names(self, dispatch):
         dist = Normal(loc=0.0, scale=1.0, name="x")
-        result = self._difference(include_inputs=True)(dist, dist)
+        result = self._difference(dispatch=dispatch, include_inputs=True)(dist, dist)
 
         np.testing.assert_array_equal(
             np.asarray(result.input_samples["a"]), np.asarray(result.input_samples["b"])

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -504,6 +504,51 @@ class TestCoSamplingThroughACall:
         assert np.asarray(one["a/x"]).shape == ()
         np.testing.assert_allclose(float(np.asarray(one["_output"])), float(np.asarray(one["a/y"])))
 
+    def test_a_nested_record_valued_law_is_refused_until_batches_nest(self):
+        """A record batch is child-keyed, so it cannot hold a nested record yet.
+
+        The refusal names the argument and the shape rather than surfacing what
+        the container said, which mentions neither. Flip this to the working case
+        once record batches are leaf-keyed (#340).
+        """
+        empirical = RecordEmpiricalDistribution(
+            Record(
+                "r", group={"x": jnp.array([1.0, 2.0, 3.0]), "y": jnp.array([10.0, 20.0, 30.0])}
+            ),
+            name="e",
+        )
+        lifted = Function(
+            func=lambda a: a["group/y"], dispatch="sequential", n_broadcast_samples=6, seed=0
+        )
+
+        with pytest.raises(TypeError, match=r"lifting 'a' would batch a record with nested fields"):
+            lifted(empirical)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="record batches are child-keyed, so a nested record cannot be batched (#340)",
+    )
+    def test_a_nested_record_valued_law_lifts(self):
+        """The case above, as it should read once record batches nest."""
+        empirical = RecordEmpiricalDistribution(
+            Record(
+                "r", group={"x": jnp.array([1.0, 2.0, 3.0]), "y": jnp.array([10.0, 20.0, 30.0])}
+            ),
+            name="e",
+        )
+        lifted = Function(
+            func=lambda a: a["group/y"],
+            dispatch="sequential",
+            n_broadcast_samples=6,
+            seed=0,
+            include_inputs=True,
+        )
+
+        drawn = sample(lifted(empirical), sample_shape=(4,))
+        np.testing.assert_allclose(
+            np.asarray(drawn["_output"]).ravel(), np.asarray(drawn["a/group/y"])
+        )
+
     def test_a_record_valued_empirical_passed_twice_shares_its_atom(self):
         empirical = RecordEmpiricalDistribution(
             Record("r", x=jnp.array([1.0, 2.0, 3.0]), y=jnp.array([10.0, 20.0, 30.0])),

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -7,7 +7,13 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import BroadcastDistribution, EmpiricalDistribution, Normal, ProductDistribution
+from probpipe import (
+    BroadcastDistribution,
+    EmpiricalDistribution,
+    Function,
+    Normal,
+    ProductDistribution,
+)
 from probpipe.core import _workflow_call, _workflow_distribution_broadcast, _workflow_execution
 from probpipe.core.config import WorkflowKind
 
@@ -275,6 +281,138 @@ class TestExecuteDistributionBroadcast:
 
         assert isinstance(result, BroadcastDistribution)
         assert result.num_atoms == 3
+
+
+class TestCoSamplingGroups:
+    """One joint draw per co-sampling group, per design IV.2.
+
+    Arguments are grouped by root ancestor: the same distribution passed twice,
+    sibling views of one parent, and a parent passed alongside its own view all
+    fall in one group, and each group is drawn once. Arguments with no common
+    root are drawn independently, which samples the product of their laws.
+    """
+
+    @staticmethod
+    def _joint():
+        return ProductDistribution(
+            x=Normal(loc=0.0, scale=1.0, name="x"),
+            y=Normal(loc=10.0, scale=1.0, name="y"),
+        )
+
+    @staticmethod
+    def _sample(values, names, *, n=8, seed=3):
+        return _workflow_distribution_broadcast._sample_broadcast_args(
+            values, [_ref(name) for name in names], n, jax.random.PRNGKey(seed)
+        )
+
+    def test_the_same_distribution_passed_twice_is_drawn_once(self):
+        """The alias case: two references to one law denote one random variable."""
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+        sampled = self._sample({"a": dist, "b": dist}, ("a", "b"))
+
+        np.testing.assert_array_equal(sampled[_ref("a")], sampled[_ref("b")])
+
+    def test_a_parent_and_its_own_view_share_one_draw(self):
+        """The view's values are the parent draw's projection, not a second draw."""
+        joint = self._joint()
+        sampled = self._sample({"a": joint, "b": joint["x"]}, ("a", "b"))
+
+        np.testing.assert_array_equal(sampled[_ref("a")]["x"], sampled[_ref("b")])
+
+    def test_grouping_does_not_depend_on_argument_order(self):
+        """A group is a set of references, so the view may come first."""
+        joint = self._joint()
+        parent_first = self._sample({"a": joint, "b": joint["x"]}, ("a", "b"))
+        view_first = self._sample({"a": joint["x"], "b": joint}, ("a", "b"))
+
+        np.testing.assert_array_equal(view_first[_ref("b")]["x"], view_first[_ref("a")])
+        np.testing.assert_array_equal(parent_first[_ref("b")], view_first[_ref("a")])
+
+    def test_sibling_views_come_from_one_parent_draw(self):
+        """Distinct fields differ, but both project the same joint draw."""
+        joint = self._joint()
+        sampled = self._sample({"a": joint["x"], "b": joint["y"], "c": joint}, ("a", "b", "c"))
+
+        parent = sampled[_ref("c")]
+        np.testing.assert_array_equal(sampled[_ref("a")], parent["x"])
+        np.testing.assert_array_equal(sampled[_ref("b")], parent["y"])
+        assert not np.array_equal(sampled[_ref("a")], sampled[_ref("b")])
+
+    def test_arguments_with_no_common_root_are_drawn_independently(self):
+        """Separate groups sample the product law, one subkey per group in order.
+
+        Pinning the subkeys, not just their difference: a group of one consumes
+        exactly one split, so an aliased group cannot perturb the stream that
+        unrelated arguments already receive.
+        """
+        first = Normal(loc=0.0, scale=1.0, name="x")
+        second = Normal(loc=0.0, scale=1.0, name="y")
+        sampled = self._sample({"a": first, "b": second}, ("a", "b"))
+
+        key = jax.random.PRNGKey(3)
+        key, subkey_a = jax.random.split(key)
+        _key, subkey_b = jax.random.split(key)
+        np.testing.assert_array_equal(sampled[_ref("a")], first._sample(subkey_a, (8,)))
+        np.testing.assert_array_equal(sampled[_ref("b")], second._sample(subkey_b, (8,)))
+
+
+class TestCoSamplingThroughACall:
+    """The same contract as seen by a caller of a lifted ``Function``."""
+
+    @staticmethod
+    def _difference(**controls):
+        return Function(
+            func=lambda a, b: a - b,
+            dispatch="sequential",
+            n_broadcast_samples=controls.pop("n_broadcast_samples", 8),
+            seed=0,
+            **controls,
+        )
+
+    def test_a_law_passed_twice_approximates_f_of_one_variable(self):
+        """``f(d, d)`` is ``X - X``, not ``X1 - X2``."""
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+        result = self._difference()(dist, dist)
+
+        np.testing.assert_array_equal(np.asarray(result.samples), np.zeros(8))
+
+    def test_include_inputs_reports_one_realization_under_both_names(self):
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+        result = self._difference(include_inputs=True)(dist, dist)
+
+        np.testing.assert_array_equal(
+            np.asarray(result.input_samples["a"]), np.asarray(result.input_samples["b"])
+        )
+
+    def test_unrelated_laws_still_sample_the_product(self):
+        """The complementary case: independence must survive the fix."""
+        result = self._difference()(
+            Normal(loc=0.0, scale=1.0, name="x"), Normal(loc=0.0, scale=1.0, name="y")
+        )
+
+        assert not np.allclose(np.asarray(result.samples), 0.0)
+
+    @pytest.mark.parametrize("n_broadcast_samples", [16, 8, 3])
+    def test_an_empirical_passed_twice_enumerates_one_axis(self, n_broadcast_samples):
+        """One enumeration axis per group: the diagonal, not the squared grid.
+
+        Parameterized across the budget because the old behaviour degraded
+        differently as ``n_broadcast_samples`` fell below the product size —
+        enumerating both, then enumerating one and sampling the other.
+        """
+        empirical = EmpiricalDistribution(jnp.array([1.0, 2.0, 3.0]), name="e")
+        result = self._difference(n_broadcast_samples=n_broadcast_samples)(empirical, empirical)
+
+        samples = np.asarray(result.samples).ravel()
+        assert samples.size == 3
+        np.testing.assert_array_equal(samples, np.zeros(3))
+
+    def test_an_aliased_empirical_counts_its_weight_once(self):
+        """Weights are per group, so an alias does not square them."""
+        empirical = EmpiricalDistribution(jnp.array([1.0, 2.0, 3.0]), name="e")
+        result = self._difference(include_inputs=True)(empirical, empirical)
+
+        np.testing.assert_allclose(np.asarray(result.weights), np.full(3, 1 / 3))
 
 
 class TestIndexSampleHelper:

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -407,6 +407,34 @@ class TestCoSamplingThroughACall:
         assert samples.size == 3
         np.testing.assert_array_equal(samples, np.zeros(3))
 
+    def test_a_record_valued_law_can_be_lifted(self):
+        """Assembly counts rows by ``batch_shape``, which a record batch answers.
+
+        Its ``len`` is the field count and its ``shape`` raises, so the row count
+        had to come from somewhere that means one thing for every batched value.
+        """
+        joint = ProductDistribution(
+            x=Normal(loc=0.0, scale=1.0, name="x"),
+            y=Normal(loc=10.0, scale=1.0, name="y"),
+        )
+        lifted = Function(
+            func=lambda a: a["x"], dispatch="sequential", n_broadcast_samples=8, seed=0
+        )
+
+        assert np.asarray(lifted(joint).samples).shape[0] == 8
+
+    def test_a_parent_and_its_own_view_lift_together(self):
+        """The remaining IV.2 case, end to end: ``f(d, d["x"])`` is one draw."""
+        joint = ProductDistribution(
+            x=Normal(loc=0.0, scale=1.0, name="x"),
+            y=Normal(loc=10.0, scale=1.0, name="y"),
+        )
+        lifted = Function(
+            func=lambda a, b: a["x"] - b, dispatch="sequential", n_broadcast_samples=8, seed=0
+        )
+
+        np.testing.assert_array_equal(np.asarray(lifted(joint, joint["x"]).samples), np.zeros(8))
+
     def test_an_aliased_empirical_counts_its_weight_once(self):
         """Weights are per group, so an alias does not square them."""
         empirical = EmpiricalDistribution(jnp.array([1.0, 2.0, 3.0]), name="e")


### PR DESCRIPTION
## Summary

Within one lifted call, two references to the same law denote **one** random variable. Passing the same `Distribution` to two arguments sampled it twice, so `f(d, d)` approximated `f(X1, X2)` rather than `f(X, X)` — a silently wrong answer, not a convenience issue.

```python
difference = Function(func=lambda a, b: a - b, n_broadcast_samples=8, seed=0)
difference(dist, dist).samples
# before: [-1.89, -0.42, -2.00, ...]      after: [0. 0. 0. ...]
```

This is the contract in `design/04-functions.md` IV.2, which names the case: "The lifted arguments are grouped by **root ancestor**, transitively: sibling views of one parent, **the same distribution passed twice**, and a parent passed alongside its own view all fall in one group. Each group contributes **one joint draw** per repetition."

**Six commits.** The first shares the draw within a group, which is #388 and two further cases of the same defect. The rest fix the places broadcast assembly assumed every argument's samples were an array — without which the last of those cases would be fixed at the co-sampling layer and still unrunnable above it. That assumption is older and wider than aliasing, and each commit is separable — see below.

Fixes #388.

## Root cause — the grouping was computed and then discarded

`group_by_parent` already put aliases in one group (both references resolve to `id(dist)`). `_sample_broadcast_args` then branched on whether the group's **first** member was a field view: if it was not, it looped the members and split a fresh subkey for each; if it was, it projected *every* member as a view. One decision, taken from one member, applied to all.

That single defect produced three distinct symptoms, all confirmed on `main`:

| design IV.2 case | before | after |
|---|---|---|
| same plain distribution twice | independent draws | one draw |
| same view twice | correct | correct |
| sibling views of one parent | correct | correct |
| parent alongside its own view | `AttributeError: 'JointGaussian' object has no attribute 'field'` | one draw, parent whole and view projected — and now runs end to end |
| same empirical twice | 3×3 grid, weights squared | 3-point diagonal, weights once |
| unrelated laws | correct (product law) | unchanged, down to the subkeys |

The empirical case is a second site with the same cause: `_split_empirical_args` gave each *reference* its own enumeration axis, so an alias multiplied the grid instead of sharing an atom.

## The change

Each group is drawn **once**, from its root, and every member takes its own value out of that draw — the root whole, a view through its field path. That one shape of code replaces the branch, so all three symptoms follow from the contract rather than from three separate patches.

- `group_by_parent` → **`group_by_root`**, returning the root object alongside its references. The design's own vocabulary, and more accurate: a plain distribution is its own **root**, not its own parent.
- `_split_empirical_args` returns co-sampling **groups**. A group is enumerable only when its root is a small-enough empirical *and* every member is that root; a group holding a view goes to the sampling path whole, which prevents a parent being enumerated while its view is sampled from a different draw.
- `_broadcast_enumerate` builds one product axis per group, and counts each atom's weight once.
- The `_sample_broadcast_args` docstring stated the bug as the contract ("Plain non-view distributions are sampled independently per kwarg, even if the same object is passed under multiple names") and now states the rule.

## Commits two and three: a record-valued law can be lifted

Sharing the draw was necessary but not sufficient for `f(d, d["x"])`: with the parent's draw in hand, assembly then refused it. `BroadcastDistribution` took its row count from the samples' `shape`, which a record batch refuses unless it holds exactly one leaf — and refuses with a `TypeError`, which `hasattr` propagates rather than swallowing, so the `len` fallback written beside it was never reached.

The count now comes from one helper that reads whichever accessor means *rows* for the container it is handed: `batch_shape` for a record batch, a leaf's leading axis for a plain record batched on its leaves — which is what `RecordEmpiricalDistribution._sample` returns, so any empirical with more atoms than the sample budget takes that branch — and `shape` or `len` otherwise. Deliberately **not** `len` throughout, which is shorter and covers arrays: on a `RecordArray` that is the *field* count, documented as such at `_record_array.py:271`, so it would have returned 2 where the answer was 7 — a silently wrong `num_atoms` instead of a raise. `batch_shape` is the one accessor that means the same thing for every batched value. (This call site is one more consumer that W3.2's "a batch is a collection, not a named tree" work will simplify.)

A second site had the same assumption: enumeration stacked each argument's per-row values with `jnp.stack`, which a `Record` row is not, so a record-valued *empirical* raised even though its atoms were right. Those rows now stack through `RecordArray.stack`, the record counterpart that already exists — after which the row count above reads the resulting `batch_shape`. Record-valued empiricals therefore enumerate, and co-sample when passed twice.

The defect is older and wider than aliasing — `f(j)` with a *single* record-valued argument fails identically on `main` — but the two fixes are ~10 lines, and without them this PR would ship the parent-and-view case as fixed at the co-sampling layer and unrunnable above it. Each is its own commit, so either can be reverted independently.

## The joint also has to resample

Lifting with `include_inputs=True` returns a joint over the inputs and the output, and drawing from it gathers the same rows from every component so a drawn tuple stays paired. That gather assumed an array too, so `sample(lifted(...), sample_shape=...)` raised `TypeError: key must be str, tuple, or int, got ArrayImpl` the moment an input arrived as a record batch — a line unchanged from `main`, made reachable by the record-valued lifting above. Reading `.samples` went on working throughout, since that goes through the output marginal, which is why the record-valued test added earlier did not catch it.

One gather now reads the container it is given: an array indexes directly, a list of per-row objects gathers positionally, and a record is rebuilt from its gathered leaves. The rebuild is deliberate rather than a `jax.tree.map` — a `RecordArray` stores its row count and a `Record` its event template, both in pytree aux data, so mapping the leaves alone yields a batch quietly claiming the rows it started with. Measured: a tree-map gather of three rows by four indices leaves `batch_shape` `(3,)` over leaves of shape `(4,)`, with nothing raised.

The same gather covers the output side, where a vectorized broadcast over a record-returning function leaves the output a batched `Record`. That failure predates the record-lifting work and reproduces on `origin/main`; it is fixed here because it is the same three lines.

**Two shapes are still unsupported**, both stated in the CHANGELOG rather than implied. A record with **nested** fields cannot be batched at all, since a record batch keys its store by top-level child rather than by leaf path — `RecordArray.stack` refuses the template outright. Lifting such a law now says which argument it was and that the shape is unrepresented rather than mistaken, instead of surfacing the container's own message; a strict `xfail` marks the working case so it reports the day record batches become leaf-keyed. That is #340, not this PR's to close.

The other: a record-valued empirical passed alongside a field view of itself. That group routes to sampling rather than enumeration, and `RecordEmpiricalDistribution._sample` returns a single `Record` rather than a batch of them, so there are no rows to index. Distribution-layer contract gap, not a broadcast one; tracked in #393.

Verified working with a record-valued argument: `auto` / `sequential` / `thread` dispatch, `include_inputs`, `marginalize`, `mean`, and record-valued outputs. Explicit `dispatch="jax"` reports its usual not-traceable error when the wrapped function indexes a record, which is the designed path, and `auto` falls back correctly.

## What cannot move

Arguments with no common root are unaffected **down to the subkeys**: a group of one consumes exactly one key split, exactly as the old per-member loop did. Verified by digesting the draws of an unrelated pair, a single-argument lift, and sibling views before and after — byte-identical in every case. So no currently-correct numeric result changes; only calls that were already wrong do.

`test_arguments_with_no_common_root_are_drawn_independently` pins this in the suite by reproducing the expected subkeys explicitly rather than only asserting that the two draws differ.

## Tests

`tests/core/test_workflow_distribution_broadcast.py`, **20 new test functions** in two classes (one parameterized over three sample budgets, so 22 cases), plus five in `tests/core/test_broadcast_distribution.py` covering the gather directly.

`TestCoSamplingGroups` drives `_sample_broadcast_args` directly, over the IV.2 cases: an alias drawn once, a parent and its own view sharing a draw, the same result under either argument order, sibling views projecting one parent draw while differing from each other, and the subkey-level independence above. **Four of the five fail against unfixed source**; the fifth is the stream-preservation test, which must pass before and after by construction.

`TestCoSamplingThroughACall` asserts the same contract as a caller sees it: `f(d, d)` returns zeros, `include_inputs` reports one realization under both names, unrelated laws still sample the product, an aliased empirical enumerates 3 points across three different `n_broadcast_samples` budgets — parameterized because the old behaviour degraded *differently* as the budget fell below the product size — and its weights are `1/3` each rather than squared. Five more cover the assembly commits: a record-valued law lifts to the right row count, `f(d, d["x"])` returns zeros end to end, a record-valued empirical enumerates and co-samples when passed twice, and grouping is object identity rather than structural equality — two separately constructed laws with equal parameters *and* equal names are two random variables, and only a shared object is one.

## Out of scope

- **#384 / #389 — freshness between calls.** Untouched. This PR changes only *within*-invocation behaviour, which IV.2 already settles. Whether a separate invocation is a distinct structural position is a design question the merged IV.3 text does not answer, and #389 proposes to answer it by removing `Function(seed=)`. Independent of this fix either way.
- **Transitive grouping.** IV.2 says grouping is transitive; `group_by_root` does a single `parent` lookup. Exact today, since a view's parent is always a distribution and `select()` returns a plain dict of depth-1 views. A comment marks the assumption for whenever a nested view type arrives.

## Verification

`1999 passed, 1 xfailed` in `tests/core` (excluding the subprocess process-stability tests, which fail identically on pristine `origin/main`) and `1061 passed`, 49 skipped across `tests/distributions`, `tests/record`, `tests/modeling`, and `tests/validation`. `ruff check` and `ruff format` clean at the pinned 0.15.16.





