### PR TITLE
ci: label each PR in its own concurrency group

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,8 +17,9 @@ permissions:
   contents: read
   pull-requests: write
 
+# Keyed on the PR: `github.ref` does not vary by PR under `pull_request_target`.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

The **Auto-label PRs** workflow keyed its concurrency group on `github.ref`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Under `pull_request_target`, `github.ref` does not vary by PR, so every open PR
shared a single group. With `cancel-in-progress: true`, any pushes landing in the
same window left only the **last-created** run alive and cancelled the rest — so
those PRs never got their `area:*` labels, and `gh pr checks` renders the
cancellation as a failed check.

This keys the group on `github.event.pull_request.number`, which
`pull_request_target` always populates. That restores the intent: a new push to a
PR supersedes the run it replaces, and nothing else.

`ci.yml` is unaffected and needs no change — it triggers on `pull_request`, where
`github.ref` is the per-PR `refs/pull/N/merge` and so already isolates PRs.

## Evidence

Every batch of near-simultaneous label runs has exactly one survivor, the
latest-created, irrespective of base branch:

| Time (UTC) | Runs in the window | Survivor |
| --- | --- | --- |
| 2026-08-12 13:18 | 399 (base `main`), 401 (base `dev/record-batch`), 402 (base `dev/record-batch-gates`), 404 (base `dev/record-batch-cutover`) | 404 |
| 2026-08-12 12:34 | 309 (base `main`), 347 (base `dev/registry-catalog`), 348 (base `dev/registry-catalog`) | 309 |
| 2026-08-11 17:54 | 399, 401, 404, 402 | 402 |

Two independent observations rule out the group being per-base-branch — which is
the reading of `github.ref` one might otherwise assume:

- The 13:18 window holds **four distinct base branches** and still cancelled
  three of the four runs.
- The 12:34 window holds **two PRs sharing a base** (347, 348) and cancelled
  *both*, while a third on a different base survived.

The surviving run is the last one created in each window, which is the signature
of a single group shared by the whole workflow.

## Linked issue(s)

None — found while pushing a stack of PRs together.

## Test plan

- `.github/workflows/labeler.yml` parses (checked with `yaml.safe_load`); the
  change is three lines of `concurrency` key plus a comment.
- Verified after merge by pushing two PRs within a few seconds of each other and
  confirming both label runs complete.

Note that this PR's *own* label run still uses the old config: under
`pull_request_target` the workflow file comes from the base branch, so the fix
only takes effect once merged.

## Breaking changes

None.

## Documentation

Rationale is recorded as a comment beside the `concurrency` block, matching how
the trigger choice and `sync-labels: false` are already documented in that file.
No CHANGELOG entry: the behavior is not observable from the library, and the
`Unreleased` section is currently a set of library-behavior entries that several
in-flight PRs are all editing.
