### PR TITLE
feat(core): a joint law draws a record batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -554,6 +554,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the executor does, so a zero-width event column passes under explicit
   `dispatch="jax"`.
 
+  **Shape cannot recover axis provenance, so ambiguity refuses.** A removal
+  whose size matches more than one level (``vmap(..., in_axes=1)`` over equal
+  sizes) and a permutation of the batch axes (a transpose, which shape alone
+  cannot tell from a per-axis resize) both raise rather than guess; a
+  distinctly-sized removal now names the level that *survived*, not the
+  leftmost that fits. A pinned dtype is held like the event axes, under the
+  constructor's same-kind rule. And zero-row sweeps take one aggregation path
+  under every dispatch, so the output schema does not depend on how rows would
+  have been executed.
+
   **A same-rank transform cannot lie about sizes.** Slicing a batch's columns
   keeps every axis, so the levels carry over onto the sizes the columns actually
   have; columns left disagreeing about their batch axes are refused rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -536,6 +536,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   produces the same result by the dispatch-equivalence contract, instead of
   failing mid-call.
 
+  **Levels align by name, and only whole.** Operands carrying the same level
+  names zip; operands with no level in common form a product; a level shared by
+  operands whose other levels differ is refused — aligning it would broadcast
+  the rest, which is not built, and a product would read the shared name as two
+  unrelated axes. Operands naming the same levels must also hold them on the
+  same axes: the flat shape can agree while the partition does not. A parameter
+  annotated `Batch` (or a generic alias such as `Batch[Record]`) takes the value
+  whole, since it names a batched container.
+
+  **A transform never resizes the element's own axes.** A per-column slice can
+  pass the rank check while shrinking the event, and a transpose reads an event
+  axis as a batch axis; both now raise, as does a reduction below the event
+  rank. An empty sweep builds its declared fields only when zero rows were
+  *expected* — an empty list where rows were expected is a missing-output error,
+  not a fabrication. The dispatch probe states the flat batch size exactly as
+  the executor does, so a zero-width event column passes under explicit
+  `dispatch="jax"`.
+
   **A same-rank transform cannot lie about sizes.** Slicing a batch's columns
   keeps every axis, so the levels carry over onto the sizes the columns actually
   have; columns left disagreeing about their batch axes are refused rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -514,6 +514,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   follows the leaves — `NumericRecordBatch` when the template is numeric, the
   permissive `RecordBatch` otherwise — but a batched draw is a batch either way.
 
+  **A transform cannot add a level.** `vmap` strips the mapped axis on the way in,
+  which unflattening handles by re-deriving which levels survived; on the way out
+  it *adds* one, and an added axis belongs to no level. Unflattening has no name
+  to give, so it now raises instead of keeping the stored spec — which returned a
+  batch whose `batch_shape` its own columns contradicted, making every method that
+  reads the shape quietly wrong. Map over a batch's columns, or build the batch
+  where the axis is added.
+
+  **A batch is fingerprinted by its levels and its columns.** A multi-field batch
+  failed fingerprinting outright, so provenance omitted it; a single-field one was
+  hashed as its sole column, omitting the schema and the levels. Both are fixed:
+  the spec, the level names and their axis groups, and the raw columns in leaf
+  order all contribute.
+
+  A declared `support` on a batched output is checked column by column. Walking a
+  batch as a named tree found no children and asked a multi-field batch to convert
+  to one array, so two valid columns raised.
+
   `RecordArray` / `NumericRecordArray` still exist and are unchanged for direct
   use — no producer returns one. `NumericRecordArray.from_vector` keeps returning
   a `NumericRecordArray`, renesting the batch's flat columns itself, so the class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,6 +510,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged. And a batch has no `mean` / `var` over its batch axis; reduce the
   column, as `jnp.mean(draw["x"], axis=0)`.
 
+  An object-valued law draws a batch on the same terms as a numeric one: the class
+  follows the leaves — `NumericRecordBatch` when the template is numeric, the
+  permissive `RecordBatch` otherwise — but a batched draw is a batch either way.
+
   `RecordArray` / `NumericRecordArray` still exist and are unchanged for direct
   use — no producer returns one. `NumericRecordArray.from_vector` keeps returning
   a `NumericRecordArray`, renesting the batch's flat columns itself, so the class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,7 +498,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **A broadcast that stacks a batch per row names its own level.** Stacking rows
   that are each a batch puts the sweep in front of the levels a row already
-  carried — level names `("sweep", …)` — rather than refusing nested batched
+  carried — the swept levels' own names in front of the row's — rather than
+  refusing nested batched
   records as it used to. Since the columns are leaf-keyed, a nested element needs
   no special case.
 
@@ -521,6 +522,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   batch whose `batch_shape` its own columns contradicted, making every method that
   reads the shape quietly wrong. Map over a batch's columns, or build the batch
   where the axis is added.
+
+  **The sweep addresses a multi-level batch by position** — one indexer per
+  batch axis, where a flat index read the leading axis alone and ran off its end
+  — and the aggregate carries the swept groups' own axis partition, so two
+  independent sweeps followed by a batch-returning body mint one level per group
+  rather than refusing. An empty declared sweep builds its aggregate from the
+  output template, every declared field present at zero rows.
+
+  **Automatic dispatch probes the vmap it is choosing.** A body that traces
+  cleanly bare but cannot run under ``vmap`` — one returning a batch, whose
+  added axis no level names — now resolves to sequential dispatch, which
+  produces the same result by the dispatch-equivalence contract, instead of
+  failing mid-call.
+
+  **A same-rank transform cannot lie about sizes.** Slicing a batch's columns
+  keeps every axis, so the levels carry over onto the sizes the columns actually
+  have; columns left disagreeing about their batch axes are refused rather than
+  papered over with the stored spec.
 
   **A batch is fingerprinted by its levels and its columns.** A multi-field batch
   failed fingerprinting outright, so provenance omitted it; a single-field one was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,6 +481,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A joint law draws a `RecordBatch`.** `_sample` on the four joint laws —
+  product, sequential, Gaussian, and empirical — returns a `NumericRecordBatch`
+  (a `RecordBatch` when a leaf is non-numeric) for a batched draw, over a single
+  `draw` level spanning however many axes the `sample_shape` had. An unbatched
+  draw is a `Record`, unchanged. The flat-vector reconstruction behind
+  `unflatten_value` returns a batch for the same reason, and both classes are now
+  exported: a value handed to a caller must be nameable by that caller.
+
+  **A nested draw is one flat batch, not a batch per subtree.** A batch stores one
+  column per *field*, so a nested product draws into one mapping over leaf paths
+  and the result is a single batch whose `batch["outer"]` is a *view* over the
+  columns beneath `outer`. Where the previous nested draw built a record-array per
+  subtree, there is now one store, which is also what makes a nested field
+  reachable by path.
+
+  **A broadcast that stacks a batch per row names its own level.** Stacking rows
+  that are each a batch puts the sweep in front of the levels a row already
+  carried — level names `("sweep", …)` — rather than refusing nested batched
+  records as it used to. Since the columns are leaf-keyed, a nested element needs
+  no special case.
+
+  Three consequences for calling code. A batched draw is not a `Record`, so
+  `isinstance(draw, Record)` is `False` where it used to be `True`; ask for
+  `RecordBatch`, or for either. A batch is a collection, not a named tree, so a
+  draw's fields are read from `draw.event_template` rather than `draw.fields` /
+  `.items()` / `.at_path()`, while `draw["x"]` and `draw["outer/a"]` are
+  unchanged. And a batch has no `mean` / `var` over its batch axis; reduce the
+  column, as `jnp.mean(draw["x"], axis=0)`.
+
+  `RecordArray` / `NumericRecordArray` still exist and are unchanged for direct
+  use — no producer returns one. `NumericRecordArray.from_vector` keeps returning
+  a `NumericRecordArray`, renesting the batch's flat columns itself, so the class
+  stays coherent while it lasts.
+
 - **A batch of records is recognized wherever a batched record was.** A
   `RecordBatch` is deliberately not a `Record`, so every place that recognized a
   batched value by `isinstance(x, Record)`, by a `RecordArray` subclass check, or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -507,13 +507,13 @@ uv build packaging/probpipe   # probpipe (metapackage)
    auto-derived).
 7. **Uniform output wrap at the Function boundary** — every
    `@function` return is coerced into the
-   `Record | RecordArray | Distribution` contract before it reaches the
-   caller.  Scalars and `jnp.ndarray`s become a single-field auto-named
+   `Record | RecordBatch | RecordArray | Distribution` contract before it
+   reaches the caller.  Scalars and `jnp.ndarray`s become a single-field auto-named
    `NumericRecord` with field `fn_name` (no sweep) or
    `NumericRecordArray({fn_name: arr}, batch_shape=sweep_shape)`
    (swept); `dict` / `list` / `tuple` promote via `_make_stack`;
-   existing `Record` / `RecordArray` / `Distribution` values preserve their
-   structure and backing data but `Function.__call__` returns a shallow copy
+   existing `Record` / `RecordBatch` / `RecordArray` / `Distribution` values
+   preserve their structure and backing data but `Function.__call__` returns a shallow copy
    as an independent result term. The copy gets a fresh annotations container,
    discards the returned object's prior provenance, and records the called
    Function followed by tracked inputs as its direct parents. All resolved
@@ -541,7 +541,7 @@ uv build packaging/probpipe   # probpipe (metapackage)
    `float(mean(d))`, and `sample(grf)(X)` stay terse.
 8. **Array inputs vectorize with the product rule** — when a
    `@function` is called with array-valued inputs
-   (`RecordArray` or `DistributionArray` with nonempty
+   (`RecordBatch`, `RecordArray`, or `DistributionArray` with nonempty
    `batch_shape`) passed to slots whose hints don't match the
    batched type, the Function layer dispatches cell-by-cell
    and stacks the returns.  Multiple array inputs combine by their
@@ -572,8 +572,10 @@ uv build packaging/probpipe   # probpipe (metapackage)
 | `Distribution[T]` | Generic base parameterized by value type; provides `event_template` and the `TrackedTerm` / `Annotated` identity attributes |
 | `Record` | Named, immutable, JAX-pytree container for structured non-random values; constructed name-first (`Record(name, ...)`); leaves stored verbatim (no coercion). All-numeric construction auto-promotes to `NumericRecord`; an explicit non-numeric `event_template=` pins a plain `Record`. `Record.from_field_values(name, template, values)` is the general (de)composition inverse of `list(record.values())`; `select()` for Function splatting |
 | `NumericRecord` (subclass of `Record`) | Post-construction invariant: every leaf is numeric, **stored in native form** (jax / numpy arrays, xarray, pandas, registered backends — nothing coerced; a bare Python scalar normalises to a 0-d `jax.Array`). Conversion to `jax.Array` happens lazily at the compute boundary (pytree flatten, `to_vector`, the scalar shim) through a set-once per-leaf cache. Adds `to_vector` / `vector_size` and the classmethod inverse `NumericRecord.from_vector(name, template, vec)` (the numeric 1-D serialization). `to_numeric()` is the identity on it; `Record.to_numeric()` validates (never converts), and native containers are read back directly from the fields. |
-| `RecordArray` | Batch of `Record` elements with a `EventTemplate`; integer index → element, field index → batched array |
-| `NumericRecordArray` (subclass of `RecordArray`) | Batch of `NumericRecord` elements; adds `to_vector` / `mean` / `var` |
+| `RecordBatch` | Batch of `Record` elements over named levels (`level_names` / `axis_groups`), stored one column per leaf path; positional index → element or sub-batch view, field index → the column in its batch form. A batched draw from a joint law is one of these. Deliberately **not** a `Record`: fields are read from `event_template`, not `fields` / `items()`. |
+| `NumericRecordBatch` (subclass of `RecordBatch`) | All-numeric batch; adds `to_vector` / `from_vector(name, template, vec, *, level_names)` and the single-field array shims. Reduce a column directly (`jnp.mean(batch["x"], axis=0)`) — the batch has no `mean` / `var` of its own. |
+| `RecordArray` | Legacy batch of `Record` elements with a `EventTemplate`; integer index → element, field index → batched array. No producer returns one; being replaced by `RecordBatch`. |
+| `NumericRecordArray` (subclass of `RecordArray`) | Legacy numeric batch; adds `to_vector` / `mean` / `var` |
 | `EventTemplate` | Structural skeleton (field names, per-field shapes or `None`); the value classmethods `NumericRecord.from_vector(name, template, vec)` / `NumericRecordArray.from_vector(...)` rebuild a numeric value from its 1-D vector given a template, without an example instance |
 | `RecordDistribution` | Record-based distribution base; `fields`, `__getitem__` → `_RecordDistributionView`, `select()` / `select_all()` for correlated broadcasting. A `Distribution` represents one random variable; use `DistributionArray` for collections. |
 | `_RecordDistributionView` | Lightweight component reference; dynamic protocol support matching parent capabilities |
@@ -809,7 +811,9 @@ Three rules govern how the framework's universal types relate.
 
 3. **Iteration is a Record-family convention.** `Record`,
    `NumericRecord`, `RecordArray`, `NumericRecordArray` iterate field
-   names dict-style. `DistributionArray` is positional (``len(da)``
+   names dict-style. A `RecordBatch` is a collection, not a named tree:
+   it iterates leading-axis views, and its fields are read from
+   `event_template`. `DistributionArray` is positional (``len(da)``
    is the leading-axis size, ``prod(da.batch_shape)`` is the total
    cell count; access via ``da[i]``). Every other `Distribution`
    subclass — including `EmpiricalDistribution`,

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -111,8 +111,8 @@ are authoritative schemas but never derive or replace that signature. Use
 Use `__call__` for distribution lifting, array sweeps, orchestration, result
 wrapping, and Function-first provenance.
 
-If an implementation returns an existing `Record`, `RecordArray`, or
-`Distribution`, `apply` preserves its identity. `__call__` instead creates a
+If an implementation returns an existing `Record`, `RecordBatch`,
+`RecordArray`, or `Distribution`, `apply` preserves its identity. `__call__` instead creates a
 shallow result copy that shares value data and templates, owns a separate
 annotations container, and receives only the current call's provenance. Do not
 restore identity-through behavior at the workflow boundary. Variadic Functions
@@ -281,7 +281,9 @@ Parametric distributions do not have either property.
 
 Iteration is reserved for the `Record` family — `Record`,
 `NumericRecord`, `RecordArray`, `NumericRecordArray` — which iterate
-field names dict-style (`keys()` / `values()` / `items()`).
+field names dict-style (`keys()` / `values()` / `items()`). A
+`RecordBatch` is a collection, not a named tree: it iterates leading-axis
+views like an array, and its fields are read from `event_template`.
 
 `DistributionArray` is positional and follows numpy/jax conventions:
 `len(da)` is the leading-axis dim and `da.size` is the total cell

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -120,7 +120,7 @@ deduplicated lineage parents; ordinary slots remain distinct in
 `apply` deliberately performs no distribution lifting, batch sweep, result
 wrapping, orchestration, or call-provenance creation. It is therefore also the
 raw execution boundary used by inference integrations. If the implementation
-returns an existing `Record`, `RecordArray`, or `Distribution`, `apply`
+returns an existing `Record`, batch of records, or `Distribution`, `apply`
 preserves that object's identity, annotations, and provenance. `__call__`
 instead creates a shallow independent result item: value data and templates are
 shared by default, the annotations container is copied, prior provenance is

--- a/docs/user_guide/01_distributions.ipynb
+++ b/docs/user_guide/01_distributions.ipynb
@@ -366,7 +366,7 @@
     "\n",
     "The `key` argument is optional. When you omit it, ProbPipe derives one from a deterministic per-session counter, so your output stays reproducible within a single interpreter run.\n",
     "\n",
-    "> **Note.** Samples come back wrapped as `NumericRecord` or `NumericRecordArray` (the same containers used everywhere else in ProbPipe), so call `jnp.asarray(...)` when you want a plain array for plotting or slicing."
+    "> **Note.** Samples come back wrapped as a `NumericRecord` for one draw, or a `NumericRecordBatch` for several (the same containers used everywhere else in ProbPipe), so call `jnp.asarray(...)` when you want a plain array for plotting or slicing."
    ]
   },
   {

--- a/docs/user_guide/02_records.ipynb
+++ b/docs/user_guide/02_records.ipynb
@@ -1440,7 +1440,7 @@
     "What does `sample(dist)` give you back? It depends on whether the distribution has one field or several:\n",
     "\n",
     "- **Single-field** (`Normal`, `MultivariateNormal`, ...) → a raw `jax.Array` of shape `sample_shape + event_shape`.\n",
-    "- **Multi-field** (`ProductDistribution`, ...) → a `Record` (or `NumericRecordArray` if you asked for several samples), keyed by `dist.fields`.\n",
+    "- **Multi-field** (`ProductDistribution`, ...) → a `Record` (or a `NumericRecordBatch` over one `draw` level if you asked for several samples), keyed by `dist.fields`.\n",
     "\n",
     "That way, the result you get back already has the right shape and naming to flow into the rest of your workflow — no manual repackaging."
    ]

--- a/docs/user_guide/04_joint_distributions.ipynb
+++ b/docs/user_guide/04_joint_distributions.ipynb
@@ -393,7 +393,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "y draws (all centred near theta=1.5): NumericRecordArray(batch_shape=(5,), y=array(shape=(5,)))\n"
+      "y draws (all centred near theta=1.5): NumericRecordBatch(name='sequential(theta,y)', draw=5)\n"
      ]
     }
    ],

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -41,8 +41,10 @@ from probpipe.core._batch import Batch, BatchSpec
 from probpipe.core._distribution_array import DistributionArray
 from probpipe.core._function_batch import FunctionBatch
 from probpipe.core._numeric_record import NumericRecord
+from probpipe.core._numeric_record_batch import NumericRecordBatch
 from probpipe.core._opaque_batch import OpaqueBatch
 from probpipe.core._record_array import NumericRecordArray, RecordArray
