### PR TITLE
refactor(core): recognize a batch of records wherever a batched record was

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,6 +510,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RecordEmpiricalDistribution`, which requires a `Record` and is the subject of
   #340.
 
+  Level alignment reads the levels an operand **has**. A batched operand carrying
+  none of its own — a `RecordArray`, or a `DistributionArray`, which is swept by
+  its `batch_shape` without being a `Batch` — has an anonymous multiplicity: it
+  aligns with nothing by name and products with everything. Standing its parameter
+  name in for the levels it lacks made a parameter named `draw` collide with a real
+  `draw` level on another operand, refusing a call whose two axes are independent,
+  over a level neither operand disagreed about. A `DistributionArray` stays
+  levelless past the cutover, so this outlives the `RecordArray` removal.
+
 - **Renamed, for the storage rule (#381):** `FunctionSpec.output_template` is
   now **`output_spec`**, storing any `ValueSpec` or `None`, and
   `DistributionSpec.event_template` is now **`event_spec`**, storing a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,6 +481,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A batch of records is recognized wherever a batched record was.** A
+  `RecordBatch` is deliberately not a `Record`, so every place that recognized a
+  batched value by `isinstance(x, Record)`, by a `RecordArray` subclass check, or
+  by duck-typing on `.fields` stopped recognizing one when a batch arrived. None
+  of those gates raise — they take the other branch — so a batch would have been
+  re-wrapped as a single opaque field, minibatched by its field count, or read as
+  a bare array. Each now admits a batch and does with it what it did with a
+  `RecordArray`:
+
+  the `Function` boundary keeps a returned batch as the batch it is and copies it
+  into an independent result under the declared output template, validating each
+  column against its field; broadcast planning treats a batch argument as a
+  batched one and sweeps its rows, handing the body an *element*; the broadcast
+  helpers count, gather, and unwrap a batch's rows, a gather keeping the levels it
+  started with; a marginal peels a batch's rows axis into a record of batched
+  leaves; a field view reads its column out of a batch; the flat-vector boundary,
+  the joint log-densities, and the GLM design coercion accept one; minibatching
+  reads its row count from `batch_shape` and gathers a field at a time; and the
+  ArviZ bridge finds its variables through `event_template`, which a batch has and
+  `.fields` is not.
+
+  Producers still return `RecordArray`, so nothing changes for existing code:
+  these are the gates a batch will arrive at, opened first and on their own. Two
+  paths are deliberately left for the cutover, each needing a decision rather than
+  a wider gate: stacking a list of batched records from a broadcast, which has to
+  name the levels the broadcast grid mints, and
+  `RecordEmpiricalDistribution`, which requires a `Record` and is the subject of
+  #340.
+
 - **Renamed, for the storage rule (#381):** `FunctionSpec.output_template` is
   now **`output_spec`**, storing any `ValueSpec` or `None`, and
   `DistributionSpec.event_template` is now **`event_spec`**, storing a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -544,9 +544,14 @@ uv build packaging/probpipe   # probpipe (metapackage)
    (`RecordArray` or `DistributionArray` with nonempty
    `batch_shape`) passed to slots whose hints don't match the
    batched type, the Function layer dispatches cell-by-cell
-   and stacks the returns.  Multiple array inputs combine by the
-   **product rule** (Cartesian full factorial); the sweep's
-   `batch_shape` is the concatenation of each array arg's
+   and stacks the returns.  Multiple array inputs combine by their
+   **levels**: operands carrying the same level names (sibling views of
+   one batch, or two batches naming the same levels on the same axes)
+   zip along them, operands with no level in common combine by the
+   **product rule** (Cartesian full factorial), and one level name at
+   two geometries — or shared by operands whose other levels differ —
+   is refused rather than producted silently.  The sweep's
+   `batch_shape` is the concatenation of each zip group's
    `batch_shape`.  Scalar `Distribution` inputs marginalise via
    Monte Carlo, unchanged.  A `DistributionArray` is always treated
    as `Array[Distribution]` (never marginalised in-place), so

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -27,6 +27,7 @@ from ._empirical import (
     RecordEmpiricalDistribution,
 )
 from ._record_array import NumericRecordArray, RecordArray
+from ._record_batch import RecordBatch
 from .event_template import EventTemplate, NumericEventTemplate, _full_array_shape_or_none
 from .protocols import (
     SupportsLogProb,
@@ -58,19 +59,19 @@ class _RecordMarginal(RecordEmpiricalDistribution):
 
     def __init__(
         self,
-        samples: Record | RecordArray | Array,
+        samples: Record | RecordArray | RecordBatch | Array,
         weights: Array | Weights | None = None,
         *,
         log_weights: Array | Weights | None = None,
         name: str | None = None,
         event_template: EventTemplate | None = None,
     ):
-        # RecordArray is structurally a Record with batched leaves;
-        # peel off the rows axis so the merged constructor sees one
-        # row per batch index. Leaf-keyed (template.keys()) so a nested
-        # batch peels correctly; path-keyed construction rebuilds nesting.
-        if isinstance(samples, RecordArray):
-            template = samples.template
+        # A batch of records holds its rows axis in the batch, and the merged
+        # constructor wants one row per batch index, so peel it: the leaves keep
+        # the rows axis and the record above them loses it. Leaf-keyed, so a
+        # nested batch peels correctly; path-keyed construction rebuilds nesting.
+        if isinstance(samples, (RecordArray, RecordBatch)):
+            template = samples.event_template
             samples = Record(samples.name, {k: samples[k] for k in template}, name_is_auto=True)
         else:
             template = None
@@ -82,7 +83,7 @@ class _RecordMarginal(RecordEmpiricalDistribution):
         if event_template is not None:
             self._event_template = event_template
         elif template is not None:
-            # Preserve the exact template the RecordArray carried.
+            # Preserve the exact template the batch carried.
             self._event_template = template
 
     def __repr__(self):
@@ -439,7 +440,7 @@ def _make_marginal(
             name_is_auto=True,
         )
 
-    if isinstance(output_samples, RecordArray):
+    if isinstance(output_samples, (RecordArray, RecordBatch)):
         return _RecordMarginal(
             output_samples,
             weights,
@@ -932,6 +933,18 @@ def _take_rows(component: Any, indices: Array) -> Any:
     """
     if isinstance(component, list):
         return [component[int(i)] for i in indices]
+    if isinstance(component, RecordBatch):
+        # Only the leading axis's size changes, so the levels carry over with
+        # that one size rewritten; which level holds the axis is unchanged.
+        leading, *rest = component.axis_groups
+        return type(component)(
+            {path: component[path][indices] for path in component.event_template},
+            component.level_names,
+            element_spec=component.element_spec,
+            axis_groups=((indices.shape[0], *leading[1:]), *rest),
+            name=component.name,
+            name_is_auto=True,
+        )
     if isinstance(component, RecordArray):
         # Keyed by the template, which is leaf-keyed, rather than by ``fields``,
         # which names the top-level children and is retained only for the
@@ -955,7 +968,7 @@ def _one_row(component: Any) -> Any:
     and the object itself rather than a one-element list. Field names survive —
     one draw of a record-valued component is a record, whatever its field count.
     """
-    if isinstance(component, RecordArray):
+    if isinstance(component, (RecordArray, RecordBatch)):
         return component[0]
     if isinstance(component, Record):
         return _record_rows(component, 0)

--- a/probpipe/core/_function_contract.py
+++ b/probpipe/core/_function_contract.py
@@ -14,6 +14,7 @@ import numpy as np
 from ._array_backend import _numpy_dtype_of
 from ._distribution_base import Distribution
 from ._record_array import RecordArray
+from ._record_batch import RecordBatch
 from .constraints import _supports_compatible
 from .event_template import (
     ArraySpec,
@@ -267,10 +268,11 @@ def _validate_function_output(
         context=f"Function {function_name!r} output_template",
     )
 
-    # Record and Distribution are schema-carrying result containers. Other
+    # A record, a batch of records, and a distribution are the schema-carrying
+    # result containers. Other
     # tracked terms remain leaf values under the default event-result contract
     # and are validated by their ValueSpec (for example, FunctionSpec).
-    if isinstance(result, (Record, Distribution)):
+    if isinstance(result, (Record, RecordBatch, Distribution)):
         try:
             actual_template = cast(Any, result).event_template
         except (AttributeError, TypeError) as error:
@@ -299,8 +301,8 @@ def _validate_function_output(
             declared_template=concrete,
             actual_template=actual_template,
         )
-        if isinstance(result, RecordArray):
-            _validate_function_record_array_output_values(
+        if isinstance(result, (RecordArray, RecordBatch)):
+            _validate_batched_function_output_values(
                 function_name=function_name,
                 template=concrete,
                 value=result,
@@ -353,11 +355,11 @@ def _validate_function_output(
     return concrete
 
 
-def _validate_function_record_array_output_values(
+def _validate_batched_function_output_values(
     *,
     function_name: str,
     template: EventTemplate,
-    value: RecordArray,
+    value: RecordArray | RecordBatch,
 ) -> None:
     """Validate batched numeric leaves against their per-element specs."""
     batch_shape = value.batch_shape
@@ -485,11 +487,11 @@ def _wrap_declared_function_output(
 ) -> Record | Distribution:
     """Wrap a validated event result under its authoritative template.
 
-    Schema-carrying Record and Distribution results retain their structure.
-    Other tracked terms are event leaves until #369 supplies an explicit
-    term-result plan.
+    Schema-carrying results — a record, a batch of records, a distribution —
+    retain their structure. Other tracked terms are event leaves until #369
+    supplies an explicit term-result plan.
     """
-    if isinstance(result, (Record, Distribution)):
+    if isinstance(result, (Record, RecordBatch, Distribution)):
         return result
     if isinstance(result, Mapping):
         fields = result

--- a/probpipe/core/_numeric_record_distribution.py
+++ b/probpipe/core/_numeric_record_distribution.py
@@ -510,17 +510,18 @@ class NumericRecordDistribution(RecordDistribution):
     def flatten_value(value, *, event_shape: tuple[int, ...] = ()) -> Array:
         """Flatten a sample to a flat trailing axis.
 
-        Accepts ``Record`` / ``NumericRecord`` / ``NumericRecordArray``
+        Accepts a ``Record``, a ``NumericRecord``, or a batch of either
         (which already carry their template) or a raw array. Raw-array
         inputs need ``event_shape`` to disambiguate batch axes from
         event axes; without it, the input gets a trailing singleton
         axis (matching the scalar-event default).
         """
         from ._numeric_record import NumericRecord
+        from ._numeric_record_batch import NumericRecordBatch
         from ._record_array import NumericRecordArray
         from .record import Record
 
-        if isinstance(value, (NumericRecordArray, NumericRecord)):
+        if isinstance(value, (NumericRecordArray, NumericRecordBatch, NumericRecord)):
             return value.to_vector()
         if isinstance(value, Record):
             return value.to_numeric().to_vector()
@@ -1012,6 +1013,7 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
     # Imports hoisted once for all closures below (and to avoid
     # circular-import risk at module load time).
     from ._numeric_record import NumericRecord
+    from ._numeric_record_batch import NumericRecordBatch
     from ._record_array import NumericRecordArray
 
     protocols: set[str] = set()
@@ -1053,7 +1055,7 @@ def _numeric_record_distribution_view_class_for_base(base: Distribution) -> type
         extra_bases.append(SupportsLogProb)
 
         def _log_prob(self, x) -> Array:
-            if isinstance(x, (NumericRecord, NumericRecordArray)):
+            if isinstance(x, (NumericRecord, NumericRecordArray, NumericRecordBatch)):
                 flat = x.to_vector()
             else:
                 flat = jnp.asarray(x)

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -1218,6 +1218,27 @@ def _refuse_a_retyped_element(
         shape = _column_shape(column)
         field = template[path]
         if not isinstance(field, ArraySpec):
+            # A field with no stacked form is checked the way the constructor
+            # checks it: entry by entry against its own spec. A shape-preserving
+            # transform can replace a column of callables with integers and leave
+            # the rank untouched, so without this the rebuilt batch keeps
+            # declaring ``FunctionSpec`` over values that are not callable.
+            if not _is_object_array(column):
+                raise TypeError(
+                    f"a transform left the column {path!r} as a "
+                    f"{type(column).__name__} where its field declares "
+                    f"{type(field).__name__}, whose column holds one entry per element as an "
+                    f"object array"
+                )
+            for index, entry in np.ndenumerate(column):
+                if not field.is_valid(entry):
+                    position = index[0] if len(index) == 1 else index
+                    raise TypeError(
+                        f"a transform left the entry at {position} of the column {path!r} a "
+                        f"{type(entry).__name__}, which its field's {type(field).__name__} does "
+                        f"not admit; a transform may keep or remove batch axes, never retype the "
+                        f"element"
+                    )
             continue
         _check_array_column(column, field, path=path, kind=kind)
         if shape is None or not all(isinstance(s, int) for s in field.shape):

--- a/probpipe/core/_record_distribution.py
+++ b/probpipe/core/_record_distribution.py
@@ -258,10 +258,11 @@ class _RecordDistributionView(Distribution):
     # -- Internals ----------------------------------------------------------
 
     def _extract(self, structured: Any) -> Array:
-        """Extract this field from a parent sample (Record, NumericRecordArray, or flat array)."""
+        """Extract this field from a parent sample (a record, a batch of them, or a flat array)."""
         from ._record_array import RecordArray
+        from ._record_batch import RecordBatch
 
-        if isinstance(structured, (Record, RecordArray)):
+        if isinstance(structured, (Record, RecordArray, RecordBatch)):
             return structured[self._key]
         # Flat array — unflatten via the parent's static unflatten_value.
         # Only numeric parents define unflatten_value; non-numeric Record
@@ -277,7 +278,7 @@ class _RecordDistributionView(Distribution):
             jnp.asarray(structured),
             template=self._parent.event_template,
         )
-        if isinstance(result, (Record, RecordArray)):
+        if isinstance(result, (Record, RecordArray, RecordBatch)):
             return result[self._key]
         return result
 
@@ -293,9 +294,10 @@ class _RecordDistributionView(Distribution):
         expose ``draws()``.
         """
         from ._record_array import RecordArray
+        from ._record_batch import RecordBatch
 
         draws = self._parent.draws()
-        if isinstance(draws, (Record, RecordArray)):
+        if isinstance(draws, (Record, RecordArray, RecordBatch)):
             return jnp.asarray(draws[self._key])
         from ._numeric_record import _reconstruct_from_vector
 

--- a/probpipe/core/_workflow_distribution_broadcast.py
+++ b/probpipe/core/_workflow_distribution_broadcast.py
@@ -540,11 +540,13 @@ def _stack_rows(rows: list[Any], *, arg_name: str) -> Any:
 
 def _index_sample(s: Any, i: int) -> Any:
     """Index row ``i`` of a per-argument sample batch."""
+    from ._record_batch import RecordBatch
     from .record import Record
 
-    if isinstance(s, Record):
+    if isinstance(s, (Record, RecordBatch)):
         # Index each leaf field's batch row; rebuild by path key so a nested
-        # sample is reconstructed with its structure intact.
+        # sample is reconstructed with its structure intact. A row of a batch is
+        # a single record, so the rebuild is the same either way.
         leaf_paths = tuple(s.event_template.keys())
         if len(leaf_paths) == 1:
             return s[leaf_paths[0]][i]

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from math import prod
-from typing import Any, Literal
+from typing import Any, Literal, get_origin
 
 from . import _workflow_call, _workflow_distribution_normalization
 from ._batch import Batch
@@ -143,7 +143,19 @@ def group_array_args_by_parent(
         batch_shape = tuple(first.batch_shape)
         for ref in arg_refs[1:]:
             other = _workflow_call.input_ref_value(values, ref)
-            if tuple(other.batch_shape) != batch_shape:
+            if isinstance(first, Batch):
+                # Two operands naming the same levels claim the same axes, group
+                # by group: agreeing on the flat shape alone would zip a
+                # ((2,), (3, 4)) partition with a ((2, 3), (4,)) one and hand the
+                # output whichever arrived first.
+                if tuple(getattr(other, "axis_groups", ())) != tuple(first.axis_groups):
+                    raise ValueError(
+                        f"{arg_refs[0].label!r} and {ref.label!r} carry the same levels but "
+                        f"are batched differently: {tuple(first.axis_groups)} against "
+                        f"{tuple(getattr(other, 'axis_groups', ()))}. Levels align by name, "
+                        f"so operands naming the same levels must hold them on the same axes"
+                    )
+            elif tuple(other.batch_shape) != batch_shape:
                 raise ValueError(
                     f"{arg_refs[0].label!r} and {ref.label!r} are zipped together but are "
                     f"batched differently: {batch_shape} against {tuple(other.batch_shape)}. "
@@ -157,6 +169,26 @@ def group_array_args_by_parent(
                 size=prod(batch_shape),
             )
         )
+    # A level name in two groups is one multiplicity read at two geometries:
+    # the groups differ, so their level tuples differ, and aligning the shared
+    # level across differently-leveled operands — broadcasting the rest — is
+    # not built yet. Refused rather than producted: a product would read the
+    # shared name as two unrelated axes, and the aggregate would then mint the
+    # same level twice.
+    owners: dict[str, tuple[str, tuple[str, ...]]] = {}
+    for group in groups:
+        first = _workflow_call.input_ref_value(values, group.arg_refs[0])
+        names = tuple(first.level_names) if isinstance(first, Batch) else (group.arg_refs[0].label,)
+        for level_name in dict.fromkeys(names):
+            prior = owners.setdefault(level_name, (group.arg_refs[0].label, names))
+            if prior[1] != names or prior[0] != group.arg_refs[0].label:
+                raise ValueError(
+                    f"{prior[0]!r} and {group.arg_refs[0].label!r} share the level "
+                    f"{level_name!r} without sharing all their levels ({prior[1]} against "
+                    f"{names}). Aligning one shared level across differently-leveled operands "
+                    f"is not supported yet; rename it with with_level_names to sweep them "
+                    f"independently, or give both operands the same levels to zip them"
+                )
     return tuple(groups)
 
 
@@ -185,11 +217,12 @@ def _value_matches_hint(value: Any, expected: Any) -> bool:
     so family membership alone would deliver a batch whole to a body that
     declared it takes something else, silently skipping the sweep.
     """
+    base = get_origin(expected) or expected
     try:
         return (
-            isinstance(expected, type)
-            and issubclass(expected, (RecordArray, RecordBatch, DistributionArray))
-            and isinstance(value, expected)
+            isinstance(base, type)
+            and issubclass(base, (Batch, RecordArray, DistributionArray))
+            and isinstance(value, base)
         )
     except TypeError:
         return False

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -13,6 +13,7 @@ from math import prod
 from typing import Any, Literal
 
 from . import _workflow_call, _workflow_distribution_normalization
+from ._batch import Batch
 from ._distribution_array import DistributionArray
 from ._record_array import RecordArray
 from ._record_batch import RecordBatch
@@ -58,14 +59,7 @@ def build_broadcast_plan(
         is_batched_record = isinstance(value, (RecordArray, RecordBatch))
         is_dist_array = isinstance(value, DistributionArray)
         if (is_batched_record or is_dist_array) and len(value.batch_shape) > 0:
-            if (
-                _is_same_array_hint(
-                    expected,
-                    is_batched_record=is_batched_record,
-                    is_dist_array=is_dist_array,
-                )
-                or expected is Any
-            ):
+            if _value_matches_hint(value, expected) or expected is Any:
                 continue
             array_args.append(ref)
             continue
@@ -103,15 +97,32 @@ def group_by_root(
     their members keep argument order, so the grouping is a deterministic
     function of the call.
 
-    A root is found by a single ``parent`` lookup, which is exact for the view
-    types that exist: a view's parent is always a distribution, never another
-    view. A nested view type would need this walked transitively.
+    A view with a ``parent`` is grouped by a single lookup, which is exact for
+    the view types that carry one: such a view's parent is always a distribution
+    or a record array, never another view. A nested view type would need this
+    walked transitively.
+
+    A batch has no parent to look up — a view over one is another batch over the
+    same axes — so it is grouped by its **level names** instead. That is the level
+    algebra's own rule: operands align by level name, so two batches carrying the
+    same level are two readings of one multiplicity and zip, while batches with no
+    level in common are independent and form a product. Sibling views from one
+    batch's ``select_all`` therefore zip, as do a batch and a view of it.
     """
-    groups: dict[int, tuple[Any, list[_workflow_call.WorkflowInputRef]]] = {}
+    groups: dict[Any, tuple[Any, list[_workflow_call.WorkflowInputRef]]] = {}
     for ref in refs:
         value = _workflow_call.input_ref_value(values, ref)
-        root = getattr(value, "parent", value)
-        groups.setdefault(id(root), (root, []))[1].append(ref)
+        parent = getattr(value, "parent", None)
+        if parent is not None:
+            key: Any = id(parent)
+            root = parent
+        elif isinstance(value, Batch):
+            key = value.level_names
+            root = value
+        else:
+            key = id(value)
+            root = value
+        groups.setdefault(key, (root, []))[1].append(ref)
     return [(root, tuple(group_refs)) for root, group_refs in groups.values()]
 
 
@@ -120,11 +131,25 @@ def group_array_args_by_parent(
     values: Mapping[str, Any],
     refs: Sequence[_workflow_call.WorkflowInputRef],
 ) -> tuple[ArrayBroadcastGroup, ...]:
-    """Build parent-identity groups for array-valued sweep arguments."""
+    """Build the zip groups for array-valued sweep arguments.
+
+    Every argument in a group is read along the same axes, so they must agree on
+    what those axes are; a disagreement is a mistake about which multiplicity is
+    which rather than a product to be formed silently.
+    """
     groups: list[ArrayBroadcastGroup] = []
     for _root, arg_refs in group_by_root(values=values, refs=refs):
         first = _workflow_call.input_ref_value(values, arg_refs[0])
         batch_shape = tuple(first.batch_shape)
+        for ref in arg_refs[1:]:
+            other = _workflow_call.input_ref_value(values, ref)
+            if tuple(other.batch_shape) != batch_shape:
+                raise ValueError(
+                    f"{arg_refs[0].label!r} and {ref.label!r} are zipped together but are "
+                    f"batched differently: {batch_shape} against {tuple(other.batch_shape)}. "
+                    f"Arguments sharing a level name are read along the same axes, so give "
+                    f"one of them a level of its own to sweep them independently"
+                )
         groups.append(
             ArrayBroadcastGroup(
                 arg_refs=tuple(arg_refs),
@@ -149,16 +174,22 @@ def _broadcast_regime(
     return "none"
 
 
-def _is_same_array_hint(
-    expected: Any,
-    *,
-    is_batched_record: bool,
-    is_dist_array: bool,
-) -> bool:
+def _value_matches_hint(value: Any, expected: Any) -> bool:
+    """Whether the annotation names a batched container the value satisfies.
+
+    Both halves are load-bearing. The annotation must be a batched-container
+    class, because an *element* annotation — ``p: Record``, which a record array
+    also satisfies by subclassing — is how a body says it wants one row, and the
+    sweep is what delivers rows. And the value must actually satisfy it: a
+    parameter annotated with one batched-record class does not accept the other,
+    so family membership alone would deliver a batch whole to a body that
+    declared it takes something else, silently skipping the sweep.
+    """
     try:
-        return isinstance(expected, type) and (
-            (is_batched_record and issubclass(expected, (RecordArray, RecordBatch)))
-            or (is_dist_array and issubclass(expected, DistributionArray))
+        return (
+            isinstance(expected, type)
+            and issubclass(expected, (RecordArray, RecordBatch, DistributionArray))
+            and isinstance(value, expected)
         )
     except TypeError:
         return False

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -179,7 +179,14 @@ def group_array_args_by_parent(
     owners: dict[str, tuple[str, tuple[str, ...]]] = {}
     for group in groups:
         first = _workflow_call.input_ref_value(values, group.arg_refs[0])
-        names = tuple(first.level_names) if isinstance(first, Batch) else (group.arg_refs[0].label,)
+        if not isinstance(first, Batch):
+            # An operand carrying no levels of its own cannot share one: its
+            # multiplicity is anonymous, so it aligns with nothing by name and
+            # products with everything. Standing the parameter's name in for the
+            # levels it does not have would collide with a real level of that name
+            # on another operand and refuse a call whose axes are independent.
+            continue
+        names = tuple(first.level_names)
         for level_name in dict.fromkeys(names):
             prior = owners.setdefault(level_name, (group.arg_refs[0].label, names))
             if prior[1] != names or prior[0] != group.arg_refs[0].label:

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from math import prod
-from typing import Any, Literal, get_origin
+from types import UnionType
+from typing import Any, Literal, Union, get_args, get_origin
 
 from . import _workflow_call, _workflow_distribution_normalization
 from ._batch import Batch
@@ -217,7 +218,12 @@ def _value_matches_hint(value: Any, expected: Any) -> bool:
     so family membership alone would deliver a batch whole to a body that
     declared it takes something else, silently skipping the sweep.
     """
-    base = get_origin(expected) or expected
+    origin = get_origin(expected)
+    if origin in (Union, UnionType):
+        # An optional container annotation still names the container: the value
+        # answers whichever arm it satisfies, and ``None`` answers none.
+        return any(_value_matches_hint(value, arm) for arm in get_args(expected))
+    base = origin or expected
     try:
         return (
             isinstance(base, type)

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -15,6 +15,7 @@ from typing import Any, Literal
 from . import _workflow_call, _workflow_distribution_normalization
 from ._distribution_array import DistributionArray
 from ._record_array import RecordArray
+from ._record_batch import RecordBatch
 from .distribution import Distribution
 
 BroadcastRegime = Literal["none", "distribution", "sweep", "nested"]
@@ -54,13 +55,13 @@ def build_broadcast_plan(
         value = _workflow_call.input_ref_value(values, ref)
         expected = _workflow_call.input_ref_hint(signature_info, ref)
 
-        is_record_array = isinstance(value, RecordArray)
+        is_batched_record = isinstance(value, (RecordArray, RecordBatch))
         is_dist_array = isinstance(value, DistributionArray)
-        if (is_record_array or is_dist_array) and len(value.batch_shape) > 0:
+        if (is_batched_record or is_dist_array) and len(value.batch_shape) > 0:
             if (
                 _is_same_array_hint(
                     expected,
-                    is_record_array=is_record_array,
+                    is_batched_record=is_batched_record,
                     is_dist_array=is_dist_array,
                 )
                 or expected is Any
@@ -151,12 +152,12 @@ def _broadcast_regime(
 def _is_same_array_hint(
     expected: Any,
     *,
-    is_record_array: bool,
+    is_batched_record: bool,
     is_dist_array: bool,
 ) -> bool:
     try:
         return isinstance(expected, type) and (
-            (is_record_array and issubclass(expected, RecordArray))
+            (is_batched_record and issubclass(expected, (RecordArray, RecordBatch)))
             or (is_dist_array and issubclass(expected, DistributionArray))
         )
     except TypeError:

--- a/probpipe/core/_workflow_result.py
+++ b/probpipe/core/_workflow_result.py
@@ -1,7 +1,7 @@
 """Default event-result contract helpers for Function calls.
 
 This private module owns the boundary rule that raw workflow returns
-become ``Record | RecordArray | Distribution`` values and receive
+become a record, a batch of records, or a distribution, and receive
 provenance when appropriate. Other tracked terms remain event payloads under
 this default contract; returning one directly requires the explicit term-result
 planning reserved for #369.
@@ -9,6 +9,7 @@ planning reserved for #369.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any, Literal
 
 import jax.numpy as jnp
@@ -18,6 +19,7 @@ from ._distribution_base import Distribution
 from ._function_contract import _wrap_declared_function_output
 from ._numeric_record import _is_numeric_leaf
 from ._record_array import RecordArray
+from ._record_batch import RecordBatch
 from .event_template import EventTemplate, _to_record_declaration
 from .provenance import Provenance
 from .record import Record
@@ -40,11 +42,11 @@ def _wrap_as_record(
     field_name: str,
     output_template: EventTemplate | None = None,
 ) -> Any:
-    """Coerce a raw return into the Record | RecordArray | Distribution contract.
+    """Coerce a raw return into the record / batch / distribution contract.
 
     Uniform rule applied at the Function boundary:
 
-    - Already-structured values (``Record`` / ``RecordArray`` /
+    - Already-structured values (a record, a batch of records, or a
       ``Distribution``) retain their structure here. ``_coerce_output``
       copies a directly returned tracked value before attaching call
       provenance.
@@ -71,7 +73,7 @@ def _wrap_as_record(
             function_name=field_name,
             output_template=output_template,
         )
-    if isinstance(value, (Distribution, Record)):
+    if isinstance(value, (Distribution, Record, RecordBatch)):
         return value
     if isinstance(value, dict) and value:
         return Record(field_name, value, name_is_auto=True)
@@ -98,7 +100,7 @@ def _coerce_output(
     field_name: str,
     output_template: EventTemplate | None = None,
 ) -> Any:
-    """Enforce the Record | RecordArray | Distribution output contract.
+    """Enforce the record / batch / distribution output contract.
 
     Parameters
     ----------
@@ -112,9 +114,9 @@ def _coerce_output(
         * ``"wrap"`` — non-broadcast call; ``value`` is whatever the
           user's function returned. Scalars / arrays become
           a single-field record named after the function; dict / list / tuple
-          promote via ``_wrap_as_record``; existing Record /
-          RecordArray / Distribution values become independent shallow
-          result copies.
+          promote via ``_wrap_as_record``; an existing record, batch of
+          records, or ``Distribution`` becomes an independent shallow
+          result copy.
         * ``"stack"`` — array-valued broadcast; ``value`` is a stacked
           aggregate from ``_make_stack`` (``NumericRecordArray`` /
           ``RecordArray`` / ``DistributionArray``).
@@ -129,7 +131,7 @@ def _coerce_output(
 
     Returns
     -------
-    Record | RecordArray | Distribution
+    Record | RecordArray | RecordBatch | Distribution
         The value, possibly wrapped or shallow-copied, with the current
         call's ``.provenance`` attached. A copied result does not retain the
         implementation-returned object's prior provenance.
@@ -157,7 +159,10 @@ def _copy_result_term(
     """Copy a retained tracked container into an independent result term."""
     clone = value._shallow_copy()
     if output_template is not None:
-        if isinstance(clone, RecordArray):
+        if isinstance(clone, RecordBatch):
+            element_spec = _to_record_declaration(output_template)
+            object.__setattr__(clone, "_spec", replace(clone.spec, element_spec=element_spec))
+        elif isinstance(clone, RecordArray):
             object.__setattr__(clone, "_template", output_template)
         elif isinstance(clone, Record):
             object.__setattr__(clone, "_spec", _to_record_declaration(output_template))

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -43,6 +43,7 @@ from ._function_contract import (
     _wrap_declared_function_output,
 )
 from ._record_array import RecordArray
+from ._record_batch import RecordBatch
 from .event_template import ArraySpec, EventTemplate, _concretize_event_template
 from .provenance import Provenance
 from .tracked import Annotated, TrackedTerm, auto_name
@@ -886,10 +887,10 @@ class Function(Node, TrackedTerm, Annotated):
             for ref in _workflow_call.iter_input_refs(self._signature_info, values):
                 v = _workflow_call.input_ref_value(values, ref)
                 if ref in broadcast_refs:
-                    # RecordArray input: construct a single Record from
-                    # row 0 so the dummy call sees what an inner sweep
-                    # iteration will actually receive.
-                    if isinstance(v, RecordArray):
+                    # Batched-record input: take row 0 so the dummy call
+                    # sees what an inner sweep iteration will actually
+                    # receive.
+                    if isinstance(v, (RecordArray, RecordBatch)):
                         replacement = v[0]
                     else:
                         dist = v

--- a/probpipe/diagnostics/_arviz_bridge.py
+++ b/probpipe/diagnostics/_arviz_bridge.py
@@ -18,7 +18,7 @@ import numpy as np
 
 # Absolute (not relative) so this file stays loadable standalone — the
 # missing-xarray fallback test execs it outside the package.
-from probpipe.diagnostics._utils import _leaf_keys
+from probpipe.diagnostics._utils import _is_structured, _leaf_keys
 
 try:
     import xarray as xr
@@ -74,7 +74,7 @@ def extract_draws(posterior: Any) -> dict[str, np.ndarray]:
     # Case 1: ApproximateDistribution with .draws()
     if hasattr(posterior, "draws"):
         raw = posterior.draws()
-        if hasattr(raw, "fields"):
+        if _is_structured(raw):
             # One variable per leaf field, keyed by its full /-path (see
             # ``_leaf_keys`` for the nested-vs-duck-typed rule).
             return {k: np.asarray(raw[k]) for k in _leaf_keys(raw)}
@@ -84,7 +84,7 @@ def extract_draws(posterior: Any) -> dict[str, np.ndarray]:
     # Case 2: EmpiricalDistribution with .samples
     if hasattr(posterior, "samples"):
         samples = posterior.samples
-        if hasattr(samples, "fields"):
+        if _is_structured(samples):
             return {k: np.asarray(samples[k]) for k in _leaf_keys(samples)}
         return {"x": np.asarray(samples)}
 
@@ -127,7 +127,7 @@ def to_arviz_dataset(
         raise ImportError("xarray is required. Install with: pip install xarray")
 
     # ── ApproximateDistribution: delegate to the canonical builder ────────────
-    if hasattr(posterior, "chains") and hasattr(posterior, "fields"):
+    if hasattr(posterior, "chains") and _is_structured(posterior):
         from ._datatree_store import to_named_posterior_dataset
 
         ds = to_named_posterior_dataset(posterior)

--- a/probpipe/diagnostics/_utils.py
+++ b/probpipe/diagnostics/_utils.py
@@ -24,6 +24,17 @@ import json
 import numpy as np
 
 
+def _is_structured(value: Any) -> bool:
+    """Whether *value* enumerates named fields, so one export variable fits each.
+
+    A record or a batch of them carries an ``event_template``, which is the
+    nested-aware enumeration :func:`_leaf_keys` reads. A test double may expose
+    only the top-level ``.fields``; either is enough to key the export by field
+    rather than treating the value as one opaque array.
+    """
+    return hasattr(value, "event_template") or hasattr(value, "fields")
+
+
 def _leaf_keys(value: Any) -> list[str]:
     """Leaf keys of a draws/samples container, one export variable per leaf.
 

--- a/probpipe/distributions/_joint_gaussian.py
+++ b/probpipe/distributions/_joint_gaussian.py
@@ -190,13 +190,14 @@ class JointGaussian(
 
     def _log_prob(self, value) -> Array:
         from ..core._record_array import RecordArray
+        from ..core._record_batch import RecordBatch
 
-        if not isinstance(value, (Record, RecordArray)):
+        if not isinstance(value, (Record, RecordArray, RecordBatch)):
             value = Record(self.name, value, name_is_auto=True)
         from .multivariate import MultivariateNormal as MVN
 
         full_mvn = MVN(loc=self._mean_vec, cov=self._cov_mat, name="_jg_internal")
-        # ``Record``/``RecordArray`` carry their own structure, so the
+        # A record, and a batch of them, carry their own structure, so the
         # static ``flatten_value`` ignores ``event_shape`` for these
         # inputs — don't ask ``self.event_shape`` (it raises on a
         # multi-field joint).

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -321,6 +321,8 @@ class ProductDistribution(
         available there.
         """
         from ..core._record_array import RecordArray
+        from ..core._record_batch import RecordBatch
+        from ..core.named_tree import _unflatten_paths
 
         if isinstance(value, jnp.ndarray):
             if not isinstance(self, NumericRecordDistribution):
@@ -345,7 +347,11 @@ class ProductDistribution(
             if isinstance(value, jnp.ndarray):
                 (field_name,) = self.event_template.fields
                 value = {field_name: value}
-        if isinstance(value, RecordArray):
+        if isinstance(value, RecordBatch):
+            # Leaf-keyed columns, re-nested, so the tree map below pairs each
+            # column with the component that declared it.
+            value = _unflatten_paths({path: value[path] for path in value.event_template})
+        elif isinstance(value, RecordArray):
             value = {k: v for k, v in value.items()}
         if isinstance(value, Record):
             value = value.to_dict()

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -348,7 +348,11 @@ class SequentialJointDistribution(
             (with conditioned values plugged in as parents), giving the
             normalized conditional when the Markov structure permits it.
         """
-        if isinstance(value, Record):
+        from ..core._record_batch import RecordBatch
+
+        if isinstance(value, RecordBatch):
+            value = {path: value[path] for path in value.event_template}
+        elif isinstance(value, Record):
             value = value.to_dict()
         structured = {k: jnp.asarray(v) for k, v in value.items()}
 

--- a/probpipe/distributions/kde.py
+++ b/probpipe/distributions/kde.py
@@ -18,6 +18,7 @@ from .._dtype import _as_float_array
 from .._weights import Weights
 from ..core._empirical import RecordEmpiricalDistribution
 from ..core._numeric_record import NumericRecord
+from ..core._numeric_record_batch import NumericRecordBatch
 from ..core._numeric_record_distribution import NumericRecordDistribution
 from ..core._record_array import NumericRecordArray
 from ..core.constraints import Constraint, real
@@ -180,7 +181,7 @@ class KDEDistribution(TFPDistribution):
     def _log_prob(self, value: Any) -> Array:
         tpl = getattr(self, "_event_template", None)
         if tpl is not None and len(tpl.fields) > 1:
-            if isinstance(value, (Record, NumericRecord, NumericRecordArray)):
+            if isinstance(value, (Record, NumericRecord, NumericRecordArray, NumericRecordBatch)):
                 value = NumericRecordDistribution.flatten_value(value)
         return self._tfp_dist.log_prob(jnp.asarray(value))
 

--- a/probpipe/inference/_bayesflow_common.py
+++ b/probpipe/inference/_bayesflow_common.py
@@ -23,6 +23,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from ..core._numeric_record_batch import NumericRecordBatch
 from ..core._record_array import NumericRecordArray
 from ..core.distribution import Distribution
 from ..core.ops import sample as _sample_op
@@ -172,7 +173,7 @@ def _simulate_offline(
     # Round-trip through the canonical 1-D vector layout: single-field priors'
     # raw draws are not field-indexable by name, so from_vector gives uniform
     # named access. Structured draws serialize via to_vector; raw arrays ravel.
-    if isinstance(theta, NumericRecordArray):
+    if isinstance(theta, (NumericRecordArray, NumericRecordBatch)):
         theta_flat = jnp.asarray(theta.to_vector()).reshape(num_simulations, -1)
     else:
         theta_flat = jnp.asarray(theta).reshape(num_simulations, -1)

--- a/probpipe/inference/_bayesflow_likelihoods.py
+++ b/probpipe/inference/_bayesflow_likelihoods.py
@@ -122,13 +122,14 @@ class _BayesFlowLikelihoodBase(ConditionallyIndependentLikelihood, GenerativeLik
         ``event_size`` (static under jit: shapes are concrete at trace time).
         """
         from ..core._numeric_record import NumericRecord
+        from ..core._numeric_record_batch import NumericRecordBatch
         from ..core._record_array import NumericRecordArray
         from ..core.record import Record
 
         # ``Record`` now carries the JAX-pytree ``flatten`` (returns
         # ``(leaves, aux)``), so dispatch on type rather than ``hasattr`` to get
         # the canonical 1-D ``vec`` via ``to_vector``.
-        if isinstance(params, (NumericRecord, NumericRecordArray)):
+        if isinstance(params, (NumericRecord, NumericRecordArray, NumericRecordBatch)):
             t = params.to_vector()
         elif isinstance(params, Record):
             t = params.to_numeric().to_vector()

--- a/probpipe/inference/_minibatch.py
+++ b/probpipe/inference/_minibatch.py
@@ -43,6 +43,7 @@ from ..core._distribution_base import Distribution
 from ..core._random_functions import RandomFunction
 from ..core._random_measures import RandomMeasure
 from ..core._record_array import RecordArray
+from ..core._record_batch import RecordBatch
 from ..core.protocols import (
     SupportsLogProb,
     SupportsRandomUnnormalizedLogProb,
@@ -67,12 +68,12 @@ __all__ = ["MinibatchedDistribution"]
 def _data_size(data: Any) -> int:
     """Return the leading-axis length of *data*.
 
-    Accepts a ``RecordArray`` (uses ``batch_shape[0]``), a flat
+    Accepts a batch of records (uses ``batch_shape[0]``), a flat
     ``Record`` of equal-leading-axis array leaves, an array-like with
     ``.shape``, or any object with ``__len__``. Nested Records are
     rejected — minibatching expects a flat-field layout.
     """
-    if isinstance(data, RecordArray):
+    if isinstance(data, (RecordArray, RecordBatch)):
         return data.batch_shape[0]
     if isinstance(data, Record):
         children = dict(data.children)
@@ -98,15 +99,20 @@ def _data_size(data: Any) -> int:
 
 
 def _index_along_leading(data: Any, indices: Array) -> Any:
-    """Index along the leading axis. Works for Records, arrays, RecordArrays.
+    """Index along the leading axis. Works for records, batches of them, and arrays.
 
-    Returns a plain ``Record`` (not a ``RecordArray``) when the source
-    is Record-shaped — the minibatch needs a flat dict of indexed
-    leaves; per-datum vmap dispatches over the leading axis of each.
-    ``RecordArray.__getitem__`` doesn't accept array indices, but since
-    ``RecordArray`` subclasses ``Record``, the Record branch picks it
-    up via field-name access.
+    Returns a plain ``Record`` (never a batch) when the source is
+    record-shaped — the minibatch needs a flat dict of indexed leaves;
+    per-datum vmap dispatches over the leading axis of each. Neither a
+    ``RecordArray`` nor a ``RecordBatch`` indexes by an array of positions, so
+    both are read a field at a time.
     """
+    if isinstance(data, RecordBatch):
+        return Record(
+            data.name,
+            {path: jnp.asarray(data[path])[indices] for path in data.event_template},
+            name_is_auto=True,
+        )
     if isinstance(data, Record):
         # Covers Record and RecordArray (the latter via subclass).
         return Record(

--- a/probpipe/modeling/_glm.py
+++ b/probpipe/modeling/_glm.py
@@ -16,16 +16,17 @@ __all__ = ["GLMLikelihood"]
 def _coerce_array(x: ArrayLike | Record) -> jnp.ndarray:
     """Extract a JAX array from a Record, RecordArray, or raw array-like.
 
-    Single-field Record/RecordArray: extract the field.
+    A single-field record, or batch of them: extract the field.
     Multi-field: stack fields into a vector (preserving leading batch dims).
     """
     from ..core._record_array import RecordArray
+    from ..core._record_batch import RecordBatch
 
     if isinstance(x, jnp.ndarray):
         return x
-    if isinstance(x, (Record, RecordArray)):
-        # Leaf keys via the template (RecordArray's own keys() is top-level and
-        # its [] is leaf-only), so a nested value coerces instead of raising.
+    if isinstance(x, (Record, RecordArray, RecordBatch)):
+        # Leaf keys via the template (a record's own keys() is top-level and its
+        # [] is leaf-only), so a nested value coerces instead of raising.
         keys = list(x.event_template.keys())
         if len(keys) == 1:
             return jnp.asarray(x[keys[0]])

--- a/tests/core/test_record_batch.py
+++ b/tests/core/test_record_batch.py
@@ -1474,6 +1474,39 @@ class TestPyTreeRebuildContract:
         with pytest.raises(TypeError, match="does not admit"):
             jax.tree.map(lambda column: column.astype(jnp.float32), batch)
 
+    def test_retyping_a_callable_column_is_refused(self):
+        """A shape-preserving transform can swap what a column holds without
+        touching its rank, so a column of callables can come back as integers
+        while the batch still declares ``FunctionSpec``. The element's kind is
+        the element type's, not the transform's."""
+        column = _object_column([lambda x: x, lambda x: 2 * x])
+        batch = RecordBatch({"f": column}, "row", element_spec=EventTemplate(f=FunctionSpec()))
+        with pytest.raises(TypeError, match="does not admit"):
+            jax.tree.map(lambda _: np.array([1, 2], dtype=object), batch)
+
+    def test_retyping_an_opaque_column_is_refused(self):
+        """The same for a field whose spec narrows what an entry may be."""
+        from probpipe.core.event_template import OpaqueSpec
+
+        column = _object_column(["north", "south"])
+        batch = RecordBatch(
+            {"site": column}, "row", element_spec=EventTemplate(site=OpaqueSpec(meta="units"))
+        )
+        replacement = np.empty(2, dtype=object)
+        replacement[0], replacement[1] = {"a": 1}, {"b": 2}
+        # A mapping is the one thing an opaque field refuses, since it would slip
+        # past the per-entry check the object batches make.
+        with pytest.raises(TypeError, match="does not admit|transform left"):
+            jax.tree.map(lambda _: replacement, batch)
+
+    def test_an_object_column_replaced_by_an_array_is_refused(self):
+        """A non-array field's column holds one entry per element; a dense array
+        would make its *entries* array elements rather than the values."""
+        column = _object_column([lambda x: x, lambda x: 2 * x])
+        batch = RecordBatch({"f": column}, "row", element_spec=EventTemplate(f=FunctionSpec()))
+        with pytest.raises(TypeError, match="object array"):
+            jax.tree.map(lambda _: jnp.zeros(2), batch)
+
     def test_a_resized_event_axis_is_refused(self):
         """The batch axes are the transform's; the element's own are the element
         type's."""

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -24,6 +24,7 @@ from probpipe import (
     NumericRecord,
     ProductDistribution,
     Record,
+    function,
 )
 from probpipe.core._numeric_record_batch import NumericRecordBatch
 from probpipe.core._record_batch import RecordBatch
@@ -290,3 +291,25 @@ class TestDiagnosticsBridge:
         assert sorted(extracted) == ["a", "b"]
         assert extracted["a"].shape == (4,)
         assert extracted["b"].shape == (4, 2)
+
+
+class TestSiblingViewsZipThroughACall:
+    def test_select_all_views_sweep_zipped_not_producted(self):
+        """Two views of one batch are two readings of one multiplicity — they
+        share its level — so a call over both zips rows rather than forming the
+        (n, n) product a per-object grouping would."""
+        batch = NumericRecordBatch(
+            {"x": jnp.arange(3.0), "y": jnp.arange(3.0) * 10},
+            "draw",
+            element_spec=EventTemplate(x=(), y=()),
+        )
+        views = batch.select_all()
+
+        @function
+        def add(x, y):
+            return jnp.asarray(x["x"]) + jnp.asarray(y["y"])
+
+        out = add(x=views["x"], y=views["y"])
+
+        assert out.batch_shape == (3,)
+        np.testing.assert_allclose(np.asarray(out["add"]), [0.0, 11.0, 22.0])

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -1,0 +1,292 @@
+"""Tests that the package's consumers of a batched record accept a `RecordBatch`.
+
+A `RecordBatch` is deliberately not a `Record`, so every consumer that recognised
+a batch by `isinstance(x, Record)` — or by a `RecordArray` subclass check, or by
+duck-typing on `.fields` — stops recognising one when the batch arrives. Those
+gates do not raise; they take the other branch, which is why widening them needs
+its own tests rather than the producers' own.
+
+Each test here drives a batch built by hand through one such consumer, so the
+gates are pinned before any producer starts returning batches.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import (
+    ArraySpec,
+    EventTemplate,
+    Function,
+    Normal,
+    NumericRecord,
+    ProductDistribution,
+    Record,
+)
+from probpipe.core._numeric_record_batch import NumericRecordBatch
+from probpipe.core._record_batch import RecordBatch
+from probpipe.core.event_template import NumericEventTemplate
+
+ELEMENT = NumericEventTemplate(a=(), b=(2,))
+
+
+def _draws(n: int = 4, *, name: str = "draws") -> NumericRecordBatch:
+    """*n* draws of a two-field numeric element, over a single ``draw`` level."""
+    return NumericRecordBatch(
+        {"a": jnp.arange(n, dtype=float), "b": jnp.ones((n, 2))},
+        "draw",
+        element_spec=ELEMENT,
+        axis_groups=((n,),),
+        name=name,
+    )
+
+
+def _one_field(n: int = 4, *, name: str = "draws") -> NumericRecordBatch:
+    return NumericRecordBatch(
+        {"x": jnp.arange(n, dtype=float)},
+        "draw",
+        element_spec=NumericEventTemplate(x=()),
+        axis_groups=((n,),),
+        name=name,
+    )
+
+
+class TestFunctionBoundary:
+    """The wrap boundary keeps a returned batch as the batch it is."""
+
+    def test_a_returned_batch_is_not_rewrapped(self):
+        batch = _draws()
+
+        f = Function(func=lambda: batch)
+
+        result = f()
+
+        assert isinstance(result, NumericRecordBatch)
+        assert result.batch_shape == (4,)
+        assert result.level_names == ("draw",)
+        assert list(result.event_template.keys()) == ["a", "b"]
+
+    def test_a_returned_batch_becomes_an_independent_result(self):
+        batch = _draws()
+
+        f = Function(func=lambda: batch)
+
+        result = f()
+
+        assert result is not batch
+        assert result.provenance is not None
+        assert batch.provenance is None
+
+    def test_a_declared_output_template_retypes_a_returned_batch(self):
+        batch = _draws()
+
+        f = Function(func=lambda: batch, output_template=EventTemplate(a=(), b=(2,)))
+
+        result = f()
+
+        assert isinstance(result, NumericRecordBatch)
+        assert result.element_spec.event_template == batch.event_template
+
+    def test_a_declared_output_template_checks_a_batch_column(self):
+        batch = _draws()
+        declared = EventTemplate(a=ArraySpec((), dtype=jnp.int32), b=(2,))
+
+        f = Function(func=lambda: batch, output_template=declared)
+
+        with pytest.raises(ValueError, match="does not conform to"):
+            f()
+
+
+class TestBroadcastPlanning:
+    """A batch passed as a workflow input broadcasts over its rows."""
+
+    def test_a_batch_argument_sweeps(self):
+        double = Function(func=lambda v: 2.0 * v["x"])
+
+        result = double(_one_field(3))
+
+        assert result.batch_shape == (3,)
+
+    def test_a_batch_argument_reaches_the_body_as_an_element(self):
+        seen: list = []
+
+        def note_row(v):
+            seen.append(v)
+            return 0.0
+
+        Function(func=note_row)(_one_field(3))
+
+        # The sweep traces the body rather than running it per row, so what
+        # matters is the *kind* it is handed: an element, never the batch.
+        assert seen
+        assert all(isinstance(row, Record) for row in seen)
+        assert not any(isinstance(row, RecordBatch) for row in seen)
+
+
+class TestFieldExtraction:
+    """A field view reads its column out of a batch."""
+
+    def test_a_field_view_extracts_its_column_from_a_batch(self):
+        joint = ProductDistribution(
+            a=Normal(loc=0.0, scale=1.0, name="a"),
+            b=Normal(loc=0.0, scale=1.0, name="b"),
+            name="joint",
+        )
+        batch = NumericRecordBatch(
+            {"a": jnp.arange(4.0), "b": jnp.ones(4)},
+            "draw",
+            element_spec=NumericEventTemplate(a=(), b=()),
+            axis_groups=((4,),),
+        )
+
+        assert np.allclose(joint["a"]._extract(batch), batch["a"])
+
+
+class TestFlatVectorBoundary:
+    """The distribution-level flatten accepts a batch."""
+
+    def test_flatten_value_ravels_a_batch(self):
+        from probpipe.core._numeric_record_distribution import NumericRecordDistribution
+
+        batch = _draws(3)
+
+        flat = NumericRecordDistribution.flatten_value(batch)
+
+        assert np.allclose(flat, batch.to_vector())
+
+
+class TestMinibatching:
+    """Minibatching reads a batch's row count and gathers its rows."""
+
+    def test_data_size_reads_the_leading_axis(self):
+        from probpipe.inference._minibatch import _data_size
+
+        assert _data_size(_draws(7)) == 7
+
+    def test_indexing_gathers_the_named_columns(self):
+        from probpipe.inference._minibatch import _index_along_leading
+
+        batch = _draws(5)
+
+        picked = _index_along_leading(batch, jnp.array([0, 2, 4]))
+
+        assert isinstance(picked, Record)
+        assert list(picked.event_template.keys()) == ["a", "b"]
+        assert np.allclose(picked["a"], jnp.array([0.0, 2.0, 4.0]))
+
+
+class TestDesignCoercion:
+    """A GLM design coerces a batch the way it coerces a record."""
+
+    def test_a_single_field_batch_coerces_to_its_column(self):
+        from probpipe.modeling._glm import _coerce_array
+
+        batch = _one_field(4)
+
+        assert np.allclose(_coerce_array(batch), batch["x"])
+
+    def test_a_multi_field_batch_stacks_its_columns(self):
+        from probpipe.modeling._glm import _coerce_array
+
+        batch = _one_field(4).merge(
+            NumericRecordBatch(
+                {"y": jnp.ones(4)},
+                "draw",
+                element_spec=NumericEventTemplate(y=()),
+                axis_groups=((4,),),
+            )
+        )
+
+        assert _coerce_array(batch).shape == (4, 2)
+
+
+class TestBroadcastComponents:
+    """The broadcast helpers gather and unwrap a batch's rows."""
+
+    def test_taking_rows_keeps_the_batch_and_its_levels(self):
+        from probpipe.core._broadcast_distributions import _take_rows
+
+        batch = _draws(5)
+
+        taken = _take_rows(batch, jnp.array([1, 3]))
+
+        assert isinstance(taken, NumericRecordBatch)
+        assert taken.batch_shape == (2,)
+        assert taken.level_names == ("draw",)
+        assert np.allclose(taken["a"], jnp.array([1.0, 3.0]))
+
+    def test_taking_rows_keeps_a_trailing_axis_of_the_same_level(self):
+        from probpipe.core._broadcast_distributions import _take_rows
+
+        batch = NumericRecordBatch(
+            {"a": jnp.zeros((5, 2))},
+            "draw",
+            element_spec=NumericEventTemplate(a=()),
+            axis_groups=((5, 2),),
+        )
+
+        taken = _take_rows(batch, jnp.array([1, 3]))
+
+        assert taken.batch_shape == (2, 2)
+        assert taken.level_names == ("draw",)
+
+    def test_one_row_of_a_batch_is_a_record(self):
+        from probpipe.core._broadcast_distributions import _one_row
+
+        row = _one_row(_draws(5))
+
+        assert isinstance(row, NumericRecord)
+        assert not isinstance(row, RecordBatch)
+
+    def test_the_row_count_of_a_batch_reads_its_batch_shape(self):
+        from probpipe.core._broadcast_distributions import _row_count
+
+        assert _row_count(_draws(6)) == 6
+
+    def test_a_batch_marginal_peels_the_rows_axis(self):
+        from probpipe.core._broadcast_distributions import _RecordMarginal
+
+        batch = _draws(4)
+
+        marginal = _RecordMarginal(batch, None)
+
+        assert marginal.event_template == batch.event_template
+        assert marginal.num_atoms == 4
+
+
+class TestDistributionBroadcastIndexing:
+    """Indexing one row of a batched per-argument sample gives a record."""
+
+    def test_indexing_a_batch_sample_gives_one_record(self):
+        from probpipe.core._workflow_distribution_broadcast import _index_sample
+
+        row = _index_sample(_draws(4), 2)
+
+        assert isinstance(row, Record)
+        assert np.allclose(row["a"], 2.0)
+
+    def test_indexing_a_single_field_batch_sample_gives_its_scalar(self):
+        from probpipe.core._workflow_distribution_broadcast import _index_sample
+
+        assert np.allclose(_index_sample(_one_field(4), 3), 3.0)
+
+
+class TestDiagnosticsBridge:
+    """The ArviZ bridge reads a batch of draws by its schema, not by ``.fields``."""
+
+    def test_draws_returning_a_batch_yields_one_variable_per_column(self):
+        from probpipe.diagnostics._arviz_bridge import extract_draws
+
+        batch = _draws(4)
+
+        class Posterior:
+            def draws(self):
+                return batch
+
+        extracted = extract_draws(Posterior())
+
+        assert sorted(extracted) == ["a", "b"]
+        assert extracted["a"].shape == (4,)
+        assert extracted["b"].shape == (4, 2)

--- a/tests/core/test_workflow_plan.py
+++ b/tests/core/test_workflow_plan.py
@@ -6,10 +6,12 @@ import inspect
 from typing import Any
 
 import jax.numpy as jnp
+import pytest
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from probpipe import DistributionArray, Normal, NumericRecord, NumericRecordArray
 from probpipe.core import _workflow_call
+from probpipe.core._numeric_record_batch import NumericRecordBatch
 from probpipe.core._workflow_distribution_normalization import (
     normalize_distribution_values,
 )
@@ -268,3 +270,59 @@ class TestAnnotationDispatch:
         plan = _plan({"p": ra}, hints={"p": RecordBatch})
 
         assert plan.regime == "sweep"
+
+
+class TestPartialLevelOverlap:
+    def test_a_shared_level_across_different_level_sets_is_refused(self):
+        """Aligning one shared level across differently-leveled operands is not
+        built; a product would read the shared name as two unrelated axes and
+        mint the same level twice."""
+        from probpipe.core.event_template import EventTemplate
+
+        two = NumericRecordBatch(
+            {"x": jnp.arange(6.0).reshape(2, 3)},
+            ("chain", "draw"),
+            element_spec=EventTemplate(x=()),
+            axis_groups=((2,), (3,)),
+        )
+        one = _batch("draw", 3)
+
+        with pytest.raises(ValueError, match="share the level 'draw'"):
+            _plan({"a": two, "b": one})
+
+    def test_the_same_levels_at_different_geometries_are_refused(self):
+        """The flat shape can agree while the partition does not; zipping would
+        hand the output whichever partition arrived first."""
+        from probpipe.core.event_template import EventTemplate
+
+        ga = NumericRecordBatch(
+            {"x": jnp.zeros((2, 3, 4))},
+            ("a", "b"),
+            element_spec=EventTemplate(x=()),
+            axis_groups=((2,), (3, 4)),
+        )
+        gb = NumericRecordBatch(
+            {"y": jnp.zeros((2, 3, 4))},
+            ("a", "b"),
+            element_spec=EventTemplate(y=()),
+            axis_groups=((2, 3), (4,)),
+        )
+
+        with pytest.raises(ValueError, match="same levels but are batched differently"):
+            _plan({"a": ga, "b": gb})
+
+
+class TestBatchAnnotationsSuppressTheSweep:
+    def test_the_abstract_batch_annotation_takes_the_value_whole(self):
+        from probpipe.core._batch import Batch
+
+        plan = _plan({"p": _batch()}, hints={"p": Batch})
+
+        assert plan.regime == "none"
+
+    def test_a_generic_alias_answers_by_its_origin(self):
+        from probpipe.core._batch import Batch
+
+        plan = _plan({"p": _batch()}, hints={"p": Batch[dict]})
+
+        assert plan.regime == "none"

--- a/tests/core/test_workflow_plan.py
+++ b/tests/core/test_workflow_plan.py
@@ -190,3 +190,81 @@ class TestPlanPurity:
         assert values["x"] is external
         assert raw_plan.regime == "none"
         assert normalized_plan.regime == "distribution"
+
+
+def _batch(level: str = "draw", n: int = 3, **fields) -> Any:
+    from probpipe.core._numeric_record_batch import NumericRecordBatch
+    from probpipe.core.event_template import EventTemplate
+
+    fields = fields or {"x": jnp.arange(float(n))}
+    return NumericRecordBatch(
+        dict(fields),
+        (level,),
+        element_spec=EventTemplate({name: value.shape[1:] for name, value in fields.items()}),
+    )
+
+
+class TestBatchGrouping:
+    """A batch has no parent pointer, so grouping follows its level names."""
+
+    def test_sibling_select_all_views_zip_into_one_group(self):
+        batch = _batch(x=jnp.arange(3.0), y=jnp.arange(3.0) * 10)
+        views = batch.select_all()
+
+        plan = _plan({"x": views["x"], "y": views["y"]})
+
+        assert plan.regime == "sweep"
+        assert len(plan.array_groups) == 1
+        assert plan.array_groups[0].arg_refs == (_ref("x"), _ref("y"))
+        assert plan.sweep_batch_shape == (3,)
+        assert plan.n_sweep == 3
+
+    def test_a_batch_zips_with_its_own_view(self):
+        batch = _batch(x=jnp.arange(3.0), y=jnp.arange(3.0) * 10)
+
+        plan = _plan({"whole": batch, "x": batch.select("x")["x"]})
+
+        assert len(plan.array_groups) == 1
+        assert plan.n_sweep == 3
+
+    def test_batches_with_no_level_in_common_form_a_product(self):
+        plan = _plan({"a": _batch("outer", 3), "b": _batch("inner", 2)})
+
+        assert len(plan.array_groups) == 2
+        assert plan.sweep_batch_shape == (3, 2)
+        assert plan.n_sweep == 6
+
+    def test_one_level_name_at_two_sizes_is_refused(self):
+        """Two batches naming the same level claim to range over the same thing,
+        so disagreeing about its size is a mistake rather than a product."""
+        import pytest
+
+        with pytest.raises(ValueError, match="batched differently"):
+            _plan({"a": _batch("draw", 3), "b": _batch("draw", 2)})
+
+
+class TestAnnotationDispatch:
+    """The hint says what the body accepts whole, so the value answers it."""
+
+    def test_the_exact_annotation_skips_the_sweep(self):
+        from probpipe.core._numeric_record_batch import NumericRecordBatch
+
+        batch = _batch()
+        plan = _plan({"p": batch}, hints={"p": NumericRecordBatch})
+
+        assert plan.regime == "none"
+
+    def test_the_other_family_member_does_not_skip_it(self):
+        batch = _batch()
+        plan = _plan({"p": batch}, hints={"p": NumericRecordArray})
+
+        assert plan.regime == "sweep"
+        assert plan.array_args == (_ref("p"),)
+
+    def test_a_record_array_annotated_as_a_batch_is_swept(self):
+        from probpipe.core._record_batch import RecordBatch
+
+        ra = _numeric_record_array("x", range(3))
+        plan = _plan({"p": ra}, hints={"p": RecordBatch})
+
+        assert plan.regime == "sweep"

--- a/tests/core/test_workflow_plan.py
+++ b/tests/core/test_workflow_plan.py
@@ -290,6 +290,31 @@ class TestPartialLevelOverlap:
         with pytest.raises(ValueError, match="share the level 'draw'"):
             _plan({"a": two, "b": one})
 
+    def test_a_levelless_operand_does_not_own_its_parameter_name_as_a_level(self):
+        """An operand with no levels of its own cannot share one.
+
+        Its multiplicity is anonymous, so it aligns with nothing by name and
+        products with everything. Standing the parameter's name in for the levels
+        it does not have collides with a real level of that name on another
+        operand — and refuses a call whose two axes are simply independent, on
+        the strength of a level neither operand disagrees about.
+
+        A ``DistributionArray`` is the levelless operand that outlives the
+        cutover: it is swept by its ``batch_shape`` without being a ``Batch``, so
+        it carries no level names of its own either before or after the batch
+        types stop being records.
+        """
+        levelless = DistributionArray.from_batched_params(
+            Normal, batch_shape=(2,), loc=jnp.asarray([0.0, 1.0]), scale=1.0, name="d"
+        )
+        batch = _batch("draw", 3)
+
+        plan = _plan({"draw": levelless, "other": batch})
+
+        assert plan.regime == "sweep"
+        # Two independent multiplicities: a product, not a zip.
+        assert len(plan.array_groups) == 2
+
     def test_the_same_levels_at_different_geometries_are_refused(self):
         """The flat shape can agree while the partition does not; zipping would
         hand the output whichever partition arrived first."""

--- a/tests/core/test_workflow_plan.py
+++ b/tests/core/test_workflow_plan.py
@@ -326,3 +326,27 @@ class TestBatchAnnotationsSuppressTheSweep:
         plan = _plan({"p": _batch()}, hints={"p": Batch[dict]})
 
         assert plan.regime == "none"
+
+
+class TestOptionalBatchAnnotations:
+    def test_an_optional_container_annotation_still_takes_the_value_whole(self):
+        """``Batch | None`` names the container as surely as ``Batch``: the value
+        answers whichever arm it satisfies, and ``None`` answers none."""
+        from typing import Optional
+
+        from probpipe.core._batch import Batch
+        from probpipe.core._record_batch import RecordBatch
+
+        batch = _batch()
+        hints = (Batch | None, RecordBatch | None, Optional[Batch], Batch[dict] | None)  # noqa: UP045
+        for hint in hints:
+            plan = _plan({"p": batch}, hints={"p": hint})
+
+            assert plan.regime == "none", hint
+
+    def test_a_non_container_union_still_sweeps(self):
+        from probpipe import Record
+
+        plan = _plan({"p": _batch()}, hints={"p": Record | None})
+
+        assert plan.regime == "sweep"


### PR DESCRIPTION
## What this is

A `RecordBatch` is deliberately **not** a `Record`. Every place in the package
that recognized a batched value by `isinstance(x, Record)`, by a `RecordArray`
subclass check, or by duck-typing on `.fields` therefore stops recognizing one
when a batch arrives.

None of those gates raise. They take the other branch. A batch reaching
`_wrap_as_record` would be re-wrapped as a single opaque field named after the
function; a batch reaching `_data_size` would be minibatched by its *field*
count; a batch reaching the ArviZ bridge would be read as a bare array under the
variable name `"x"`. Each of those is a wrong answer, not an error.

This PR opens those gates and pins them with tests. **No producer returns a batch
yet**, so the suite is unchanged in behavior and every existing path still runs
on `RecordArray`.

Stacks on #399 (`dev/record-batch`), which adds the classes.

## The gates, and what each now does

**The `Function` boundary** (`_workflow_result`, `_function_contract`). A returned
batch stays the batch it is instead of being wrapped, and becomes an independent
result copy: for a batch, retyping under a declared output template replaces the
`element_spec` inside its `BatchSpec` rather than overwriting a template, since
the batch's own type is the `BatchSpec`. Declared-output validation accepts a
batch as a schema-carrying result and checks each column against its field spec.

**Broadcast planning** (`_workflow_plan`, `node`). A batch argument is a batched
argument: it sweeps its rows, the trace probe takes row 0 for the dummy call, and
the hint check accepts a `RecordBatch` annotation. The plan's flag is now
`is_batched_record`, which is what it has always meant.

**The broadcast helpers** (`_broadcast_distributions`). `_row_count`,
`_take_rows`, and `_one_row` count, gather, and unwrap a batch's rows. A gather
rebuilds the batch with the same levels and only the leading axis's size
rewritten, so which level holds that axis is preserved. `_RecordMarginal` peels a
batch's rows axis into a record of batched leaves, reading `event_template` —
the accessor that means the same thing on a `RecordArray` and a batch.

**The value boundaries.** `NumericRecordDistribution.flatten_value` and the
dynamic `_log_prob` take a `NumericRecordBatch` through `to_vector`; a
`_RecordDistributionView` reads its column out of a batch; the joint Gaussian and
product / sequential-joint log-densities accept one, the two joints re-nesting a
batch's leaf-keyed columns so the tree map still pairs each column with the
component that declared it; and the GLM design coercion extracts or stacks a
batch's columns.

**Minibatching** (`_minibatch`). Row count from `batch_shape`; row gathering a
field at a time, since neither a `RecordArray` nor a batch indexes by an array of
positions.

**The ArviZ bridge** (`_arviz_bridge`). Variables are found through
`event_template`, which a batch has, *or* `.fields`, which a duck-typed
record-like may be all that has — `_leaf_keys` already reads whichever is
present.

## Deliberately left for the cutover

Two paths need a decision rather than a wider gate, and are called out in the
changelog:

- Stacking a list of batched records from a broadcast has to name the levels the
  broadcast grid mints. That is a naming decision, not a widening.
- `RecordEmpiricalDistribution` requires a `Record` outright; migrating it is
  #340.

## Testing

`tests/core/test_record_batch_interop.py` — 20 tests, one per gate, each driving
a hand-built batch through the consumer rather than through a producer. That is
the only way to reach these branches while producers still return `RecordArray`,
and it is why they get their own file.

**Two of the gates are the sweep planner's.** Levels align by name, and only
whole: a level shared by operands whose other levels differ is refused rather
than silently producted, operands naming the same levels must hold them on the
same axes, and the annotation that takes a batched value whole answers `Batch`,
generic aliases, and optional unions (`Batch | None`) alike — while an element
annotation such as `p: Record` keeps the sweep.

**Two of the gates are the sweep planner's.** A batch view has no parent to look
up — a view over a batch is another batch over the same axes — so the planner
groups batches by their **level names**, the level algebra's own alignment rule:
sibling `select_all` views zip, batches with no level in common form a product,
and one level name at two sizes is refused rather than producted silently. And
the annotation that lets a body take a batched value whole is answered by the
value, and only when it names a batched container: family membership alone
delivered a batch whole to a body annotated with the other batched-record class,
while an element annotation like `p: Record` — which a record array satisfies by
subclassing — keeps the sweep, since asking for an element is asking for rows.

Existing: full suite green, **4730 passed / 48 skipped / 1 xfailed / 1 xpassed**
with every optional backend installed. `uvx ruff check` and `uvx ruff format`
clean.

Part of #350 (W3.2) and a prerequisite for #340.



