### PR TITLE
feat(core): add FunctionBatch and OpaqueBatch, the batch forms that store objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`FunctionBatch` and `OpaqueBatch` — the batch forms that store objects.** A
+  numeric array batches natively, with the batch axes leading, so it needs no
+  class; a callable and an opaque object have no such form, so each gets a thin
+  `Batch` that stores its elements and carries the one `element_spec` they all
+  satisfy, adding no interface beyond it. Elements go in as a flat sequence or
+  as an object array of any shape, with a name required for every level — a
+  placeholder would read as meaning something while naming nothing, the same
+  reason a level clash is not resolved by suffixing.
+
+  Storage is a numpy object array, chosen for the contract rather than for
+  arrays: numpy basic indexing returns a **view**, so a sub-batch shares its
+  parent's store, and it honors a descending or stepped slice in the order
+  given, which is the order a view's derived names are stated in. Elements are
+  never unpacked, so a batch of arrays or of lists stays a batch of two things
+  rather than becoming one 2-d array. An element comes back as the object that
+  was stored: identity is derived where a batch materializes an element per
+  index, and these store theirs.
+
+  `OpaqueBatch` is the case a batch's own spec exists for — an `OpaqueSpec`
+  names no ProbPipe kind, yet the batch is specified all the same, at the family
+  kind over it. Every element is checked against the shared spec at construction,
+  reporting the position that failed, since a batch asserts that spec of *all*
+  of them.
+
 - **`TermSpec` — the term-spec sub-hierarchy, and declarations stored as specs
   (#381).** `ValueSpec` now splits into *raw-value specs* (`ArraySpec`,
   `OpaqueSpec`), which name no ProbPipe kind, and *term specs*, one per kind,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,18 +35,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Storage is a numpy object array, chosen for the contract rather than for
   arrays: numpy basic indexing returns a **view**, so a sub-batch shares its
-  parent's store, and it honors a descending or stepped slice in the order
-  given, which is the order a view's derived names are stated in. Elements are
-  never unpacked, so a batch of arrays or of lists stays a batch of two things
-  rather than becoming one 2-d array. An element comes back as the object that
-  was stored: identity is derived where a batch materializes an element per
-  index, and these store theirs.
+  parent's store in every indexing form, and it honors a descending or stepped
+  slice in the order given, which is the order a view's derived names are stated
+  in. The store is frozen and a supplied array is copied — only the pointer
+  array, so the elements stay shared — so a batch holds the elements it
+  validated and a view cannot write through to its parent. Elements are never
+  unpacked: a batch of arrays or of lists stays a batch of two things rather than
+  becoming one 2-d array, and a container that iterates into its *parts* rather
+  than into elements (a string, a mapping, a numeric array) is refused, since
+  each would otherwise yield a batch of pieces of one object.
+
+  An element comes back as the object that was stored, untouched — neither
+  renamed nor given provenance. Identity and lineage are derived where a batch
+  *materializes* an element per index; these store theirs, so what the caller put
+  in is what comes out.
 
   `OpaqueBatch` is the case a batch's own spec exists for — an `OpaqueSpec`
   names no ProbPipe kind, yet the batch is specified all the same, at the family
   kind over it. Every element is checked against the shared spec at construction,
   reporting the position that failed, since a batch asserts that spec of *all*