+from probpipe.core._record_batch import RecordBatch
 from probpipe.core.config import ProvenanceMode, WorkflowKind, prefect_config, provenance_config
 from probpipe.core.constraints import (
     Constraint,
@@ -274,6 +276,7 @@ __all__ = [
     "NumericRandomMeasure",
     "NumericRecord",
     "NumericRecordArray",
+    "NumericRecordBatch",
     "NumericRecordDistribution",
     "NumericRecordDistributionView",
     "OpaqueBatch",
@@ -293,6 +296,7 @@ __all__ = [
     # Record
     "Record",
     "RecordArray",
+    "RecordBatch",
     "RecordBootstrapReplicateDistribution",
     "RecordDistribution",
     "RecordEmpiricalDistribution",

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -554,10 +554,10 @@ def _make_marginal(
 # ---------------------------------------------------------------------------
 
 
-# The level a broadcast mints for its own axes: one multiplicity over the sweep
-# grid, however many axes it spans, sitting in front of whatever levels a row
-# already carried.
-SWEEP_LEVEL = "sweep"
+# The level a draw mints, which the design names (05-operations, ``sample``). A
+# broadcast has no name of its own to give: the level it mints is the one it
+# swept, so the caller supplies that name rather than this module inventing one.
+DRAW_LEVEL = "draw"
 
 
 def _make_stack(
@@ -565,6 +565,7 @@ def _make_stack(
     *,
     batch_shape: tuple[int, ...] | None = None,
     n: int | None = None,
+    level_names: tuple[str, ...],
     name: str | None = None,
     field_name: str,
     event_template: EventTemplate | None = None,
@@ -592,6 +593,13 @@ def _make_stack(
         ``batch_shape`` or ``n`` (the 1-D shortcut); exactly one.
     n : int, optional
         Shortcut for ``batch_shape=(n,)``.
+    level_names : tuple of str
+        Names the levels this aggregation mints, one per group of
+        ``batch_shape``'s axes, and required for the reason
+        :meth:`Batch.with_level_names` gives: an operation that mints a level
+        takes the name to give it, since operands align by level name and only
+        the caller knows what the axes range over. A sweep passes the names of
+        the levels it swept, so the aggregate aligns with the input it came from.
     name : str, optional
         Name for the resulting aggregate.
 
@@ -667,7 +675,7 @@ def _make_stack(
                     columns[path] = stacked.reshape(batch_shape + stacked.shape[1:])
                 return type(first)(
                     columns,
-                    (SWEEP_LEVEL, *first.level_names),
+                    (*level_names, *first.level_names),
                     element_spec=first.element_spec,
                     axis_groups=(batch_shape, *first.axis_groups),
                     name=name or field_name,

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -688,8 +688,11 @@ def _make_stack(
     if isinstance(inner_outputs, list):
         # With no rows there is no output to read a type off, so the declared
         # template is the only honest source; without one, the generic handlers
-        # below would name a single opaque field after the function.
-        if not inner_outputs and event_template is not None:
+        # below would name a single opaque field after the function. Only a
+        # sweep that *expects* zero rows takes this path — an empty list where
+        # rows were expected is a missing-output error, and fabricating the
+        # declared fields would hide it.
+        if not inner_outputs and n_total == 0 and event_template is not None:
             return _empty_declared_stack(
                 batch_shape,
                 template=event_template,

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -28,7 +28,7 @@ from ._empirical import (
 )
 from ._object_batch import _is_object_array
 from ._record_array import NumericRecordArray, RecordArray
-from ._record_batch import RecordBatch
+from ._record_batch import RecordBatch, _batch_class_for
 from .event_template import (
     ArraySpec,
     EventTemplate,
@@ -721,40 +721,61 @@ def _make_stack(
         # rows' own levels. Checked before the Record branch below, which would
         # otherwise claim a RecordArray (a Record subclass) and collapse its
         # inner batch axis.
-        if outs and all(isinstance(o, RecordBatch) for o in outs):
+        if outs and any(isinstance(o, RecordBatch) for o in outs):
+            # A batch row is all-or-nothing. Falling through on a mixture, or on
+            # rows that disagree, reaches the generic handlers — which would take a
+            # single-field numeric batch for an array, read its inner batch axis as
+            # an event axis, and discard the level names with it. There is no
+            # aggregate to build from rows that do not agree on what they hold, so
+            # this says so where the disagreement is visible.
+            if not all(isinstance(o, RecordBatch) for o in outs):
+                kinds = sorted({type(o).__name__ for o in outs})
+                raise TypeError(
+                    f"{field_name}: some rows returned a batch of records and some did not "
+                    f"({', '.join(kinds)}). A swept body returns one kind for every row, since "
+                    f"the aggregate has one schema; return a batch from every row or from none"
+                )
             first = outs[0]
             # Every row must agree on what it holds and on which axes hold it.
             # Matching the shape alone would take the first row's schema and level
             # names for all of them, dropping a field the others have and
             # misnaming their axes — a batch whose spec is a false statement about
             # its own columns.
-            if all(
-                o.element_spec == first.element_spec
-                and o.level_names == first.level_names
-                and o.axis_groups == first.axis_groups
-                for o in outs
-            ):
-                # Columns are leaf-keyed, so a nested element needs no special
-                # case — and they are read raw: a field that is not an array
-                # presents as its own object batch, and what stacks is the
-                # column, through numpy so the objects are taken as they are.
-                columns = {}
-                for path in first.event_template:
-                    cols = [o._raw_column(path) for o in outs]
-                    if any(_is_object_array(c) for c in cols):
-                        stacked = np.stack(cols, axis=0)
-                    else:
-                        stacked = jnp.stack(cols, axis=0)
-                    columns[path] = stacked.reshape(batch_shape + stacked.shape[1:])
-                return type(first)(
-                    columns,
-                    (*level_names, *first.level_names),
-                    element_spec=first.element_spec,
-                    axis_groups=(*sweep_groups, *first.axis_groups),
-                    name=name or field_name,
-                    name_is_auto=True,
+            for other in outs[1:]:
+                if (
+                    other.element_spec == first.element_spec
+                    and other.batch_shape == first.batch_shape
+                    and other.level_names == first.level_names
+                    and other.axis_groups == first.axis_groups
+                ):
+                    continue
+                raise ValueError(
+                    f"{field_name}: the rows returned batches that disagree — "
+                    f"{first.level_names} over {first.batch_shape} against "
+                    f"{other.level_names} over {other.batch_shape}. Rows stack into one batch, "
+                    f"which states one element spec and one multiplicity for all of them, so "
+                    f"every row must return the same schema on the same levels"
                 )
-            # Mismatched inner shapes fall through to the generic handlers.
+            # Columns are leaf-keyed, so a nested element needs no special
+            # case — and they are read raw: a field that is not an array
+            # presents as its own object batch, and what stacks is the
+            # column, through numpy so the objects are taken as they are.
+            columns = {}
+            for path in first.event_template:
+                cols = [o._raw_column(path) for o in outs]
+                if any(_is_object_array(c) for c in cols):
+                    stacked = np.stack(cols, axis=0)
+                else:
+                    stacked = jnp.stack(cols, axis=0)
+                columns[path] = stacked.reshape(batch_shape + stacked.shape[1:])
+            return _batch_class_for(first.element_spec)(
+                columns,
+                (*level_names, *first.level_names),
+                element_spec=first.element_spec,
+                axis_groups=(*sweep_groups, *first.axis_groups),
+                name=name or field_name,
+                name_is_auto=True,
+            )
 
         if outs and all(isinstance(o, RecordArray) for o in outs):
             first = outs[0]
@@ -773,7 +794,20 @@ def _make_stack(
                 reshaped = {
                     fname: arr.reshape(batch_shape + arr.shape[1:]) for fname, arr in fields.items()
                 }
-                return type(first)(
+                # The class follows the element template, not the row that
+                # happened to arrive first: a subclass with its own constructor —
+                # a ``Design``, built from marginals — is not something an
+                # aggregate over its rows can be rebuilt as.
+                # Imported locally because later branches of this function do,
+                # which makes the name local to it throughout.
+                from ._record_array import NumericRecordArray
+
+                aggregate = (
+                    NumericRecordArray
+                    if isinstance(first.template, NumericEventTemplate)
+                    else RecordArray
+                )
+                return aggregate(
                     reshaped,
                     batch_shape=batch_shape + first.batch_shape,
                     template=first.template,

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -548,6 +548,12 @@ def _make_marginal(
 # ---------------------------------------------------------------------------
 
 
+# The level a broadcast mints for its own axes: one multiplicity over the sweep
+# grid, however many axes it spans, sitting in front of whatever levels a row
+# already carried.
+SWEEP_LEVEL = "sweep"
+
+
 def _make_stack(
     inner_outputs: Any,
     *,
@@ -630,10 +636,29 @@ def _make_stack(
                 for output in outs
             ]
 
-        # Check the more-specific subclass first: all RecordArrays
-        # (since ``RecordArray`` is itself a ``Record`` subclass, the
-        # generic Record branch below would otherwise claim them and
-        # collapse the inner batch axis).
+        # A batch per row stacks into one batch with the sweep in front of the
+        # rows' own levels. Checked before the Record branch below, which would
+        # otherwise claim a RecordArray (a Record subclass) and collapse its
+        # inner batch axis.
+        if outs and all(isinstance(o, RecordBatch) for o in outs):
+            first = outs[0]
+            if all(o.batch_shape == first.batch_shape for o in outs):
+                # Columns are leaf-keyed, so a nested element needs no special
+                # case: each column stacks and reshapes like any other.
+                columns = {}
+                for path in first.event_template:
+                    stacked = jnp.stack([o[path] for o in outs], axis=0)
+                    columns[path] = stacked.reshape(batch_shape + stacked.shape[1:])
+                return type(first)(
+                    columns,
+                    (SWEEP_LEVEL, *first.level_names),
+                    element_spec=first.element_spec,
+                    axis_groups=(batch_shape, *first.axis_groups),
+                    name=name or field_name,
+                    name_is_auto=True,
+                )
+            # Mismatched inner shapes fall through to the generic handlers.
+
         if outs and all(isinstance(o, RecordArray) for o in outs):
             first = outs[0]
             if any(isinstance(c, EventTemplate) for c in first.template.children.values()):

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -29,7 +29,12 @@ from ._empirical import (
 from ._object_batch import _is_object_array
 from ._record_array import NumericRecordArray, RecordArray
 from ._record_batch import RecordBatch
-from .event_template import EventTemplate, NumericEventTemplate, _full_array_shape_or_none
+from .event_template import (
+    ArraySpec,
+    EventTemplate,
+    NumericEventTemplate,
+    _full_array_shape_or_none,
+)
 from .protocols import (
     SupportsLogProb,
     SupportsMean,
@@ -404,6 +409,34 @@ def _stack_declared_records(
     )
 
 
+def _empty_declared_stack(
+    batch_shape: tuple[int, ...],
+    *,
+    template: EventTemplate,
+    name: str,
+) -> Any:
+    """The declared aggregate at zero rows: every field present, every axis empty.
+
+    Built exactly as :func:`_stack_declared_records` would have built it, so an
+    empty sweep and a one-row sweep hand back the same type with the same fields
+    — a numeric leaf is an empty array of its declared shape and dtype, and a
+    non-array field an empty object column.
+    """
+    from ._record_array import NumericRecordArray, RecordArray
+
+    fields: dict[str, Any] = {}
+    for field_name, spec in template.children.items():
+        if isinstance(spec, EventTemplate):
+            fields[field_name] = _empty_declared_stack(batch_shape, template=spec, name=field_name)
+        elif isinstance(spec, ArraySpec) and all(isinstance(size, int) for size in spec.shape):
+            dtype = spec.dtype if spec.dtype is not None else jnp.zeros(()).dtype
+            fields[field_name] = jnp.zeros((*batch_shape, *spec.shape), dtype=dtype)
+        else:
+            fields[field_name] = np.empty(batch_shape, dtype=object)
+    cls = NumericRecordArray if isinstance(template, NumericEventTemplate) else RecordArray
+    return cls(fields, batch_shape=batch_shape, template=template, name=name)
+
+
 def _make_marginal(
     output_samples: Any,
     weights: Array | Weights | None = None,
@@ -445,6 +478,18 @@ def _make_marginal(
             {only_path: output_samples},
             name_is_auto=True,
         )
+
+    if isinstance(output_samples, RecordBatch) and not isinstance(
+        output_samples.event_template, NumericEventTemplate
+    ):
+        # The record marginal is empirical over numeric leaves — its reductions
+        # and resampling convert columns to arrays — so a batch holding a
+        # non-numeric field takes the general list marginal over its elements.
+        rows = [
+            output_samples[tuple(int(i) for i in position)]
+            for position in np.ndindex(*output_samples.batch_shape)
+        ]
+        return _ListMarginal(rows, weights, name=name)
 
     if isinstance(output_samples, (RecordArray, RecordBatch)):
         return _RecordMarginal(
@@ -566,6 +611,7 @@ def _make_stack(
     batch_shape: tuple[int, ...] | None = None,
     n: int | None = None,
     level_names: tuple[str, ...],
+    axis_groups: tuple[tuple[int, ...], ...] | None = None,
     name: str | None = None,
     field_name: str,
     event_template: EventTemplate | None = None,
@@ -628,9 +674,27 @@ def _make_stack(
         batch_shape = (n,)
     batch_shape = tuple(batch_shape)
     n_total = int(prod(batch_shape)) if batch_shape else 1
+    # One level per swept group, tiling the aggregate's leading axes. A single
+    # name takes them all, which is what a one-group sweep and the ``n``
+    # shortcut both are.
+    sweep_groups = tuple(axis_groups) if axis_groups is not None else (batch_shape,)
+    if len(sweep_groups) != len(level_names):
+        raise ValueError(
+            f"_make_stack mints one level per group of axes: {len(sweep_groups)} groups "
+            f"{sweep_groups} against {len(level_names)} names {list(level_names)}"
+        )
 
     # --- List-of-X path (Python-loop execution) -------------------------
     if isinstance(inner_outputs, list):
+        # With no rows there is no output to read a type off, so the declared
+        # template is the only honest source; without one, the generic handlers
+        # below would name a single opaque field after the function.
+        if not inner_outputs and event_template is not None:
+            return _empty_declared_stack(
+                batch_shape,
+                template=event_template,
+                name=name or field_name,
+            )
         if len(inner_outputs) != n_total:
             raise ValueError(
                 f"_make_stack got {len(inner_outputs)} outputs but "
@@ -668,16 +732,22 @@ def _make_stack(
                 for o in outs
             ):
                 # Columns are leaf-keyed, so a nested element needs no special
-                # case: each column stacks and reshapes like any other.
+                # case — and they are read raw: a field that is not an array
+                # presents as its own object batch, and what stacks is the
+                # column, through numpy so the objects are taken as they are.
                 columns = {}
                 for path in first.event_template:
-                    stacked = jnp.stack([o[path] for o in outs], axis=0)
+                    cols = [o._raw_column(path) for o in outs]
+                    if any(_is_object_array(c) for c in cols):
+                        stacked = np.stack(cols, axis=0)
+                    else:
+                        stacked = jnp.stack(cols, axis=0)
                     columns[path] = stacked.reshape(batch_shape + stacked.shape[1:])
                 return type(first)(
                     columns,
                     (*level_names, *first.level_names),
                     element_spec=first.element_spec,
-                    axis_groups=(batch_shape, *first.axis_groups),
+                    axis_groups=(*sweep_groups, *first.axis_groups),
                     name=name or field_name,
                     name_is_auto=True,
                 )

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -26,6 +26,7 @@ from ._empirical import (
     EmpiricalDistribution,
     RecordEmpiricalDistribution,
 )
+from ._object_batch import _is_object_array
 from ._record_array import NumericRecordArray, RecordArray
 from ._record_batch import RecordBatch
 from .event_template import EventTemplate, NumericEventTemplate, _full_array_shape_or_none
@@ -70,7 +71,12 @@ class _RecordMarginal(RecordEmpiricalDistribution):
         # constructor wants one row per batch index, so peel it: the leaves keep
         # the rows axis and the record above them loses it. Leaf-keyed, so a
         # nested batch peels correctly; path-keyed construction rebuilds nesting.
-        if isinstance(samples, (RecordArray, RecordBatch)):
+        if isinstance(samples, RecordBatch):
+            template = samples.event_template
+            # Raw columns: a non-array field presents as its own object batch,
+            # which is not what belongs in a record of batched leaves.
+            samples = Record(samples.name, samples._raw_columns(), name_is_auto=True)
+        elif isinstance(samples, RecordArray):
             template = samples.event_template
             samples = Record(samples.name, {k: samples[k] for k in template}, name_is_auto=True)
         else:
@@ -642,7 +648,17 @@ def _make_stack(
         # inner batch axis.
         if outs and all(isinstance(o, RecordBatch) for o in outs):
             first = outs[0]
-            if all(o.batch_shape == first.batch_shape for o in outs):
+            # Every row must agree on what it holds and on which axes hold it.
+            # Matching the shape alone would take the first row's schema and level
+            # names for all of them, dropping a field the others have and
+            # misnaming their axes — a batch whose spec is a false statement about
+            # its own columns.
+            if all(
+                o.element_spec == first.element_spec
+                and o.level_names == first.level_names
+                and o.axis_groups == first.axis_groups
+                for o in outs
+            ):
                 # Columns are leaf-keyed, so a nested element needs no special
                 # case: each column stacks and reshapes like any other.
                 columns = {}
@@ -946,6 +962,18 @@ def _row_count(component: Any) -> int:
     return component.shape[0] if hasattr(component, "shape") else len(component)
 
 
+def _gather_column(column: Any, indices: Array) -> Any:
+    """One column's rows at *indices*, keeping the column's own kind.
+
+    A numeric column gathers as an array. An object column holds one Python value
+    per row and gathers through numpy, which takes the positions without trying to
+    make an array of the values themselves.
+    """
+    if _is_object_array(column):
+        return column[np.asarray(indices)]
+    return column[indices]
+
+
 def _take_rows(component: Any, indices: Array) -> Any:
     """Gather the rows *indices* of one batched component, keeping its container.
 
@@ -963,7 +991,10 @@ def _take_rows(component: Any, indices: Array) -> Any:
         # that one size rewritten; which level holds the axis is unchanged.
         leading, *rest = component.axis_groups
         return type(component)(
-            {path: component[path][indices] for path in component.event_template},
+            {
+                path: _gather_column(component._raw_column(path), indices)
+                for path in component.event_template
+            },
             component.level_names,
             element_spec=component.element_spec,
             axis_groups=((indices.shape[0], *leading[1:]), *rest),

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -159,6 +159,8 @@ def _update(
 
     if isinstance(obj, (_NP_ARRAY_TYPE, _JAX_ARRAY_TYPE)):
         _update_array(h, obj, max_array_bytes, state)
+    elif _is_record_batch(obj):
+        _update_record_batch(h, obj, depth, max_array_bytes, state)
     elif _is_record(obj):
         _update_record(h, obj, depth, max_array_bytes, state)
     elif _is_distribution(obj):
@@ -544,6 +546,52 @@ def _update_tfp_object(
 # ---------------------------------------------------------------------------
 # Record hashing
 # ---------------------------------------------------------------------------
+
+
+def _is_record_batch(obj: Any) -> bool:
+    try:
+        from ._record_batch import RecordBatch
+
+        return isinstance(obj, RecordBatch)
+    except ImportError:
+        return False
+
+
+def _update_record_batch(
+    h: hashlib._Hash,
+    batch: Any,
+    depth: int,
+    max_array_bytes: int | None,
+    state: _FingerprintState,
+) -> None:
+    """Hash a batch by its own type, its levels, and its columns in leaf order.
+
+    A batch is not a record, and is checked before one for that reason: a
+    single-field batch converts to its sole column, so an array-shaped read would
+    hash that column alone and call two batches equal that differ in schema or in
+    how their axes are grouped. The multiplicity is part of a batch's type, so the
+    levels and the element spec are hashed rather than left implicit.
+
+    Columns are read raw. A field that is not an array *presents* as the batch of
+    its element kind, and hashing that would fingerprint a wrapper minted for the
+    read rather than the values stored.
+    """
+    h.update(b"record_batch:")
+    h.update(type(batch).__name__.encode())
+    h.update(b":levels=")
+    for name, group in zip(batch.level_names, batch.axis_groups, strict=True):
+        h.update(name.encode())
+        h.update(b"@")
+        h.update(repr(tuple(group)).encode())
+        h.update(b",")
+    h.update(b":spec=")
+    _update(h, batch.element_spec, depth + 1, max_array_bytes, state)
+    h.update(b":")
+    for path in batch.event_template:
+        h.update(path.encode())
+        h.update(b"=")
+        _update(h, batch._raw_column(path), depth + 1, max_array_bytes, state)
+        h.update(b";")
 
 
 def _is_record(obj: Any) -> bool:

--- a/probpipe/core/_function_contract.py
+++ b/probpipe/core/_function_contract.py
@@ -425,6 +425,22 @@ def _validate_function_output_supports(
     value: Any,
 ) -> None:
     """Validate declared ArraySpec supports at an eager execution boundary."""
+    if isinstance(value, RecordBatch):
+        # A batch is a collection, not a named tree: its columns are keyed by leaf
+        # path and each carries the batch axes in front of its event shape, which a
+        # support check reads elementwise. Walking it as a tree would find no
+        # children and take the single-leaf path, which asks a multi-field batch to
+        # convert to one array.
+        for path, spec in template.items():
+            assert isinstance(spec, ValueSpec)
+            _validate_function_output_leaf_support(
+                function_name=function_name,
+                path=path,
+                spec=spec,
+                value=value._raw_column(path),
+            )
+        return
+
     children = getattr(value, "children", None)
     if not isinstance(children, Mapping):
         children = value if isinstance(value, Mapping) else None

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -524,10 +524,10 @@ def _reconstruct_from_vector(
 
     Splits *vec* along its trailing axis into *template*'s leaves (canonical
     leaf order), reshapes each to its event shape, and rebuilds the structured
-    value: a single :class:`NumericRecord` when *vec* is 1-D, a batched
-    :class:`~probpipe.NumericRecordArray` (``batch_shape == vec.shape[:-1]``)
-    otherwise. This is the value-level machinery behind
-    :meth:`NumericRecord.from_vector` / :meth:`NumericRecordArray.from_vector`;
+    value: a single :class:`NumericRecord` when *vec* is 1-D, a
+    :class:`~probpipe.NumericRecordBatch` over one level of
+    ``vec.shape[:-1]`` otherwise. This is the value-level machinery behind
+    :meth:`NumericRecord.from_vector` / :meth:`NumericRecordBatch.from_vector`;
     the template supplies only the leaf layout (shapes, order), never
     constructing the value itself.
 

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -18,7 +18,7 @@ lazy conversion contract, the flat-vector layout (``to_vector`` /
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from math import prod
 from typing import Any
 
@@ -482,9 +482,7 @@ class NumericRecord(Record):
 # ---------------------------------------------------------------------------
 
 
-def _value_treedef(
-    template: NumericEventTemplate, batch_shape: tuple[int, ...]
-) -> jax.tree_util.PyTreeDef:
+def _value_treedef(template: NumericEventTemplate) -> jax.tree_util.PyTreeDef:
     """PyTreeDef of the value :func:`_reconstruct_from_vector` builds.
 
     A throwaway ``NumericRecord`` / ``NumericRecordArray`` skeleton mirroring
@@ -501,11 +499,7 @@ def _value_treedef(
             if isinstance(spec, NumericEventTemplate):
                 fields[name] = _build(spec)
             else:
-                fields[name] = jnp.broadcast_to(numeric_fill, (*batch_shape, *spec.shape))
-        if batch_shape:
-            from ._record_array import NumericRecordArray
-
-            return NumericRecordArray(fields, batch_shape=batch_shape, template=tpl)
+                fields[name] = jnp.broadcast_to(numeric_fill, spec.shape)
         # A template carries no name; the caller renames the reconstructed
         # value. Skip leaf validation: the placeholder fill is float32 and the
         # template may pin another dtype (int32 / bool) — this skeleton exists
@@ -519,7 +513,12 @@ def _value_treedef(
 
 
 def _reconstruct_from_vector(
-    name: str, template: NumericEventTemplate, vec: Array, *, name_is_auto: bool
+    name: str,
+    template: NumericEventTemplate,
+    vec: Array,
+    *,
+    name_is_auto: bool,
+    level_names: str | Iterable[str] = "draw",
 ) -> NumericRecord | Any:
     """Reconstruct a numeric value from its flat vector, under *name*.
 
@@ -573,7 +572,23 @@ def _reconstruct_from_vector(
                 leaves.append(leaf)
 
     _collect(template)
-    value = jax.tree_util.tree_unflatten(_value_treedef(template, batch_shape), leaves)
+    if batch_shape:
+        # A batch reconstructs itself: its storage is one array per field, which
+        # the flat blocks already are, so there is no tree to unflatten.
+        from ._numeric_record_batch import NumericRecordBatch
+
+        # One level over however many axes the flat vector carried: a
+        # ``sample_shape`` of several axes is one multiplicity, named once, which
+        # is what the operation model says a draw level is.
+        return NumericRecordBatch(
+            dict(zip(template.keys(), leaves, strict=True)),
+            level_names,
+            element_spec=template,
+            axis_groups=(batch_shape,),
+            name=name,
+            name_is_auto=name_is_auto,
+        )
+    value = jax.tree_util.tree_unflatten(_value_treedef(template), leaves)
     object.__setattr__(value, "_name", name)
     object.__setattr__(value, "_name_is_auto", name_is_auto)
     return value

--- a/probpipe/core/_numeric_record_batch.py
+++ b/probpipe/core/_numeric_record_batch.py
@@ -212,8 +212,11 @@ class NumericRecordBatch(RecordBatch):
             :meth:`RecordBatch.stack` states, and plural because *vec* may carry
             several batch axes: naming them is how a multi-level batch round-trips.
         axis_groups : iterable of iterable of int, optional
-            The axis sizes each level holds, as for the constructor. Defaults to
-            one axis per level.
+            The axis sizes each level holds, as for the constructor. Omitted, a
+            single name takes **all** of *vec*'s batch axes as one level and
+            several names take one axis each. The first is why a draw of several
+            axes reconstructs without naming each: a ``sample_shape`` is one
+            multiplicity however many axes it spans.
 
         Returns
         -------
@@ -269,9 +272,12 @@ class NumericRecordBatch(RecordBatch):
                 block = block.astype(declared.dtype)
             columns[key] = block
             offset += size
+        names = (level_names,) if isinstance(level_names, str) else tuple(level_names)
+        if axis_groups is None and len(names) == 1:
+            axis_groups = (batch_shape,)
         return cls(
             columns,
-            level_names,
+            names,
             element_spec=template,
             axis_groups=axis_groups,
             name=name,

--- a/probpipe/core/_numeric_record_distribution.py
+++ b/probpipe/core/_numeric_record_distribution.py
@@ -215,9 +215,9 @@ class NumericRecordDistribution(RecordDistribution):
     - **Single-leaf** template → ``_sample(key, sample_shape)`` returns
       a raw ``jax.Array`` of shape ``sample_shape + event_shape``.
     - **Multi-leaf** template → ``_sample(key, sample_shape)`` returns a
-      :class:`~probpipe.NumericRecord` (or
-      :class:`~probpipe.NumericRecordArray` for a non-empty
-      ``sample_shape``) keyed by ``event_template.fields``.
+      :class:`~probpipe.NumericRecord` (or a
+      :class:`~probpipe.NumericRecordBatch` over one ``draw`` level for a
+      non-empty ``sample_shape``) keyed by ``event_template.fields``.
 
     The :attr:`treedef` property locks this invariant by deriving from
     ``event_template``.
@@ -534,10 +534,10 @@ class NumericRecordDistribution(RecordDistribution):
 
     @staticmethod
     def unflatten_value(flat, *, template):
-        """Unflatten a flat trailing axis back to event dims, Record, or NumericRecordArray.
+        """Unflatten a flat trailing axis back to event dims, a record, or a batch.
 
         Multi-field templates → ``NumericRecord`` (single sample, i.e.
-        ``flat.ndim == 1``) or ``NumericRecordArray`` (batched). Single-
+        ``flat.ndim == 1``) or ``NumericRecordBatch`` (batched). Single-
         field templates → raw array reshaped to ``(*batch, *event_shape)``
         for ``_log_prob`` compatibility (preserves the original "single-
         leaf returns raw array" contract).

--- a/probpipe/core/_record_array.py
+++ b/probpipe/core/_record_array.py
@@ -638,7 +638,26 @@ class NumericRecordArray(RecordArray):
                 f"(shape (*batch_shape, vector_size)); got shape {tuple(vec.shape)}. "
                 f"Reconstruct a single value with NumericRecord.from_vector."
             )
-        return _reconstruct_from_vector(name, template, vec, name_is_auto=False)
+        batch = _reconstruct_from_vector(name, template, vec, name_is_auto=False)
+        return cls._from_batch(name, template, batch)
+
+    @classmethod
+    def _from_batch(cls, name: str, template: EventTemplate, batch: Any) -> NumericRecordArray:
+        """This class's nested form of a batch's flat columns.
+
+        A batch stores one column per *leaf*; this class stores one child per
+        *top-level* field, nesting an array of its own under an interior node. The
+        flat split itself lives on the batch, so only the renesting is here — and
+        it goes when this class does.
+        """
+        fields: dict[str, Any] = {}
+        for field, spec in template.children.items():
+            fields[field] = (
+                cls._from_batch(field, spec, batch[field])
+                if isinstance(spec, EventTemplate)
+                else batch[field]
+            )
+        return cls(fields, batch_shape=batch.batch_shape, template=template)
 
     # -- Reductions ---------------------------------------------------------
 

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -636,11 +636,7 @@ class RecordBatch(Batch[Record]):
         and left to the constructor to re-derive when it was auto, since the old one
         described the pre-edit fields.
         """
-        # Lazy: the numeric module builds on this one, so the edge points that way.
-        from ._numeric_record_batch import NumericRecordBatch
-
-        cls = NumericRecordBatch if isinstance(template, NumericEventTemplate) else RecordBatch
-        return cls(
+        return _batch_class_for(template)(
             dict(columns),
             self.level_names,
             element_spec=template,
@@ -759,6 +755,22 @@ class RecordBatch(Batch[Record]):
 # ---------------------------------------------------------------------------
 # Construction helpers
 # ---------------------------------------------------------------------------
+
+
+def _batch_class_for(element_spec: RecordSpec | EventTemplate) -> type[RecordBatch]:
+    """The batch class an element declaration calls for.
+
+    The kind of batch follows the *element*: an all-numeric element gets the
+    numeric specialization and its flat layout, anything else the permissive base.
+    Read the class from the declaration rather than from a batch that happens to
+    be at hand — a subclass carrying its own constructor, a ``Design`` built from
+    marginals, is not a thing an aggregate over its rows can be rebuilt as.
+    """
+    # Lazy: the numeric module builds on this one, so the edge points that way.
+    from ._numeric_record_batch import NumericRecordBatch
+
+    template = _record_declaration_template(element_spec)
+    return NumericRecordBatch if isinstance(template, NumericEventTemplate) else RecordBatch
 
 
 def _record_element_spec(decl: RecordSpec | EventTemplate, *, kind: str) -> RecordSpec:

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -335,6 +335,23 @@ class RecordBatch(Batch[Record]):
 
     # -- field access -------------------------------------------------------
 
+    def _raw_column(self, path: str) -> Any:
+        """One field's column exactly as stored, before any presentation.
+
+        ``batch[path]`` *presents* a column: an array field is the array, but a
+        callable or opaque field comes back as the batch of its element kind, a
+        :class:`FunctionBatch` or an :class:`OpaqueBatch`, which is what reading
+        one field wants. An operation rearranging the storage itself — gathering
+        rows, peeling the batch axis off — needs the column, object array and
+        all, and presenting it first would make those operations wrong for every
+        field that is not an array.
+        """
+        return self._columns[path]
+
+    def _raw_columns(self) -> dict[str, Any]:
+        """Every column as stored, keyed by leaf path."""
+        return dict(self._columns)
+
     def _column_as_batch(self, key: str) -> Any:
         """One field's column, in the batch form its spec calls for.
 

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -36,6 +36,7 @@ class ArrayBroadcastGroup:
     # named for the argument it arrived as, which is a name from the call rather
     # than one invented here.
     level_names: tuple[str, ...]
+    axis_groups: tuple[tuple[int, ...], ...]
 
 
 @dataclass(frozen=True)
@@ -48,6 +49,7 @@ class BroadcastPlan:
     array_groups: tuple[ArrayBroadcastGroup, ...]
     sweep_batch_shape: tuple[int, ...]
     sweep_level_names: tuple[str, ...]
+    sweep_axis_groups: tuple[tuple[int, ...], ...]
     n_sweep: int
 
 
@@ -80,6 +82,7 @@ def build_broadcast_plan(
     array_groups = group_array_args_by_parent(values=values, refs=array_args)
     sweep_batch_shape = tuple(axis for group in array_groups for axis in group.batch_shape)
     sweep_level_names = tuple(n for group in array_groups for n in group.level_names)
+    sweep_axis_groups = tuple(g for group in array_groups for g in group.axis_groups)
     n_sweep = prod(sweep_batch_shape)
 
     return BroadcastPlan(
@@ -89,6 +92,7 @@ def build_broadcast_plan(
         array_groups=tuple(array_groups),
         sweep_batch_shape=sweep_batch_shape,
         sweep_level_names=sweep_level_names,
+        sweep_axis_groups=sweep_axis_groups,
         n_sweep=n_sweep,
     )
 
@@ -151,7 +155,12 @@ def group_array_args_by_parent(
     for _root, arg_refs in group_by_root(values=values, refs=refs):
         first = _workflow_call.input_ref_value(values, arg_refs[0])
         batch_shape = tuple(first.batch_shape)
-        level_names = tuple(first.level_names) if isinstance(first, Batch) else (arg_refs[0].label,)
+        if isinstance(first, Batch):
+            level_names = tuple(first.level_names)
+            group_axes = tuple(first.axis_groups)
+        else:
+            level_names = (arg_refs[0].label,)
+            group_axes = (batch_shape,)
         for ref in arg_refs[1:]:
             other = _workflow_call.input_ref_value(values, ref)
             if isinstance(first, Batch):
@@ -179,6 +188,7 @@ def group_array_args_by_parent(
                 batch_shape=batch_shape,
                 size=prod(batch_shape),
                 level_names=level_names,
+                axis_groups=group_axes,
             )
         )
     # A level name in two groups is one multiplicity read at two geometries:

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -30,6 +30,12 @@ class ArrayBroadcastGroup:
     arg_refs: tuple[_workflow_call.WorkflowInputRef, ...]
     batch_shape: tuple[int, ...]
     size: int
+    # What the group's axes range over, for the aggregate to mint its levels
+    # under. A batched operand already says: its own level names are what an
+    # output must carry to align with it. An operand with no levels of its own is
+    # named for the argument it arrived as, which is a name from the call rather
+    # than one invented here.
+    level_names: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -41,6 +47,7 @@ class BroadcastPlan:
     array_args: tuple[_workflow_call.WorkflowInputRef, ...]
     array_groups: tuple[ArrayBroadcastGroup, ...]
     sweep_batch_shape: tuple[int, ...]
+    sweep_level_names: tuple[str, ...]
     n_sweep: int
 
 
@@ -72,6 +79,7 @@ def build_broadcast_plan(
 
     array_groups = group_array_args_by_parent(values=values, refs=array_args)
     sweep_batch_shape = tuple(axis for group in array_groups for axis in group.batch_shape)
+    sweep_level_names = tuple(n for group in array_groups for n in group.level_names)
     n_sweep = prod(sweep_batch_shape)
 
     return BroadcastPlan(
@@ -80,6 +88,7 @@ def build_broadcast_plan(
         array_args=tuple(array_args),
         array_groups=tuple(array_groups),
         sweep_batch_shape=sweep_batch_shape,
+        sweep_level_names=sweep_level_names,
         n_sweep=n_sweep,
     )
 
@@ -142,6 +151,7 @@ def group_array_args_by_parent(
     for _root, arg_refs in group_by_root(values=values, refs=refs):
         first = _workflow_call.input_ref_value(values, arg_refs[0])
         batch_shape = tuple(first.batch_shape)
+        level_names = tuple(first.level_names) if isinstance(first, Batch) else (arg_refs[0].label,)
         for ref in arg_refs[1:]:
             other = _workflow_call.input_ref_value(values, ref)
             if isinstance(first, Batch):
@@ -168,6 +178,7 @@ def group_array_args_by_parent(
                 arg_refs=tuple(arg_refs),
                 batch_shape=batch_shape,
                 size=prod(batch_shape),
+                level_names=level_names,
             )
         )
     # A level name in two groups is one multiplicity read at two geometries:

--- a/probpipe/core/_workflow_result.py
+++ b/probpipe/core/_workflow_result.py
@@ -79,7 +79,11 @@ def _wrap_as_record(
         return Record(field_name, value, name_is_auto=True)
     if isinstance(value, (list, tuple)) and value:
         try:
-            return _make_stack(list(value), n=len(value), field_name=field_name)
+            # A returned sequence ranges over nothing the call named, so the
+            # level takes the function's own name.
+            return _make_stack(
+                list(value), n=len(value), level_names=(field_name,), field_name=field_name
+            )
         except (TypeError, ValueError):
             pass
     # Numeric scalar / array → NumericRecord with the function's

--- a/probpipe/core/_workflow_result.py
+++ b/probpipe/core/_workflow_result.py
@@ -162,6 +162,12 @@ def _copy_result_term(
         if isinstance(clone, RecordBatch):
             element_spec = _to_record_declaration(output_template)
             object.__setattr__(clone, "_spec", replace(clone.spec, element_spec=element_spec))
+            # The columns are reordered to match: a batch flattens its columns in
+            # its spec's leaf order, so a declared template that orders the same
+            # fields differently would otherwise pair every value with the wrong
+            # key on the next unflatten.
+            columns = clone._raw_columns()
+            object.__setattr__(clone, "_columns", {p: columns[p] for p in output_template})
         elif isinstance(clone, RecordArray):
             object.__setattr__(clone, "_template", output_template)
         elif isinstance(clone, Record):

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -75,6 +75,9 @@ def execute_sweep(
         aggregate = _make_stack(
             per_row,
             batch_shape=plan.sweep_batch_shape,
+            # The aggregate mints the levels the sweep ranged over, so it aligns
+            # by name with the batch it swept.
+            level_names=plan.sweep_level_names,
             name=workflow_name,
             field_name=workflow_name,
             event_template=output_template,

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -12,8 +12,10 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 import jax
+import numpy as np
 
 from . import _workflow_call, _workflow_execution, _workflow_plan, _workflow_result
+from ._batch import Batch
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
 from ._record_array import _RecordArrayView
@@ -78,6 +80,7 @@ def execute_sweep(
             # The aggregate mints the levels the sweep ranged over, so it aligns
             # by name with the batch it swept.
             level_names=plan.sweep_level_names,
+            axis_groups=plan.sweep_axis_groups,
             name=workflow_name,
             field_name=workflow_name,
             event_template=output_template,
@@ -149,7 +152,7 @@ def slice_sweep_values(
     index: int,
     array_groups: tuple[_workflow_plan.ArrayBroadcastGroup, ...],
 ) -> dict[str, Any]:
-    """Materialize one row-major sweep cell under parent-grouped arrays."""
+    """Materialize one row-major sweep cell under the zip groups."""
     out = dict(values)
     rem = index
     # Highest-index group varies fastest under row-major flattening of
@@ -157,11 +160,21 @@ def slice_sweep_values(
     for group in reversed(array_groups):
         idx = rem % group.size
         rem = rem // group.size
+        # A batch spanning several axes addresses its element by position, one
+        # indexer per axis; a flat index would read the leading axis alone and
+        # run off its end. Positional tuples are a batch key — on a record
+        # array a tuple spells a field path — so the legacy class keeps its
+        # flat index.
+        position: Any = idx
+        if len(group.batch_shape) > 1:
+            position = tuple(int(i) for i in np.unravel_index(idx, group.batch_shape))
         replacements: dict[_workflow_call.WorkflowInputRef, Any] = {}
         for ref in group.arg_refs:
             source = _workflow_call.input_ref_value(values, ref)
             if isinstance(source, DistributionArray):
                 replacements[ref] = source._flat_component(idx)
+            elif isinstance(source, Batch):
+                replacements[ref] = source[position]
             else:
                 replacements[ref] = source[idx]
         out = _workflow_call.replace_input_refs(out, replacements)

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -196,6 +196,13 @@ def execute_sweep_rows(
     require_jax_traceable: Callable[[dict[str, Any], list[_workflow_call.WorkflowInputRef]], None],
 ) -> Any:
     """Execute pure sweep rows through JAX vmap or row-wise execution."""
+    # Zero rows run nothing, so there is no body for a dispatch to trace and no
+    # per-row output for the paths to disagree over: every dispatch takes the
+    # same empty aggregation, which is what keeps the output schema independent
+    # of how the rows would have been executed.
+    if plan.n_sweep == 0:
+        return []
+
     has_dist_array = any(
         isinstance(_workflow_call.input_ref_value(values, ref), DistributionArray)
         for ref in array_args

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import math
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
@@ -954,11 +955,15 @@ class Function(Node, TrackedTerm, Annotated):
                 probe_leaves = []
                 for source in batched_sources.values():
                     n_batch = len(source.batch_shape)
+                    # The flat size is stated, exactly as the executor states it:
+                    # a ``-1`` cannot be inferred over a zero-width event, which
+                    # is a shape the real reshape handles.
+                    n_rows = int(math.prod(source.batch_shape))
                     probe_leaves.append(
                         {
                             leaf: jnp.reshape(
                                 jnp.asarray(source[leaf]),
-                                (-1, *jnp.shape(source[leaf])[n_batch:]),
+                                (n_rows, *jnp.shape(source[leaf])[n_batch:]),
                             )[:1]
                             for leaf in source.event_template
                         }

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -46,6 +46,7 @@ from ._record_array import RecordArray
 from ._record_batch import RecordBatch
 from .event_template import ArraySpec, EventTemplate, _concretize_event_template
 from .provenance import Provenance
+from .record import Record
 from .tracked import Annotated, TrackedTerm, auto_name
 
 logger = logging.getLogger(__name__)
@@ -880,10 +881,22 @@ class Function(Node, TrackedTerm, Annotated):
         *,
         func: Callable[..., Any],
     ) -> Exception | None:
-        """Return the JAX trace-probe error for the current call, if any."""
+        """Return the JAX trace-probe error for the current call, if any.
+
+        The probe traces the operation the dispatch is choosing, not merely the
+        body: a sweep runs the body under ``jax.vmap``, and a body can trace
+        cleanly bare yet be impossible under the transform — one that returns a
+        batch, whose added axis no level can name. So a batched-record argument
+        is probed the way ``execute_sweep_rows_jax`` will actually feed it: its
+        leaf columns, mapped over one row, rebuilt into a ``Record`` inside the
+        traced call. A probe failure means sequential dispatch, which is always
+        able to run the call — the two paths agree on results by contract, so
+        falling back costs speed, never correctness.
+        """
         try:
             dummy_kw = dict(values)
             broadcast_refs = set(broadcast_args)
+            batched_sources: dict[_workflow_call.WorkflowInputRef, Any] = {}
             for ref in _workflow_call.iter_input_refs(self._signature_info, values):
                 v = _workflow_call.input_ref_value(values, ref)
                 if ref in broadcast_refs:
@@ -892,6 +905,7 @@ class Function(Node, TrackedTerm, Annotated):
                     # receive.
                     if isinstance(v, (RecordArray, RecordBatch)):
                         replacement = v[0]
+                        batched_sources[ref] = v
                     else:
                         dist = v
                         # ``event_shape`` raises on multi-field NRDs
@@ -926,7 +940,32 @@ class Function(Node, TrackedTerm, Annotated):
                     else:
                         replacement = v
                     dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, replacement)
-            jax.make_jaxpr(lambda kw: func(**kw))(dummy_kw)
+            if batched_sources:
+                refs = list(batched_sources)
+
+                def _row_call(rows_leaves):
+                    kw = dummy_kw
+                    for row_ref, leaves in zip(refs, rows_leaves):
+                        kw = _workflow_call.replace_input_ref(
+                            kw, row_ref, Record(row_ref.label, leaves, name_is_auto=True)
+                        )
+                    return func(**kw)
+
+                probe_leaves = []
+                for source in batched_sources.values():
+                    n_batch = len(source.batch_shape)
+                    probe_leaves.append(
+                        {
+                            leaf: jnp.reshape(
+                                jnp.asarray(source[leaf]),
+                                (-1, *jnp.shape(source[leaf])[n_batch:]),
+                            )[:1]
+                            for leaf in source.event_template
+                        }
+                    )
+                jax.make_jaxpr(jax.vmap(_row_call))(tuple(probe_leaves))
+            else:
+                jax.make_jaxpr(lambda kw: func(**kw))(dummy_kw)
         except Exception as exc:
             return exc
         return None

--- a/probpipe/diagnostics/_utils.py
+++ b/probpipe/diagnostics/_utils.py
@@ -38,7 +38,7 @@ def _is_structured(value: Any) -> bool:
 def _leaf_keys(value: Any) -> list[str]:
     """Leaf keys of a draws/samples container, one export variable per leaf.
 
-    A real ``Record`` / ``RecordArray`` (or a posterior wrapping one) exposes
+    A real ``Record`` / ``RecordBatch`` (or a posterior wrapping one) exposes
     the ``/``-path of every leaf via its ``event_template`` — the nested-aware
     enumeration, and the single duck-typing rule the diagnostics exporters
     share. Objects without a template (e.g. test doubles) fall back to the

--- a/probpipe/distributions/_joint_empirical.py
+++ b/probpipe/distributions/_joint_empirical.py
@@ -366,14 +366,17 @@ class NumericJointEmpirical(
     # -- Sampling: return NumericRecordArray for batched draws --------------
 
     def _sample_joint_rows(self, key: PRNGKey, sample_shape: tuple[int, ...]):
-        from ..core._record_array import NumericRecordArray
+        from ..core._numeric_record_batch import NumericRecordBatch
 
         result = self._resample_rows(key, sample_shape)
         if sample_shape:
-            return NumericRecordArray(
+            return NumericRecordBatch(
                 result,
-                batch_shape=sample_shape,
-                template=self.event_template,
+                "draw",
+                element_spec=self.event_template,
+                axis_groups=(sample_shape,),
+                name=self.name,
+                name_is_auto=True,
             )
         return Record(self.name, result, name_is_auto=True)
 

--- a/probpipe/distributions/_joint_empirical.py
+++ b/probpipe/distributions/_joint_empirical.py
@@ -208,12 +208,32 @@ class JointEmpirical(RecordDistribution, SupportsSampling, SupportsConditioning)
     def _sample_joint_rows(self, key: PRNGKey, sample_shape: tuple[int, ...]):
         """Resample rows jointly, preserving per-row correlation.
 
-        The generic base returns a ``Record`` regardless of
-        ``sample_shape`` (with batched fields for non-empty shapes).
-        Subclasses override to return a typed batched container (e.g.
-        ``NumericRecordArray``) when the leaves are numeric.
+        A batched draw is a batch over one ``draw`` level, a single draw a
+        ``Record``. The class follows the leaves — a numeric template gives a
+        :class:`NumericRecordBatch` and anything else the permissive
+        :class:`RecordBatch` — so an object-valued law draws a batch on the same
+        terms as a numeric one.
         """
-        return Record(self.name, self._resample_rows(key, sample_shape), name_is_auto=True)
+        from ..core._numeric_record_batch import NumericRecordBatch
+        from ..core._record_batch import RecordBatch
+        from ..core.event_template import NumericEventTemplate
+
+        rows = self._resample_rows(key, sample_shape)
+        if not sample_shape:
+            return Record(self.name, rows, name_is_auto=True)
+        cls = (
+            NumericRecordBatch
+            if isinstance(self.event_template, NumericEventTemplate)
+            else RecordBatch
+        )
+        return cls(
+            rows,
+            "draw",
+            element_spec=self.event_template,
+            axis_groups=(sample_shape,),
+            name=self.name,
+            name_is_auto=True,
+        )
 
     def _resample_rows(
         self,
@@ -362,23 +382,6 @@ class NumericJointEmpirical(
             cname: RecordEmpiricalDistribution(arr, weights=self._w, name=cname)
             for cname, arr in self._joint_samples.items()
         }
-
-    # -- Sampling: return NumericRecordArray for batched draws --------------
-
-    def _sample_joint_rows(self, key: PRNGKey, sample_shape: tuple[int, ...]):
-        from ..core._numeric_record_batch import NumericRecordBatch
-
-        result = self._resample_rows(key, sample_shape)
-        if sample_shape:
-            return NumericRecordBatch(
-                result,
-                "draw",
-                element_spec=self.event_template,
-                axis_groups=(sample_shape,),
-                name=self.name,
-                name_is_auto=True,
-            )
-        return Record(self.name, result, name_is_auto=True)
 
     # -- event_shapes (used by the record template) ------------------------
 

--- a/probpipe/distributions/_joint_gaussian.py
+++ b/probpipe/distributions/_joint_gaussian.py
@@ -174,17 +174,20 @@ class JointGaussian(
 
     def _unflatten_flat_vec(self, flat: Array, sample_shape: tuple[int, ...] = ()):
         """Split a flat Gaussian sample vector into per-component arrays."""
-        from ..core._record_array import NumericRecordArray
+        from ..core._numeric_record_batch import NumericRecordBatch
 
         result = {}
         for cname in self._component_shapes:
             sl = self._component_slices[cname]
             result[cname] = flat[..., sl]
         if sample_shape:
-            return NumericRecordArray(
+            return NumericRecordBatch(
                 result,
-                batch_shape=sample_shape,
-                template=self.event_template,
+                "draw",
+                element_spec=self.event_template,
+                axis_groups=(sample_shape,),
+                name=self.name,
+                name_is_auto=True,
             )
         return Record(self.name, result, name_is_auto=True)
 

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -275,7 +275,8 @@ class ProductDistribution(
             a :class:`NumericRecordDistribution` (the dynamic mixin
             case), otherwise a plain :class:`RecordArray`.
         """
-        from ..core._record_array import NumericRecordArray, RecordArray
+        from ..core._numeric_record_batch import NumericRecordBatch
+        from ..core._record_batch import RecordBatch
 
         names = list(self._components.keys())
         keys = jax.random.split(key, len(names))
@@ -296,15 +297,21 @@ class ProductDistribution(
             # NRD mixin → numeric batched container; otherwise the
             # plain RecordArray which doesn't require numeric leaves.
             if isinstance(self, NumericRecordDistribution):
-                return NumericRecordArray(
+                return NumericRecordBatch(
                     fields,
-                    batch_shape=sample_shape,
-                    template=self.event_template,
+                    "draw",
+                    element_spec=self.event_template,
+                    axis_groups=(sample_shape,),
+                    name=self.name,
+                    name_is_auto=True,
                 )
-            return RecordArray(
+            return RecordBatch(
                 fields,
-                batch_shape=sample_shape,
-                template=self.event_template,
+                "draw",
+                element_spec=self.event_template,
+                axis_groups=(sample_shape,),
+                name=self.name,
+                name_is_auto=True,
             )
         return Record(self.name, fields, name_is_auto=True)
 
@@ -560,10 +567,18 @@ def _sample_nested(name: str, components: dict, key, sample_shape, template=None
         else:
             fields[field_name] = comp._sample(subkey, sample_shape)
     if sample_shape and template is not None:
-        from ..core._record_array import NumericRecordArray, RecordArray
+        from ..core._numeric_record_batch import NumericRecordBatch
+        from ..core._record_batch import RecordBatch
 
-        cls = NumericRecordArray if numeric else RecordArray
-        return cls(fields, batch_shape=sample_shape, template=template)
+        cls = NumericRecordBatch if numeric else RecordBatch
+        return cls(
+            fields,
+            "draw",
+            element_spec=template,
+            axis_groups=(sample_shape,),
+            name=name,
+            name_is_auto=True,
+        )
     return Record(name, fields, name_is_auto=True)
 
 

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -28,6 +28,7 @@ from ..core._record_distribution import (
     _build_event_template,
     _register_dynamic_subclass,
 )
+from ..core.named_tree import _PATH_SEP
 from ..core.protocols import (
     SupportsConditioning,
     SupportsLogProb,
@@ -269,49 +270,40 @@ class ProductDistribution(
 
         Returns
         -------
-        Record or NumericRecordArray or RecordArray
+        Record or NumericRecordBatch or RecordBatch
             ``Record`` when ``sample_shape == ()``. With a non-empty
-            ``sample_shape``: ``NumericRecordArray`` when every leaf is
-            a :class:`NumericRecordDistribution` (the dynamic mixin
-            case), otherwise a plain :class:`RecordArray`.
+            ``sample_shape``: a batch of draws over one ``draw`` level,
+            :class:`NumericRecordBatch` when every leaf is a
+            :class:`NumericRecordDistribution` (the dynamic mixin case),
+            otherwise a plain :class:`RecordBatch`.
         """
         from ..core._numeric_record_batch import NumericRecordBatch
         from ..core._record_batch import RecordBatch
 
-        names = list(self._components.keys())
-        keys = jax.random.split(key, len(names))
-        numeric = isinstance(self, NumericRecordDistribution)
-        fields: dict[str, jnp.ndarray | Record] = {}
-        for subkey, name in zip(keys, names):
-            comp = self._components[name]
-            if isinstance(comp, dict):
-                # Pass the sub-template so a batched nested draw is a nested
-                # record-array (canonical, flattenable), not a plain Record.
-                sub_template = self.event_template.children[name] if sample_shape else None
-                fields[name] = _sample_nested(
-                    name, comp, subkey, sample_shape, template=sub_template, numeric=numeric
-                )
-            else:
-                fields[name] = comp._sample(subkey, sample_shape)
         if sample_shape:
-            # NRD mixin → numeric batched container; otherwise the
-            # plain RecordArray which doesn't require numeric leaves.
-            if isinstance(self, NumericRecordDistribution):
-                return NumericRecordBatch(
-                    fields,
-                    "draw",
-                    element_spec=self.event_template,
-                    axis_groups=(sample_shape,),
-                    name=self.name,
-                    name_is_auto=True,
-                )
-            return RecordBatch(
-                fields,
+            # A batch stores one column per *field*, so a nested product's draw
+            # is one flat batch over leaf paths rather than a batch per subtree.
+            # NRD mixin → the numeric batch; otherwise the plain one, which does
+            # not require numeric leaves.
+            cls = NumericRecordBatch if isinstance(self, NumericRecordDistribution) else RecordBatch
+            return cls(
+                _sample_columns(self._components, key, sample_shape),
                 "draw",
                 element_spec=self.event_template,
                 axis_groups=(sample_shape,),
                 name=self.name,
                 name_is_auto=True,
+            )
+
+        names = list(self._components.keys())
+        keys = jax.random.split(key, len(names))
+        fields: dict[str, jnp.ndarray | Record] = {}
+        for subkey, name in zip(keys, names):
+            comp = self._components[name]
+            fields[name] = (
+                _sample_nested(name, comp, subkey)
+                if isinstance(comp, dict)
+                else comp._sample(subkey, ())
             )
         return Record(self.name, fields, name_is_auto=True)
 
@@ -543,41 +535,54 @@ class TFPProductDistribution(ProductDistribution):
 # -- Helpers for nested component pytrees ----------------------------------
 
 
-def _sample_nested(name: str, components: dict, key, sample_shape, template=None, numeric=False):
-    """Recursively sample from nested component dicts.
+def _sample_columns(components: dict, key, sample_shape) -> dict:
+    """One column per leaf of *components*, keyed by its leaf path.
 
-    For an **unbatched** draw (``sample_shape == ()``) returns a plain nested
-    ``Record``. For a **batched** draw returns a nested record-array
-    (``NumericRecordArray`` when ``numeric`` else ``RecordArray``) carrying the
-    sub-``template`` and ``batch_shape``, so the result is canonical and
-    flattenable rather than a plain ``Record`` with batch-shaped leaves.
+    A batch stores a column per field rather than a value per element, so a
+    nested product draws into one flat mapping over ``/``-paths — the keying the
+    batch constructor takes. A component that draws a structured value of its own
+    contributes its leaves under its own path, so a sub-product nests by path
+    rather than by containment.
+
+    Keys are split per level, exactly as the unbatched recursion splits them, so
+    a batched draw and a single draw derive their subkeys the same way.
     """
+    from ..core._record_batch import RecordBatch
+
+    names = list(components.keys())
+    keys = jax.random.split(key, len(names))
+    columns: dict = {}
+    for subkey, field_name in zip(keys, names):
+        comp = components[field_name]
+        if isinstance(comp, dict):
+            columns.update(
+                {
+                    f"{field_name}{_PATH_SEP}{path}": column
+                    for path, column in _sample_columns(comp, subkey, sample_shape).items()
+                }
+            )
+            continue
+        drawn = comp._sample(subkey, sample_shape)
+        if isinstance(drawn, (Record, RecordBatch)):
+            columns.update(
+                {f"{field_name}{_PATH_SEP}{path}": drawn[path] for path in drawn.event_template}
+            )
+        else:
+            columns[field_name] = drawn
+    return columns
+
+
+def _sample_nested(name: str, components: dict, key) -> Record:
+    """One single draw from nested component dicts, as a nested ``Record``."""
     names = list(components.keys())
     keys = jax.random.split(key, len(names))
     fields: dict = {}
     for subkey, field_name in zip(keys, names):
         comp = components[field_name]
-        if isinstance(comp, dict):
-            # ``children`` (not ``[]``): the sub-template is an interior node,
-            # and template ``[]`` is leaf-only.
-            sub_template = template.children[field_name] if template is not None else None
-            fields[field_name] = _sample_nested(
-                field_name, comp, subkey, sample_shape, template=sub_template, numeric=numeric
-            )
-        else:
-            fields[field_name] = comp._sample(subkey, sample_shape)
-    if sample_shape and template is not None:
-        from ..core._numeric_record_batch import NumericRecordBatch
-        from ..core._record_batch import RecordBatch
-
-        cls = NumericRecordBatch if numeric else RecordBatch
-        return cls(
-            fields,
-            "draw",
-            element_spec=template,
-            axis_groups=(sample_shape,),
-            name=name,
-            name_is_auto=True,
+        fields[field_name] = (
+            _sample_nested(field_name, comp, subkey)
+            if isinstance(comp, dict)
+            else comp._sample(subkey, ())
         )
     return Record(name, fields, name_is_auto=True)
 

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -563,7 +563,16 @@ def _sample_columns(components: dict, key, sample_shape) -> dict:
             )
             continue
         drawn = comp._sample(subkey, sample_shape)
-        if isinstance(drawn, (Record, RecordBatch)):
+        if isinstance(drawn, RecordBatch):
+            # Raw columns: a field that is not an array presents as its own object
+            # batch, and what belongs in this batch's storage is the column.
+            columns.update(
+                {
+                    f"{field_name}{_PATH_SEP}{path}": column
+                    for path, column in drawn._raw_columns().items()
+                }
+            )
+        elif isinstance(drawn, Record):
             columns.update(
                 {f"{field_name}{_PATH_SEP}{path}": drawn[path] for path in drawn.event_template}
             )

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -321,15 +321,18 @@ class SequentialJointDistribution(
         key: PRNGKey,
         sample_shape: tuple[int, ...] = (),
     ):
-        from ..core._record_array import NumericRecordArray
+        from ..core._numeric_record_batch import NumericRecordBatch
 
         full = self._sample_sequential(key, sample_shape)
         fields = {k: v for k, v in full.items() if k not in self._conditioned_names}
         if sample_shape:
-            return NumericRecordArray(
+            return NumericRecordBatch(
                 fields,
-                batch_shape=sample_shape,
-                template=self.event_template,
+                "draw",
+                element_spec=self.event_template,
+                axis_groups=(sample_shape,),
+                name=self.name,
+                name_is_auto=True,
             )
         return Record(self.name, fields, name_is_auto=True)
 

--- a/probpipe/inference/_minibatch.py
+++ b/probpipe/inference/_minibatch.py
@@ -38,8 +38,10 @@ from typing import TYPE_CHECKING, Any
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from ..core._distribution_base import Distribution
+from ..core._object_batch import _is_object_array
 from ..core._random_functions import RandomFunction
 from ..core._random_measures import RandomMeasure
 from ..core._record_array import RecordArray
@@ -98,6 +100,13 @@ def _data_size(data: Any) -> int:
     return len(data)
 
 
+def _index_column(column: Any, indices: Array) -> Any:
+    """One column's rows at *indices*, keeping an object column out of ``jnp``."""
+    if _is_object_array(column):
+        return column[np.asarray(indices)]
+    return jnp.asarray(column)[indices]
+
+
 def _index_along_leading(data: Any, indices: Array) -> Any:
     """Index along the leading axis. Works for records, batches of them, and arrays.
 
@@ -108,9 +117,11 @@ def _index_along_leading(data: Any, indices: Array) -> Any:
     both are read a field at a time.
     """
     if isinstance(data, RecordBatch):
+        # Raw columns, not ``data[path]``: a non-array field presents as its own
+        # object batch, which ``jnp.asarray`` cannot take.
         return Record(
             data.name,
-            {path: jnp.asarray(data[path])[indices] for path in data.event_template},
+            {path: _index_column(data._raw_column(path), indices) for path in data.event_template},
             name_is_auto=True,
         )
     if isinstance(data, Record):

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -830,7 +830,7 @@ class TestMakeStack:
         from probpipe import NumericRecordArray
         from probpipe.core._broadcast_distributions import _make_stack
 
-        out = _make_stack([1.0, 2.0, 3.0, 4.0], n=4, field_name="demo")
+        out = _make_stack([1.0, 2.0, 3.0, 4.0], n=4, field_name="demo", level_names=("sweep",))
         assert isinstance(out, NumericRecordArray)
         assert out.batch_shape == (4,)
         assert out.fields == ("demo",)
@@ -841,7 +841,7 @@ class TestMakeStack:
         from probpipe.core._broadcast_distributions import _make_stack
 
         values = [jnp.arange(3.0) + 10.0 * i for i in range(4)]
-        out = _make_stack(values, n=4, field_name="demo")
+        out = _make_stack(values, n=4, field_name="demo", level_names=("sweep",))
         assert isinstance(out, NumericRecordArray)
         assert out.batch_shape == (4,)
         assert out["demo"].shape == (4, 3)
@@ -851,7 +851,7 @@ class TestMakeStack:
         from probpipe.core._broadcast_distributions import _make_stack
 
         records = [NumericRecord("nr", a=float(i), b=float(i) * 2) for i in range(5)]
-        out = _make_stack(records, n=5, field_name="demo")
+        out = _make_stack(records, n=5, field_name="demo", level_names=("sweep",))
         assert isinstance(out, NumericRecordArray)
         assert out.batch_shape == (5,)
         np.testing.assert_allclose(out["a"], [0, 1, 2, 3, 4])
@@ -866,7 +866,7 @@ class TestMakeStack:
         from probpipe.core._broadcast_distributions import _make_stack
 
         records = [Record("r", a=float(i), label=f"row{i}") for i in range(3)]
-        out = _make_stack(records, n=3, field_name="demo")
+        out = _make_stack(records, n=3, field_name="demo", level_names=("sweep",))
         assert isinstance(out, RecordArray)
         assert not isinstance(out, NumericRecordArray)
         np.testing.assert_allclose(out["a"], [0.0, 1.0, 2.0])
@@ -881,7 +881,7 @@ class TestMakeStack:
         from probpipe.core.event_template import ArraySpec, OpaqueSpec
 
         records = [Record("r", x=jnp.ones(2, dtype=jnp.bfloat16), label=f"r{i}") for i in range(3)]
-        out = _make_stack(records, n=3, field_name="demo")
+        out = _make_stack(records, n=3, field_name="demo", level_names=("sweep",))
         assert isinstance(out, RecordArray)
         assert out["x"].dtype == jnp.bfloat16
         assert out.template["x"] == ArraySpec((2,))  # numeric, not None/opaque
@@ -892,7 +892,7 @@ class TestMakeStack:
         from probpipe.core._broadcast_distributions import _make_stack
 
         comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(3)]
-        out = _make_stack(comps, n=3, field_name="demo")
+        out = _make_stack(comps, n=3, field_name="demo", level_names=("sweep",))
         assert isinstance(out, DistributionArray)
         assert out.batch_shape == (3,)
         assert out[0] is comps[0]
@@ -907,7 +907,7 @@ class TestMakeStack:
             NumericRecordArray.stack([NumericRecord("nr", x=float(i * 10 + j)) for j in range(4)])
             for i in range(3)
         ]
-        out = _make_stack(inner, n=3, field_name="demo")
+        out = _make_stack(inner, n=3, field_name="demo", level_names=("sweep",))
         assert isinstance(out, NumericRecordArray)
         assert out.batch_shape == (3, 4)
         np.testing.assert_allclose(out["x"][0], [0, 1, 2, 3])
@@ -920,7 +920,7 @@ class TestMakeStack:
         from probpipe.core._broadcast_distributions import _make_stack
 
         arr = jnp.arange(12.0).reshape(4, 3)
-        out = _make_stack(arr, n=4, field_name="demo")
+        out = _make_stack(arr, n=4, field_name="demo", level_names=("sweep",))
         assert isinstance(out, NumericRecordArray)
         assert out.batch_shape == (4,)
         assert out["demo"].shape == (4, 3)
@@ -935,6 +935,7 @@ class TestMakeStack:
                 n=4,
                 field_name="demo",
                 event_template=EventTemplate(left=(2,), right=(2,)),
+                level_names=("sweep",),
             )
 
     def test_declared_vmap_array_preserves_nested_single_leaf_path(self):
@@ -949,6 +950,7 @@ class TestMakeStack:
             n=4,
             field_name="demo",
             event_template=template,
+            level_names=("sweep",),
         )
 
         assert out.event_template == template
@@ -966,6 +968,7 @@ class TestMakeStack:
             batch_shape=(2, 3),
             field_name="demo",
             event_template=template,
+            level_names=("sweep",),
         )
 
         assert out.batch_shape == (2, 3)
@@ -980,7 +983,7 @@ class TestMakeStack:
         from probpipe.core._broadcast_distributions import _make_stack
 
         rec = Record("r", x=jnp.arange(5.0), y=jnp.arange(5.0) + 10)
-        out = _make_stack(rec, n=5, field_name="demo")
+        out = _make_stack(rec, n=5, field_name="demo", level_names=("sweep",))
         assert isinstance(out, NumericRecordArray)
         assert out.batch_shape == (5,)
 
@@ -988,13 +991,13 @@ class TestMakeStack:
         from probpipe.core._broadcast_distributions import _make_stack
 
         with pytest.raises(ValueError, match=r"expected prod\(batch_shape\)=5"):
-            _make_stack([1.0, 2.0, 3.0], n=5, field_name="demo")
+            _make_stack([1.0, 2.0, 3.0], n=5, field_name="demo", level_names=("sweep",))
 
     def test_ndarray_leading_axis_mismatch_raises(self):
         from probpipe.core._broadcast_distributions import _make_stack
 
         with pytest.raises(ValueError, match="expected leading axis"):
-            _make_stack(jnp.arange(6.0), n=4, field_name="demo")
+            _make_stack(jnp.arange(6.0), n=4, field_name="demo", level_names=("sweep",))
 
 
 # ===========================================================================
@@ -1056,6 +1059,7 @@ class TestCoerceOutput:
             [Normal(loc=0.0, scale=1.0, name=f"d{i}") for i in range(3)],
             n=3,
             field_name="demo",
+            level_names=("sweep",),
         )
         assert isinstance(da, DistributionArray)
         assert da.provenance is None

--- a/tests/core/test_distribution_array.py
+++ b/tests/core/test_distribution_array.py
@@ -498,7 +498,9 @@ class TestSampleViaSweep:
         da = _make_distribution_array(comps)
         s = sample(da, sample_shape=(5,))
         assert isinstance(s, NumericRecordBatch)
-        assert s.level_names == ("sweep", "draw")
+        # The sweep mints the level it swept — here the argument's own name,
+        # the distribution array carrying no levels of its own yet.
+        assert s.level_names == ("dist", "draw")
         # sweep (3,) + inner batch (5,) → (3, 5); fields carry no leaf
         # (scalar Normals inside the Product).
         assert s.batch_shape == (3, 5)

--- a/tests/core/test_distribution_array.py
+++ b/tests/core/test_distribution_array.py
@@ -33,6 +33,7 @@ from probpipe.core._distribution_array import (
     DistributionArray,
     _make_distribution_array,
 )
+from probpipe.core._numeric_record_batch import NumericRecordBatch
 
 # ---------------------------------------------------------------------------
 # Construction & invariants
@@ -496,7 +497,8 @@ class TestSampleViaSweep:
         ]
         da = _make_distribution_array(comps)
         s = sample(da, sample_shape=(5,))
-        assert isinstance(s, NumericRecordArray)
+        assert isinstance(s, NumericRecordBatch)
+        assert s.level_names == ("sweep", "draw")
         # sweep (3,) + inner batch (5,) → (3, 5); fields carry no leaf
         # (scalar Normals inside the Product).
         assert s.batch_shape == (3, 5)

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -8,7 +8,8 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import NumericRecord, NumericRecordArray, Record
+from probpipe import NumericRecord, Record
+from probpipe.core._numeric_record_batch import NumericRecordBatch
 from probpipe.core.event_template import (
     ArraySpec,
     DistributionSpec,
@@ -1301,8 +1302,8 @@ class TestToVector:
     def test_batched_shape_is_batch_shape_plus_vector_size(self):
         tpl = EventTemplate(x=(), y=(3,))
         flat = jnp.arange(2 * 5 * tpl.vector_size, dtype=float).reshape(2, 5, tpl.vector_size)
-        v = NumericRecordArray.from_vector("nra", tpl, flat)
-        assert isinstance(v, NumericRecordArray)
+        v = NumericRecordBatch.from_vector("nra", tpl, flat, level_names="draw")
+        assert isinstance(v, NumericRecordBatch)
         assert v.to_vector().shape == (2, 5, tpl.vector_size)
 
 
@@ -1349,32 +1350,32 @@ class TestFromVectorRoundTripBatched:
     def test_single_batch_axis(self):
         tpl = EventTemplate(x=(), y=(3,))
         flat = jnp.arange(4 * tpl.vector_size, dtype=float).reshape(4, tpl.vector_size)
-        v = NumericRecordArray.from_vector("nra", tpl, flat)
-        assert isinstance(v, NumericRecordArray)
+        v = NumericRecordBatch.from_vector("nra", tpl, flat, level_names="draw")
+        assert isinstance(v, NumericRecordBatch)
         assert v.batch_shape == (4,)
-        assert NumericRecordArray.from_vector("nra", tpl, v.to_vector()) == v
+        assert NumericRecordBatch.from_vector("nra", tpl, v.to_vector(), level_names="draw") == v
 
     def test_multi_axis_batch_shape(self):
         # batch_shape=(2, 3) catches trailing-axis split / reshape bugs.
         tpl = EventTemplate(x=(), y=(3,), z=(2, 2))
         flat = jnp.arange(2 * 3 * tpl.vector_size, dtype=float).reshape(2, 3, tpl.vector_size)
-        v = NumericRecordArray.from_vector("nra", tpl, flat)
-        assert isinstance(v, NumericRecordArray)
+        v = NumericRecordBatch.from_vector("nra", tpl, flat, level_names="draw")
+        assert isinstance(v, NumericRecordBatch)
         assert v.batch_shape == (2, 3)
         assert jnp.array_equal(v.to_vector(), flat)
-        assert NumericRecordArray.from_vector("nra", tpl, v.to_vector()) == v
+        assert NumericRecordBatch.from_vector("nra", tpl, v.to_vector(), level_names="draw") == v
 
     def test_nested_multi_axis_batch_shape(self):
         # Nested numeric subtree + multi-axis batch: from_vector builds a nested
-        # NumericRecordArray as a field of the outer NumericRecordArray.
+        # NumericRecordBatch as a field of the outer NumericRecordBatch.
         tpl = EventTemplate(x=(), nested=EventTemplate(a=(), b=(2,)), y=(3,))
         flat = jnp.arange(2 * 3 * tpl.vector_size, dtype=float).reshape(2, 3, tpl.vector_size)
-        v = NumericRecordArray.from_vector("nra", tpl, flat)
-        assert isinstance(v, NumericRecordArray)
+        v = NumericRecordBatch.from_vector("nra", tpl, flat, level_names="draw")
+        assert isinstance(v, NumericRecordBatch)
         assert v.batch_shape == (2, 3)
-        assert isinstance(v.at_path("nested"), NumericRecordArray)
+        assert isinstance(v["nested"], NumericRecordBatch)
         assert v["nested/b"].shape == (2, 3, 2)
-        assert NumericRecordArray.from_vector("nra", tpl, v.to_vector()) == v
+        assert NumericRecordBatch.from_vector("nra", tpl, v.to_vector(), level_names="draw") == v
 
 
 class TestFromVectorErrors:

--- a/tests/core/test_first_class_function.py
+++ b/tests/core/test_first_class_function.py
@@ -1421,3 +1421,38 @@ class TestVariadicPlanning:
 
         assert result.num_atoms == 8
         assert result.provenance.metadata["broadcast_args"] == ["**extras['x']"]
+
+
+class TestDeclaredSupportOnABatchedOutput:
+    def test_every_column_is_checked_against_its_own_support(self):
+        """A batch is a collection, not a named tree: walking it as one finds no
+        children and asks a multi-field batch to convert to a single array."""
+        from probpipe import NumericRecordBatch
+
+        template = EventTemplate(
+            a=ArraySpec((), support=positive), b=ArraySpec((), support=positive)
+        )
+        valid = NumericRecordBatch(
+            {"a": jnp.ones(3), "b": jnp.ones(3) * 2},
+            "draw",
+            element_spec=EventTemplate(a=(), b=()),
+        )
+
+        result = Function(func=lambda: valid, output_template=template).apply()
+
+        assert result is valid
+
+    def test_a_column_outside_its_support_is_named(self):
+        from probpipe import NumericRecordBatch
+
+        template = EventTemplate(
+            a=ArraySpec((), support=positive), b=ArraySpec((), support=positive)
+        )
+        invalid = NumericRecordBatch(
+            {"a": jnp.ones(3), "b": jnp.asarray([1.0, -2.0, 3.0])},
+            "draw",
+            element_spec=EventTemplate(a=(), b=()),
+        )
+
+        with pytest.raises(ValueError, match=r"output at 'b'.*support positive"):
+            Function(func=lambda: invalid, output_template=template).apply()

--- a/tests/core/test_numeric_record_distribution_view.py
+++ b/tests/core/test_numeric_record_distribution_view.py
@@ -22,7 +22,7 @@ from probpipe import (
     Normal,
     NumericEventTemplate,
     NumericRecord,
-    NumericRecordArray,
+    NumericRecordBatch,
     ProductDistribution,
     cov,
     expectation,
@@ -121,7 +121,7 @@ class TestSampling:
     def test_sample_batched_is_record_array(self, mvn4, split_template):
         rec = mvn4.as_record_distribution(template=split_template)
         draws = sample(rec, key=jax.random.PRNGKey(0), sample_shape=(5,))
-        assert isinstance(draws, NumericRecordArray)
+        assert isinstance(draws, NumericRecordBatch)
         assert draws.batch_shape == (5,)
         assert draws["intercept"].shape == (5,)
         assert draws["slope"].shape == (5, 3)
@@ -186,7 +186,7 @@ class TestLogProb:
         rec = mvn4.as_record_distribution(template=split_template)
         key = jax.random.PRNGKey(5)
         flat_xs = mvn4._sample(key, sample_shape=(10,))
-        rec_xs = NumericRecordArray.from_vector("nra", split_template, flat_xs)
+        rec_xs = NumericRecordBatch.from_vector("nra", split_template, flat_xs, level_names="draw")
         lp_rec = jnp.asarray(log_prob(rec, rec_xs))
         lp_flat = jnp.asarray(log_prob(mvn4, flat_xs))
         np.testing.assert_allclose(lp_rec, lp_flat, rtol=1e-5)

--- a/tests/core/test_protocols.py
+++ b/tests/core/test_protocols.py
@@ -395,7 +395,7 @@ class TestSampleReturnTypeConvention:
 
     - Numeric distributions return ``Array`` (sample_shape + event_shape).
     - Record-based joints return ``Record`` / ``NumericRecord`` for an
-      unbatched draw (``sample_shape == ()``) and ``NumericRecordArray``
+      unbatched draw (``sample_shape == ()``) and ``NumericRecordBatch``
       for a batched draw.
     """
 
@@ -410,7 +410,7 @@ class TestSampleReturnTypeConvention:
 
     def test_product_distribution_return_types(self):
         from probpipe import Record
-        from probpipe.core._record_array import NumericRecordArray
+        from probpipe.core._numeric_record_batch import NumericRecordBatch
 
         dist = ProductDistribution(
             x=Normal(loc=0.0, scale=1.0, name="x"),
@@ -422,7 +422,7 @@ class TestSampleReturnTypeConvention:
         assert isinstance(s0, Record)
         # batched
         s1 = dist._sample(k, (5,))
-        assert isinstance(s1, NumericRecordArray)
+        assert isinstance(s1, NumericRecordBatch)
         assert s1.batch_shape == (5,)
 
     def test_no_distribution_exposes_sample_one(self):
@@ -446,7 +446,7 @@ class TestSampleReturnTypeConvention:
         import numpy as np
 
         from probpipe import Record
-        from probpipe.core._record_array import NumericRecordArray
+        from probpipe.core._numeric_record_batch import NumericRecordBatch
 
         # Build a small JointEmpirical from stored per-component samples
         je = JointEmpirical(
@@ -455,12 +455,12 @@ class TestSampleReturnTypeConvention:
         )
         k = jax.random.PRNGKey(0)
         assert isinstance(je._sample(k, ()), Record)
-        assert isinstance(je._sample(k, (4,)), NumericRecordArray)
+        assert isinstance(je._sample(k, (4,)), NumericRecordBatch)
         assert je._sample(k, (4,)).batch_shape == (4,)
 
     def test_joint_gaussian_return_types(self):
         from probpipe import Record
-        from probpipe.core._record_array import NumericRecordArray
+        from probpipe.core._numeric_record_batch import NumericRecordBatch
 
         jg = JointGaussian(
             x=1,
@@ -470,7 +470,7 @@ class TestSampleReturnTypeConvention:
         )
         k = jax.random.PRNGKey(0)
         assert isinstance(jg._sample(k, ()), Record)
-        assert isinstance(jg._sample(k, (5,)), NumericRecordArray)
+        assert isinstance(jg._sample(k, (5,)), NumericRecordBatch)
         assert jg._sample(k, (5,)).batch_shape == (5,)
 
 

--- a/tests/core/test_record_batch.py
+++ b/tests/core/test_record_batch.py
@@ -1003,10 +1003,34 @@ class TestFlatLayout:
         assert rebuilt["f"].dtype == jnp.float32
         np.testing.assert_array_equal(np.asarray(rebuilt["i"]), np.asarray([0, 1, 2]))
 
-    def test_from_vector_needs_a_name_for_every_batch_axis(self):
+    def test_from_vector_takes_every_batch_axis_as_one_named_level(self):
+        """One name is one level however many axes the flat vector carried: the
+        draw it came from is one multiplicity, not one per axis."""
+        template = EventTemplate(x=(2,))
+
+        batch = NumericRecordBatch.from_vector(
+            "v", template, jnp.zeros((4, 5, 2)), level_names="draw"
+        )
+
+        assert batch.level_names == ("draw",)
+        assert batch.batch_shape == (4, 5)
+        assert batch.axis_groups == ((4, 5),)
+
+    def test_from_vector_gives_several_names_one_axis_each(self):
+        template = EventTemplate(x=(2,))
+
+        batch = NumericRecordBatch.from_vector(
+            "v", template, jnp.zeros((4, 5, 2)), level_names=("chain", "draw")
+        )
+
+        assert batch.axis_groups == ((4,), (5,))
+
+    def test_from_vector_refuses_more_names_than_axes(self):
         template = EventTemplate(x=(2,))
         with pytest.raises(ValueError, match="need 2 level names"):
-            NumericRecordBatch.from_vector("v", template, jnp.zeros((4, 5, 2)), level_names="draw")
+            NumericRecordBatch.from_vector(
+                "v", template, jnp.zeros((4, 5, 2)), level_names=("chain", "draw", "extra")
+            )
 
     def test_to_vector_on_an_empty_selection(self):
         """The class advertises ``batch[0:0]``, so vectorizing one must work: the

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -443,6 +443,34 @@ class TestBatchFingerprinting:
 
         assert fingerprint(self._one()) != fingerprint(jnp.arange(3.0))
 
+    def test_equal_multi_field_batches_hash_equal(self):
+        from probpipe.core._fingerprint import fingerprint
+
+        def build():
+            return NumericRecordBatch(
+                {"a": jnp.arange(3.0), "b": jnp.arange(3.0) * 10},
+                "draw",
+                element_spec=EventTemplate(a=(), b=()),
+            )
+
+        assert fingerprint(build()) == fingerprint(build())
+
+    def test_swapping_two_columns_values_changes_the_hash(self):
+        from probpipe.core._fingerprint import fingerprint
+
+        ab = NumericRecordBatch(
+            {"a": jnp.arange(3.0), "b": jnp.arange(3.0) * 10},
+            "draw",
+            element_spec=EventTemplate(a=(), b=()),
+        )
+        ba = NumericRecordBatch(
+            {"a": jnp.arange(3.0) * 10, "b": jnp.arange(3.0)},
+            "draw",
+            element_spec=EventTemplate(a=(), b=()),
+        )
+
+        assert fingerprint(ab) != fingerprint(ba)
+
     def test_axis_grouping_changes_the_fingerprint(self):
         from probpipe.core._fingerprint import fingerprint
 
@@ -460,3 +488,180 @@ class TestBatchFingerprinting:
         )
 
         assert fingerprint(split) != fingerprint(joined)
+
+
+class TestMultiLevelSweeps:
+    def test_a_two_level_batch_sweeps_its_full_grid(self):
+        """The sweep addresses an element by position, one indexer per batch
+        axis; a flat index would read the leading axis alone and run off its
+        end at the third cell."""
+        grid = NumericRecordBatch(
+            {"x": jnp.arange(6.0).reshape(2, 3)},
+            ("chain", "draw"),
+            element_spec=EventTemplate(x=()),
+            axis_groups=((2,), (3,)),
+        )
+
+        @function
+        def scale(p):
+            return jnp.asarray(p["x"]) * 10.0
+
+        out = scale(p=grid)
+
+        assert out.batch_shape == (2, 3)
+        np.testing.assert_allclose(np.asarray(out["scale"]), np.arange(6.0).reshape(2, 3) * 10.0)
+
+    def test_two_groups_and_a_returned_batch_keep_their_partition(self):
+        """The aggregate mints one level per swept group, then the rows' own
+        levels: collapsing the sweep into one group would leave more names than
+        levels and refuse."""
+        a = NumericRecordBatch({"a": jnp.arange(2.0)}, "outer", element_spec=EventTemplate(a=()))
+        b = NumericRecordBatch({"b": jnp.arange(3.0)}, "inner", element_spec=EventTemplate(b=()))
+
+        @function
+        def rows(a, b):
+            return NumericRecordBatch(
+                {"s": jnp.asarray(a["a"]) + jnp.asarray(b["b"]) + jnp.zeros(2)},
+                "rows",
+                element_spec=EventTemplate(s=()),
+                axis_groups=((2,),),
+            )
+
+        out = rows(a=a, b=b)
+
+        assert out.level_names == ("outer", "inner", "rows")
+        assert out.axis_groups == ((2,), (3,), (2,))
+
+
+class TestAutoDispatchFallsBackForABatchReturningBody:
+    def test_the_default_dispatch_produces_the_sequential_result(self):
+        """The probe traces the vmap the dispatch is choosing, so a body vmap
+        cannot run — one returning a batch, whose added axis no level names —
+        resolves to sequential instead of failing mid-call. Dispatch paths
+        agree on results by contract, so the fallback changes speed alone."""
+        source = NumericRecordBatch(
+            {"x": jnp.arange(3.0)}, "draw", element_spec=EventTemplate(x=())
+        )
+
+        @function
+        def widen(v):
+            return NumericRecordBatch(
+                {"s": jnp.asarray(v["x"]) + jnp.zeros(2)},
+                "inner",
+                element_spec=EventTemplate(s=()),
+                axis_groups=((2,),),
+            )
+
+        out = widen(v=source)
+
+        assert out.level_names == ("draw", "inner")
+        assert out.batch_shape == (3, 2)
+
+    def test_a_numeric_body_is_unaffected(self):
+        source = NumericRecordBatch(
+            {"x": jnp.arange(3.0)}, "draw", element_spec=EventTemplate(x=())
+        )
+
+        @function
+        def double(v):
+            return jnp.asarray(v["x"]) * 2.0
+
+        out = double(v=source)
+
+        assert out.batch_shape == (3,)
+        np.testing.assert_allclose(np.asarray(out["double"]), [0.0, 2.0, 4.0])
+
+
+class TestSameRankTransformsCannotLieEither:
+    def test_a_resizing_transform_rewrites_the_level_sizes(self):
+        """Slicing keeps every axis, so the levels carry over onto the sizes the
+        columns actually have — where reusing the stored spec would claim two
+        rows above one-row columns."""
+        batch = NumericRecordBatch(
+            {"x": jnp.arange(2.0), "y": jnp.arange(2.0) * 10},
+            "draw",
+            element_spec=EventTemplate(x=(), y=()),
+        )
+
+        sliced = jax.tree.map(lambda leaf: leaf[:1], batch)
+
+        assert sliced.batch_shape == (1,)
+        assert sliced.level_names == ("draw",)
+        assert sliced._raw_column("x").shape == (1,)
+
+    def test_columns_that_disagree_are_refused(self):
+        import jax.tree_util as jtu
+
+        batch = NumericRecordBatch(
+            {"x": jnp.arange(2.0), "y": jnp.arange(2.0)},
+            "draw",
+            element_spec=EventTemplate(x=(), y=()),
+        )
+        _, treedef = jtu.tree_flatten(batch)
+
+        with pytest.raises(ValueError, match="disagreeing batch axes"):
+            jtu.tree_unflatten(treedef, [jnp.zeros(2), jnp.zeros(3)])
+
+
+class TestOpaqueBatchesStack:
+    def test_rows_holding_opaque_fields_stack_by_raw_column(self):
+        """One row's opaque field presents as an OpaqueBatch; stacking the
+        presented form hands wrappers to jnp.stack. The columns stack, through
+        numpy, so the objects ride as they are."""
+        from probpipe.core._broadcast_distributions import _make_stack
+
+        rows = [
+            RecordBatch(
+                {
+                    "tag": np.array([f"{i}a", f"{i}b"], dtype=object),
+                    "x": jnp.arange(2.0) + i,
+                },
+                "inner",
+                element_spec=EventTemplate(tag=None, x=()),
+            )
+            for i in range(3)
+        ]
+
+        out = _make_stack(rows, n=3, field_name="demo", level_names=("sweep",))
+
+        assert out.level_names == ("sweep", "inner")
+        assert out.batch_shape == (3, 2)
+        assert list(out._raw_column("tag")[2]) == ["2a", "2b"]
+        np.testing.assert_allclose(np.asarray(out._raw_column("x")[1]), [1.0, 2.0])
+
+
+class TestObjectValuedMarginals:
+    def test_an_object_batch_takes_the_list_marginal(self):
+        """The record marginal is empirical over numeric leaves, so an object
+        batch routes to the general list marginal: atoms and weights, no
+        numeric pretence."""
+        from probpipe.core._broadcast_distributions import _ListMarginal, _make_marginal
+
+        batch = RecordBatch(
+            {"tag": np.array(["a", "b", "c"], dtype=object), "x": jnp.arange(3.0)},
+            "draw",
+            element_spec=EventTemplate(tag=None, x=()),
+        )
+
+        marginal = _make_marginal(batch)
+
+        assert isinstance(marginal, _ListMarginal)
+        assert marginal.num_atoms == 3
+        assert [row["tag"] for row in marginal.items] == ["a", "b", "c"]
+
+
+class TestAnEmptySweepAnswersToItsTemplate:
+    def test_zero_rows_still_build_the_declared_fields(self):
+        source = NumericRecordBatch(
+            {"x": jnp.zeros((0,))}, "design", element_spec=EventTemplate(x=())
+        )
+
+        @function(output_template=EventTemplate(y=()))
+        def fit(p):
+            return {"y": jnp.asarray(p["x"]) * 2.0}
+
+        out = fit(p=source)
+
+        assert list(out.event_template) == ["y"]
+        assert out.batch_shape == (0,)
+        assert np.asarray(out["y"]).shape == (0,)

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -12,6 +12,8 @@ gates are pinned before any producer starts returning batches.
 
 from __future__ import annotations
 
+from typing import Any
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -375,3 +377,86 @@ class TestRetypingADeclaredOutputKeepsColumnsWithTheirKeys:
 
         np.testing.assert_array_equal(np.asarray(roundtripped["a"]), [0.0, 1.0, 2.0])
         np.testing.assert_array_equal(np.asarray(roundtripped["b"]), [0.0, 10.0, 20.0])
+
+
+class TestATransformCannotAddAnUnnamedLevel:
+    def test_an_added_batch_axis_is_refused(self):
+        """``vmap`` adds an axis on the way out, and unflattening has no name to
+        give the level it would belong to. Taking the stored spec instead would
+        return a batch whose own ``batch_shape`` its columns contradict."""
+
+        def body(x):
+            return NumericRecordBatch(
+                {"s": x + jnp.zeros(2)},
+                "inner",
+                element_spec=EventTemplate(s=()),
+                axis_groups=((2,),),
+            )
+
+        with pytest.raises(ValueError, match="An added axis belongs to no level"):
+            jax.vmap(body)(jnp.arange(3.0))
+
+    def test_a_dropped_batch_axis_still_renames_the_levels(self):
+        """The refusal is for *added* axes only: dropping one is what a transform
+        ordinarily does, and the surviving levels are named as before."""
+        batch = NumericRecordBatch(
+            {"s": jnp.zeros((3, 2))},
+            ("outer", "inner"),
+            element_spec=EventTemplate(s=()),
+            axis_groups=((3,), (2,)),
+        )
+
+        seen: list[Any] = []
+        jax.vmap(lambda b: seen.append(b) or jnp.zeros(()))(batch)
+
+        assert seen[0].level_names == ("inner",)
+        assert seen[0].batch_shape == (2,)
+
+
+class TestBatchFingerprinting:
+    """A batch's multiplicity is part of its type, so it is hashed."""
+
+    @staticmethod
+    def _one(level: str = "draw", groups=((3,),)):
+        return NumericRecordBatch(
+            {"x": jnp.arange(3.0)}, (level,), element_spec=EventTemplate(x=()), axis_groups=groups
+        )
+
+    def test_a_multi_field_batch_fingerprints(self):
+        from probpipe.core._fingerprint import fingerprint
+
+        batch = NumericRecordBatch(
+            {"a": jnp.arange(3.0), "b": jnp.arange(3.0)},
+            "draw",
+            element_spec=EventTemplate(a=(), b=()),
+        )
+
+        assert isinstance(fingerprint(batch), str)
+
+    def test_level_names_change_the_fingerprint(self):
+        from probpipe.core._fingerprint import fingerprint
+
+        assert fingerprint(self._one("draw")) != fingerprint(self._one("chain"))
+
+    def test_a_single_field_batch_is_not_its_column(self):
+        from probpipe.core._fingerprint import fingerprint
+
+        assert fingerprint(self._one()) != fingerprint(jnp.arange(3.0))
+
+    def test_axis_grouping_changes_the_fingerprint(self):
+        from probpipe.core._fingerprint import fingerprint
+
+        split = NumericRecordBatch(
+            {"x": jnp.zeros((2, 3))},
+            ("a", "b"),
+            element_spec=EventTemplate(x=()),
+            axis_groups=((2,), (3,)),
+        )
+        joined = NumericRecordBatch(
+            {"x": jnp.zeros((2, 3))},
+            "a",
+            element_spec=EventTemplate(x=()),
+            axis_groups=((2, 3),),
+        )
+
+        assert fingerprint(split) != fingerprint(joined)

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -396,9 +396,10 @@ class TestATransformCannotAddAnUnnamedLevel:
         with pytest.raises(ValueError, match="An added axis belongs to no level"):
             jax.vmap(body)(jnp.arange(3.0))
 
-    def test_a_dropped_batch_axis_still_renames_the_levels(self):
-        """The refusal is for *added* axes only: dropping one is what a transform
-        ordinarily does, and the surviving levels are named as before."""
+    def test_dropping_one_of_two_batch_axes_is_refused_too(self):
+        """An added axis is refused because no level names it; a *partially*
+        dropped one is refused because no shape says which level went. Removing
+        every axis is the case that works, and it yields a ``Record``."""
         batch = NumericRecordBatch(
             {"s": jnp.zeros((3, 2))},
             ("outer", "inner"),
@@ -406,11 +407,13 @@ class TestATransformCannotAddAnUnnamedLevel:
             axis_groups=((3,), (2,)),
         )
 
-        seen: list[Any] = []
-        jax.vmap(lambda b: seen.append(b) or jnp.zeros(()))(batch)
+        with pytest.raises(ValueError, match="keeps every batch axis or removes all of them"):
+            jax.vmap(lambda b: jnp.zeros(()))(batch)
 
-        assert seen[0].level_names == ("inner",)
-        assert seen[0].batch_shape == (2,)
+        single = NumericRecordBatch({"s": jnp.zeros(3)}, "outer", element_spec=EventTemplate(s=()))
+        seen: list[Any] = []
+        jax.vmap(lambda b: seen.append(type(b).__name__) or jnp.zeros(()))(single)
+        assert seen == ["NumericRecord"]
 
 
 class TestBatchFingerprinting:
@@ -580,18 +583,21 @@ class TestAutoDispatchFallsBackForABatchReturningBody:
 
 
 class TestSameRankTransformsCannotLieEither:
-    def test_a_resizing_transform_rewrites_the_level_sizes(self):
-        """Slicing keeps every axis, so the levels carry over onto the sizes the
-        columns actually have — where reusing the stored spec would claim two
-        rows above one-row columns."""
+    def test_a_resizing_transform_is_refused(self):
+        """Slicing keeps every axis and changes what the level holds. Carrying the
+        names onto the new sizes is right for a per-level slice and wrong for
+        anything else landing on the same shape, so it is refused; indexing is the
+        route that carries its selection instead of inferring it."""
         batch = NumericRecordBatch(
             {"x": jnp.arange(2.0), "y": jnp.arange(2.0) * 10},
             "draw",
             element_spec=EventTemplate(x=(), y=()),
         )
 
-        sliced = jax.tree.map(lambda leaf: leaf[:1], batch)
+        with pytest.raises(ValueError, match="keeps every batch axis or removes all of them"):
+            jax.tree.map(lambda leaf: leaf[:1], batch)
 
+        sliced = batch[0:1]
         assert sliced.batch_shape == (1,)
         assert sliced.level_names == ("draw",)
         assert sliced._raw_column("x").shape == (1,)
@@ -750,8 +756,11 @@ class TestZeroWidthEventsUnderExplicitJax:
 
 
 class TestShapeCannotRecoverAxisProvenance:
-    """Which axis a transform took is not readable off sizes alone; where two
-    stories explain one shape, the batch refuses rather than guesses."""
+    """Which axis a transform took is not readable off sizes alone, so a batch is
+    rebuilt only where no axis has to be identified: all of them kept, or all
+    removed. A partial reduction is refused whatever the sizes are — distinct
+    sizes narrow the candidates without establishing which axis the transform
+    actually consumed."""
 
     @staticmethod
     def _grid(chain: int, draw: int):
@@ -762,23 +771,16 @@ class TestShapeCannotRecoverAxisProvenance:
             axis_groups=((chain,), (draw,)),
         )
 
-    def test_removing_one_of_two_equal_axes_is_ambiguous(self):
-        with pytest.raises(ValueError, match="more than one of the levels"):
-            jax.vmap(lambda v: 0.0, in_axes=1)(self._grid(2, 2))
+    @pytest.mark.parametrize(("chain", "draw"), [(2, 2), (2, 3)], ids=["equal", "distinct"])
+    def test_removing_one_of_two_axes_is_refused(self, chain, draw):
+        with pytest.raises(ValueError, match="keeps every batch axis or removes all of them"):
+            jax.vmap(lambda v: 0.0, in_axes=1)(self._grid(chain, draw))
 
-    def test_a_distinctly_sized_removal_names_the_survivor(self):
-        """``in_axes=1`` strips ``draw``, so the body's batch is ``chain`` — the
-        level that survived, not the leftmost that fits."""
-        seen: list[Any] = []
-        jax.vmap(lambda v: seen.append(v) or 0.0, in_axes=1)(self._grid(2, 3))
-
-        assert seen[0].level_names == ("chain",)
-        assert seen[0].batch_shape == (2,)
-
-    def test_a_permutation_of_the_batch_axes_is_refused(self):
-        """A transpose reads like a per-axis resize by shape alone; retiling
-        would keep each level's name on an axis now holding another's rows."""
-        with pytest.raises(ValueError, match="permutation of the same sizes"):
+    def test_an_unequal_permutation_is_refused(self):
+        """A transpose changes the batch shape here, so it is caught by the same
+        gate a resize is. An *equal*-sized transpose changes nothing about the
+        shape and is undetectable — see the batch's own contract tests."""
+        with pytest.raises(ValueError, match="keeps every batch axis or removes all of them"):
             jax.tree.map(lambda leaf: leaf.T, self._grid(2, 3))
 
 
@@ -790,7 +792,7 @@ class TestATransformCannotRetypeTheElement:
             element_spec=EventTemplate(x=ArraySpec((), dtype=jnp.float32)),
         )
 
-        with pytest.raises(ValueError, match=r"never\s+retype the element"):
+        with pytest.raises(TypeError, match="does not admit"):
             jax.tree.map(lambda leaf: leaf.astype(jnp.complex64), batch)
 
     def test_a_same_kind_widening_is_admitted(self):

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -12,6 +12,7 @@ gates are pinned before any producer starts returning batches.
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -22,6 +23,7 @@ from probpipe import (
     Function,
     Normal,
     NumericRecord,
+    OpaqueBatch,
     ProductDistribution,
     Record,
     function,
@@ -313,3 +315,63 @@ class TestSiblingViewsZipThroughACall:
 
         assert out.batch_shape == (3,)
         np.testing.assert_allclose(np.asarray(out["add"]), [0.0, 11.0, 22.0])
+
+
+class TestOpaqueColumnsAreRearrangedRaw:
+    """A non-array field presents as its own object batch, so an operation that
+    rearranges the *storage* must read the column itself. Reading the presented
+    form instead breaks every field that is not an array."""
+
+    @staticmethod
+    def _mixed():
+        return RecordBatch(
+            {
+                "tag": np.array(["a", "b", "c"], dtype=object),
+                "x": jnp.arange(3.0),
+            },
+            "draw",
+            element_spec=EventTemplate(tag=None, x=()),
+        )
+
+    def test_presented_and_raw_columns_differ_for_an_opaque_field(self):
+        batch = self._mixed()
+
+        assert isinstance(batch["tag"], OpaqueBatch)
+        assert isinstance(batch._raw_column("tag"), np.ndarray)
+        # An array field is its column either way.
+        assert batch._raw_column("x") is batch["x"]
+
+    def test_gathering_rows_keeps_an_opaque_column(self):
+        from probpipe.core._broadcast_distributions import _take_rows
+
+        gathered = _take_rows(self._mixed(), jnp.array([2, 0]))
+
+        assert list(gathered._raw_column("tag")) == ["c", "a"]
+        np.testing.assert_array_equal(np.asarray(gathered._raw_column("x")), [2.0, 0.0])
+
+    def test_indexing_a_minibatch_keeps_an_opaque_column(self):
+        from probpipe.inference._minibatch import _index_along_leading
+
+        indexed = _index_along_leading(self._mixed(), jnp.array([1, 2]))
+
+        assert list(indexed["tag"]) == ["b", "c"]
+        np.testing.assert_array_equal(np.asarray(indexed["x"]), [1.0, 2.0])
+
+
+class TestRetypingADeclaredOutputKeepsColumnsWithTheirKeys:
+    def test_a_reordered_declaration_does_not_swap_columns(self):
+        """A batch flattens in its spec's leaf order, so retyping the spec alone
+        would pair every value with the wrong key on the next unflatten."""
+        from probpipe.core._workflow_result import _copy_result_term
+
+        batch = NumericRecordBatch(
+            {"a": jnp.arange(3.0), "b": jnp.arange(3.0) * 10},
+            "draw",
+            element_spec=EventTemplate(a=(), b=()),
+        )
+
+        retyped = _copy_result_term(batch, output_template=EventTemplate(b=(), a=()))
+        roundtripped = jax.jit(lambda x: x)(retyped)
+
+        np.testing.assert_array_equal(np.asarray(roundtripped["a"]), [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(np.asarray(roundtripped["b"]), [0.0, 10.0, 20.0])

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -558,9 +558,11 @@ class TestAutoDispatchFallsBackForABatchReturningBody:
         assert out.level_names == ("draw", "inner")
         assert out.batch_shape == (3, 2)
         # The fallback and an explicit sequential dispatch agree on values —
-        # the dispatch-equivalence contract, checked rather than assumed.
+        # the dispatch-equivalence contract — and both match the independently
+        # computed result, so agreement is not two wrongs agreeing.
         explicit = Function(func=body, dispatch="sequential")(v=source)
         np.testing.assert_allclose(np.asarray(out["s"]), np.asarray(explicit["s"]))
+        np.testing.assert_allclose(np.asarray(out["s"]), [[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
 
     def test_a_numeric_body_is_unaffected(self):
         source = NumericRecordBatch(
@@ -731,10 +733,125 @@ class TestZeroWidthEventsUnderExplicitJax:
         be inferred over zero width, so the probe states the size exactly as the
         executor does."""
         source = NumericRecordBatch(
-            {"x": jnp.zeros((3, 0))}, "draw", element_spec=EventTemplate(x=(0,))
+            {"x": jnp.zeros((3, 0)), "row": jnp.arange(3.0)},
+            "draw",
+            element_spec=EventTemplate(x=(0,), row=()),
         )
 
-        out = Function(func=lambda v: jnp.sum(jnp.asarray(v["x"])), dispatch="jax")(v=source)
+        out = Function(
+            func=lambda v: jnp.sum(jnp.asarray(v["x"])) + jnp.asarray(v["row"]),
+            dispatch="jax",
+        )(v=source)
 
         assert out.batch_shape == (3,)
-        np.testing.assert_allclose(np.asarray(out["<lambda>"]), [0.0, 0.0, 0.0])
+        # Row identities survive, so the zero-width column really was carried
+        # per row rather than the output being indistinguishable zeros.
+        np.testing.assert_allclose(np.asarray(out["<lambda>"]), [0.0, 1.0, 2.0])
+
+
+class TestShapeCannotRecoverAxisProvenance:
+    """Which axis a transform took is not readable off sizes alone; where two
+    stories explain one shape, the batch refuses rather than guesses."""
+
+    @staticmethod
+    def _grid(chain: int, draw: int):
+        return NumericRecordBatch(
+            {"x": jnp.arange(float(chain * draw)).reshape(chain, draw)},
+            ("chain", "draw"),
+            element_spec=EventTemplate(x=()),
+            axis_groups=((chain,), (draw,)),
+        )
+
+    def test_removing_one_of_two_equal_axes_is_ambiguous(self):
+        with pytest.raises(ValueError, match="more than one of the levels"):
+            jax.vmap(lambda v: 0.0, in_axes=1)(self._grid(2, 2))
+
+    def test_a_distinctly_sized_removal_names_the_survivor(self):
+        """``in_axes=1`` strips ``draw``, so the body's batch is ``chain`` — the
+        level that survived, not the leftmost that fits."""
+        seen: list[Any] = []
+        jax.vmap(lambda v: seen.append(v) or 0.0, in_axes=1)(self._grid(2, 3))
+
+        assert seen[0].level_names == ("chain",)
+        assert seen[0].batch_shape == (2,)
+
+    def test_a_permutation_of_the_batch_axes_is_refused(self):
+        """A transpose reads like a per-axis resize by shape alone; retiling
+        would keep each level's name on an axis now holding another's rows."""
+        with pytest.raises(ValueError, match="permutation of the same sizes"):
+            jax.tree.map(lambda leaf: leaf.T, self._grid(2, 3))
+
+
+class TestATransformCannotRetypeTheElement:
+    def test_a_changed_kind_is_refused(self):
+        batch = NumericRecordBatch(
+            {"x": jnp.zeros(3, dtype=jnp.float32)},
+            "draw",
+            element_spec=EventTemplate(x=ArraySpec((), dtype=jnp.float32)),
+        )
+
+        with pytest.raises(ValueError, match=r"never\s+retype the element"):
+            jax.tree.map(lambda leaf: leaf.astype(jnp.complex64), batch)
+
+    def test_a_same_kind_widening_is_admitted(self):
+        """The constructor admits same-kind casts, so the transform guard does
+        too — the two must agree on what conforms."""
+        batch = NumericRecordBatch(
+            {"x": jnp.zeros(3, dtype=jnp.float16)},
+            "draw",
+            element_spec=EventTemplate(x=ArraySpec((), dtype=jnp.float32)),
+        )
+
+        widened = jax.tree.map(lambda leaf: leaf.astype(jnp.float32), batch)
+
+        assert widened._raw_column("x").dtype == jnp.float32
+
+
+class TestZeroRowsAgreeAcrossDispatch:
+    def test_every_dispatch_takes_the_same_empty_aggregation(self):
+        """Zero rows run nothing, so there is no body to trace and no per-row
+        output for the paths to disagree over; the output schema must not
+        depend on how the rows would have been executed."""
+        source = NumericRecordBatch(
+            {"x": jnp.zeros((2, 0))},
+            ("a", "b"),
+            element_spec=EventTemplate(x=()),
+            axis_groups=((2,), (0,)),
+        )
+
+        def body(v):
+            return jnp.sum(jnp.asarray(v["x"]))
+
+        results = {
+            name: Function(func=body, dispatch=name)(v=source)
+            for name in ("auto", "sequential", "jax")
+        }
+
+        types = {type(r).__name__ for r in results.values()}
+        templates = {repr(r.event_template) for r in results.values()}
+        assert len(types) == 1
+        assert len(templates) == 1
+
+
+class TestFunctionValuedColumnsStack:
+    def test_rows_holding_callable_fields_stack_by_raw_column(self):
+        """A callable field presents as a FunctionBatch; the raw columns are
+        what stack, and the presentation survives the aggregation."""
+        from probpipe.core._broadcast_distributions import _make_stack
+        from probpipe.core._function_batch import FunctionBatch
+        from probpipe.core.event_template import FunctionSpec
+
+        rows = [
+            RecordBatch(
+                {"f": np.array([(lambda i=i, j=j: i * 10 + j) for j in range(2)], dtype=object)},
+                "inner",
+                element_spec=EventTemplate(f=FunctionSpec()),
+            )
+            for i in range(3)
+        ]
+
+        out = _make_stack(rows, n=3, field_name="demo", level_names=("sweep",))
+
+        assert out.level_names == ("sweep", "inner")
+        assert isinstance(out["f"], FunctionBatch)
+        assert out._raw_column("f")[2, 1]() == 21

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -531,6 +531,8 @@ class TestMultiLevelSweeps:
 
         assert out.level_names == ("outer", "inner", "rows")
         assert out.axis_groups == ((2,), (3,), (2,))
+        expected = (jnp.arange(2.0)[:, None] + jnp.arange(3.0)[None, :])[..., None] + jnp.zeros(2)
+        np.testing.assert_allclose(np.asarray(out["s"]), np.asarray(expected))
 
 
 class TestAutoDispatchFallsBackForABatchReturningBody:
@@ -543,8 +545,7 @@ class TestAutoDispatchFallsBackForABatchReturningBody:
             {"x": jnp.arange(3.0)}, "draw", element_spec=EventTemplate(x=())
         )
 
-        @function
-        def widen(v):
+        def body(v):
             return NumericRecordBatch(
                 {"s": jnp.asarray(v["x"]) + jnp.zeros(2)},
                 "inner",
@@ -552,10 +553,14 @@ class TestAutoDispatchFallsBackForABatchReturningBody:
                 axis_groups=((2,),),
             )
 
-        out = widen(v=source)
+        out = Function(func=body)(v=source)
 
         assert out.level_names == ("draw", "inner")
         assert out.batch_shape == (3, 2)
+        # The fallback and an explicit sequential dispatch agree on values —
+        # the dispatch-equivalence contract, checked rather than assumed.
+        explicit = Function(func=body, dispatch="sequential")(v=source)
+        np.testing.assert_allclose(np.asarray(out["s"]), np.asarray(explicit["s"]))
 
     def test_a_numeric_body_is_unaffected(self):
         source = NumericRecordBatch(
@@ -665,3 +670,71 @@ class TestAnEmptySweepAnswersToItsTemplate:
         assert list(out.event_template) == ["y"]
         assert out.batch_shape == (0,)
         assert np.asarray(out["y"]).shape == (0,)
+
+
+class TestATransformCannotResizeTheElement:
+    """The batch axes are a transform's to drop or resize; the element's own
+    axes are the element type's."""
+
+    @staticmethod
+    def _vector_batch():
+        return NumericRecordBatch(
+            {"x": jnp.zeros((3, 2))}, "draw", element_spec=EventTemplate(x=(2,))
+        )
+
+    def test_slicing_an_event_axis_is_refused(self):
+        with pytest.raises(ValueError, match="never the element's own"):
+            jax.tree.map(lambda leaf: leaf[:, :1], self._vector_batch())
+
+    def test_transposing_batch_and_event_axes_is_refused(self):
+        with pytest.raises(ValueError, match="never the element's own"):
+            jax.tree.map(lambda leaf: leaf.T, self._vector_batch())
+
+    def test_reducing_below_the_event_rank_is_refused(self):
+        with pytest.raises(ValueError, match="fewer axes"):
+            jax.tree.map(jnp.sum, self._vector_batch())
+
+
+class TestAnEmptySweepIsNotAMissingOutput:
+    def test_zero_expected_rows_build_the_declared_fields(self):
+        from probpipe.core._broadcast_distributions import _make_stack
+
+        out = _make_stack(
+            [],
+            batch_shape=(0,),
+            field_name="fit",
+            level_names=("design",),
+            event_template=EventTemplate(y=()),
+        )
+
+        assert list(out.event_template) == ["y"]
+        assert np.asarray(out["y"]).shape == (0,)
+
+    def test_missing_outputs_are_an_error_not_a_fabrication(self):
+        """An empty list where rows were expected reports the count mismatch;
+        fabricating the declared fields would hide a swallowed failure."""
+        from probpipe.core._broadcast_distributions import _make_stack
+
+        with pytest.raises(ValueError, match="got 0 outputs but expected"):
+            _make_stack(
+                [],
+                n=3,
+                field_name="fit",
+                level_names=("s",),
+                event_template=EventTemplate(y=()),
+            )
+
+
+class TestZeroWidthEventsUnderExplicitJax:
+    def test_the_probe_accepts_what_the_executor_runs(self):
+        """A (0,)-event column reshapes at the stated flat size; a ``-1`` cannot
+        be inferred over zero width, so the probe states the size exactly as the
+        executor does."""
+        source = NumericRecordBatch(
+            {"x": jnp.zeros((3, 0))}, "draw", element_spec=EventTemplate(x=(0,))
+        )
+
+        out = Function(func=lambda v: jnp.sum(jnp.asarray(v["x"])), dispatch="jax")(v=source)
+
+        assert out.batch_shape == (3,)
+        np.testing.assert_allclose(np.asarray(out["<lambda>"]), [0.0, 0.0, 0.0])

--- a/tests/core/test_workflow_plan.py
+++ b/tests/core/test_workflow_plan.py
@@ -70,7 +70,9 @@ class TestBroadcastRegime:
         assert plan.dist_args == ()
         assert plan.array_args == (_ref("p"),)
         assert plan.array_groups == (
-            ArrayBroadcastGroup(arg_refs=(_ref("p"),), batch_shape=(4,), size=4),
+            ArrayBroadcastGroup(
+                arg_refs=(_ref("p"),), batch_shape=(4,), size=4, level_names=("p",)
+            ),
         )
         assert plan.sweep_batch_shape == (4,)
         assert plan.n_sweep == 4
@@ -128,7 +130,9 @@ class TestArrayGrouping:
         assert plan.regime == "sweep"
         assert plan.array_args == (_ref("x"), _ref("y"))
         assert plan.array_groups == (
-            ArrayBroadcastGroup(arg_refs=(_ref("x"), _ref("y")), batch_shape=(4,), size=4),
+            ArrayBroadcastGroup(
+                arg_refs=(_ref("x"), _ref("y")), batch_shape=(4,), size=4, level_names=("x",)
+            ),
         )
         assert plan.sweep_batch_shape == (4,)
         assert plan.n_sweep == 4
@@ -141,8 +145,12 @@ class TestArrayGrouping:
 
         assert plan.regime == "sweep"
         assert plan.array_groups == (
-            ArrayBroadcastGroup(arg_refs=(_ref("a"),), batch_shape=(3,), size=3),
-            ArrayBroadcastGroup(arg_refs=(_ref("b"),), batch_shape=(2,), size=2),
+            ArrayBroadcastGroup(
+                arg_refs=(_ref("a"),), batch_shape=(3,), size=3, level_names=("a",)
+            ),
+            ArrayBroadcastGroup(
+                arg_refs=(_ref("b"),), batch_shape=(2,), size=2, level_names=("b",)
+            ),
         )
         assert plan.sweep_batch_shape == (3, 2)
         assert plan.n_sweep == 6
@@ -161,7 +169,9 @@ class TestArrayGrouping:
         assert plan.regime == "sweep"
         assert plan.array_args == (_ref("d"),)
         assert plan.array_groups == (
-            ArrayBroadcastGroup(arg_refs=(_ref("d"),), batch_shape=(2, 3), size=6),
+            ArrayBroadcastGroup(
+                arg_refs=(_ref("d"),), batch_shape=(2, 3), size=6, level_names=("d",)
+            ),
         )
         assert plan.sweep_batch_shape == (2, 3)
         assert plan.n_sweep == 6

--- a/tests/core/test_workflow_plan.py
+++ b/tests/core/test_workflow_plan.py
@@ -71,7 +71,11 @@ class TestBroadcastRegime:
         assert plan.array_args == (_ref("p"),)
         assert plan.array_groups == (
             ArrayBroadcastGroup(
-                arg_refs=(_ref("p"),), batch_shape=(4,), size=4, level_names=("p",)
+                arg_refs=(_ref("p"),),
+                batch_shape=(4,),
+                size=4,
+                level_names=("p",),
+                axis_groups=((4,),),
             ),
         )
         assert plan.sweep_batch_shape == (4,)
@@ -131,7 +135,11 @@ class TestArrayGrouping:
         assert plan.array_args == (_ref("x"), _ref("y"))
         assert plan.array_groups == (
             ArrayBroadcastGroup(
-                arg_refs=(_ref("x"), _ref("y")), batch_shape=(4,), size=4, level_names=("x",)
+                arg_refs=(_ref("x"), _ref("y")),
+                batch_shape=(4,),
+                size=4,
+                level_names=("x",),
+                axis_groups=((4,),),
             ),
         )
         assert plan.sweep_batch_shape == (4,)
@@ -146,10 +154,18 @@ class TestArrayGrouping:
         assert plan.regime == "sweep"
         assert plan.array_groups == (
             ArrayBroadcastGroup(
-                arg_refs=(_ref("a"),), batch_shape=(3,), size=3, level_names=("a",)
+                arg_refs=(_ref("a"),),
+                batch_shape=(3,),
+                size=3,
+                level_names=("a",),
+                axis_groups=((3,),),
             ),
             ArrayBroadcastGroup(
-                arg_refs=(_ref("b"),), batch_shape=(2,), size=2, level_names=("b",)
+                arg_refs=(_ref("b"),),
+                batch_shape=(2,),
+                size=2,
+                level_names=("b",),
+                axis_groups=((2,),),
             ),
         )
         assert plan.sweep_batch_shape == (3, 2)
@@ -170,7 +186,11 @@ class TestArrayGrouping:
         assert plan.array_args == (_ref("d"),)
         assert plan.array_groups == (
             ArrayBroadcastGroup(
-                arg_refs=(_ref("d"),), batch_shape=(2, 3), size=6, level_names=("d",)
+                arg_refs=(_ref("d"),),
+                batch_shape=(2, 3),
+                size=6,
+                level_names=("d",),
+                axis_groups=((2, 3),),
             ),
         )
         assert plan.sweep_batch_shape == (2, 3)

--- a/tests/diagnostics/test_nested_diagnostics_export.py
+++ b/tests/diagnostics/test_nested_diagnostics_export.py
@@ -15,7 +15,8 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from probpipe import EventTemplate, MultivariateNormal, NumericEventTemplate, NumericRecordArray
+from probpipe import EventTemplate, MultivariateNormal, NumericEventTemplate
+from probpipe.core._numeric_record_batch import NumericRecordBatch
 from probpipe.diagnostics._arviz_bridge import extract_draws
 from probpipe.diagnostics._datatree_store import to_named_posterior_dataset
 from probpipe.diagnostics._loo import _add_log_likelihood
@@ -115,7 +116,9 @@ class _RecordDrawsPosterior:
         return self._n_draws
 
     def draws(self, *, chain):
-        return NumericRecordArray.from_vector("nra", self._template, self._chains[chain])
+        return NumericRecordBatch.from_vector(
+            "nra", self._template, self._chains[chain], level_names="draw"
+        )
 
 
 class _LinearModel:

--- a/tests/distributions/test_joint_empirical.py
+++ b/tests/distributions/test_joint_empirical.py
@@ -19,6 +19,7 @@ from probpipe import (
     sample,
     variance,
 )
+from probpipe.core._record_batch import RecordBatch
 from probpipe.core._record_distribution import _RecordDistributionView
 from probpipe.core.node import Function
 
@@ -131,7 +132,7 @@ class TestSampling:
         )
         key = jax.random.PRNGKey(1)
         s = sample(je, key=key, sample_shape=(10,))
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, RecordBatch)
         assert s["x"].shape == (10,)
         assert s["y"].shape == (10,)
 
@@ -309,7 +310,7 @@ class TestConditionOn:
         )
         cond = condition_on(je, x=jnp.array(1.0))
         s = sample(cond, key=jax.random.PRNGKey(0), sample_shape=(5,))
-        assert set(s.fields) == {"y"}
+        assert set(s.event_template) == {"y"}
         assert s["y"].shape == (5,)
 
     def test_condition_on_preserves_correlation(self):

--- a/tests/distributions/test_joint_empirical.py
+++ b/tests/distributions/test_joint_empirical.py
@@ -409,3 +409,31 @@ class TestBroadcasting:
         # Mean of x is 2.0, so mean of a+b should be ~22
         mean_val = float(jnp.mean(result.samples))
         assert abs(mean_val - 22.0) < 5.0
+
+
+class TestObjectValuedDrawsAreBatches:
+    """An object-valued law draws on the same terms as a numeric one: the class
+    follows the leaves, but a batched draw is a batch either way."""
+
+    def test_object_valued_batched_draw_is_a_plain_batch(self):
+        je = JointEmpirical(
+            labels=np.array(["a", "b", "c"], dtype=object),
+            y=np.asarray([1.0, 2.0, 3.0]),
+        )
+
+        drawn = je._sample(jax.random.PRNGKey(0), (4,))
+
+        assert type(drawn) is RecordBatch
+        assert drawn.level_names == ("draw",)
+        assert drawn.batch_shape == (4,)
+        assert set(drawn.event_template) == {"labels", "y"}
+
+    def test_object_valued_single_draw_is_a_record(self):
+        je = JointEmpirical(
+            labels=np.array(["a", "b", "c"], dtype=object),
+            y=np.asarray([1.0, 2.0, 3.0]),
+        )
+
+        drawn = je._sample(jax.random.PRNGKey(0), ())
+
+        assert isinstance(drawn, Record) and not isinstance(drawn, RecordBatch)

--- a/tests/distributions/test_joint_empirical.py
+++ b/tests/distributions/test_joint_empirical.py
@@ -428,6 +428,25 @@ class TestObjectValuedDrawsAreBatches:
         assert drawn.batch_shape == (4,)
         assert set(drawn.event_template) == {"labels", "y"}
 
+    def test_object_valued_rows_stay_paired_through_sample(self):
+        """Rows are resampled jointly, so a drawn label always arrives with the
+        numeric value it was stored beside — checked through the public
+        ``sample`` op, not the private ``_sample``."""
+        je = JointEmpirical(
+            labels=np.array(["a", "b", "c"], dtype=object),
+            y=np.asarray([1.0, 2.0, 3.0]),
+        )
+
+        drawn = sample(je, key=jax.random.PRNGKey(7), sample_shape=(64,))
+
+        stored = {("a", 1.0), ("b", 2.0), ("c", 3.0)}
+        seen = {
+            (label, float(value))
+            for label, value in zip(drawn._raw_column("labels"), np.asarray(drawn["y"]))
+        }
+        assert seen <= stored
+        assert len(seen) > 1  # 64 draws of 3 rows: more than one row appears
+
     def test_object_valued_single_draw_is_a_record(self):
         je = JointEmpirical(
             labels=np.array(["a", "b", "c"], dtype=object),

--- a/tests/distributions/test_joint_gaussian.py
+++ b/tests/distributions/test_joint_gaussian.py
@@ -19,6 +19,7 @@ from probpipe import (
     sample,
     variance,
 )
+from probpipe.core._record_batch import RecordBatch
 from probpipe.core.node import Function
 
 # ---------------------------------------------------------------------------
@@ -132,7 +133,7 @@ class TestSampling:
         )
         key = jax.random.PRNGKey(1)
         s = sample(jg, key=key, sample_shape=(10,))
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, RecordBatch)
         assert s["x"].shape == (10, 1)
         assert s["y"].shape == (10, 1)
 
@@ -436,7 +437,7 @@ class TestConditionOn:
         # sd / sqrt(5000) ~ 0.006
         key = jax.random.PRNGKey(20)
         s = sample(cond, key=key, sample_shape=(5000,))
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, RecordBatch)
         np.testing.assert_allclose(float(jnp.mean(s["y"])), 2.7, atol=0.03)
 
     def test_dict_for_leaf_raises(self):

--- a/tests/distributions/test_kde.py
+++ b/tests/distributions/test_kde.py
@@ -22,7 +22,7 @@ from probpipe import (
 )
 from probpipe.core._empirical import RecordEmpiricalDistribution
 from probpipe.core._numeric_record import NumericRecord as _NumericRecord
-from probpipe.core._record_array import NumericRecordArray
+from probpipe.core._numeric_record_batch import NumericRecordBatch
 from probpipe.distributions.kde import KDEDistribution
 
 # ---------------------------------------------------------------------------
@@ -95,7 +95,7 @@ class TestSampleRoundTrip:
         )
         s = kde._sample(jax.random.PRNGKey(0), ())
         assert isinstance(s, _NumericRecord)
-        assert s.fields == ("intercept", "slope")
+        assert tuple(s.event_template.keys()) == ("intercept", "slope")
 
     def test_sample_batched_returns_record_array(self, two_field_template, flat_samples):
         kde = KDEDistribution(
@@ -104,9 +104,9 @@ class TestSampleRoundTrip:
             name="post",
         )
         s = kde._sample(jax.random.PRNGKey(1), (8,))
-        assert isinstance(s, NumericRecordArray)
+        assert isinstance(s, NumericRecordBatch)
         assert s.batch_shape == (8,)
-        assert s.fields == ("intercept", "slope")
+        assert tuple(s.event_template.keys()) == ("intercept", "slope")
 
     def test_sample_no_template_returns_raw_array(self, flat_samples):
         """With auto-build single-field template the sample stays a raw
@@ -146,18 +146,18 @@ class TestLogProbDualInput:
         assert jnp.isfinite(lp)
 
     def test_batched_record_array(self, two_field_template, flat_samples):
-        """A NumericRecordArray input is flattened to (batch, d) and the
+        """A NumericRecordBatch input is flattened to (batch, d) and the
         TFP mixture log-prob returns a (batch,) array."""
         kde = KDEDistribution(
             flat_samples,
             event_template=two_field_template,
             name="post",
         )
-        # Build a 3-row NumericRecordArray
-        nra = NumericRecordArray(
+        # Build a 3-row NumericRecordBatch
+        nra = NumericRecordBatch(
             {"intercept": jnp.array([0.5, 0.6, 0.7]), "slope": jnp.array([-0.3, -0.4, -0.5])},
-            batch_shape=(3,),
-            template=NumericEventTemplate(intercept=(), slope=()),
+            "draw",
+            element_spec=NumericEventTemplate(intercept=(), slope=()),
         )
         lp = kde._log_prob(nra)
         assert lp.shape == (3,)
@@ -195,7 +195,7 @@ class TestFromEmpirical:
         # Samples come back structured
         s = kde._sample(jax.random.PRNGKey(2), ())
         assert isinstance(s, _NumericRecord)
-        assert s.fields == ("intercept", "slope")
+        assert tuple(s.event_template.keys()) == ("intercept", "slope")
 
     def test_single_field_record_empirical(self):
         """Single-field empirical → single-field KDE (no multi-field

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -22,7 +22,8 @@ from probpipe import (
     sample,
     variance,
 )
-from probpipe.core._record_array import RecordArray
+from probpipe.core._numeric_record_batch import NumericRecordBatch
+from probpipe.core._record_batch import RecordBatch
 from probpipe.core._record_distribution import _RecordDistributionView
 from probpipe.core.node import Function
 from probpipe.core.record import Record
@@ -107,7 +108,7 @@ class TestProductDistribution:
     def test_sample_returns_values(self, joint_xy):
         key = jax.random.PRNGKey(0)
         s = sample(joint_xy, key=key)
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, Record)
         assert set(s.fields) == {"x", "y"}
 
     def test_sample_shapes_scalar(self, joint_xy):
@@ -232,7 +233,7 @@ class TestFlattenUnflatten:
     def test_roundtrip_scalar_components(self, joint_xy):
         key = jax.random.PRNGKey(60)
         s = sample(joint_xy, key=key)
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, Record)
         flat = joint_xy.flatten_value(s)
         assert flat.shape == (2,)
         recovered = joint_xy.unflatten_value(
@@ -246,7 +247,7 @@ class TestFlattenUnflatten:
     def test_roundtrip_mixed_components(self, joint_xz):
         key = jax.random.PRNGKey(61)
         s = sample(joint_xz, key=key)
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, Record)
         flat = joint_xz.flatten_value(s)
         assert flat.shape == (4,)
         recovered = joint_xz.unflatten_value(
@@ -260,7 +261,7 @@ class TestFlattenUnflatten:
     def test_roundtrip_no_batch_dim(self, joint_xy):
         key = jax.random.PRNGKey(62)
         s = sample(joint_xy, key=key)
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, Record)
         flat = joint_xy.flatten_value(s)
         assert flat.shape == (2,)
         recovered = joint_xy.unflatten_value(
@@ -278,9 +279,9 @@ class TestFlattenUnflatten:
 
 
 class TestNestedSampleFlatten:
-    """A batched draw from a nested ProductDistribution is a canonical, nested
-    NumericRecordArray that flattens and round-trips; the unbatched draw stays
-    a plain Record."""
+    """A batched draw from a nested ProductDistribution is one flat
+    NumericRecordBatch over leaf paths that flattens and round-trips; the
+    unbatched draw stays a plain Record."""
 
     @pytest.fixture
     def nested(self):
@@ -293,26 +294,22 @@ class TestNestedSampleFlatten:
             m=Normal(loc=-1.0, scale=1.0, name="m"),
         )
 
-    def test_batched_nested_field_is_record_array(self, nested):
-        from probpipe.core._record_array import NumericRecordArray
-
+    def test_batched_nested_field_is_a_sub_batch(self, nested):
         s = sample(nested, key=jax.random.PRNGKey(0), sample_shape=(6,))
-        assert isinstance(s, NumericRecordArray)
-        assert isinstance(s.at_path("outer"), NumericRecordArray)  # not a plain Record
+        assert isinstance(s, NumericRecordBatch)
+        assert isinstance(s["outer"], NumericRecordBatch)  # the sub-batch, not a plain Record
 
     def test_unbatched_nested_field_stays_record(self, nested):
         s = sample(nested, key=jax.random.PRNGKey(0))
-        assert isinstance(s, Record) and not isinstance(s, RecordArray)
+        assert isinstance(s, Record) and not isinstance(s, RecordBatch)
         assert isinstance(s.at_path("outer"), Record) and not isinstance(
-            s.at_path("outer"), RecordArray
+            s.at_path("outer"), RecordBatch
         )
 
     def test_batched_depth_two_nested_sampling(self):
         # A depth-2 nesting exercises the interior-subtree lookup inside
         # _sample_nested (template.children, since template [] is leaf-only);
         # only leaf components sit below depth 1 in the fixtures above.
-        from probpipe.core._record_array import NumericRecordArray
-
         deep = ProductDistribution(
             name="deep",
             grp={
@@ -322,13 +319,11 @@ class TestNestedSampleFlatten:
             noise=Normal(loc=0.0, scale=1.0, name="noise"),
         )
         s = sample(deep, key=jax.random.PRNGKey(0), sample_shape=(4,))
-        assert isinstance(s, NumericRecordArray)
-        assert tuple(s.template.keys()) == ("grp/sub/force", "grp/mass", "noise")
+        assert isinstance(s, NumericRecordBatch)
+        assert tuple(s.event_template.keys()) == ("grp/sub/force", "grp/mass", "noise")
         assert s["grp/sub/force"].shape == (4,)
 
     def test_batched_nested_flatten_roundtrip(self, nested):
-        from probpipe.core._record_array import NumericRecordArray
-
         s = sample(nested, key=jax.random.PRNGKey(1), sample_shape=(6,))
         leaves = list(nested.event_template.leaf_shapes)
         flat = s.to_vector()
@@ -340,16 +335,15 @@ class TestNestedSampleFlatten:
         for i, leaf in enumerate(leaves):
             np.testing.assert_allclose(flat[:, i], s[leaf], atol=1e-6)
         # Secondary: the columns round-trip back to the same leaves via unflatten.
-        rec = NumericRecordArray.from_vector("nra", nested.event_template, flat)
+        rec = NumericRecordBatch.from_vector("nrb", nested.event_template, flat, level_names="draw")
         for leaf in leaves:
             np.testing.assert_allclose(rec[leaf], s[leaf], atol=1e-6)
 
-    def test_batched_nested_non_numeric_field_is_plain_record_array(self):
+    def test_batched_nested_non_numeric_field_is_a_plain_batch(self):
         # A non-numeric joint (an object-dtype JointEmpirical leaf) makes the
-        # batched nested field a plain RecordArray, not a NumericRecordArray
-        # (the else branch of _sample_nested); such a field is not flattenable.
+        # batched draw a plain RecordBatch, not a NumericRecordBatch; such a
+        # field is not flattenable.
         from probpipe import JointEmpirical
-        from probpipe.core._record_array import NumericRecordArray, RecordArray
 
         je = JointEmpirical(
             labels=np.array(["a", "b", "c"], dtype=object),
@@ -366,9 +360,9 @@ class TestNestedSampleFlatten:
         )
         assert not isinstance(joint, NumericRecordDistribution)
         s = sample(joint, key=jax.random.PRNGKey(0), sample_shape=(4,))
-        assert isinstance(s, RecordArray) and not isinstance(s, NumericRecordArray)
-        assert isinstance(s.at_path("outer"), RecordArray)
-        assert not isinstance(s.at_path("outer"), NumericRecordArray)
+        assert isinstance(s, RecordBatch) and not isinstance(s, NumericRecordBatch)
+        assert isinstance(s["outer"], RecordBatch)
+        assert not isinstance(s["outer"], NumericRecordBatch)
 
 
 # ===========================================================================
@@ -449,8 +443,9 @@ class TestConditionOn:
         cond = condition_on(joint_xy, x=jnp.array(2.0))
         key = jax.random.PRNGKey(20)
         s = sample(cond, key=key, sample_shape=(10,))
-        assert "x" not in s
-        assert "y" in s
+        # A batch is a collection, so its fields are read from the schema.
+        assert "x" not in s.event_template
+        assert "y" in s.event_template
 
     def test_unconditioned_component_still_varies(self, joint_xy):
         cond = condition_on(joint_xy, x=jnp.array(0.0))
@@ -862,7 +857,7 @@ class TestLogProbBatchValues:
         batch_lps = jnp.asarray(log_prob(joint_xy, samples))
 
         for i in range(10):
-            s_i = Record("r", {k: v[i] for k, v in samples.items()})
+            s_i = Record("r", {k: samples[k][i] for k in samples.event_template})
             expected = float(log_prob(normal_x, s_i["x"])) + float(log_prob(normal_y, s_i["y"]))
             np.testing.assert_allclose(float(batch_lps[i]), expected, atol=1e-5)
 
@@ -1092,7 +1087,7 @@ class TestNestedProductDistribution:
     def test_sample_returns_nested_values(self, nested_joint):
         key = jax.random.PRNGKey(1)
         s = sample(nested_joint, key=key)
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, Record)
         assert isinstance(s.at_path("physics"), Record)
         assert "force" in s.at_path("physics")
         assert "mass" in s.at_path("physics")
@@ -1159,7 +1154,7 @@ class TestNestedProductDistribution:
     def test_flatten_unflatten_roundtrip(self, nested_joint):
         key = jax.random.PRNGKey(20)
         s = sample(nested_joint, key=key)
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, Record)
         flat = nested_joint.flatten_value(s)
         assert flat.shape == (3,)
         recovered = nested_joint.unflatten_value(
@@ -1235,12 +1230,11 @@ class TestNestedProductDistribution:
         cond = condition_on(nested_joint, physics={"force": jnp.array(1.0)})
         key = jax.random.PRNGKey(50)
         s = sample(cond, key=key, sample_shape=(5,))
-        assert isinstance(s, (Record, RecordArray))
-        assert "physics" in s
-        assert isinstance(s.at_path("physics"), Record)
-        assert "mass" in s.at_path("physics")
-        assert "force" not in s.at_path("physics")
-        assert "observation" in s
+        assert isinstance(s, RecordBatch)
+        assert isinstance(s["physics"], RecordBatch)
+        assert "physics/mass" in s.event_template
+        assert "physics/force" not in s.event_template
+        assert "observation" in s.event_template
         assert s["physics/mass"].shape == (5,)
         assert s["observation"].shape == (5,)
 
@@ -1401,8 +1395,8 @@ class TestNestedWithMVN:
     def test_sample_and_flatten(self, nested_mvn):
         key = jax.random.PRNGKey(50)
         s = sample(nested_mvn, key=key, sample_shape=(5,))
-        assert isinstance(s, (Record, RecordArray))
-        assert isinstance(s.at_path("group"), Record)
+        assert isinstance(s, RecordBatch)
+        assert isinstance(s["group"], RecordBatch)
         assert s["group/position"].shape == (5, 2)
         assert s["group/scale"].shape == (5,)
         assert s["label"].shape == (5,)

--- a/tests/distributions/test_sequential_joint.py
+++ b/tests/distributions/test_sequential_joint.py
@@ -19,6 +19,7 @@ from probpipe import (
     sample,
     unnormalized_log_prob,
 )
+from probpipe.core._record_batch import RecordBatch
 from probpipe.core._record_distribution import _RecordDistributionView
 from probpipe.core.node import Function
 
@@ -115,7 +116,7 @@ class TestSampling:
         )
         key = jax.random.PRNGKey(1)
         s = sample(joint, key=key, sample_shape=(10,))
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, RecordBatch)
         assert s["z"].shape == (10,)
         assert s["x"].shape == (10,)
 
@@ -137,7 +138,7 @@ class TestSampling:
             x=lambda z: Normal(loc=z, scale=0.5, name="x"),
         )
         s = sample(joint, sample_shape=(5,))
-        assert isinstance(s, (Record, RecordArray))
+        assert isinstance(s, RecordBatch)
         assert s["z"].shape == (5,)
         assert s["x"].shape == (5,)
 
@@ -395,8 +396,8 @@ class TestConditionOn:
         cond2 = condition_on(cond1, z=jnp.array(0.0))
         assert cond2.fields == ("y",)
         s = sample(cond2, sample_shape=(5,))
-        assert isinstance(s, (Record, RecordArray))
-        assert set(s.fields) == {"y"}
+        assert isinstance(s, RecordBatch)
+        assert set(s.event_template) == {"y"}
         assert s["y"].shape == (5,)
 
     def test_raises_on_conditioning_all(self):

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -737,7 +737,7 @@ class TestRWMH:
 
         raw_draws = result.draws()
         if hasattr(raw_draws, "fields"):
-            raw_draws = jnp.concatenate([raw_draws[f] for f in raw_draws.fields], axis=-1)
+            raw_draws = jnp.concatenate([raw_draws[f] for f in raw_draws.event_template], axis=-1)
         draws = np.asarray(raw_draws).reshape(-1, 2)
         # MC standard error: posterior_sd / sqrt(effective_n).
         # ``adapt=True`` (the default) fits the proposal covariance from

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -19,6 +19,7 @@ from probpipe import (
     EventTemplate,
     MultivariateNormal,
     Normal,
+    NumericRecordBatch,
     ProductDistribution,
     Record,
     mean,
@@ -258,7 +259,7 @@ class TestApproximateDistributionValuesTemplate:
 
     def test_draws_returns_values(self, posterior_with_template):
         draws = posterior_with_template.draws()
-        assert isinstance(draws, Record | RecordBatch)
+        assert isinstance(draws, NumericRecordBatch)
         # Insertion order from the template fixture: r, K, phi.
         assert tuple(draws.event_template.keys()) == ("r", "K", "phi")
         assert draws["r"].shape == (100,)
@@ -283,7 +284,7 @@ class TestApproximateDistributionValuesTemplate:
 
     def test_draws_single_chain_returns_values(self, posterior_with_template):
         draws = posterior_with_template.draws(chain=0)
-        assert isinstance(draws, Record | RecordBatch)
+        assert isinstance(draws, NumericRecordBatch)
         assert draws["r"].shape == (100,)
 
     def test_without_template_returns_array(self):
@@ -489,7 +490,7 @@ class TestApproximateDistributionValuesTemplate:
             event_template=template,
         )
         draws = post.draws(include_warmup=True)
-        assert isinstance(draws, Record | RecordBatch)
+        assert isinstance(draws, NumericRecordBatch)
         assert draws["a"].shape == (60,)  # 10 warmup + 50 draws
         assert draws["b"].shape == (60,)
 
@@ -509,7 +510,7 @@ class TestApproximateDistributionValuesTemplate:
             event_template=template,
         )
         draws = post.draws()
-        assert isinstance(draws, Record | RecordBatch)
+        assert isinstance(draws, NumericRecordBatch)
         assert isinstance(draws["params"], RecordBatch)
         assert draws["params/a"].shape == (30,)
         assert draws["params/b"].shape == (30,)
@@ -1276,7 +1277,7 @@ class TestEndToEndValuesPipeline:
     def test_draws_are_named_values(self, posterior):
         """draws() returns Record with correct field names and shapes."""
         draws = posterior.draws()
-        assert isinstance(draws, Record | RecordBatch)
+        assert isinstance(draws, NumericRecordBatch)
         assert tuple(draws.event_template.keys()) == ("params",)
         assert draws["params"].shape == (500, 2)
 
@@ -1368,7 +1369,7 @@ class TestEndToEndValuesPipeline:
             event_template=template,
         )
         draws = post.draws()
-        assert isinstance(draws, Record | RecordBatch)
+        assert isinstance(draws, NumericRecordBatch)
         assert tuple(draws.event_template.keys()) == ("a", "b", "c")
         assert draws["a"].shape == (200,)
 

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -21,11 +21,11 @@ from probpipe import (
     Normal,
     ProductDistribution,
     Record,
-    RecordArray,
     mean,
     sample,
     variance,
 )
+from probpipe.core._record_batch import RecordBatch
 from probpipe.core.distribution import _RecordDistributionView
 from probpipe.core.event_template import ArraySpec
 from probpipe.inference import rwmh
@@ -258,14 +258,14 @@ class TestApproximateDistributionValuesTemplate:
 
     def test_draws_returns_values(self, posterior_with_template):
         draws = posterior_with_template.draws()
-        assert isinstance(draws, (Record, RecordArray))
+        assert isinstance(draws, Record | RecordBatch)
         # Insertion order from the template fixture: r, K, phi.
-        assert draws.fields == ("r", "K", "phi")
+        assert tuple(draws.event_template.keys()) == ("r", "K", "phi")
         assert draws["r"].shape == (100,)
 
     def test_draws_has_correct_fields(self, posterior_with_template):
         draws = posterior_with_template.draws()
-        assert draws.fields == ("r", "K", "phi")
+        assert tuple(draws.event_template.keys()) == ("r", "K", "phi")
 
     def test_draws_field_shapes(self, posterior_with_template):
         draws = posterior_with_template.draws()
@@ -283,7 +283,7 @@ class TestApproximateDistributionValuesTemplate:
 
     def test_draws_single_chain_returns_values(self, posterior_with_template):
         draws = posterior_with_template.draws(chain=0)
-        assert isinstance(draws, (Record, RecordArray))
+        assert isinstance(draws, Record | RecordBatch)
         assert draws["r"].shape == (100,)
 
     def test_without_template_returns_array(self):
@@ -489,7 +489,7 @@ class TestApproximateDistributionValuesTemplate:
             event_template=template,
         )
         draws = post.draws(include_warmup=True)
-        assert isinstance(draws, (Record, RecordArray))
+        assert isinstance(draws, Record | RecordBatch)
         assert draws["a"].shape == (60,)  # 10 warmup + 50 draws
         assert draws["b"].shape == (60,)
 
@@ -509,8 +509,8 @@ class TestApproximateDistributionValuesTemplate:
             event_template=template,
         )
         draws = post.draws()
-        assert isinstance(draws, (Record, RecordArray))
-        assert isinstance(draws.at_path("params"), (Record, RecordArray))
+        assert isinstance(draws, Record | RecordBatch)
+        assert isinstance(draws["params"], RecordBatch)
         assert draws["params/a"].shape == (30,)
         assert draws["params/b"].shape == (30,)
         assert draws["scale"].shape == (30,)
@@ -573,7 +573,8 @@ class TestApproximateDistributionValuesTemplate:
         assert v["scale"].shape == ()
         # ``draws()`` walks the full template (incl. nesting).
         draws = post.draws()
-        assert draws.fields == expected_fields
+        # Top-level names, which is what the accessors are keyed by.
+        assert tuple(draws.event_template.children) == expected_fields
         assert draws["params/a"].shape == (40,)
         assert draws["params/b"].shape == (40,)
         assert draws["scale"].shape == (40,)
@@ -1275,8 +1276,8 @@ class TestEndToEndValuesPipeline:
     def test_draws_are_named_values(self, posterior):
         """draws() returns Record with correct field names and shapes."""
         draws = posterior.draws()
-        assert isinstance(draws, (Record, RecordArray))
-        assert draws.fields == ("params",)
+        assert isinstance(draws, Record | RecordBatch)
+        assert tuple(draws.event_template.keys()) == ("params",)
         assert draws["params"].shape == (500, 2)
 
     def test_draws_values_correct(self, posterior):
@@ -1367,8 +1368,8 @@ class TestEndToEndValuesPipeline:
             event_template=template,
         )
         draws = post.draws()
-        assert isinstance(draws, (Record, RecordArray))
-        assert draws.fields == ("a", "b", "c")
+        assert isinstance(draws, Record | RecordBatch)
+        assert tuple(draws.event_template.keys()) == ("a", "b", "c")
         assert draws["a"].shape == (200,)
 
         # Per-field views

--- a/tests/inference/test_nutpie.py
+++ b/tests/inference/test_nutpie.py
@@ -300,7 +300,7 @@ class TestNutpieIntegration:
         # so draws() returns a NumericRecordArray keyed by RV name. The
         # only parameter is `mu`, with event_shape ().
         draws = result.draws()
-        assert draws.fields == ("mu",)
+        assert draws.event_template.fields == ("mu",)
         mu_draws = jnp.asarray(draws["mu"])
         assert mu_draws.shape == (1000,)  # 2 chains × 500 draws, flattened
         # With 1000 draws total, MC SE for mean ~ post_sd / sqrt(1000) ~ 0.014
@@ -351,7 +351,7 @@ class TestNutpieIntegration:
             random_seed=0,
         )
         draws = result.draws()
-        assert draws.fields == ("zeta", "alpha", "mu")
+        assert draws.event_template.fields == ("zeta", "alpha", "mu")
         for field, prior_mean in [("zeta", 100.0), ("alpha", 0.0), ("mu", -100.0)]:
             got = float(jnp.mean(jnp.asarray(draws[field])))
             np.testing.assert_allclose(got, prior_mean, atol=10.0)
@@ -384,6 +384,6 @@ class TestNutpieIntegration:
             random_seed=0,
         )
         draws = result.draws()
-        assert set(draws.fields) == {"mu", "X"}
+        assert set(draws.event_template.fields) == {"mu", "X"}
         np.testing.assert_allclose(float(jnp.mean(jnp.asarray(draws["mu"]))), 100.0, atol=10.0)
         np.testing.assert_allclose(float(jnp.mean(jnp.asarray(draws["X"]))), -100.0, atol=10.0)

--- a/tests/inference/test_pyabc.py
+++ b/tests/inference/test_pyabc.py
@@ -201,7 +201,7 @@ class TestPyABCWeightsAndDraws:
             random_seed=0,
         )
         draws = post.draws()
-        assert "theta" in draws.fields
+        assert "theta" in draws.event_template.fields
         assert np.asarray(draws["theta"]).shape == (post.num_atoms,)
 
     def test_summary_fn_applied(self):

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -374,7 +374,7 @@ class TestEventTemplate:
             random_seed=0,
         )
         draws = result.draws()
-        assert draws.fields == ("intercept", "alpha")
+        assert draws.event_template.fields == ("intercept", "alpha")
         assert jnp.asarray(draws["intercept"]).shape == (20,)
         assert jnp.asarray(draws["alpha"]).shape == (20, N)
 
@@ -410,7 +410,7 @@ class TestEventTemplate:
         )
         assert result.algorithm == "pymc_advi"
         draws = result.draws()
-        assert draws.fields == ("intercept", "alpha")
+        assert draws.event_template.fields == ("intercept", "alpha")
         assert jnp.asarray(draws["intercept"]).shape == (25,)
         assert jnp.asarray(draws["alpha"]).shape == (25, 3)
 
@@ -512,7 +512,7 @@ class TestEventTemplate:
             num_chains=1,
             random_seed=0,
         )
-        assert set(result.draws().fields) == {"mu", "X"}
+        assert set(result.draws().event_template.fields) == {"mu", "X"}
 
     def test_partial_conditioning_draws_not_mislabeled(self):
         """The inferred observed variable's draws are labeled correctly —
@@ -544,7 +544,7 @@ class TestEventTemplate:
             random_seed=0,
         )
         draws = result.draws()
-        assert set(draws.fields) == {"mu", "X"}
+        assert set(draws.event_template.fields) == {"mu", "X"}
         assert float(jnp.mean(jnp.asarray(draws["mu"]))) > 50.0  # ~ +100
         assert float(jnp.mean(jnp.asarray(draws["X"]))) < -50.0  # ~ -100
 
@@ -582,7 +582,7 @@ class TestEventTemplate:
         )
         draws = result.draws()
         # Declared order, not nutpie/pymc's alphabetical data_vars order.
-        assert draws.fields == ("zeta", "alpha", "mu")
+        assert draws.event_template.fields == ("zeta", "alpha", "mu")
         for field, prior_mean in [("zeta", 100.0), ("alpha", 0.0), ("mu", -100.0)]:
             got = float(jnp.mean(jnp.asarray(draws[field])))
             np.testing.assert_allclose(got, prior_mean, atol=10.0)


### PR DESCRIPTION
## What this is

The joint laws now draw a `RecordBatch`. `_sample` on product, sequential,
Gaussian, and empirical returns a `NumericRecordBatch` for a batched draw — a
`RecordBatch` when a leaf is non-numeric — over a single `draw` level spanning
however many axes the `sample_shape` had. An unbatched draw is still a `Record`.
The class follows the leaves, so an object-valued law draws a batch on the same
terms as a numeric one.

Stacks on #401, which opens the gates a batch arrives at.

## The two real changes

**A nested draw is one flat batch, not a batch per subtree.** A batch stores one
column per *field*, so a nested product draws into one mapping over `/`-paths and
the result is a single store whose `batch["outer"]` is a *view* over the columns
beneath `outer`. The recursion that used to build a record-array per subtree now
collects columns, splitting keys per level exactly as the single-draw recursion
does, so a batched draw and a single draw derive their subkeys the same way. This
is also what makes a nested field reachable by path, and it removes the
`NotImplementedError` that refused nested batched records.

**A broadcast mints the levels it swept.** Stacking rows that are each a batch
puts the swept levels in front of the levels a row already carried. An operation
that mints a level takes the name to give it (design/02, level names), so
`_make_stack` requires `level_names` — one per swept group, with each group's
own axis partition carried through the plan — rather than naming a level itself:
the sweep passes the operand's own names when it carries them, so the aggregate
aligns by name with the batch it came from, and the argument's label otherwise.
Leaf-keyed columns are why the nested case needs no special handling here either.
The sweep addresses a multi-level batch by unraveled position, one indexer per
batch axis; a flat index read the leading axis alone and ran off its end. An
empty declared sweep builds its aggregate from the output template, every
declared field present at zero rows.

**Rearranging a batch reads its columns, not its fields.** A field that is not an
array presents as the batch of its element kind — a `FunctionBatch` or an
`OpaqueBatch` — which is what reading one field wants and the wrong thing for an
operation moving the storage around. Four such operations were reading the
presented form: gathering rows for a broadcast, peeling the batch axis for a
marginal, indexing a minibatch, and splicing a component's draw into a product.
`_raw_column` / `_raw_columns` name the seam, and an object column gathers through
numpy so the positions are taken without trying to make an array of the values.

**A declared output template that reorders the same fields no longer swaps
columns.** A batch flattens in its spec's leaf order, so retyping a copied batch's
spec alone left the next unflatten pairing every value with the wrong key.

**Stacking a batch per row requires the rows to agree** on element spec, level
names, and axis groups, not merely on batch shape — otherwise the first row's
schema and level names were taken for all of them, dropping a field the others
carried and misnaming their axes.

**Levels align by name, and only whole** (with #401): a level shared by
operands whose other levels differ is refused rather than silently producted,
operands naming the same levels must hold them on the same axes, and a
parameter annotated `Batch` or `Batch[Record]` takes the value whole.

**A transform cannot lie about a batch's multiplicity — or its element.** `vmap` strips the
mapped axis on the way in, which unflattening handles by re-deriving the
surviving levels; on the way out it *adds* one, and an added axis belongs to no
level, so unflattening raises rather than keeping the stored spec — which
returned a batch whose `batch_shape` its own columns contradicted. A same-rank
transform is held to the same standard: slicing keeps every axis, so the levels
carry over onto the sizes the columns actually have, and columns left
disagreeing about their batch axes are refused. The element's own axes are the
element type's: a per-column slice that shrinks the event, a transpose that
reads an event axis as a batch axis, and a reduction below the event rank all
raise rather than rebuild a batch declaring an element it does not hold.

**Shape cannot recover axis provenance, so ambiguity refuses.** A removal whose
size matches more than one level and a permutation of the batch axes both raise
rather than guess — the leftmost-fit answer handed a `vmap(in_axes=1)` body a
batch named for the level that was *removed*, and a transpose kept each level's
name on an axis holding another's rows. A distinctly-sized removal names the
level that survived. A pinned dtype is held like the event axes, under the
constructor's same-kind rule.

**Zero rows is not missing output — and one schema under every dispatch.** An empty sweep builds its declared fields
only when zero rows were *expected*; an empty list where rows were expected
reports the count mismatch instead of fabricating a well-typed result. Zero-row
sweeps take one aggregation path under every dispatch, so the output schema no
longer depends on how the rows would have been executed. The
dispatch probe states the flat batch size exactly as the executor does, so a
zero-width event column passes under explicit `dispatch="jax"`.

**Automatic dispatch probes the vmap it is choosing.** The traceability probe
traced a bare call, so a body that traces cleanly but cannot run under `vmap` —
one returning a batch — passed the probe, took the jax path, and failed
mid-call. The probe now feeds a batched argument the way `execute_sweep_rows_jax`
will — leaf columns over one row, rebuilt into a `Record` inside the traced call,
under `vmap` — and a probe failure means sequential dispatch, which agrees on
results by the dispatch-equivalence contract. Fixes #403.

**Rows holding opaque or callable fields stack, and marginalize.** Stacking read
each field through the presenting accessor and handed `OpaqueBatch` wrappers to
`jnp.stack`; the raw columns stack, through numpy. An object-valued batch
marginal routes to the general list marginal rather than inheriting numeric
empirical validation.

**A batch is fingerprinted by its levels and its columns.** A multi-field batch
failed fingerprinting outright, so provenance recorded no input; a single-field
one hashed as its sole column, omitting schema and levels.

**A declared `support` on a batched output is checked column by column.** Walking
a batch as a named tree found no children and asked a multi-field batch to convert
to one array, so two valid columns raised.

## Consequences for calling code

Three, all stated in the changelog:

- A batched draw is not a `Record`, so `isinstance(draw, Record)` is now `False`
  where it was `True`. Ask for `RecordBatch`, or for either.
- A batch is a collection, not a named tree: a draw's fields come from
  `draw.event_template`, not `draw.fields` / `.items()` / `.at_path()`.
  `draw["x"]` and `draw["outer/a"]` are unchanged.
- A batch has no `mean` / `var` over its batch axis. Reduce the column:
  `jnp.mean(draw["x"], axis=0)`.

Both batch classes are now exported from `probpipe`. A batched draw is what a
joint law hands back, so a caller has to be able to name its type — the other
`*Batch` classes were already public.

## `RecordArray` is untouched

It still exists, is still exported, and behaves exactly as before for direct use.
No producer returns one.

One coupling did need attention: `NumericRecordArray.from_vector` delegated to the
shared flat-vector reconstruction, which now builds a batch — so the classmethod
was returning the other class, and its nested accessors (`at_path`, `mean`,
`var`) disappeared with it. It now renests the batch's flat columns itself. The
flat split belongs on the batch; only the renesting is on the class, and it goes
when the class does.

**Deleting `RecordArray` is a further step, not this one**: 670 references across
the package and its tests. Worth its own PR now that nothing produces one.
`RecordEmpiricalDistribution` (#340) and reparenting `Design` belong with it.

## Testing

Full suite green with every optional backend installed: **4777 passed / 48
skipped / 1 xfailed / 1 xpassed**, no failures and no collection errors.
`uvx ruff check` and `uvx ruff format` clean.

Test changes follow the contract rather than the class — a batched draw is a
`RecordBatch`, its fields are read from `event_template`, a row is gathered by
column. `from_vector`'s level rule gets the coverage it was missing: one name is
one level however many axes the vector carried, several names take one axis each,
and more names than axes still raises.

All 12 user-guide notebooks and both tutorials execute.

Part of #350.