-  of them.
+  of them, and `axis_groups` must tile the shape the elements are stored in, so
+  the spec cannot describe a shape the storage does not have.
 
 - **`TermSpec` — the term-spec sub-hierarchy, and declarations stored as specs
   (#381).** `ValueSpec` now splits into *raw-value specs* (`ArraySpec`,

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -97,6 +97,7 @@ if it were user-guide reference text.
 | `Record` / `NumericRecord` | docstrings in `probpipe/core/record.py`, `_numeric_record.py`; #235 Chapter 2 |
 | `Batch` / `BatchSpec` (the multiplicity axis: levels, level names, view identity) | docstrings in `probpipe/core/_batch.py`; #235 Chapter 2 |
 | Batch types (`RecordArray`/`NumericRecordArray`/`DistributionArray` → `*Batch`) | docstrings in `_record_array.py`, `_distribution_array.py`; #235 Chapter 2 |
+| `FunctionBatch` / `OpaqueBatch` (the batch forms that *store* their elements, over shared object-array storage) | docstrings in `probpipe/core/_function_batch.py`, `_opaque_batch.py` (storage in `_object_batch.py`); #235 Chapter 2 |
 | `Function` & ops (`sample`, `log_prob`, …) | docstrings in `core/node.py`, `core/ops.py`, `_workflow_result.py`; #235 Chapter 3 |
 | Naming / provenance / annotations (`TrackedTerm` / `Annotated` mixins) | docstrings in `probpipe/core/tracked.py` (and `provenance.py` for `Provenance` / `ParentInfo`); the naming contract in #235 Chapter 5 |
 
@@ -110,6 +111,7 @@ if it were user-guide reference text.
 | batch axes tiled into levels | `axis_groups` |
 | one name per level of a batch | `level_names` |
 | the spec every element of a batch satisfies | `element_spec` |
+| the objects a batch is built from | `elements` |
 | independent-draw shape prefix for `sample` | `sample_shape` |
 | a distribution's structural schema | `event_template` |
 | PRNG key | `key` |

--- a/design/03-values-and-distributions.md
+++ b/design/03-values-and-distributions.md
@@ -77,6 +77,8 @@ An object declares `SupportsDifferentiation` at construction to state which valu
 
 Every value spec has a **batch form**. Since an `ArraySpec` value batches natively, as an array with the batch axes leading, no class is needed. Function-valued and opaque values have no native stacking, so two thin `Batch` specializations provide it. Each is `Batch` over its element type and carries the shared spec its elements satisfy, adding no other interface.
 
+Both **store** their elements rather than materializing them, which fixes two things II.5 leaves to the storage. Indexing one element hands back the object that was put in, under its own name and lineage: these are the storing case of the identity rule, so a `Function` selected out of a `FunctionBatch` is the same object under the same name, while a *sub-batch* takes the derived name as any view does. And every element is checked against the shared `element_spec` at construction, reporting the position that failed, since the batch asserts that spec of all of them — one element that fails it would make the batch's own spec a false statement.
+
 ```python
 class FunctionBatch(Batch[Callable]):
     @property

--- a/design/package-structure.md
+++ b/design/package-structure.md
@@ -35,6 +35,7 @@ probpipe/
 ├── values/                    # the value layer (III.1–III.3)
 │   ├── _function_base.py      #   Function itself (templates, identity, controls and with_options,
 │   │                          #     plain evaluation), FunctionSpec, and the function capabilities
+│   ├── _object_batch.py       #   object-array storage the two batch forms share
 │   ├── _function_batch.py     #   FunctionBatch (III.1)
 │   ├── _opaque_batch.py       #   OpaqueBatch (III.1)
 │   ├── _record.py             #   Record, NumericRecord (III.2), RecordSpec (II.2)

--- a/docs/api/records.md
+++ b/docs/api/records.md
@@ -48,6 +48,21 @@ class. A callable and an opaque object have no such form — there is nothing to
 stack them into — so each gets a thin `Batch` that stores its elements and
 carries the one specification they all satisfy, adding no other interface.
 
+Both take their elements the same way. Pass a flat sequence, or an object array
+of any shape to give the batch more than one axis; a nested sequence is *not*
+unpacked, since what nesting means for an arbitrary object is the caller's to
+decide. Elements are never looked inside, so a batch of two arrays stays a batch
+of two things rather than becoming one 2-d array. Every level takes a name, with
+one axis per level unless `axis_groups` states otherwise, and every element is
+checked against the shared specification at construction.
+
+Two consequences worth knowing. The store is frozen and a supplied array is
+copied — the pointer array only, so the elements themselves stay shared — so a
+batch holds the elements it validated even if the caller keeps writing to the
+array they passed. And construction needs at least one element, while *selecting*
+none is fine: an empty batch is reached with `batch[0:0]` rather than built from
+an empty sequence, whose shape could not be inferred anyway.
+
 ::: probpipe.FunctionBatch
 
 ::: probpipe.OpaqueBatch

--- a/docs/api/records.md
+++ b/docs/api/records.md
@@ -41,6 +41,17 @@ or by position with `[]`, and indexing returns a view named by what it selected
 
 ::: probpipe.BatchSpec
 
+### Batch forms that store objects
+
+A numeric array batches natively, with the batch axes leading, so it needs no
+class. A callable and an opaque object have no such form — there is nothing to
+stack them into — so each gets a thin `Batch` that stores its elements and
+carries the one specification they all satisfy, adding no other interface.
+
+::: probpipe.FunctionBatch
+
+::: probpipe.OpaqueBatch
+
 ## Record arrays
 
 ::: probpipe.RecordArray

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -201,15 +201,18 @@ from probpipe.validation import predictive_check
 
 __all__ = [
     "Annotated",
+    # Inference
     "ApproximateDistribution",
     "ArrayBackend",
     "ArrayRandomFunction",
     "ArraySpec",
     "Batch",
     "BatchSpec",
+    # Array-backend registry
     "BayesFlowLikelihood",
     "BayesFlowModel",
     "BayesFlowRatio",
+    # Discrete
     "Bernoulli",
     "Beta",
     "Binomial",
@@ -219,12 +222,15 @@ __all__ = [
     "Categorical",
     "Cauchy",
     "ConditionallyIndependentLikelihood",
+    # Constraints
     "Constraint",
     "ConversionInfo",
     "ConversionMethod",
     "Converter",
+    # Record-based designs
     "Design",
     "Dirichlet",
+    # Base classes
     "Distribution",
     "DistributionArray",
     "DistributionSpec",
@@ -237,6 +243,7 @@ __all__ = [
     "Function",
     "FunctionBatch",
     "FunctionSpec",
+    # Modeling
     "GLMLikelihood",
     "Gamma",
     "GaussianRandomFunction",
@@ -247,6 +254,7 @@ __all__ = [
     "InverseGamma",
     "JointEmpirical",
     "JointGaussian",
+    # KDE
     "KDEDistribution",
     "Laplace",
     "Likelihood",
@@ -255,9 +263,11 @@ __all__ = [
     "MinibatchedDistribution",
     "Module",
     "Multinomial",
+    # Multivariate
     "MultivariateNormal",
     "NamedTree",
     "NegativeBinomial",
+    # Continuous
     "Normal",
     "NumericEventTemplate",
     "NumericJointEmpirical",
@@ -272,11 +282,15 @@ __all__ = [
     "Pareto",
     "Poisson",
     "ProbabilisticModel",
+    # Joint
     "ProductDistribution",
     "Provenance",
     "ProvenanceMode",
+    # Random functions
     "RandomFunction",
+    # Random measures
     "RandomMeasure",
+    # Record
     "Record",
     "RecordArray",
     "RecordBootstrapReplicateDistribution",
@@ -290,6 +304,7 @@ __all__ = [
     "SupportsArrayBackend",
     "SupportsConditioning",
     "SupportsCovariance",
+    # Protocols
     "SupportsExpectation",
     "SupportsLogProb",
     "SupportsMean",
@@ -302,19 +317,23 @@ __all__ = [
     "TFPDistribution",
     "TermSpec",
     "TrackedTerm",
+    # Transformed
     "TransformedDistribution",
     "TruncatedNormal",
     "Uniform",
     "ValueSpec",
     "VonMisesFisher",
+    # Weights
     "Weights",
     "Wishart",
+    # Configuration
     "WorkflowKind",
     "abstract_workflow_method",
     "array_backend_for",
     "bijector_for",
     "boolean",
     "condition_on_nutpie",
+    # Converters
     "converter_registry",
     "elliptical_slice",
     "function",
@@ -322,6 +341,7 @@ __all__ = [
     "inference_method_registry",
     "integer_interval",
     "interval",
+    # Transition / iteration
     "iterate",
     "learn_amortized_likelihood",
     "learn_amortized_posterior",
@@ -330,8 +350,10 @@ __all__ = [
     "non_negative_integer",
     "positive",
     "positive_definite",
+    # Validation
     "predictive_check",
     "prefect_config",
+    # Provenance
     "provenance_ancestors",
     "provenance_config",
     "provenance_dag",

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -39,7 +39,9 @@ from probpipe.core._array_backend import (
 )
 from probpipe.core._batch import Batch, BatchSpec
 from probpipe.core._distribution_array import DistributionArray
+from probpipe.core._function_batch import FunctionBatch
 from probpipe.core._numeric_record import NumericRecord
+from probpipe.core._opaque_batch import OpaqueBatch
 from probpipe.core._record_array import NumericRecordArray, RecordArray
 from probpipe.core.config import ProvenanceMode, WorkflowKind, prefect_config, provenance_config
 from probpipe.core.constraints import (
@@ -199,18 +201,15 @@ from probpipe.validation import predictive_check
 
 __all__ = [
     "Annotated",
-    # Inference
     "ApproximateDistribution",
     "ArrayBackend",
     "ArrayRandomFunction",
     "ArraySpec",
     "Batch",
     "BatchSpec",
-    # Array-backend registry
     "BayesFlowLikelihood",
     "BayesFlowModel",
     "BayesFlowRatio",
-    # Discrete
     "Bernoulli",
     "Beta",
     "Binomial",
@@ -220,15 +219,12 @@ __all__ = [
     "Categorical",
     "Cauchy",
     "ConditionallyIndependentLikelihood",
-    # Constraints
     "Constraint",
     "ConversionInfo",
     "ConversionMethod",
     "Converter",
-    # Record-based designs
     "Design",
     "Dirichlet",
-    # Base classes
     "Distribution",
     "DistributionArray",
     "DistributionSpec",
@@ -239,8 +235,8 @@ __all__ = [
     "FlattenedDistributionView",
     "FullFactorialDesign",
     "Function",
+    "FunctionBatch",
     "FunctionSpec",
-    # Modeling
     "GLMLikelihood",
     "Gamma",
     "GaussianRandomFunction",
@@ -251,7 +247,6 @@ __all__ = [
     "InverseGamma",
     "JointEmpirical",
     "JointGaussian",
-    # KDE
     "KDEDistribution",
     "Laplace",
     "Likelihood",
@@ -260,11 +255,9 @@ __all__ = [
     "MinibatchedDistribution",
     "Module",
     "Multinomial",
-    # Multivariate
     "MultivariateNormal",
     "NamedTree",
     "NegativeBinomial",
-    # Continuous
     "Normal",
     "NumericEventTemplate",
     "NumericJointEmpirical",
@@ -273,20 +266,17 @@ __all__ = [
     "NumericRecordArray",
     "NumericRecordDistribution",
     "NumericRecordDistributionView",
+    "OpaqueBatch",
     "OpaqueSpec",
     "ParentInfo",
     "Pareto",
     "Poisson",
     "ProbabilisticModel",
-    # Joint
     "ProductDistribution",
     "Provenance",
     "ProvenanceMode",
-    # Random functions
     "RandomFunction",
-    # Random measures
     "RandomMeasure",
-    # Record
     "Record",
     "RecordArray",
     "RecordBootstrapReplicateDistribution",
@@ -300,7 +290,6 @@ __all__ = [
     "SupportsArrayBackend",
     "SupportsConditioning",
     "SupportsCovariance",
-    # Protocols
     "SupportsExpectation",
     "SupportsLogProb",
     "SupportsMean",
@@ -313,23 +302,19 @@ __all__ = [
     "TFPDistribution",
     "TermSpec",
     "TrackedTerm",
-    # Transformed
     "TransformedDistribution",
     "TruncatedNormal",
     "Uniform",
     "ValueSpec",
     "VonMisesFisher",
-    # Weights
     "Weights",
     "Wishart",
-    # Configuration
     "WorkflowKind",
     "abstract_workflow_method",
     "array_backend_for",
     "bijector_for",
     "boolean",
     "condition_on_nutpie",
-    # Converters
     "converter_registry",
     "elliptical_slice",
     "function",
@@ -337,7 +322,6 @@ __all__ = [
     "inference_method_registry",
     "integer_interval",
     "interval",
-    # Transition / iteration
     "iterate",
     "learn_amortized_likelihood",
     "learn_amortized_posterior",
@@ -346,10 +330,8 @@ __all__ = [
     "non_negative_integer",
     "positive",
     "positive_definite",
-    # Validation
     "predictive_check",
     "prefect_config",
-    # Provenance
     "provenance_ancestors",
     "provenance_config",
     "provenance_dag",

--- a/probpipe/core/_function_batch.py
+++ b/probpipe/core/_function_batch.py
@@ -5,7 +5,7 @@ See design III.1.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable
 
 import numpy as np
 
@@ -19,29 +19,38 @@ __all__ = ["FunctionBatch"]
 class FunctionBatch(_ObjectBatch[Callable]):
     """A batch of callables sharing one :class:`FunctionSpec`.
 
-    A callable has no native stacked form, so the collection is a batch rather
-    than an array. Every element satisfies the shared ``element_spec``, and the
-    spec is callable-generic: a plain lambda, a NumPy function, and a
-    ``Function`` are all admitted, the wrapper being one such element and not the
-    required type.
-
     Parameters
     ----------
-    elements : numpy.ndarray or sequence of callable
-        The callables, as an object array of any shape or a flat sequence.
-    level_names : str or sequence of str
+    elements : numpy.ndarray or iterable of callable
+        The callables, as an object array of any shape or a flat iterable.
+    level_names : str or iterable of str
         One name per level, outermost first.
     element_spec : FunctionSpec, optional
         What every element satisfies. Defaults to ``FunctionSpec()``, which
         specifies a callable and neither of its templates.
-    axis_groups : sequence of sequence of int, optional
-        The axes each level holds; defaults to one axis per level.
+    axis_groups : iterable of iterable of int, optional
+        The axis sizes each level holds; defaults to one axis per level.
+    name : str, optional
+        The batch's name; defaults to ``"functionbatch"``, marked auto-derived.
+    name_is_auto : bool, default False
+        Whether *name* is auto-derived rather than user-given.
+    provenance : Provenance, optional
+        How this batch was produced.
 
     Raises
     ------
     TypeError
-        If ``element_spec`` is not a :class:`FunctionSpec`, or an element is not
-        callable.
+        If ``element_spec`` is not a :class:`FunctionSpec`, if an element is not
+        callable, or for any reason :class:`_ObjectBatch` refuses ``elements``.
+    ValueError
+        For any reason :class:`_ObjectBatch` refuses the shape or the levels.
+
+    Notes
+    -----
+    A callable has no native stacked form, so the collection is a batch rather
+    than an array. The spec is callable-generic: a plain lambda, a NumPy
+    function, and a ``Function`` are all admitted, the wrapper being one such
+    element and not the required type.
 
     Examples
     --------
@@ -54,9 +63,11 @@ class FunctionBatch(_ObjectBatch[Callable]):
 
     __slots__ = ()
 
+    _element_rule = "be callable"
+
     def __init__(
         self,
-        elements: np.ndarray | Sequence[Callable],
+        elements: np.ndarray | Iterable[Callable],
         level_names: str | Iterable[str],
         *,
         element_spec: FunctionSpec | None = None,
@@ -81,7 +92,6 @@ class FunctionBatch(_ObjectBatch[Callable]):
             name_is_auto=name_is_auto,
             provenance=provenance,
         )
-        _require_callable(self)
 
     @property
     def element_spec(self) -> FunctionSpec:
@@ -89,20 +99,3 @@ class FunctionBatch(_ObjectBatch[Callable]):
         spec = self._spec.element_spec
         assert isinstance(spec, FunctionSpec)  # narrowed at construction
         return spec
-
-
-def _require_callable(batch: FunctionBatch) -> None:
-    """Fail at construction on any element the shared spec does not admit.
-
-    Checked here rather than left to ``is_valid`` because a batch asserts that
-    *every* element satisfies one spec: an element that does not makes the
-    batch's own spec a false statement about it, and the position it sits at is
-    what a caller needs to hear about.
-    """
-    for index, element in np.ndenumerate(batch._store):
-        if not batch.element_spec.is_valid(element):
-            position = index[0] if len(index) == 1 else index
-            raise TypeError(
-                f"every element of a FunctionBatch is callable; the element at "
-                f"{position} is a {type(element).__name__}"
-            )

--- a/probpipe/core/_function_batch.py
+++ b/probpipe/core/_function_batch.py
@@ -1,0 +1,108 @@
+"""FunctionBatch — the batch form of the function kind.
+
+See design III.1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+
+import numpy as np
+
+from ._object_batch import _ObjectBatch
+from .event_template import FunctionSpec
+from .provenance import Provenance
+
+__all__ = ["FunctionBatch"]
+
+
+class FunctionBatch(_ObjectBatch[Callable]):
+    """A batch of callables sharing one :class:`FunctionSpec`.
+
+    A callable has no native stacked form, so the collection is a batch rather
+    than an array. Every element satisfies the shared ``element_spec``, and the
+    spec is callable-generic: a plain lambda, a NumPy function, and a
+    ``Function`` are all admitted, the wrapper being one such element and not the
+    required type.
+
+    Parameters
+    ----------
+    elements : numpy.ndarray or sequence of callable
+        The callables, as an object array of any shape or a flat sequence.
+    level_names : str or sequence of str
+        One name per level, outermost first.
+    element_spec : FunctionSpec, optional
+        What every element satisfies. Defaults to ``FunctionSpec()``, which
+        specifies a callable and neither of its templates.
+    axis_groups : sequence of sequence of int, optional
+        The axes each level holds; defaults to one axis per level.
+
+    Raises
+    ------
+    TypeError
+        If ``element_spec`` is not a :class:`FunctionSpec`, or an element is not
+        callable.
+
+    Examples
+    --------
+    >>> batch = FunctionBatch([lambda x: x, lambda x: 2 * x], "variant", name="f")
+    >>> batch.batch_shape
+    (2,)
+    >>> batch[1](3)
+    6
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        elements: np.ndarray | Sequence[Callable],
+        level_names: str | Iterable[str],
+        *,
+        element_spec: FunctionSpec | None = None,
+        axis_groups: Iterable[Iterable[int]] | None = None,
+        name: str | None = None,
+        name_is_auto: bool = False,
+        provenance: Provenance | None = None,
+    ) -> None:
+        if element_spec is None:
+            element_spec = FunctionSpec()
+        elif not isinstance(element_spec, FunctionSpec):
+            raise TypeError(
+                f"FunctionBatch.element_spec must be a FunctionSpec, "
+                f"got {type(element_spec).__name__}"
+            )
+        super().__init__(
+            elements,
+            level_names,
+            element_spec=element_spec,
+            axis_groups=axis_groups,
+            name=name,
+            name_is_auto=name_is_auto,
+            provenance=provenance,
+        )
+        _require_callable(self)
+
+    @property
+    def element_spec(self) -> FunctionSpec:
+        """The :class:`FunctionSpec` every element satisfies — a view on ``spec``."""
+        spec = self._spec.element_spec
+        assert isinstance(spec, FunctionSpec)  # narrowed at construction
+        return spec
+
+
+def _require_callable(batch: FunctionBatch) -> None:
+    """Fail at construction on any element the shared spec does not admit.
+
+    Checked here rather than left to ``is_valid`` because a batch asserts that
+    *every* element satisfies one spec: an element that does not makes the
+    batch's own spec a false statement about it, and the position it sits at is
+    what a caller needs to hear about.
+    """
+    for index, element in np.ndenumerate(batch._store):
+        if not batch.element_spec.is_valid(element):
+            position = index[0] if len(index) == 1 else index
+            raise TypeError(
+                f"every element of a FunctionBatch is callable; the element at "
+                f"{position} is a {type(element).__name__}"
+            )

--- a/probpipe/core/_function_batch.py
+++ b/probpipe/core/_function_batch.py
@@ -40,10 +40,15 @@ class FunctionBatch(_ObjectBatch[Callable]):
     Raises
     ------
     TypeError
-        If ``element_spec`` is not a :class:`FunctionSpec`, if an element is not
-        callable, or for any reason :class:`_ObjectBatch` refuses ``elements``.
+        If ``element_spec`` is not a :class:`FunctionSpec`; if an element is not
+        callable, naming the position that failed; if ``elements`` is a string, a
+        mapping, or an array that is not ``dtype=object`` — each iterates into
+        something other than its elements — or is not iterable at all.
     ValueError
-        For any reason :class:`_ObjectBatch` refuses the shape or the levels.
+        If ``elements`` is empty, or is a zero-dimensional array (one object with
+        no batch axis); if ``axis_groups`` does not tile the shape the elements are
+        stored in; or if ``axis_groups`` is omitted and the number of level names
+        does not match the number of axes.
 
     Notes
     -----
@@ -51,6 +56,11 @@ class FunctionBatch(_ObjectBatch[Callable]):
     than an array. The spec is callable-generic: a plain lambda, a NumPy
     function, and a ``Function`` are all admitted, the wrapper being one such
     element and not the required type.
+
+    This batch **stores** its elements, so ``batch[i]`` is the callable that was
+    put in — the same object, under its own name and lineage, not a copy renamed
+    to its position. A sub-batch is a view and takes a derived name as any view
+    does.
 
     Examples
     --------

--- a/probpipe/core/_object_batch.py
+++ b/probpipe/core/_object_batch.py
@@ -17,16 +17,15 @@ See design III.1.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping
 from typing import Any, Self
 
+import jax
 import numpy as np
 
-from ._batch import Batch, BatchSpec
+from ._batch import Batch, BatchSpec, _axis_size
 from .event_template import ValueSpec
 from .provenance import Provenance
-
-__all__ = ["_ObjectBatch"]
 
 
 class _ObjectBatch[E](Batch[E]):
@@ -34,26 +33,41 @@ class _ObjectBatch[E](Batch[E]):
 
     Parameters
     ----------
-    elements : numpy.ndarray or sequence
-        The elements, as an object array of any shape or a flat sequence. A
+    elements : numpy.ndarray or iterable
+        The elements, as an object array of any shape or a flat iterable. A
         nested sequence is not unpacked: build the array to state a shape of
         more than one axis, since what nesting means for an arbitrary Python
-        object is the caller's to decide.
-    level_names : str or sequence of str
+        object is the caller's to decide. A supplied array is copied and the
+        store frozen, so the batch holds the elements it validated.
+    level_names : str or iterable of str
         One name per level, outermost first; a single string names a single
         level. There is no default, deliberately — see *Notes*.
-    axis_groups : sequence of sequence of int, optional
-        The axes each level holds. Defaults to one axis per level, which
-        requires as many names as ``elements`` has axes; a level spanning
-        several axes is stated explicitly.
+    element_spec : ValueSpec
+        What every element satisfies, checked against each at construction.
+    axis_groups : iterable of iterable of int, optional
+        The axis *sizes* each level holds, in order, tiling the shape the
+        elements are stored in. Defaults to one axis per level, which requires
+        as many names as ``elements`` has axes; a level spanning several axes is
+        stated explicitly.
+    name : str, optional
+        The batch's name. Defaults to the class name lowercased, marked
+        auto-derived.
+    name_is_auto : bool, default False
+        Whether *name* is auto-derived rather than user-given. A batch left
+        unnamed is auto-named regardless.
+    provenance : Provenance, optional
+        How this batch was produced.
 
     Raises
     ------
     TypeError
-        If ``elements`` is neither an ndarray nor a sequence.
+        If ``elements`` is a string, a mapping, or a non-object array — each of
+        which iterates into something other than its elements — if it is not
+        iterable at all, or if an ndarray of elements is not ``dtype=object``.
     ValueError
-        If ``elements`` is empty, or if ``axis_groups`` is omitted and the
-        number of names does not match the number of axes.
+        If ``elements`` is empty or a single object, if ``axis_groups`` does not
+        tile the stored shape, or if ``axis_groups`` is omitted and the number of
+        names does not match the number of axes.
 
     Notes
     -----
@@ -62,13 +76,24 @@ class _ObjectBatch[E](Batch[E]):
     read as meaning something while naming nothing, which is the same reason
     :class:`~probpipe.core._batch.Batch` refuses to resolve a clash by
     suffixing. The caller that mints a level knows what it means.
+
+    Construction requires at least one element, while *selecting* none is
+    allowed: ``batch[0:0]`` is a batch of nothing, as the level algebra intends.
+    The asymmetry is deliberate — an empty literal at construction is almost
+    always a mistake, and a shape cannot be inferred from it — so an empty batch
+    is reached by selecting one rather than by building one.
     """
+
+    _store: np.ndarray
 
     __slots__ = ("_store",)
 
+    #: What the shared spec admits, phrased for the refusal a bad element earns.
+    _element_rule = "satisfy this batch's element specification"
+
     def __init__(
         self,
-        elements: np.ndarray | Sequence[E],
+        elements: np.ndarray | Iterable[E],
         level_names: str | Iterable[str],
         *,
         element_spec: ValueSpec,
@@ -82,6 +107,9 @@ class _ObjectBatch[E](Batch[E]):
         groups = _axis_groups_for(store.shape, names, axis_groups, kind=type(self).__name__)
 
         object.__setattr__(self, "_store", store)
+        _check_elements(
+            store, element_spec, describing=self._element_rule, kind=type(self).__name__
+        )
         self._init_batch(
             BatchSpec(element_spec, groups, names),
             name=name if name is not None else type(self).__name__.lower(),
@@ -114,18 +142,27 @@ class _ObjectBatch[E](Batch[E]):
         the name are already decided and re-deriving them from the view's own
         shape would lose the levels a dropped axis came from.
         """
-        view = type(self).__new__(type(self))
+        # ``object.__new__`` for the reason ``TrackedTerm._shallow_copy`` gives: a
+        # host's own ``__new__`` may select a class from constructor arguments and
+        # must not run again where there are none.
+        view = object.__new__(type(self))
         object.__setattr__(view, "_store", self._store[index])
         view._init_batch(spec, name=name, name_is_auto=True)
         return view
 
 
-def _as_object_array(elements: np.ndarray | Sequence[Any], *, kind: str) -> np.ndarray:
-    """*elements* as an object array, without unpacking what it holds.
+def _as_object_array(elements: np.ndarray | Iterable[Any], *, kind: str) -> np.ndarray:
+    """*elements* as a writable-by-nobody object array, without unpacking it.
 
     ``np.asarray`` would look inside each element and stack anything array-like,
     turning a batch of two arrays into one 2-d numeric array. Allocating empty
     and assigning keeps each object whole, whatever it is.
+
+    A supplied array is copied and the store is frozen, so the batch's elements
+    are the ones it validated: a caller who keeps a handle on the array they
+    passed cannot write a mapping into an ``OpaqueBatch`` afterwards, and a view,
+    which shares this buffer, cannot write through to its parent. Only the
+    pointer array is copied — the elements themselves stay shared.
     """
     if isinstance(elements, np.ndarray):
         if elements.dtype != object:
@@ -133,23 +170,55 @@ def _as_object_array(elements: np.ndarray | Sequence[Any], *, kind: str) -> np.n
                 f"{kind} stores objects, so an ndarray of elements must have dtype=object; "
                 f"got dtype={elements.dtype}"
             )
-        store = elements
+        # A subclass — np.matrix, a masked array — indexes by its own rules and
+        # would not hand back the objects that were stored.
+        store = np.array(elements, dtype=object, subok=False)
     else:
-        try:
-            flat = list(elements)
-        except TypeError:
-            raise TypeError(
-                f"{kind} takes an object ndarray or a sequence of elements; "
-                f"got {type(elements).__name__}"
-            ) from None
-        store = np.empty(len(flat), dtype=object)
-        for position, element in enumerate(flat):
-            store[position] = element
+        _refuse_container(elements, kind=kind)
+        store = _from_iterable(elements, kind=kind)
 
     if store.size == 0:
         raise ValueError(f"{kind} requires at least one element")
     if store.ndim == 0:
         raise ValueError(f"{kind} requires at least one batch axis; got a single object")
+    store.setflags(write=False)
+    return store
+
+
+def _refuse_container(elements: Any, *, kind: str) -> None:
+    """Refuse an *elements* that iterates into something other than its elements.
+
+    A string iterates into characters, a mapping into its keys, and a numeric
+    array into scalars — each a batch of parts of one object rather than a batch
+    of objects, and the mapping case would slip past the per-element check that
+    refuses a mapping *as* an element. Wrap the one object in a list to mean a
+    batch of one.
+    """
+    if isinstance(elements, str | bytes | Mapping):
+        raise TypeError(
+            f"{kind} takes a sequence of elements, and a {type(elements).__name__} iterates "
+            f"into its parts rather than into elements; wrap it in a list to batch it as one"
+        )
+    if isinstance(elements, np.ndarray | jax.Array):
+        raise TypeError(
+            f"{kind} stores objects, so an array of elements must have dtype=object; "
+            f"got a {type(elements).__name__} of {elements.dtype}"
+        )
+
+
+def _from_iterable(elements: Iterable[Any], *, kind: str) -> np.ndarray:
+    """An object array holding each of *elements*, whole."""
+    try:
+        iterator = iter(elements)
+    except TypeError:
+        raise TypeError(
+            f"{kind} takes an object ndarray or an iterable of elements; "
+            f"got {type(elements).__name__}"
+        ) from None
+    flat = list(iterator)
+    store = np.empty(len(flat), dtype=object)
+    for position, element in enumerate(flat):
+        store[position] = element
     return store
 
 
@@ -160,12 +229,51 @@ def _axis_groups_for(
     *,
     kind: str,
 ) -> tuple[tuple[int, ...], ...]:
-    """The axis groups for *shape*, defaulting to one axis per level."""
-    if axis_groups is not None:
-        return tuple(tuple(group) for group in axis_groups)
-    if len(names) != len(shape):
+    """The axis groups for *shape*, defaulting to one axis per level.
+
+    A supplied grouping must tile the store's own shape: it says which axes each
+    level holds, and the axes are the ones the elements are actually arranged in.
+    A grouping that disagreed would make every accessor — ``batch_shape``,
+    ``len``, ``repr``, the spec itself — a statement about a shape the storage
+    does not have, and indexing would leave the batch's own bounds check to fail
+    somewhere inside numpy instead.
+    """
+    if axis_groups is None:
+        if len(names) != len(shape):
+            axes = "axis" if len(shape) == 1 else "axes"
+            raise ValueError(
+                f"{kind} places one axis per level unless axis_groups says otherwise, so "
+                f"{len(shape)} {axes} need {len(shape)} level names; "
+                f"got {len(names)}: {list(names)}"
+            )
+        return tuple((size,) for size in shape)
+
+    groups = tuple(tuple(_axis_size(size) for size in group) for group in axis_groups)
+    tiled = tuple(size for group in groups for size in group)
+    if tiled != shape:
         raise ValueError(
-            f"{kind} places one axis per level unless axis_groups says otherwise, so "
-            f"{len(shape)} axes need {len(shape)} level names; got {len(names)}: {list(names)}"
+            f"axis_groups must tile the shape the elements are stored in: {groups} tiles "
+            f"{tiled}, but {kind} was given elements of shape {shape}. Each entry is an axis "
+            f"*size*, and the sizes in order are the store's own shape"
         )
-    return tuple((size,) for size in shape)
+    return groups
+
+
+def _check_elements(
+    store: np.ndarray, element_spec: ValueSpec, *, describing: str, kind: str
+) -> None:
+    """Fail on the first element the shared spec does not admit, naming its position.
+
+    Checked at construction rather than left to ``is_valid`` because a batch
+    asserts its ``element_spec`` of *every* element: one that does not satisfy it
+    makes the batch's own spec a false statement, and where it sits is what a
+    caller needs to hear. *describing* states positively what an element must be,
+    so each class supplies only its own phrase.
+    """
+    for index, element in np.ndenumerate(store):
+        if not element_spec.is_valid(element):
+            position = index[0] if len(index) == 1 else index
+            raise TypeError(
+                f"every element of a {kind} must {describing}; the element at {position} "
+                f"is a {type(element).__name__}"
+            )

--- a/probpipe/core/_object_batch.py
+++ b/probpipe/core/_object_batch.py
@@ -1,0 +1,171 @@
+"""Object-array storage for the batch forms of values that do not stack natively.
+
+An ``ArraySpec`` value batches natively — an array with the batch axes leading —
+so no class is needed for it. A callable and an opaque object have no such form:
+there is nothing to stack them *into*. :class:`_ObjectBatch` supplies the
+storage those two batch forms share, a numpy object array, leaving each public
+class to say only what its elements are and which spec they satisfy.
+
+The object array earns its place by answering the storage contract
+:class:`~probpipe.core._batch.Batch` states rather than by holding arrays:
+numpy's basic indexing returns a **view** over the same objects, so a
+sub-batch shares its parent's store, and it honors a descending or stepped
+slice in the order given, which the derived names of a view are stated in.
+
+See design III.1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any, Self
+
+import numpy as np
+
+from ._batch import Batch, BatchSpec
+from .event_template import ValueSpec
+from .provenance import Provenance
+
+__all__ = ["_ObjectBatch"]
+
+
+class _ObjectBatch[E](Batch[E]):
+    """A :class:`Batch` storing its elements in a numpy object array.
+
+    Parameters
+    ----------
+    elements : numpy.ndarray or sequence
+        The elements, as an object array of any shape or a flat sequence. A
+        nested sequence is not unpacked: build the array to state a shape of
+        more than one axis, since what nesting means for an arbitrary Python
+        object is the caller's to decide.
+    level_names : str or sequence of str
+        One name per level, outermost first; a single string names a single
+        level. There is no default, deliberately — see *Notes*.
+    axis_groups : sequence of sequence of int, optional
+        The axes each level holds. Defaults to one axis per level, which
+        requires as many names as ``elements`` has axes; a level spanning
+        several axes is stated explicitly.
+
+    Raises
+    ------
+    TypeError
+        If ``elements`` is neither an ndarray nor a sequence.
+    ValueError
+        If ``elements`` is empty, or if ``axis_groups`` is omitted and the
+        number of names does not match the number of axes.
+
+    Notes
+    -----
+    A level name is required rather than defaulted because a batch's levels are
+    named so that operations can align operands by meaning: a placeholder would
+    read as meaning something while naming nothing, which is the same reason
+    :class:`~probpipe.core._batch.Batch` refuses to resolve a clash by
+    suffixing. The caller that mints a level knows what it means.
+    """
+
+    __slots__ = ("_store",)
+
+    def __init__(
+        self,
+        elements: np.ndarray | Sequence[E],
+        level_names: str | Iterable[str],
+        *,
+        element_spec: ValueSpec,
+        axis_groups: Iterable[Iterable[int]] | None = None,
+        name: str | None = None,
+        name_is_auto: bool = False,
+        provenance: Provenance | None = None,
+    ) -> None:
+        store = _as_object_array(elements, kind=type(self).__name__)
+        names = (level_names,) if isinstance(level_names, str) else tuple(level_names)
+        groups = _axis_groups_for(store.shape, names, axis_groups, kind=type(self).__name__)
+
+        object.__setattr__(self, "_store", store)
+        self._init_batch(
+            BatchSpec(element_spec, groups, names),
+            name=name if name is not None else type(self).__name__.lower(),
+            name_is_auto=name is None or name_is_auto,
+            provenance=provenance,
+        )
+
+    # -- the storage seam ---------------------------------------------------
+
+    def _element_at(self, index: tuple[int, ...], *, name: str) -> E:
+        """The stored object at *index*, as it was given.
+
+        *name* is unused, which is the whole of the identity rule for a batch
+        that **stores** its elements: the object handed back is the caller's own,
+        so whatever identity it arrived with is what it keeps. A tracked element
+        takes a derived name where a batch *materializes* one per index — a row
+        of columnar storage has no identity until it is built — but a callable
+        placed here by name already means something, and renaming it to its
+        position would lose that and hand back a copy besides. The batch remains
+        the one place the position is recorded.
+        """
+        return self._store[index]
+
+    def _sub_batch_at(self, index: tuple[int | slice, ...], *, spec: BatchSpec, name: str) -> Self:
+        """A view over the same store, indexed as given.
+
+        numpy basic indexing returns a view, so the selection shares its
+        parent's objects and is presented in the order *index* states, a
+        descending slice included. Built without ``__init__``, since the spec and
+        the name are already decided and re-deriving them from the view's own
+        shape would lose the levels a dropped axis came from.
+        """
+        view = type(self).__new__(type(self))
+        object.__setattr__(view, "_store", self._store[index])
+        view._init_batch(spec, name=name, name_is_auto=True)
+        return view
+
+
+def _as_object_array(elements: np.ndarray | Sequence[Any], *, kind: str) -> np.ndarray:
+    """*elements* as an object array, without unpacking what it holds.
+
+    ``np.asarray`` would look inside each element and stack anything array-like,
+    turning a batch of two arrays into one 2-d numeric array. Allocating empty
+    and assigning keeps each object whole, whatever it is.
+    """
+    if isinstance(elements, np.ndarray):
+        if elements.dtype != object:
+            raise TypeError(
+                f"{kind} stores objects, so an ndarray of elements must have dtype=object; "
+                f"got dtype={elements.dtype}"
+            )
+        store = elements
+    else:
+        try:
+            flat = list(elements)
+        except TypeError:
+            raise TypeError(
+                f"{kind} takes an object ndarray or a sequence of elements; "
+                f"got {type(elements).__name__}"
+            ) from None
+        store = np.empty(len(flat), dtype=object)
+        for position, element in enumerate(flat):
+            store[position] = element
+
+    if store.size == 0:
+        raise ValueError(f"{kind} requires at least one element")
+    if store.ndim == 0:
+        raise ValueError(f"{kind} requires at least one batch axis; got a single object")
+    return store
+
+
+def _axis_groups_for(
+    shape: tuple[int, ...],
+    names: tuple[str, ...],
+    axis_groups: Iterable[Iterable[int]] | None,
+    *,
+    kind: str,
+) -> tuple[tuple[int, ...], ...]:
+    """The axis groups for *shape*, defaulting to one axis per level."""
+    if axis_groups is not None:
+        return tuple(tuple(group) for group in axis_groups)
+    if len(names) != len(shape):
+        raise ValueError(
+            f"{kind} places one axis per level unless axis_groups says otherwise, so "
+            f"{len(shape)} axes need {len(shape)} level names; got {len(names)}: {list(names)}"
+        )
+    return tuple((size,) for size in shape)

--- a/probpipe/core/_object_batch.py
+++ b/probpipe/core/_object_batch.py
@@ -65,9 +65,10 @@ class _ObjectBatch[E](Batch[E]):
         which iterates into something other than its elements — if it is not
         iterable at all, or if an ndarray of elements is not ``dtype=object``.
     ValueError
-        If ``elements`` is empty or a single object, if ``axis_groups`` does not
-        tile the stored shape, or if ``axis_groups`` is omitted and the number of
-        names does not match the number of axes.
+        If ``elements`` is empty, or is a zero-dimensional array (one object with
+        no batch axis), if ``axis_groups`` does not tile the stored shape, or if
+        ``axis_groups`` is omitted and the number of names does not match the
+        number of axes.
 
     Notes
     -----
@@ -120,16 +121,20 @@ class _ObjectBatch[E](Batch[E]):
     # -- the storage seam ---------------------------------------------------
 
     def _element_at(self, index: tuple[int, ...], *, name: str) -> E:
-        """The stored object at *index*, as it was given.
+        """The stored object at *index*: the caller's own, under its own identity.
 
-        *name* is unused, which is the whole of the identity rule for a batch
-        that **stores** its elements: the object handed back is the caller's own,
-        so whatever identity it arrived with is what it keeps. A tracked element
-        takes a derived name where a batch *materializes* one per index — a row
-        of columnar storage has no identity until it is built — but a callable
-        placed here by name already means something, and renaming it to its
-        position would lose that and hand back a copy besides. The batch remains
-        the one place the position is recorded.
+        *name*, the identity derived for the position, is unused, and no
+        provenance is written — this is the *storing* side of both rules
+        :meth:`~probpipe.core._batch.Batch._element_at` states.
+
+        Notes
+        -----
+        A derived name belongs to an element a batch *materializes*, since a row
+        of columnar storage has no identity until it is built. An object placed
+        here already means something, so renaming it to its position would lose
+        that and hand back a copy besides. The batch stays the one place the
+        position is recorded — in the name of a sub-batch, which is a view rather
+        than a caller's object.
         """
         return self._store[index]
 

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -1,0 +1,107 @@
+"""OpaqueBatch — the batch form of the opaque kind.
+
+See design III.1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+import numpy as np
+
+from ._object_batch import _ObjectBatch
+from .event_template import OpaqueSpec
+from .provenance import Provenance
+
+__all__ = ["OpaqueBatch"]
+
+
+class OpaqueBatch(_ObjectBatch[Any]):
+    """A batch of opaque objects sharing one :class:`OpaqueSpec`.
+
+    An opaque value exposes no structure, so there is nothing to stack it into
+    and the collection is a batch. This is the case a batch's own spec exists
+    for: an ``OpaqueSpec`` names no ProbPipe kind, yet the batch is specified all
+    the same, at the family kind over it.
+
+    Parameters
+    ----------
+    elements : numpy.ndarray or sequence
+        The objects, as an object array of any shape or a flat sequence.
+    level_names : str or sequence of str
+        One name per level, outermost first.
+    element_spec : OpaqueSpec, optional
+        What every element satisfies. Defaults to ``OpaqueSpec()``.
+    axis_groups : sequence of sequence of int, optional
+        The axes each level holds; defaults to one axis per level.
+
+    Raises
+    ------
+    TypeError
+        If ``element_spec`` is not an :class:`OpaqueSpec`, or an element is a
+        mapping — which denotes tree structure, never a leaf, as everywhere else
+        in the value layer.
+
+    Examples
+    --------
+    >>> batch = OpaqueBatch(["north", "south"], "site", name="labels")
+    >>> batch.batch_shape
+    (2,)
+    >>> batch[0]
+    'north'
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        elements: np.ndarray | Sequence[Any],
+        level_names: str | Iterable[str],
+        *,
+        element_spec: OpaqueSpec | None = None,
+        axis_groups: Iterable[Iterable[int]] | None = None,
+        name: str | None = None,
+        name_is_auto: bool = False,
+        provenance: Provenance | None = None,
+    ) -> None:
+        if element_spec is None:
+            element_spec = OpaqueSpec()
+        elif not isinstance(element_spec, OpaqueSpec):
+            raise TypeError(
+                f"OpaqueBatch.element_spec must be an OpaqueSpec, got {type(element_spec).__name__}"
+            )
+        super().__init__(
+            elements,
+            level_names,
+            element_spec=element_spec,
+            axis_groups=axis_groups,
+            name=name,
+            name_is_auto=name_is_auto,
+            provenance=provenance,
+        )
+        _reject_mappings(self)
+
+    @property
+    def element_spec(self) -> OpaqueSpec:
+        """The :class:`OpaqueSpec` every element satisfies — a view on ``spec``."""
+        spec = self._spec.element_spec
+        assert isinstance(spec, OpaqueSpec)  # narrowed at construction
+        return spec
+
+
+def _reject_mappings(batch: OpaqueBatch) -> None:
+    """Fail at construction on any element the shared spec does not admit.
+
+    ``OpaqueSpec`` accepts every value except a mapping, which the value layer
+    reads as a subtree rather than a leaf. Reporting it here names the position,
+    which is what a caller needs; leaving it to ``is_valid`` would make the
+    batch's own spec a false statement about one of its elements.
+    """
+    for index, element in np.ndenumerate(batch._store):
+        if not batch.element_spec.is_valid(element):
+            position = index[0] if len(index) == 1 else index
+            raise TypeError(
+                f"an opaque element is any value but a mapping, which denotes a subtree; "
+                f"the element at {position} is a {type(element).__name__}"
+            )

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -40,10 +40,15 @@ class OpaqueBatch(_ObjectBatch[Any]):
     Raises
     ------
     TypeError
-        If ``element_spec`` is not an :class:`OpaqueSpec`, if an element is a
-        mapping, or for any reason :class:`_ObjectBatch` refuses ``elements``.
+        If ``element_spec`` is not an :class:`OpaqueSpec`; if an element is a
+        mapping, naming the position that failed; if ``elements`` is a string, a
+        mapping, or an array that is not ``dtype=object`` — each iterates into
+        something other than its elements — or is not iterable at all.
     ValueError
-        For any reason :class:`_ObjectBatch` refuses the shape or the levels.
+        If ``elements`` is empty, or is a zero-dimensional array (one object with
+        no batch axis); if ``axis_groups`` does not tile the shape the elements are
+        stored in; or if ``axis_groups`` is omitted and the number of level names
+        does not match the number of axes.
 
     Notes
     -----
@@ -54,6 +59,11 @@ class OpaqueBatch(_ObjectBatch[Any]):
     This is the case a batch's own spec exists for: an ``OpaqueSpec`` names no
     ProbPipe kind, yet the batch is specified all the same, at the family kind
     over it.
+
+    This batch **stores** its elements, so ``batch[i]`` is the object that was
+    put in — the same object, under whatever identity it already had, not a copy
+    renamed to its position. A sub-batch is a view and takes a derived name as any
+    view does.
 
     Examples
     --------

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -5,7 +5,7 @@ See design III.1.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import Any
 
 import numpy as np
@@ -20,28 +20,40 @@ __all__ = ["OpaqueBatch"]
 class OpaqueBatch(_ObjectBatch[Any]):
     """A batch of opaque objects sharing one :class:`OpaqueSpec`.
 
-    An opaque value exposes no structure, so there is nothing to stack it into
-    and the collection is a batch. This is the case a batch's own spec exists
-    for: an ``OpaqueSpec`` names no ProbPipe kind, yet the batch is specified all
-    the same, at the family kind over it.
-
     Parameters
     ----------
-    elements : numpy.ndarray or sequence
-        The objects, as an object array of any shape or a flat sequence.
-    level_names : str or sequence of str
+    elements : numpy.ndarray or iterable
+        The objects, as an object array of any shape or a flat iterable.
+    level_names : str or iterable of str
         One name per level, outermost first.
     element_spec : OpaqueSpec, optional
         What every element satisfies. Defaults to ``OpaqueSpec()``.
-    axis_groups : sequence of sequence of int, optional
-        The axes each level holds; defaults to one axis per level.
+    axis_groups : iterable of iterable of int, optional
+        The axis sizes each level holds; defaults to one axis per level.
+    name : str, optional
+        The batch's name; defaults to ``"opaquebatch"``, marked auto-derived.
+    name_is_auto : bool, default False
+        Whether *name* is auto-derived rather than user-given.
+    provenance : Provenance, optional
+        How this batch was produced.
 
     Raises
     ------
     TypeError
-        If ``element_spec`` is not an :class:`OpaqueSpec`, or an element is a
-        mapping — which denotes tree structure, never a leaf, as everywhere else
-        in the value layer.
+        If ``element_spec`` is not an :class:`OpaqueSpec`, if an element is a
+        mapping, or for any reason :class:`_ObjectBatch` refuses ``elements``.
+    ValueError
+        For any reason :class:`_ObjectBatch` refuses the shape or the levels.
+
+    Notes
+    -----
+    An opaque value exposes no structure, so there is nothing to stack it into
+    and the collection is a batch. An element may be any value except a mapping,
+    which the value layer reads as a subtree rather than a leaf.
+
+    This is the case a batch's own spec exists for: an ``OpaqueSpec`` names no
+    ProbPipe kind, yet the batch is specified all the same, at the family kind
+    over it.
 
     Examples
     --------
@@ -54,9 +66,11 @@ class OpaqueBatch(_ObjectBatch[Any]):
 
     __slots__ = ()
 
+    _element_rule = "be any value but a mapping, which denotes a subtree"
+
     def __init__(
         self,
-        elements: np.ndarray | Sequence[Any],
+        elements: np.ndarray | Iterable[Any],
         level_names: str | Iterable[str],
         *,
         element_spec: OpaqueSpec | None = None,
@@ -80,7 +94,6 @@ class OpaqueBatch(_ObjectBatch[Any]):
             name_is_auto=name_is_auto,
             provenance=provenance,
         )
-        _reject_mappings(self)
 
     @property
     def element_spec(self) -> OpaqueSpec:
@@ -88,20 +101,3 @@ class OpaqueBatch(_ObjectBatch[Any]):
         spec = self._spec.element_spec
         assert isinstance(spec, OpaqueSpec)  # narrowed at construction
         return spec
-
-
-def _reject_mappings(batch: OpaqueBatch) -> None:
-    """Fail at construction on any element the shared spec does not admit.
-
-    ``OpaqueSpec`` accepts every value except a mapping, which the value layer
-    reads as a subtree rather than a leaf. Reporting it here names the position,
-    which is what a caller needs; leaving it to ``is_valid`` would make the
-    batch's own spec a false statement about one of its elements.
-    """
-    for index, element in np.ndenumerate(batch._store):
-        if not batch.element_spec.is_valid(element):
-            position = index[0] if len(index) == 1 else index
-            raise TypeError(
-                f"an opaque element is any value but a mapping, which denotes a subtree; "
-                f"the element at {position} is a {type(element).__name__}"
-            )

--- a/tests/core/test_function_opaque_batch.py
+++ b/tests/core/test_function_opaque_batch.py
@@ -1,0 +1,325 @@
+"""Tests for `FunctionBatch` and `OpaqueBatch` — the batch forms that store objects.
+
+These two are the first concrete `Batch` implementations, so the suite carries a
+second burden beyond the classes themselves: showing that the ABC's storage
+contract is satisfiable by real storage rather than only by the test doubles in
+`test_batch.py`. The view-sharing and index-order assertions below are that
+check.
+"""
+
+from __future__ import annotations
+
+import copy
+import pickle
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import (
+    ArraySpec,
+    Batch,
+    BatchSpec,
+    EventTemplate,
+    FunctionBatch,
+    FunctionSpec,
+    OpaqueBatch,
+    OpaqueSpec,
+    TrackedTerm,
+)
+
+
+@pytest.fixture
+def functions():
+    """Three callables under one `variant` level."""
+    return FunctionBatch([lambda x: x, lambda x: 2 * x, lambda x: 3 * x], "variant", name="f")
+
+
+@pytest.fixture
+def labels():
+    """Three opaque values under one `site` level."""
+    return OpaqueBatch(["north", "east", "south"], "site", name="s")
+
+
+@pytest.fixture
+def grid():
+    """A 2x3 opaque batch over two levels."""
+    store = np.empty((2, 3), dtype=object)
+    for chain in range(2):
+        for draw in range(3):
+            store[chain, draw] = f"c{chain}d{draw}"
+    return OpaqueBatch(store, ["chain", "draw"], name="post")
+
+
+class TestConstruction:
+    def test_a_flat_sequence_is_one_axis(self, functions):
+        assert functions.batch_shape == (3,)
+        assert functions.batch_size == 3
+        assert functions.axis_groups == ((3,),)
+        assert functions.level_names == ("variant",)
+
+    def test_an_object_array_carries_its_own_shape(self, grid):
+        assert grid.batch_shape == (2, 3)
+        assert grid.axis_groups == ((2,), (3,))
+        assert grid.level_names == ("chain", "draw")
+
+    def test_axis_groups_may_put_several_axes_in_one_level(self):
+        store = np.empty((2, 3), dtype=object)
+        store[...] = "x"
+        batch = OpaqueBatch(store, "draw", axis_groups=[(2, 3)])
+
+        assert batch.axis_groups == ((2, 3),)
+        assert batch.level_names == ("draw",)
+        assert batch.batch_shape == (2, 3)
+
+    def test_a_single_string_names_a_single_level(self, labels):
+        assert labels.level_names == ("site",)
+
+    def test_an_unnamed_batch_takes_an_auto_name(self):
+        batch = OpaqueBatch(["a"], "site")
+
+        assert batch.name == "opaquebatch"
+        assert batch.name_is_auto
+
+    def test_a_given_name_is_not_auto(self, labels):
+        assert labels.name == "s"
+        assert not labels.name_is_auto
+
+
+class TestConstructionRefusals:
+    def test_a_non_callable_element_names_its_position(self):
+        with pytest.raises(TypeError, match=r"element at 1 is a int"):
+            FunctionBatch([lambda x: x, 3], "variant")
+
+    def test_a_mapping_is_not_an_opaque_element(self):
+        with pytest.raises(TypeError, match="denotes a subtree"):
+            OpaqueBatch([{"a": 1}], "site")
+
+    def test_a_multi_axis_position_is_reported_as_a_tuple(self):
+        store = np.empty((2, 2), dtype=object)
+        store[...] = "x"
+        store[1, 0] = {"a": 1}
+
+        with pytest.raises(TypeError, match=r"element at \(1, 0\)"):
+            OpaqueBatch(store, ["chain", "draw"])
+
+    def test_no_elements_is_refused(self):
+        with pytest.raises(ValueError, match="at least one element"):
+            OpaqueBatch([], "site")
+
+    def test_a_single_object_is_not_a_batch(self):
+        with pytest.raises(ValueError, match="at least one batch axis"):
+            OpaqueBatch(np.array(None, dtype=object), "site")
+
+    def test_a_numeric_array_is_not_object_storage(self):
+        with pytest.raises(TypeError, match="dtype=object"):
+            OpaqueBatch(np.zeros(3), "site")
+
+    def test_naming_fewer_levels_than_axes_is_refused(self):
+        with pytest.raises(ValueError, match="2 axes need 2 level names"):
+            OpaqueBatch(np.empty((2, 2), dtype=object), "site")
+
+    @pytest.mark.parametrize(
+        ("cls", "spec", "match"),
+        [
+            (FunctionBatch, ArraySpec(()), "must be a FunctionSpec"),
+            (OpaqueBatch, ArraySpec(()), "must be an OpaqueSpec"),
+        ],
+    )
+    def test_the_element_spec_must_be_its_own_kind(self, cls, spec, match):
+        with pytest.raises(TypeError, match=match):
+            cls([lambda: 1], "variant", element_spec=spec)
+
+
+class TestSpec:
+    def test_the_batch_is_specified_at_the_family_kind(self, functions):
+        assert isinstance(functions.spec, BatchSpec)
+        assert functions.spec == BatchSpec(FunctionSpec(), ((3,),), ("variant",))
+
+    def test_element_spec_is_a_view_of_the_declared_kind(self, functions, labels):
+        assert isinstance(functions.element_spec, FunctionSpec)
+        assert isinstance(labels.element_spec, OpaqueSpec)
+        assert functions.element_spec is functions.spec.element_spec
+
+    def test_an_element_spec_may_be_given(self):
+        declared = FunctionSpec(EventTemplate(x=()), EventTemplate(y=()))
+        batch = FunctionBatch([lambda x: x], "variant", element_spec=declared)
+
+        assert batch.element_spec == declared
+        assert batch.spec.element_spec == declared
+
+    def test_a_batch_naming_no_kind_is_specified_all_the_same(self, labels):
+        """The case `BatchSpec` exists for: `OpaqueSpec` names no kind."""
+        assert not isinstance(labels.element_spec, type(labels.spec))
+        assert labels.spec.is_valid(labels)
+
+    def test_is_valid_reads_the_whole_multiplicity(self, functions):
+        assert functions.spec.is_valid(functions)
+        assert not functions.spec.is_valid(FunctionBatch([lambda x: x], "variant", name="other"))
+
+
+class TestElements:
+    def test_an_element_is_the_object_that_was_stored(self, labels):
+        stored = ["north", "east", "south"]
+        assert [labels[i] for i in range(3)] == stored
+
+    def test_a_callable_element_is_callable(self, functions):
+        assert functions[1](5) == 10
+
+    def test_a_tracked_element_keeps_its_own_name(self):
+        """A stored element is handed back as given, not renamed to its position.
+
+        The identity rule applies to a batch that materializes an element per
+        index; here the caller's own object comes back, so a name that means
+        something is not replaced by one that states a position.
+        """
+
+        class _Named(TrackedTerm):
+            __slots__ = ("_name", "_name_is_auto", "_provenance")
+
+            def __init__(self, name):
+                self._init_tracked(name)
+
+            def __call__(self):
+                return self._name
+
+        element = _Named("alpha")
+        batch = FunctionBatch([element], "variant", name="f")
+
+        assert batch[0] is element
+        assert batch[0].name == "alpha"
+
+    def test_iteration_walks_the_leading_axis(self, functions):
+        assert [f(2) for f in functions] == [2, 4, 6]
+
+    def test_len_is_the_leading_axis(self, grid):
+        assert len(grid) == 2
+        assert [len(inner) for inner in grid] == [3, 3]
+
+    def test_elements_holding_arrays_are_not_unpacked(self):
+        """`np.asarray` would stack these into one numeric array."""
+        batch = OpaqueBatch([jnp.zeros(3), jnp.ones(3)], "site")
+
+        assert batch.batch_shape == (2,)
+        np.testing.assert_array_equal(np.asarray(batch[1]), np.ones(3))
+
+    def test_elements_holding_sequences_are_not_unpacked(self):
+        batch = OpaqueBatch([[1, 2], [3, 4]], "site")
+
+        assert batch.batch_shape == (2,)
+        assert batch[0] == [1, 2]
+
+
+class TestTheStorageContractIsSatisfiable:
+    """A sub-batch is a view over the parent's store, in the order asked for.
+
+    `Batch._sub_batch_at` contracts for both, and until now only test doubles
+    answered it. These assertions are the ABC's contract checked against real
+    storage.
+    """
+
+    def test_a_sub_batch_shares_the_parent_store(self, labels):
+        assert np.shares_memory(labels[0:2]._store, labels._store)
+
+    def test_a_view_of_a_view_still_shares(self, grid):
+        assert np.shares_memory(grid[0:2][1:3]._store, grid._store)
+
+    def test_a_descending_slice_is_presented_in_the_order_given(self, labels):
+        assert [labels[::-1][i] for i in range(3)] == ["south", "east", "north"]
+
+    def test_a_stepped_slice_is_presented_in_the_order_given(self, functions):
+        assert [f(1) for f in functions[::2]] == [1, 3]
+
+    def test_selecting_everything_is_a_view_and_not_the_batch_itself(self, labels):
+        whole = labels.at_levels()
+
+        assert whole is not labels
+        assert np.shares_memory(whole._store, labels._store)
+        assert [whole[i] for i in range(3)] == [labels[i] for i in range(3)]
+
+    def test_a_view_carries_the_spec_the_abc_computed(self, grid):
+        assert grid.at_levels(chain=0).spec == BatchSpec(OpaqueSpec(), ((3,),), ("draw",))
+
+
+class TestNaming:
+    def test_a_view_is_named_by_what_it_selects(self, grid):
+        assert grid.at_levels(chain=0).name == "post[chain=0]"
+        assert grid.at_levels(draw=slice(1, 3)).name == "post[draw=1:3]"
+
+    def test_a_derived_name_is_auto(self, labels):
+        assert labels[0:2].name_is_auto
+
+    def test_positional_and_named_indexing_derive_one_name(self, grid):
+        assert grid[0].name == grid.at_levels(chain=0).name
+
+    def test_level_names_can_be_repinned(self, labels):
+        renamed = labels.with_level_names(site="place")
+
+        assert renamed.level_names == ("place",)
+        assert renamed[0:2].name == "s[place=0:2]"
+
+    def test_with_name_re_roots_a_view(self, labels):
+        assert labels[0:2].with_name("q")[0:1].name == "q[site=0:1]"
+
+
+class TestFieldKeys:
+    def test_these_elements_have_no_fields(self, functions):
+        with pytest.raises(TypeError, match="have no fields to address by name"):
+            functions["anything"]
+
+    def test_the_message_names_the_concrete_class(self, labels):
+        with pytest.raises(TypeError, match="this OpaqueBatch"):
+            labels["anything"]
+
+
+class TestRoundTrips:
+    @pytest.mark.parametrize("clone", [pickle.loads, copy.copy], ids=["pickle", "copy"])
+    def test_a_batch_survives(self, labels, clone):
+        restored = clone(pickle.dumps(labels)) if clone is pickle.loads else clone(labels)
+
+        assert restored.name == labels.name
+        assert restored.level_names == labels.level_names
+        assert [restored[i] for i in range(3)] == ["north", "east", "south"]
+
+    def test_a_view_survives_pickling(self, labels):
+        restored = pickle.loads(pickle.dumps(labels[0:2]))
+
+        assert restored.name == "s[site=0:2]"
+        assert [restored[i] for i in range(2)] == ["north", "east"]
+
+    def test_the_store_travels_without_being_declared(self, labels):
+        """`Batch.__getstate__` walks the MRO, so `_store` needs no restating."""
+        assert "_store" in labels.__getstate__()[1]
+
+
+class TestImmutability:
+    def test_assignment_is_refused(self, labels):
+        with pytest.raises(AttributeError, match="OpaqueBatch is immutable"):
+            labels._store = None
+
+    def test_deletion_is_refused(self, labels):
+        with pytest.raises(AttributeError, match="OpaqueBatch is immutable"):
+            del labels._store
+
+
+class TestTheseAreBatches:
+    def test_both_are_batches(self, functions, labels):
+        assert isinstance(functions, Batch)
+        assert isinstance(labels, Batch)
+
+    def test_both_are_tracked_terms(self, functions, labels):
+        assert isinstance(functions, TrackedTerm)
+        assert isinstance(labels, TrackedTerm)
+
+    def test_neither_adds_public_interface_beyond_the_abc(self):
+        """Design III.1: each carries its shared spec, adding no other interface."""
+        added = {
+            name
+            for cls in (FunctionBatch, OpaqueBatch)
+            for name in vars(cls)
+            if not name.startswith("_")
+        }
+        assert added == {"element_spec"}
+
+    def test_repr_reads_the_levels_and_no_elements(self, grid):
+        assert repr(grid) == "OpaqueBatch(name='post', chain=2, draw=3)"

--- a/tests/core/test_function_opaque_batch.py
+++ b/tests/core/test_function_opaque_batch.py
@@ -25,8 +25,11 @@ from probpipe import (
     FunctionSpec,
     OpaqueBatch,
     OpaqueSpec,
+    Record,
+    TermSpec,
     TrackedTerm,
 )
+from probpipe.core.provenance import Provenance
 
 
 @pytest.fixture
@@ -39,6 +42,16 @@ def functions():
 def labels():
     """Three opaque values under one `site` level."""
     return OpaqueBatch(["north", "east", "south"], "site", name="s")
+
+
+@pytest.fixture
+def function_grid():
+    """A 2x2 FunctionBatch, so multi-axis behavior is pinned for both classes."""
+    store = np.empty((2, 2), dtype=object)
+    for row in range(2):
+        for column in range(2):
+            store[row, column] = lambda x, r=row, c=column: 10 * r + c + x
+    return FunctionBatch(store, ["chain", "draw"], name="fg")
 
 
 @pytest.fixture
@@ -85,6 +98,25 @@ class TestConstruction:
         assert labels.name == "s"
         assert not labels.name_is_auto
 
+    def test_a_given_name_can_still_be_marked_auto(self):
+        """The shape an operation deriving a batch name needs: named, but re-derivable."""
+        batch = OpaqueBatch(["a"], "site", name="given", name_is_auto=True)
+
+        assert batch.name == "given"
+        assert batch.name_is_auto
+
+    def test_a_provenance_is_carried_as_given(self):
+        record = Provenance.create("sample", parents=[])
+        batch = OpaqueBatch(["a"], "site", provenance=record)
+
+        assert batch.provenance is record
+
+    def test_a_generator_is_materialized_into_one_axis(self):
+        batch = OpaqueBatch((str(i) for i in range(3)), "site")
+
+        assert batch.batch_shape == (3,)
+        assert [batch[i] for i in range(3)] == ["0", "1", "2"]
+
 
 class TestConstructionRefusals:
     def test_a_non_callable_element_names_its_position(self):
@@ -95,13 +127,19 @@ class TestConstructionRefusals:
         with pytest.raises(TypeError, match="denotes a subtree"):
             OpaqueBatch([{"a": 1}], "site")
 
-    def test_a_multi_axis_position_is_reported_as_a_tuple(self):
+    @pytest.mark.parametrize(
+        ("cls", "good", "bad"),
+        [(OpaqueBatch, "x", {"a": 1}), (FunctionBatch, lambda x: x, 3)],
+        ids=["opaque", "function"],
+    )
+    def test_a_multi_axis_position_is_reported_as_a_tuple(self, cls, good, bad):
+        """Both classes render the position the same way, from the shared check."""
         store = np.empty((2, 2), dtype=object)
-        store[...] = "x"
-        store[1, 0] = {"a": 1}
+        store[...] = good
+        store[1, 0] = bad
 
         with pytest.raises(TypeError, match=r"element at \(1, 0\)"):
-            OpaqueBatch(store, ["chain", "draw"])
+            cls(store, ["chain", "draw"])
 
     def test_no_elements_is_refused(self):
         with pytest.raises(ValueError, match="at least one element"):
@@ -130,6 +168,44 @@ class TestConstructionRefusals:
         with pytest.raises(TypeError, match=match):
             cls([lambda: 1], "variant", element_spec=spec)
 
+    @pytest.mark.parametrize(
+        ("axis_groups", "why"),
+        [
+            ([(5, 7)], "sizes disagree with the store"),
+            ([(2,)], "an axis is left out"),
+            ([(2,), (3,), (4,)], "an axis is invented"),
+            ([(3,), (2,)], "the sizes are transposed"),
+        ],
+        ids=["wrong-sizes", "too-few-axes", "too-many-axes", "transposed"],
+    )
+    def test_axis_groups_must_tile_the_stored_shape(self, axis_groups, why):
+        """A grouping that disagrees would make every accessor a false statement."""
+        store = np.empty((2, 3), dtype=object)
+        store[...] = "x"
+
+        with pytest.raises(ValueError, match="must tile the shape"):
+            OpaqueBatch(store, ["a", "b"][: len(axis_groups)], axis_groups=axis_groups)
+
+    @pytest.mark.parametrize(
+        ("elements", "match"),
+        [
+            ("north", "iterates into its parts"),
+            (b"ab", "iterates into its parts"),
+            ({"a": 1, "b": 2}, "iterates into its parts"),
+            (np.zeros(3), "must have dtype=object"),
+            (jnp.zeros(3), "must have dtype=object"),
+        ],
+        ids=["str", "bytes", "mapping", "ndarray", "jax"],
+    )
+    def test_a_container_that_iterates_into_its_parts_is_refused(self, elements, match):
+        """Each would give a batch of pieces of one object, not a batch of objects."""
+        with pytest.raises(TypeError, match=match):
+            OpaqueBatch(elements, "site")
+
+    def test_something_not_iterable_at_all_is_refused(self):
+        with pytest.raises(TypeError, match="iterable of elements"):
+            OpaqueBatch(3, "site")
+
 
 class TestSpec:
     def test_the_batch_is_specified_at_the_family_kind(self, functions):
@@ -140,6 +216,7 @@ class TestSpec:
         assert isinstance(functions.element_spec, FunctionSpec)
         assert isinstance(labels.element_spec, OpaqueSpec)
         assert functions.element_spec is functions.spec.element_spec
+        assert labels.element_spec is labels.spec.element_spec
 
     def test_an_element_spec_may_be_given(self):
         declared = FunctionSpec(EventTemplate(x=()), EventTemplate(y=()))
@@ -149,13 +226,20 @@ class TestSpec:
         assert batch.spec.element_spec == declared
 
     def test_a_batch_naming_no_kind_is_specified_all_the_same(self, labels):
-        """The case `BatchSpec` exists for: `OpaqueSpec` names no kind."""
-        assert not isinstance(labels.element_spec, type(labels.spec))
-        assert labels.spec.is_valid(labels)
+        """The case `BatchSpec` exists for: `OpaqueSpec` names no kind, the batch does."""
+        assert not isinstance(labels.element_spec, TermSpec)
+        assert isinstance(labels.spec, TermSpec)
 
-    def test_is_valid_reads_the_whole_multiplicity(self, functions):
+    def test_is_valid_reads_every_part_of_the_spec(self, functions):
+        """All three fields: the element spec, the axis sizes, and the level names."""
+        three = [lambda x: x, lambda x: 2 * x, lambda x: 3 * x]
+
         assert functions.spec.is_valid(functions)
-        assert not functions.spec.is_valid(FunctionBatch([lambda x: x], "variant", name="other"))
+        assert not functions.spec.is_valid(FunctionBatch(three[:1], "variant"))
+        assert not functions.spec.is_valid(FunctionBatch(three, "flavor"))
+        assert not functions.spec.is_valid(
+            FunctionBatch(three, "variant", element_spec=FunctionSpec(EventTemplate(x=())))
+        )
 
 
 class TestElements:
@@ -224,6 +308,25 @@ class TestTheStorageContractIsSatisfiable:
     def test_a_view_of_a_view_still_shares(self, grid):
         assert np.shares_memory(grid[0:2][1:3]._store, grid._store)
 
+    @pytest.mark.parametrize(
+        "select",
+        [
+            lambda b: b[0:2],
+            lambda b: b[0],
+            lambda b: b.at_levels(draw=1),
+            lambda b: b.at_levels(chain=0, draw=slice(1, 3)),
+            lambda b: b[::-1],
+        ],
+        ids=["slice", "integer-outer", "integer-inner", "mixed", "reversed"],
+    )
+    def test_every_indexing_form_shares_the_store(self, grid, select):
+        """Not slices alone: an integer index drops an axis and must still view."""
+        assert np.shares_memory(select(grid)._store, grid._store)
+
+    def test_a_function_batch_shares_too(self, function_grid):
+        """The contract is the base's, so it holds for both classes."""
+        assert np.shares_memory(function_grid[0]._store, function_grid._store)
+
     def test_a_descending_slice_is_presented_in_the_order_given(self, labels):
         assert [labels[::-1][i] for i in range(3)] == ["south", "east", "north"]
 
@@ -236,6 +339,34 @@ class TestTheStorageContractIsSatisfiable:
         assert whole is not labels
         assert np.shares_memory(whole._store, labels._store)
         assert [whole[i] for i in range(3)] == [labels[i] for i in range(3)]
+
+    def test_the_store_cannot_be_written_through(self, labels):
+        """A view shares the buffer, so a writable store would reach the parent."""
+        with pytest.raises(ValueError, match="read-only"):
+            labels._store[0] = {"a": 1}
+        with pytest.raises(ValueError, match="read-only"):
+            labels[0:2]._store[0] = {"a": 1}
+
+    def test_the_array_a_caller_passes_is_copied(self):
+        """Otherwise the caller could write past the per-element check."""
+        store = np.empty(2, dtype=object)
+        store[0], store[1] = "north", "south"
+        batch = OpaqueBatch(store, "site")
+
+        store[1] = {"a": 1}
+
+        assert batch[1] == "south"
+        assert batch.element_spec.is_valid(batch[1])
+
+    def test_an_empty_selection_is_a_batch_of_nothing(self, labels):
+        """Reachable by selection though the constructor refuses it — see Notes."""
+        empty = labels[0:0]
+
+        assert empty.batch_shape == (0,)
+        assert empty.level_names == ("site",)
+        assert len(empty) == 0
+        assert list(empty) == []
+        assert empty._store.size == 0
 
     def test_a_view_carries_the_spec_the_abc_computed(self, grid):
         assert grid.at_levels(chain=0).spec == BatchSpec(OpaqueSpec(), ((3,),), ("draw",))
@@ -273,9 +404,13 @@ class TestFieldKeys:
 
 
 class TestRoundTrips:
-    @pytest.mark.parametrize("clone", [pickle.loads, copy.copy], ids=["pickle", "copy"])
+    @pytest.mark.parametrize(
+        "clone",
+        [lambda b: pickle.loads(pickle.dumps(b)), copy.copy, copy.deepcopy],
+        ids=["pickle", "copy", "deepcopy"],
+    )
     def test_a_batch_survives(self, labels, clone):
-        restored = clone(pickle.dumps(labels)) if clone is pickle.loads else clone(labels)
+        restored = clone(labels)
 
         assert restored.name == labels.name
         assert restored.level_names == labels.level_names
@@ -290,6 +425,33 @@ class TestRoundTrips:
     def test_the_store_travels_without_being_declared(self, labels):
         """`Batch.__getstate__` walks the MRO, so `_store` needs no restating."""
         assert "_store" in labels.__getstate__()[1]
+
+
+class TestProvenance:
+    """A stored element is not the batch's to attribute (design II.5)."""
+
+    def test_a_view_inherits_the_batch_lineage(self, labels, full_provenance_mode):
+        produced = labels.with_provenance(Provenance.create("collect", parents=[]))
+
+        assert produced[0:2].provenance is produced.provenance
+
+    def test_reading_an_element_leaves_the_caller_object_untouched(self, full_provenance_mode):
+        """These batches store what they were given, so a read writes to nothing."""
+        element = Record("r", x=1.0)
+        batch = OpaqueBatch([element, Record("r2", x=2.0)], "site", name="recs")
+        batch.with_provenance(Provenance.create("collect", parents=[]))
+
+        assert batch[0] is element
+        assert element.provenance is None
+
+    def test_the_caller_can_still_set_its_own_provenance_afterwards(self, full_provenance_mode):
+        """The write-once slot stays the caller's to spend."""
+        element = Record("r", x=1.0)
+        batch = OpaqueBatch([element], "site")
+        batch[0]
+
+        own = Provenance.create("fit", parents=[])
+        assert element.with_provenance(own).provenance is own
 
 
 class TestImmutability:
@@ -316,10 +478,21 @@ class TestTheseAreBatches:
         added = {
             name
             for cls in (FunctionBatch, OpaqueBatch)
-            for name in vars(cls)
+            for ancestor in cls.__mro__[: cls.__mro__.index(Batch)]
+            for name in vars(ancestor)
             if not name.startswith("_")
         }
         assert added == {"element_spec"}
 
-    def test_repr_reads_the_levels_and_no_elements(self, grid):
-        assert repr(grid) == "OpaqueBatch(name='post', chain=2, draw=3)"
+    def test_repr_reads_the_levels_and_no_elements(self):
+        """Load-bearing: `with_provenance` interpolates the batch into its own error."""
+
+        class _Unreadable:
+            def __repr__(self):
+                raise AssertionError("repr must not read an element")
+
+        store = np.empty(2, dtype=object)
+        store[0] = store[1] = _Unreadable()
+        batch = OpaqueBatch(store, "site", name="s")
+
+        assert repr(batch) == "OpaqueBatch(name='s', site=2)"

--- a/tests/core/test_function_opaque_batch.py
+++ b/tests/core/test_function_opaque_batch.py
@@ -287,6 +287,21 @@ class TestElements:
         assert batch.batch_shape == (2,)
         np.testing.assert_array_equal(np.asarray(batch[1]), np.ones(3))
 
+    def test_an_object_array_of_arrays_is_not_unpacked(self):
+        """The other input path: a supplied object array, copied rather than built.
+
+        `_as_object_array` has two branches, and this is the one numpy could
+        silently re-stack — a plain `np.asarray` of an object array of equal-shaped
+        arrays descends into them and returns one 2-d numeric array.
+        """
+        store = np.empty(2, dtype=object)
+        store[0], store[1] = jnp.zeros(3), jnp.ones(3)
+
+        batch = OpaqueBatch(store, "site")
+
+        assert batch.batch_shape == (2,)
+        np.testing.assert_array_equal(np.asarray(batch[1]), np.ones(3))
+
     def test_elements_holding_sequences_are_not_unpacked(self):
         batch = OpaqueBatch([[1, 2], [3, 4]], "site")
 


### PR DESCRIPTION
## Summary

The batch forms of the two value kinds that have no native stacked form. A numeric array batches natively, with the batch axes leading, so it needs no class; a callable and an opaque object have nothing to stack *into*, so each gets a thin `Batch` that stores its elements and carries the one `element_spec` they all satisfy, adding no interface beyond it — design III.1.

```python
FunctionBatch([lambda x: x, lambda x: 2 * x], "variant", name="f")[1](3)   # 6
OpaqueBatch(["north", "south"], "site", name="labels")[0]                  # 'north'
```

> **Stacked on #386.** These are the first implementers of the `Batch[E]` ABC, so this branches off `dev/batch-abc`. Review #386 first; once it lands this rebases onto `main` and the diff reduces to its own commit.

Implements **W3.1** of #350.

## The ABC's storage contract, checked against real storage

Worth stating plainly because it is this PR's second purpose. `Batch` has so far been exercised only through the five doubles in `test_batch.py`; these are the first real implementers, so the value here is partly in finding out whether the hook shapes hold up. They did — no change to `_batch.py` was needed — and the storage contract is now asserted against something that actually stores.

`_sub_batch_at` is contracted to present a **view** sharing the parent's store, with the index presented *in the order the view presents them*, a descending slice included. A numpy object array answers both: basic indexing returns a view, and it honors a descending or stepped slice in place. That is why the store is an object array — the contract, not any interest in arrays.

Both classes share that storage through a private `_ObjectBatch`. The alternative was ~40 lines duplicated per class, and the lines in question are exactly the contract-bearing ones: a copy could creep into one while the other stayed a view, which is the failure the ABC's docstring warns about.

## Deliberate choices, each of which could reasonably go the other way

- **A level name is required, not defaulted.** `FunctionBatch(elements, "variant")`, never `FunctionBatch(elements)`. Same reason #386 removed suffixing: a placeholder like `element` reads as meaning something while naming nothing, and levels exist so that operations can align operands by meaning. The caller minting the level knows what it means.
- **An element comes back as the object that was stored, untouched.** Neither renamed nor given provenance. Identity and lineage are derived where a batch *materializes* an element per index — a row of columnar storage has no identity until it is built — and these store theirs, so `batch[0] is element` and what the caller put in is what comes out. That has a consequence for provenance too: the ABC used to stamp whatever `_element_at` returned, which for a storing batch reached into the caller's own object. #386 now makes a selection *inherit* its batch's lineage rather than record a node, and element provenance the hook's own; W3.2's materialized rows will inherit, these do not.
- **Elements are never unpacked.** `np.asarray([jnp.zeros(3), jnp.ones(3)], dtype=object)` stacks those into one 2-d array; allocating empty and assigning keeps each object whole. A batch of two arrays stays a batch of two things.
- **Every element is checked at construction**, naming the position that failed, because a batch asserts its `element_spec` of *all* of them — an element that fails makes the batch's own spec a false statement. `FunctionSpec.is_valid` is callability; `OpaqueSpec.is_valid` is anything but a mapping, which the value layer reads as a subtree. The check lives once on the base, each class supplying only the phrase its refusal reads with.
- **The store is frozen and a supplied array copied**, so the batch holds the elements it validated and a view cannot write through to its parent. Only the pointer array is copied; the elements stay shared.
- **`axis_groups` must tile the shape the elements are stored in**, so the spec cannot describe a shape the storage does not have.
- **A container that iterates into its parts is refused** — a string, a mapping, a numeric array — since each would give a batch of pieces of one object rather than a batch of objects. The mapping case would otherwise slip past the check that refuses a mapping *as* an element.
- **Shape comes from the elements.** An object array carries its own; a flat sequence is one axis. A nested sequence is *not* unpacked into axes, since what nesting means for an arbitrary object is the caller's to decide — build the array to state more than one axis. `axis_groups` defaults to one axis per level and is given explicitly for a level spanning several.

## Deviation from the target layout

`design/package-structure.md` places these in `values/_function_batch.py` and `values/_opaque_batch.py`. The `values/` split has not happened, so they sit in `core/` under the same filenames, as the other in-place migrations do. The shared `_object_batch.py` is a third module the layout did not name; it holds the private base only, and the two public classes keep the files the design names. The layout now lists it, since `LinOpBatch` is a likely second consumer.

## `OpaqueBatch` closes a loop

It is the case a batch's own spec was introduced for. An `OpaqueSpec` names no ProbPipe kind, so under the old reading — a batch's spec being its *element's* — `OpaqueBatch.spec` would not have been a `TermSpec` at all. With `BatchSpec` it is specified like any other term, at the family kind over its element's. That argument was made in #382 and is now a class.

## Tests

`tests/core/test_function_opaque_batch.py` — **77 tests**. Construction from a sequence and from an object array, multi-level and multi-axis-level, auto vs. given names; every construction refusal (non-callable element, mapping element, no elements, a single object, a numeric ndarray, too few level names, a wrong-kind `element_spec`), each asserting the position or the count it reports; the spec at the family kind and `element_spec` as a view of the declared kind; elements returned as stored, including a tracked one keeping its own name and elements holding arrays or lists staying whole; the storage contract above; derived names, level renaming, and `with_name` re-rooting; the field-key error a batch with no fields gives; `pickle` / `copy` of a batch and of a view, including that `_store` travels without being declared; immutability; and that neither class adds public interface beyond `element_spec`.

Verified by mutation, **13 breaks each caught**. Five were chosen by me: a view turned into a copy, a descending index re-sorted, the element check dropped, `asarray` used for the store, and an element renamed to its position. The other eight close gaps the first suite left — a *partial* view regression that copied only when the index contained an integer, `is_valid` blind to `level_names`, `OpaqueBatch.element_spec` not pinned as a view, `name_is_auto` and `provenance` never read, generators rejected, the non-iterable message gutted, and `FunctionBatch`'s multi-axis position branch, which had no 2-d `FunctionBatch` to exercise it. The sharing assertions had all used pure slices and are now parametrized over every indexing form.

**2262 pass** in `tests/core`; **1061 pass**, 49 skipped across `tests/distributions`, `tests/record`, `tests/modeling`, `tests/validation`. `ruff check` and `ruff format` clean at the pinned 0.15.16.

## Follows separately

`RecordBatch` / `NumericRecordBatch` (W3.2, which fixes #340) and `DistributionBatch` (W3.3, which also needs W2.1), plus converting the existing `RecordArray` / `NumericRecordArray` / `DistributionArray`. Nothing is reparented here, so this PR is purely additive.


