### PR TITLE
fix(core): probe each mapping executor under its own map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Every dispatch presents a one-field draw the same way.** A one-field
+  record-valued law — a `ProductDistribution` over a single distribution, say —
+  draws a batch of records. The row-wise paths presented each draw as its bare
+  leaf; the `vmap` path presented the record. Since the record shim carries
+  conversions but deliberately no arithmetic, a body as ordinary as `x * 2`
+  succeeded under `dispatch="sequential"` and crashed under the mapped
+  executor. All four paths now present a draw through one rule.
+
+  Design II.4 leaves the choice itself open, riding on the single-value
+  coercion question `Record` poses. What it does not leave open is that the
+  dispatches agree, which is what this restores; the bare-leaf presentation is
+  the one three of the four paths already made.
+
 - **A body that returns a batch no longer crashes the marginalization path.**
   Calling a `Function` whose body returns a `RecordBatch` with a `Distribution`
   argument raised the pytree rank error out of `jax.vmap` instead of falling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,18 +43,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dispatches agree, which is what this restores; the bare-leaf presentation is
   the one three of the four paths already made.
 
-- **A law with no single event shape is probed rather than refused.** The
-  trace probe used to synthesize its dummy from `event_shape` and `dtype`, so a
-  law that has neither — a multi-field record-valued one — could not be probed
-  and was refused a JAX dispatch it can in fact take. The probe now draws
-  instead, and the draw supplies the structure.
+- **A law that cannot report its `dtype` is probed rather than refused.** The
+  trace probe read `event_shape` and `dtype` to size a synthetic dummy. Reading
+  `dtype` was itself the refusal: `getattr(law, "dtype", None)` swallows only
+  `AttributeError`, so a law raising anything else — a
+  `SequentialJointDistribution` view raises `NotImplementedError` — failed the
+  probe and was sent to row-wise dispatch for want of a placeholder. The probe
+  now draws a sample instead, and the draw carries both.
 
-  `dispatch="jax"` consequently accepts cases it used to reject, including
-  views of a `SequentialJointDistribution`: those build each component from a
-  Python callable, but that happens concretely while sampling, before the map,
-  so only the body is traced. The mapped result matches the row-wise one
-  exactly. An empirical law is unaffected, still enumerated so its exact
-  weights are preserved.
+  `dispatch="jax"` consequently accepts cases it used to reject, those views
+  above all. They build each component from a Python callable, which is indeed
+  not traceable, but that runs while sampling, before the map, so only the body
+  is traced; the mapped result matches the row-wise one exactly. An empirical
+  law is unaffected, still enumerated so its exact weights are preserved.
 
 - **A body that returns a batch no longer crashes the marginalization path.**
   Calling a `Function` whose body returns a `RecordBatch` with a `Distribution`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **A body that returns a batch no longer crashes the marginalization path.**
-  Calling a `Function` whose body returns a `RecordBatch` with a `Distribution`
-  argument raised the pytree rank error out of `jax.vmap` instead of falling
-  back to sequential dispatch.
-
-  The trace probe that gates JAX dispatch models the transform its executor
-  applies, so that a body which traces cleanly bare but cannot survive the
-  transform is caught while a fallback is still available. It did that for the
-  sweep executor and not for `_broadcast_jax`, which also maps — over the draw
-  axis rather than over batch rows — so a batch-returning body passed the probe
-  and then failed inside the executor, where nothing was left to fall back to.
-  Both mapping executors are now probed under a map.
-
 ### Removed (breaking)
 
 - **`RecordArray` and `NumericRecordArray` are gone; the batch of records is
@@ -44,6 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   names the classes being removed.
 
 ### Fixed
+
+- **A body that returns a batch no longer crashes the marginalization path.**
+  Calling a `Function` whose body returns a `RecordBatch` with a `Distribution`
+  argument raised the pytree rank error out of `jax.vmap` instead of falling
+  back to sequential dispatch.
+
+  The trace probe that gates JAX dispatch models the transform its executor
+  applies, so that a body which traces cleanly bare but cannot survive the
+  transform is caught while a fallback is still available. It did that for the
+  sweep executor and not for `_broadcast_jax`, which also maps — over the draw
+  axis rather than over batch rows — so a batch-returning body passed the probe
+  and then failed inside the executor, where nothing was left to fall back to.
+  Both mapping executors are now probed under a map.
 
 - **`is_concrete` no longer reports a polymorphic template as concrete (#390).**
   A symbolic dimension declared inside a term spec — a `RecordSpec`'s schema, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dispatches agree, which is what this restores; the bare-leaf presentation is
   the one three of the four paths already made.
 
+- **A law with no single event shape is probed rather than refused.** The
+  trace probe used to synthesize its dummy from `event_shape` and `dtype`, so a
+  law that has neither — a multi-field record-valued one — could not be probed
+  and was refused a JAX dispatch it can in fact take. The probe now draws
+  instead, and the draw supplies the structure.
+
+  `dispatch="jax"` consequently accepts cases it used to reject, including
+  views of a `SequentialJointDistribution`: those build each component from a
+  Python callable, but that happens concretely while sampling, before the map,
+  so only the body is traced. The mapped result matches the row-wise one
+  exactly. An empirical law is unaffected, still enumerated so its exact
+  weights are preserved.
+
 - **A body that returns a batch no longer crashes the marginalization path.**
   Calling a `Function` whose body returns a `RecordBatch` with a `Distribution`
   argument raised the pytree rank error out of `jax.vmap` instead of falling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A body that returns a batch no longer crashes the marginalization path.**
+  Calling a `Function` whose body returns a `RecordBatch` with a `Distribution`
+  argument raised the pytree rank error out of `jax.vmap` instead of falling
+  back to sequential dispatch.
+
+  The trace probe that gates JAX dispatch models the transform its executor
+  applies, so that a body which traces cleanly bare but cannot survive the
+  transform is caught while a fallback is still available. It did that for the
+  sweep executor and not for `_broadcast_jax`, which also maps — over the draw
+  axis rather than over batch rows — so a batch-returning body passed the probe
+  and then failed inside the executor, where nothing was left to fall back to.
+  Both mapping executors are now probed under a map.
+
 ### Removed (breaking)
 
 - **`RecordArray` and `NumericRecordArray` are gone; the batch of records is

--- a/probpipe/core/_workflow_distribution_broadcast.py
+++ b/probpipe/core/_workflow_distribution_broadcast.py
@@ -528,15 +528,15 @@ def _stack_rows(rows: list[Any], *, arg_name: str) -> Any:
     return jnp.stack(rows)
 
 
-def _present_draw(drawn: Any) -> Any:
-    """How one draw is presented to the wrapped function.
+def _sole_leaf_path(drawn: Any) -> str | None:
+    """The one leaf path a draw presents as, or ``None`` if it presents whole.
 
-    A single-field draw presents as its bare leaf. Design II.4 leaves the choice
-    open — it rides on the single-value-coercion question ``Record`` poses — so
-    what matters here is that every dispatch make the *same* one: the record
-    shim is deliberately narrow, carrying conversions but no arithmetic, so a
-    body written for the value would work under one dispatch and fail under
-    another if they disagreed. Every path presenting a draw goes through here.
+    The single place the single-field question is decided, so that every path
+    presenting a draw decides it the same way. Design II.4 leaves the choice
+    itself open — it rides on the single-value-coercion question ``Record``
+    poses — but not the agreement: the record shim is deliberately narrow,
+    carrying conversions and no arithmetic, so a body written for the value
+    would work under one dispatch and fail under another if they diverged.
     """
     from ._record_batch import RecordBatch
     from .record import Record
@@ -544,23 +544,29 @@ def _present_draw(drawn: Any) -> Any:
     if isinstance(drawn, (Record, RecordBatch)):
         leaf_paths = tuple(drawn.event_template.keys())
         if len(leaf_paths) == 1:
-            return drawn[leaf_paths[0]]
-    return drawn
+            return leaf_paths[0]
+    return None
+
+
+def _present_draw(drawn: Any) -> Any:
+    """How one already-sliced draw is presented to the wrapped function."""
+    path = _sole_leaf_path(drawn)
+    return drawn if path is None else drawn[path]
 
 
 def _index_sample(s: Any, i: int) -> Any:
-    """Index row ``i`` of a per-argument sample batch."""
+    """Index row ``i`` of a per-argument sample batch, as that row presents."""
     from ._record_batch import RecordBatch
     from .record import Record
 
+    path = _sole_leaf_path(s)
+    if path is not None:
+        return s[path][i]
     if isinstance(s, (Record, RecordBatch)):
         # Index each leaf field's batch row; rebuild by path key so a nested
         # sample is reconstructed with its structure intact. A row of a batch is
         # a single record, so the rebuild is the same either way.
-        leaf_paths = tuple(s.event_template.keys())
-        if len(leaf_paths) == 1:
-            return s[leaf_paths[0]][i]
-        return Record(s.name, {p: s[p][i] for p in leaf_paths}, name_is_auto=True)
+        return Record(s.name, {p: s[p][i] for p in s.event_template}, name_is_auto=True)
     return s[i]
 
 

--- a/probpipe/core/_workflow_distribution_broadcast.py
+++ b/probpipe/core/_workflow_distribution_broadcast.py
@@ -355,9 +355,7 @@ def _broadcast_jax(
         key,
     )
 
-    def single_call(broadcast_slice):
-        replacements = dict(zip(broadcast_args, broadcast_slice))
-        return func(**_workflow_call.replace_input_refs(values, replacements))
+    single_call = mapped_draw_body(func=func, values=values, broadcast_args=broadcast_args)
 
     batch = tuple(sampled[ref] for ref in broadcast_args)
 
@@ -530,6 +528,26 @@ def _stack_rows(rows: list[Any], *, arg_name: str) -> Any:
     return jnp.stack(rows)
 
 
+def _present_draw(drawn: Any) -> Any:
+    """How one draw is presented to the wrapped function.
+
+    A single-field draw presents as its bare leaf. Design II.4 leaves the choice
+    open — it rides on the single-value-coercion question ``Record`` poses — so
+    what matters here is that every dispatch make the *same* one: the record
+    shim is deliberately narrow, carrying conversions but no arithmetic, so a
+    body written for the value would work under one dispatch and fail under
+    another if they disagreed. Every path presenting a draw goes through here.
+    """
+    from ._record_batch import RecordBatch
+    from .record import Record
+
+    if isinstance(drawn, (Record, RecordBatch)):
+        leaf_paths = tuple(drawn.event_template.keys())
+        if len(leaf_paths) == 1:
+            return drawn[leaf_paths[0]]
+    return drawn
+
+
 def _index_sample(s: Any, i: int) -> Any:
     """Index row ``i`` of a per-argument sample batch."""
     from ._record_batch import RecordBatch
@@ -544,3 +562,26 @@ def _index_sample(s: Any, i: int) -> Any:
             return s[leaf_paths[0]][i]
         return Record(s.name, {p: s[p][i] for p in leaf_paths}, name_is_auto=True)
     return s[i]
+
+
+def mapped_draw_body(
+    *,
+    func: Callable[..., Any],
+    values: dict[str, Any],
+    broadcast_args: Sequence[_workflow_call.WorkflowInputRef],
+) -> Callable[[Any], Any]:
+    """The body ``jax.vmap`` runs for one draw, and the probe traces.
+
+    Shared so the probe traces exactly what the executor runs, which two
+    separately maintained functions cannot promise. Mapping a batch of records
+    yields a record per draw, which :func:`_present_draw` then presents the same
+    way the row-wise paths do.
+    """
+
+    def one_draw(broadcast_slice):
+        replacements = {
+            ref: _present_draw(drawn) for ref, drawn in zip(broadcast_args, broadcast_slice)
+        }
+        return func(**_workflow_call.replace_input_refs(values, replacements))
+
+    return one_draw

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -886,22 +886,12 @@ class Function(Node, TrackedTerm, Annotated):
         The probe traces the operation the dispatch is choosing, not merely the
         body: a body can trace cleanly bare yet be impossible under the
         transform its executor applies — one that returns a batch, whose added
-        axis no level can name. So each argument is probed the way the executor
-        that would receive it will actually feed it, and **every executor that
-        maps is probed under a map**:
-
-        - A batched-record argument goes to ``execute_sweep_rows_jax``, which
-          maps over leaf columns and rebuilds a ``Record`` inside the traced
-          call. Probed that way, over one row.
-        - A plain distribution argument goes to ``_broadcast_jax``, which draws
-          ``n`` samples and maps over the draw axis. Probed that way, over one
-          draw.
-
-        A probe that omits its executor's transform is the defect this guards:
-        the body passes and then fails inside the executor, where there is no
-        fallback left to take. A probe failure means sequential dispatch, which
-        is always able to run the call — the two paths agree on results by
-        contract, so falling back costs speed, never correctness.
+        axis no level can name. So every executor that maps is probed under a
+        map, each argument fed the way its own executor will feed it: a
+        batched-record argument over one row, a distribution over one draw. A
+        probe failure means sequential dispatch, which is always able to run the
+        call — the two paths agree on results by contract, so falling back costs
+        speed, never correctness.
         """
         try:
             dummy_kw = dict(values)
@@ -942,11 +932,6 @@ class Function(Node, TrackedTerm, Annotated):
                         # mirrors what the inner function actually sees.
                         dt = getattr(dist, "dtype", None) or jnp.zeros((), dtype=float).dtype
                         replacement = jnp.zeros(es, dtype=dt) if es else jnp.zeros((), dtype=dt)
-                        # Whatever reaches here is what ``_broadcast_jax`` will
-                        # map over, so all of it is probed under a map. A
-                        # batched ``DistributionArray`` never arrives: a sweep
-                        # carrying one takes row-wise dispatch before any probe
-                        # runs.
                         drawn_sources[ref] = (tuple(es) if es else (), dt)
                     dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, replacement)
                 else:
@@ -994,10 +979,8 @@ class Function(Node, TrackedTerm, Annotated):
                         kw = _workflow_call.replace_input_ref(kw, draw_ref, draw)
                     return func(**kw)
 
-                # One draw, shaped as ``_sample_broadcast_args`` produces them:
-                # the leading axis is the draw axis ``_broadcast_jax`` maps over,
-                # so what the traced call sees is the event-shaped slice the
-                # bare probe used to pass directly.
+                # Leading axis is the draw axis, so the traced call sees the
+                # event-shaped slice.
                 probe_draws = tuple(
                     jnp.zeros((1, *event_shape), dtype=dtype)
                     for event_shape, dtype in drawn_sources.values()

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -979,13 +979,14 @@ class Function(Node, TrackedTerm, Annotated):
                         kw = _workflow_call.replace_input_ref(kw, draw_ref, draw)
                     return func(**kw)
 
-                # Leading axis is the draw axis, so the traced call sees the
-                # event-shaped slice.
-                probe_draws = tuple(
-                    jnp.zeros((1, *event_shape), dtype=dtype)
-                    for event_shape, dtype in drawn_sources.values()
+                # Drawn the executor's own way rather than synthesized from an
+                # event shape: a record-valued law draws a batch of records, and
+                # mapping it hands the body a record where zeros of its event
+                # shape would hand it an array. One draw, so the map has an axis.
+                sampled = _workflow_distribution_broadcast._sample_broadcast_args(
+                    values, refs, 1, jax.random.PRNGKey(0)
                 )
-                jax.make_jaxpr(jax.vmap(_draw_call))(probe_draws)
+                jax.make_jaxpr(jax.vmap(_draw_call))(tuple(sampled[ref] for ref in refs))
             else:
                 jax.make_jaxpr(lambda kw: func(**kw))(dummy_kw)
         except Exception as exc:

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -972,17 +972,14 @@ class Function(Node, TrackedTerm, Annotated):
                 jax.make_jaxpr(jax.vmap(_row_call))(tuple(probe_leaves))
             elif drawn_sources:
                 refs = list(drawn_sources)
-
-                def _draw_call(draws):
-                    kw = dummy_kw
-                    for draw_ref, draw in zip(refs, draws):
-                        kw = _workflow_call.replace_input_ref(kw, draw_ref, draw)
-                    return func(**kw)
-
-                # Drawn the executor's own way rather than synthesized from an
-                # event shape: a record-valued law draws a batch of records, and
-                # mapping it hands the body a record where zeros of its event
-                # shape would hand it an array. One draw, so the map has an axis.
+                # The executor's own body and the executor's own draw, so the
+                # probe traces the value the body will actually receive: a
+                # record-valued law draws a batch of records, which zeros of its
+                # event shape would not have modelled. One draw, so the map has
+                # an axis.
+                _draw_call = _workflow_distribution_broadcast.mapped_draw_body(
+                    func=func, values=dummy_kw, broadcast_args=refs
+                )
                 sampled = _workflow_distribution_broadcast._sample_broadcast_args(
                     values, refs, 1, jax.random.PRNGKey(0)
                 )

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -897,7 +897,7 @@ class Function(Node, TrackedTerm, Annotated):
             dummy_kw = dict(values)
             broadcast_refs = set(broadcast_args)
             batched_sources: dict[_workflow_call.WorkflowInputRef, Any] = {}
-            drawn_sources: dict[_workflow_call.WorkflowInputRef, tuple[tuple[int, ...], Any]] = {}
+            drawn_refs: list[_workflow_call.WorkflowInputRef] = []
             for ref in _workflow_call.iter_input_refs(self._signature_info, values):
                 v = _workflow_call.input_ref_value(values, ref)
                 if ref in broadcast_refs:
@@ -905,35 +905,14 @@ class Function(Node, TrackedTerm, Annotated):
                     # sees what an inner sweep iteration will actually
                     # receive.
                     if isinstance(v, RecordBatch):
-                        replacement = v[0]
                         batched_sources[ref] = v
+                        dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, v[0])
                     else:
-                        dist = v
-                        # ``event_shape`` raises on multi-field NRDs
-                        # (``NotImplementedError`` on the base or
-                        # ``TypeError`` via ``_single_field_name``) —
-                        # those distributions don't have a single
-                        # array-shaped placeholder, so the probe can't
-                        # produce a dummy. Falling out to the outer
-                        # ``except Exception`` triggers row-wise dispatch,
-                        # which is the right default for multi-field
-                        # record-valued inputs.
-                        try:
-                            es = dist.event_shape
-                        except (TypeError, NotImplementedError) as exc:
-                            raise NotImplementedError(
-                                f"Cannot probe JAX traceability for "
-                                f"{type(dist).__name__} broadcast arg "
-                                f"{ref.label!r}: no single ``event_shape`` "
-                                f"(multi-field or abstract). "
-                                f"Falling back to row-wise dispatch."
-                            ) from exc
-                        # Match the distribution's own dtype so the probe
-                        # mirrors what the inner function actually sees.
-                        dt = getattr(dist, "dtype", None) or jnp.zeros((), dtype=float).dtype
-                        replacement = jnp.zeros(es, dtype=dt) if es else jnp.zeros((), dtype=dt)
-                        drawn_sources[ref] = (tuple(es) if es else (), dt)
-                    dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, replacement)
+                        # Nothing to synthesize: the draw itself supplies the
+                        # structure and dtype below, which is what lets a
+                        # multi-field law be probed at all — it has no single
+                        # event shape to stand in for one.
+                        drawn_refs.append(ref)
                 else:
                     if isinstance(v, jnp.ndarray):
                         replacement = v
@@ -970,8 +949,8 @@ class Function(Node, TrackedTerm, Annotated):
                         }
                     )
                 jax.make_jaxpr(jax.vmap(_row_call))(tuple(probe_leaves))
-            elif drawn_sources:
-                refs = list(drawn_sources)
+            elif drawn_refs:
+                refs = drawn_refs
                 # The executor's own body and the executor's own draw, so the
                 # probe traces the value the body will actually receive: a
                 # record-valued law draws a batch of records, which zeros of its

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -942,11 +942,11 @@ class Function(Node, TrackedTerm, Annotated):
                         # mirrors what the inner function actually sees.
                         dt = getattr(dist, "dtype", None) or jnp.zeros((), dtype=float).dtype
                         replacement = jnp.zeros(es, dtype=dt) if es else jnp.zeros((), dtype=dt)
-                        # Every distribution reaching here is one ``_broadcast_jax``
-                        # draws and maps over, including a ``DistributionArray``
-                        # of empty batch shape — the planner routes that to the
-                        # marginalization path, and a batched one takes row-wise
-                        # dispatch before any probe runs.
+                        # Whatever reaches here is what ``_broadcast_jax`` will
+                        # map over, so all of it is probed under a map. A
+                        # batched ``DistributionArray`` never arrives: a sweep
+                        # carrying one takes row-wise dispatch before any probe
+                        # runs.
                         drawn_sources[ref] = (tuple(es) if es else (), dt)
                     dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, replacement)
                 else:

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -884,19 +884,30 @@ class Function(Node, TrackedTerm, Annotated):
         """Return the JAX trace-probe error for the current call, if any.
 
         The probe traces the operation the dispatch is choosing, not merely the
-        body: a sweep runs the body under ``jax.vmap``, and a body can trace
-        cleanly bare yet be impossible under the transform — one that returns a
-        batch, whose added axis no level can name. So a batched-record argument
-        is probed the way ``execute_sweep_rows_jax`` will actually feed it: its
-        leaf columns, mapped over one row, rebuilt into a ``Record`` inside the
-        traced call. A probe failure means sequential dispatch, which is always
-        able to run the call — the two paths agree on results by contract, so
-        falling back costs speed, never correctness.
+        body: a body can trace cleanly bare yet be impossible under the
+        transform its executor applies — one that returns a batch, whose added
+        axis no level can name. So each argument is probed the way the executor
+        that would receive it will actually feed it, and **every executor that
+        maps is probed under a map**:
+
+        - A batched-record argument goes to ``execute_sweep_rows_jax``, which
+          maps over leaf columns and rebuilds a ``Record`` inside the traced
+          call. Probed that way, over one row.
+        - A plain distribution argument goes to ``_broadcast_jax``, which draws
+          ``n`` samples and maps over the draw axis. Probed that way, over one
+          draw.
+
+        A probe that omits its executor's transform is the defect this guards:
+        the body passes and then fails inside the executor, where there is no
+        fallback left to take. A probe failure means sequential dispatch, which
+        is always able to run the call — the two paths agree on results by
+        contract, so falling back costs speed, never correctness.
         """
         try:
             dummy_kw = dict(values)
             broadcast_refs = set(broadcast_args)
             batched_sources: dict[_workflow_call.WorkflowInputRef, Any] = {}
+            drawn_sources: dict[_workflow_call.WorkflowInputRef, tuple[tuple[int, ...], Any]] = {}
             for ref in _workflow_call.iter_input_refs(self._signature_info, values):
                 v = _workflow_call.input_ref_value(values, ref)
                 if ref in broadcast_refs:
@@ -931,6 +942,12 @@ class Function(Node, TrackedTerm, Annotated):
                         # mirrors what the inner function actually sees.
                         dt = getattr(dist, "dtype", None) or jnp.zeros((), dtype=float).dtype
                         replacement = jnp.zeros(es, dtype=dt) if es else jnp.zeros((), dtype=dt)
+                        # Every distribution reaching here is one ``_broadcast_jax``
+                        # draws and maps over, including a ``DistributionArray``
+                        # of empty batch shape — the planner routes that to the
+                        # marginalization path, and a batched one takes row-wise
+                        # dispatch before any probe runs.
+                        drawn_sources[ref] = (tuple(es) if es else (), dt)
                     dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, replacement)
                 else:
                     if isinstance(v, jnp.ndarray):
@@ -968,6 +985,24 @@ class Function(Node, TrackedTerm, Annotated):
                         }
                     )
                 jax.make_jaxpr(jax.vmap(_row_call))(tuple(probe_leaves))
+            elif drawn_sources:
+                refs = list(drawn_sources)
+
+                def _draw_call(draws):
+                    kw = dummy_kw
+                    for draw_ref, draw in zip(refs, draws):
+                        kw = _workflow_call.replace_input_ref(kw, draw_ref, draw)
+                    return func(**kw)
+
+                # One draw, shaped as ``_sample_broadcast_args`` produces them:
+                # the leading axis is the draw axis ``_broadcast_jax`` maps over,
+                # so what the traced call sees is the event-shaped slice the
+                # bare probe used to pass directly.
+                probe_draws = tuple(
+                    jnp.zeros((1, *event_shape), dtype=dtype)
+                    for event_shape, dtype in drawn_sources.values()
+                )
+                jax.make_jaxpr(jax.vmap(_draw_call))(probe_draws)
             else:
                 jax.make_jaxpr(lambda kw: func(**kw))(dummy_kw)
         except Exception as exc:

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -11,9 +13,11 @@ from probpipe import (
     BroadcastDistribution,
     EmpiricalDistribution,
     Function,
+    MultivariateNormal,
     Normal,
     ProductDistribution,
     Record,
+    RecordBatch,
     RecordEmpiricalDistribution,
     sample,
 )
@@ -639,3 +643,183 @@ class TestIndexSampleHelper:
         assert isinstance(row, NumericRecord)
         assert float(row["scalar"]) == 1.0
         np.testing.assert_array_equal(row["vec"], jnp.array([3.0, 4.0, 5.0]))
+
+
+class TestTheProbeModelsItsExecutorsTransform:
+    """``_broadcast_jax`` maps over draws, so the probe that gates it must too.
+
+    A body can trace cleanly bare and be impossible under ``jax.vmap`` — one
+    returning a batch, whose added axis no level can name. Probing such a body
+    without the transform passes it to an executor that then fails inside the
+    transform, where no fallback is left to take.
+    """
+
+    @staticmethod
+    def _returns_a_batch(**controls):
+        def body(x):
+            return RecordBatch.stack(
+                [Record("r", {"y": x * k}, name_is_auto=True) for k in (1.0, 2.0, 3.0)],
+                level_name="k",
+            )
+
+        return Function(
+            func=body,
+            dispatch=controls.pop("dispatch", "auto"),
+            n_broadcast_samples=controls.pop("n_broadcast_samples", 8),
+            seed=0,
+            **controls,
+        )
+
+    def test_a_batch_returning_body_falls_back_rather_than_failing_in_the_executor(self):
+        """The regression: this raised the pytree rank error out of ``vmap``."""
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+
+        result = self._returns_a_batch()(dist)
+
+        assert result is not None
+
+    def test_the_fallback_is_what_ran(self, caplog):
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+
+        with caplog.at_level(logging.INFO, logger="probpipe.core.node"):
+            self._returns_a_batch()(dist)
+
+        assert any("not JAX-traceable" in record.message for record in caplog.records)
+
+    def test_the_fallback_agrees_with_explicit_sequential(self):
+        """Falling back costs speed, never the answer."""
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+
+        fell_back = self._returns_a_batch(dispatch="auto")(dist)
+        sequential = self._returns_a_batch(dispatch="sequential")(dist)
+
+        np.testing.assert_array_equal(np.asarray(fell_back.samples), np.asarray(sequential.samples))
+
+    def test_requesting_jax_reports_the_dispatch_rather_than_the_pytree(self):
+        """The refusal names the choice the caller made and can change."""
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+
+        with pytest.raises(ValueError, match="dispatch='jax' failed while tracing"):
+            self._returns_a_batch(dispatch="jax")(dist)
+
+    def test_a_body_that_survives_the_transform_still_takes_jax(self, caplog):
+        """The probe gained a transform, not a blanket refusal."""
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+        doubles = Function(func=lambda x: x * 2.0, n_broadcast_samples=8, seed=0)
+
+        with caplog.at_level(logging.INFO, logger="probpipe.core.node"):
+            doubles(dist)
+
+        assert not any("not JAX-traceable" in record.message for record in caplog.records)
+
+    def test_several_distribution_arguments_are_all_mapped(self):
+        """The probe maps a tuple of draws, one per broadcast argument.
+
+        One argument exercises the loop's first iteration only; a body reading
+        two would trace under a probe that mapped just the first.
+        """
+
+        def body(x, y):
+            return RecordBatch.stack(
+                [Record("r", {"z": x * k + y}, name_is_auto=True) for k in (1.0, 2.0)],
+                level_name="k",
+            )
+
+        broadcast = Function(func=body, n_broadcast_samples=8, seed=0)
+        sequential = Function(func=body, dispatch="sequential", n_broadcast_samples=8, seed=0)
+        first = Normal(loc=0.0, scale=1.0, name="x")
+        second = Normal(loc=3.0, scale=1.0, name="y")
+
+        np.testing.assert_array_equal(
+            np.asarray(broadcast(first, second).samples),
+            np.asarray(sequential(first, second).samples),
+        )
+
+    def test_a_nonscalar_event_shape_is_probed_at_its_own_shape(self):
+        """The mapped slice is event-shaped, as the bare probe's dummy was.
+
+        A leading draw axis prepended to the wrong slice shape would trace a
+        body that indexes or reduces over the event axes against the wrong rank.
+        """
+
+        def body(v):
+            return RecordBatch.stack(
+                [Record("r", {"s": jnp.sum(v) * k}, name_is_auto=True) for k in (1.0, 2.0)],
+                level_name="k",
+            )
+
+        vector = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="v")
+        broadcast = Function(func=body, n_broadcast_samples=8, seed=0)
+        sequential = Function(func=body, dispatch="sequential", n_broadcast_samples=8, seed=0)
+
+        np.testing.assert_array_equal(
+            np.asarray(broadcast(vector).samples), np.asarray(sequential(vector).samples)
+        )
+
+    def test_a_nonscalar_event_shape_still_vectorizes_when_the_body_allows(self):
+        """The added transform did not cost the vectorized path its shapes."""
+        vector = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="v")
+        total = Function(func=lambda v: jnp.sum(v), n_broadcast_samples=8, seed=0)
+        sequential = Function(
+            func=lambda v: jnp.sum(v), dispatch="sequential", n_broadcast_samples=8, seed=0
+        )
+
+        np.testing.assert_allclose(
+            np.asarray(total(vector).samples), np.asarray(sequential(vector).samples), rtol=1e-6
+        )
+
+    def test_an_aliased_argument_still_reads_as_one_variable(self):
+        """Co-sampling is the sampler's, not the probe's.
+
+        The probe draws an independent dummy per reference, which must not be
+        mistaken for the executor's grouping: ``f(d, d)`` is still ``X - X``.
+        """
+        dist = Normal(loc=0.0, scale=1.0, name="x")
+        difference = Function(func=lambda a, b: a - b, n_broadcast_samples=8, seed=0)
+
+        np.testing.assert_array_equal(np.asarray(difference(dist, dist).samples), np.zeros(8))
+
+    def test_a_record_valued_distribution_argument_still_falls_back(self):
+        """A multi-field law has no single event-shaped dummy, so it never probes.
+
+        That path raises before the draw sources are collected; it must keep
+        reaching row-wise dispatch rather than the new mapped branch.
+        """
+        law = ProductDistribution(
+            Normal(loc=0.0, scale=1.0, name="a"), Normal(loc=1.0, scale=1.0, name="b")
+        )
+        totals = Function(func=lambda r: r["a"] + r["b"], n_broadcast_samples=8, seed=0)
+        sequential = Function(
+            func=lambda r: r["a"] + r["b"], dispatch="sequential", n_broadcast_samples=8, seed=0
+        )
+
+        np.testing.assert_array_equal(
+            np.asarray(totals(law).samples), np.asarray(sequential(law).samples)
+        )
+
+    def test_a_batch_returning_body_survives_the_nested_regime(self, caplog):
+        """A sweep crossed with a law composes the two fallbacks.
+
+        The sweep's own probe already refuses this body, so the outer path falls
+        back before the per-row marginalization is reached — this pins that the
+        composition still produces a result, not that the mapped-draw probe is
+        what caught it.
+        """
+
+        def body(p, x):
+            return RecordBatch.stack(
+                [Record("r", {"y": p["a"] * x * k}, name_is_auto=True) for k in (1.0, 2.0)],
+                level_name="k",
+            )
+
+        rows = RecordBatch.stack(
+            [Record("p", {"a": jnp.asarray(float(i))}, name_is_auto=True) for i in range(3)],
+            level_name="row",
+        )
+        nested = Function(func=body, n_broadcast_samples=8, seed=0)
+
+        with caplog.at_level(logging.INFO, logger="probpipe.core.node"):
+            result = nested(rows, Normal(loc=0.0, scale=1.0, name="x"))
+
+        assert result is not None
+        assert any("not JAX-traceable" in record.message for record in caplog.records)

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -648,10 +648,8 @@ class TestIndexSampleHelper:
 class TestTheProbeModelsItsExecutorsTransform:
     """``_broadcast_jax`` maps over draws, so the probe that gates it must too.
 
-    A body can trace cleanly bare and be impossible under ``jax.vmap`` — one
-    returning a batch, whose added axis no level can name. Probing such a body
-    without the transform passes it to an executor that then fails inside the
-    transform, where no fallback is left to take.
+    Probing without the transform passes a body to an executor that then fails
+    inside it, where no fallback is left to take.
     """
 
     @staticmethod
@@ -715,12 +713,9 @@ class TestTheProbeModelsItsExecutorsTransform:
     def test_the_mapped_probe_covers_several_distribution_arguments(self):
         """The probe builds a tuple of draws, one per broadcast argument.
 
-        This covers the multiple-reference path rather than isolating the second
-        argument: ``jax.make_jaxpr`` abstracts every argument it is given, so
-        the bare probe already sees a tracer wherever the mapped one does, and
-        no body distinguishes "mapped" from "traced" by its own arguments. What
-        distinguishes them is output reconstruction — hence a batch-returning
-        body here, as in the single-argument case.
+        Covers the multiple-reference path without isolating the second
+        argument: ``jax.make_jaxpr`` abstracts everything it is given, so no
+        body can tell "mapped" from "traced" by its arguments alone.
         """
 
         def body(x, y):
@@ -742,9 +737,9 @@ class TestTheProbeModelsItsExecutorsTransform:
     def test_the_mapped_slice_carries_the_declared_event_shape(self, caplog):
         """The slice is event-shaped, as the bare probe's dummy was.
 
-        ``v[2]`` is rank-sensitive where a reduction would not be: a dummy of
-        the wrong shape fails to trace and the call silently leaves the JAX
-        path, so staying on it is the assertion.
+        ``v[2]`` is rank-sensitive where a reduction would not be, and a dummy
+        of the wrong shape silently leaves the JAX path — so staying on it is
+        the assertion.
         """
         vector = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="v")
         third = Function(func=lambda v: v[2], n_broadcast_samples=8, seed=0)
@@ -761,10 +756,10 @@ class TestTheProbeModelsItsExecutorsTransform:
         )
 
     def test_an_aliased_argument_still_reads_as_one_variable(self):
-        """Co-sampling is the sampler's, not the probe's.
+        """Co-sampling is the sampler's, not the probe's: ``f(d, d)`` is ``X - X``.
 
-        The probe draws an independent dummy per reference, which must not be
-        mistaken for the executor's grouping: ``f(d, d)`` is still ``X - X``.
+        The probe's independent dummy per reference must not be mistaken for
+        the executor's grouping.
         """
         dist = Normal(loc=0.0, scale=1.0, name="x")
         difference = Function(func=lambda a, b: a - b, n_broadcast_samples=8, seed=0)
@@ -774,8 +769,8 @@ class TestTheProbeModelsItsExecutorsTransform:
     def test_a_record_valued_distribution_argument_still_falls_back(self):
         """A multi-field law has no single event-shaped dummy, so it never probes.
 
-        That path raises before the draw sources are collected; it must keep
-        reaching row-wise dispatch rather than the new mapped branch.
+        It raises before the draw sources are collected, and must keep reaching
+        row-wise dispatch rather than the mapped branch.
         """
         law = ProductDistribution(
             Normal(loc=0.0, scale=1.0, name="a"), Normal(loc=1.0, scale=1.0, name="b")
@@ -792,10 +787,8 @@ class TestTheProbeModelsItsExecutorsTransform:
     def test_a_batch_returning_body_survives_the_nested_regime(self, caplog):
         """A sweep crossed with a law still produces a result.
 
-        Verified by spying on the executor: ``_broadcast_jax`` is not reached in
-        this regime at all — the per-row marginalization resolves to the
-        row-wise sampler — so this pins the composition rather than the
-        mapped-draw probe, which the other tests here cover directly.
+        ``_broadcast_jax`` is not reached in this regime at all, so this pins
+        the composition rather than the mapped-draw probe.
         """
 
         def body(p, x):

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -808,3 +808,20 @@ class TestTheProbeModelsItsExecutorsTransform:
 
         assert result is not None
         assert any("not JAX-traceable" in record.message for record in caplog.records)
+
+    def test_a_one_field_record_law_is_probed_as_the_record_it_draws(self):
+        """The dummy is drawn, not synthesized from an event shape.
+
+        A one-field ``ProductDistribution`` draws a batch of records, so mapping
+        it hands the body a record; zeros of the law's event shape would hand it
+        an array, and a body that fails on the record would pass such a probe.
+        """
+        law = ProductDistribution(Normal(loc=0.0, scale=1.0, name="x"))
+        doubles = Function(func=lambda x: x * 2, n_broadcast_samples=8, seed=0)
+        sequential = Function(
+            func=lambda x: x * 2, dispatch="sequential", n_broadcast_samples=8, seed=0
+        )
+
+        np.testing.assert_array_equal(
+            np.asarray(doubles(law).samples), np.asarray(sequential(law).samples)
+        )

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -809,12 +809,13 @@ class TestTheProbeModelsItsExecutorsTransform:
         assert result is not None
         assert any("not JAX-traceable" in record.message for record in caplog.records)
 
-    def test_a_one_field_record_law_is_probed_as_the_record_it_draws(self):
-        """The dummy is drawn, not synthesized from an event shape.
+    def test_a_one_field_record_law_presents_the_same_value_to_every_dispatch(self, caplog):
+        """A one-field draw presents as its bare leaf, whichever dispatch runs.
 
-        A one-field ``ProductDistribution`` draws a batch of records, so mapping
-        it hands the body a record; zeros of the law's event shape would hand it
-        an array, and a body that fails on the record would pass such a probe.
+        The law draws a batch of records, so mapping it yields a record where
+        the row-wise paths hand over the column. The record shim carries no
+        arithmetic, so ``x * 2`` distinguishes the two: it used to crash under
+        the mapped executor and succeed row-wise.
         """
         law = ProductDistribution(Normal(loc=0.0, scale=1.0, name="x"))
         doubles = Function(func=lambda x: x * 2, n_broadcast_samples=8, seed=0)
@@ -822,6 +823,11 @@ class TestTheProbeModelsItsExecutorsTransform:
             func=lambda x: x * 2, dispatch="sequential", n_broadcast_samples=8, seed=0
         )
 
+        with caplog.at_level(logging.INFO, logger="probpipe.core.node"):
+            mapped = doubles(law)
+
+        # Consistent *and* still vectorized, rather than consistent by retreat.
+        assert not any("not JAX-traceable" in record.message for record in caplog.records)
         np.testing.assert_array_equal(
-            np.asarray(doubles(law).samples), np.asarray(sequential(law).samples)
+            np.asarray(mapped.samples), np.asarray(sequential(law).samples)
         )

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -766,11 +766,11 @@ class TestTheProbeModelsItsExecutorsTransform:
 
         np.testing.assert_array_equal(np.asarray(difference(dist, dist).samples), np.zeros(8))
 
-    def test_a_record_valued_distribution_argument_still_falls_back(self):
-        """A multi-field law has no single event-shaped dummy, so it never probes.
+    def test_a_multi_field_law_is_probed_by_its_draw(self, caplog):
+        """A multi-field law has no single event shape to synthesize a dummy from.
 
-        It raises before the draw sources are collected, and must keep reaching
-        row-wise dispatch rather than the mapped branch.
+        The draw supplies the structure instead, so such a law is probed rather
+        than refused for want of a placeholder, and vectorizes.
         """
         law = ProductDistribution(
             Normal(loc=0.0, scale=1.0, name="a"), Normal(loc=1.0, scale=1.0, name="b")
@@ -780,7 +780,30 @@ class TestTheProbeModelsItsExecutorsTransform:
             func=lambda r: r["a"] + r["b"], dispatch="sequential", n_broadcast_samples=8, seed=0
         )
 
+        with caplog.at_level(logging.INFO, logger="probpipe.core.node"):
+            mapped = totals(law)
+
+        assert not any("not JAX-traceable" in record.message for record in caplog.records)
         np.testing.assert_array_equal(
+            np.asarray(mapped.samples), np.asarray(sequential(law).samples)
+        )
+
+    def test_an_empirical_law_is_enumerated_rather_than_mapped(self):
+        """Not the probe's doing: enumeration preserves exact weights.
+
+        A record-valued empirical law takes the enumeration path whatever the
+        probe would say, so its agreeing with sequential dispatch is a property
+        of that path rather than of the mapped one.
+        """
+        law = RecordEmpiricalDistribution(
+            Record("r", {"a": jnp.arange(6.0), "b": jnp.arange(6.0) + 10.0}, name_is_auto=True)
+        )
+        totals = Function(func=lambda r: r["a"] + r["b"], n_broadcast_samples=6, seed=0)
+        sequential = Function(
+            func=lambda r: r["a"] + r["b"], dispatch="sequential", n_broadcast_samples=6, seed=0
+        )
+
+        np.testing.assert_allclose(
             np.asarray(totals(law).samples), np.asarray(sequential(law).samples)
         )
 

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -23,6 +23,7 @@ from probpipe import (
 )
 from probpipe.core import _workflow_call, _workflow_distribution_broadcast, _workflow_execution
 from probpipe.core.config import WorkflowKind
+from probpipe.distributions import SequentialJointDistribution
 
 
 def _execution_config(
@@ -766,11 +767,36 @@ class TestTheProbeModelsItsExecutorsTransform:
 
         np.testing.assert_array_equal(np.asarray(difference(dist, dist).samples), np.zeros(8))
 
-    def test_a_multi_field_law_is_probed_by_its_draw(self, caplog):
-        """A multi-field law has no single event shape to synthesize a dummy from.
+    def test_a_law_that_cannot_answer_dtype_is_still_probed(self, caplog):
+        """The draw carries structure and dtype, so neither is asked for first.
 
-        The draw supplies the structure instead, so such a law is probed rather
-        than refused for want of a placeholder, and vectorizes.
+        The regression: a ``SequentialJointDistribution`` view raises
+        ``NotImplementedError`` for ``dtype``, which the probe used to read to
+        size its dummy — and which ``getattr(..., None)`` does not swallow, so
+        the law was refused a dispatch it can take.
+        """
+        joint = SequentialJointDistribution(
+            z=Normal(loc=0.0, scale=1.0, name="z"),
+            x=lambda z: Normal(loc=z, scale=0.01, name="x"),
+        )
+        difference = Function(func=lambda a, b: a - b, n_broadcast_samples=8, seed=0)
+        sequential = Function(
+            func=lambda a, b: a - b, dispatch="sequential", n_broadcast_samples=8, seed=0
+        )
+
+        with caplog.at_level(logging.INFO, logger="probpipe.core.node"):
+            mapped = difference(a=joint["z"], b=joint["x"])
+
+        assert not any("not JAX-traceable" in record.message for record in caplog.records)
+        np.testing.assert_allclose(
+            np.asarray(mapped.samples),
+            np.asarray(sequential(a=joint["z"], b=joint["x"]).samples),
+        )
+
+    def test_a_multi_field_law_vectorizes(self, caplog):
+        """A guard, not a regression: this law answers both, so it always could.
+
+        Kept because the draw-based probe must not narrow what it accepts.
         """
         law = ProductDistribution(
             Normal(loc=0.0, scale=1.0, name="a"), Normal(loc=1.0, scale=1.0, name="b")

--- a/tests/core/test_workflow_distribution_broadcast.py
+++ b/tests/core/test_workflow_distribution_broadcast.py
@@ -712,11 +712,15 @@ class TestTheProbeModelsItsExecutorsTransform:
 
         assert not any("not JAX-traceable" in record.message for record in caplog.records)
 
-    def test_several_distribution_arguments_are_all_mapped(self):
-        """The probe maps a tuple of draws, one per broadcast argument.
+    def test_the_mapped_probe_covers_several_distribution_arguments(self):
+        """The probe builds a tuple of draws, one per broadcast argument.
 
-        One argument exercises the loop's first iteration only; a body reading
-        two would trace under a probe that mapped just the first.
+        This covers the multiple-reference path rather than isolating the second
+        argument: ``jax.make_jaxpr`` abstracts every argument it is given, so
+        the bare probe already sees a tracer wherever the mapped one does, and
+        no body distinguishes "mapped" from "traced" by its own arguments. What
+        distinguishes them is output reconstruction — hence a batch-returning
+        body here, as in the single-argument case.
         """
 
         def body(x, y):
@@ -735,37 +739,25 @@ class TestTheProbeModelsItsExecutorsTransform:
             np.asarray(sequential(first, second).samples),
         )
 
-    def test_a_nonscalar_event_shape_is_probed_at_its_own_shape(self):
-        """The mapped slice is event-shaped, as the bare probe's dummy was.
+    def test_the_mapped_slice_carries_the_declared_event_shape(self, caplog):
+        """The slice is event-shaped, as the bare probe's dummy was.
 
-        A leading draw axis prepended to the wrong slice shape would trace a
-        body that indexes or reduces over the event axes against the wrong rank.
+        ``v[2]`` is rank-sensitive where a reduction would not be: a dummy of
+        the wrong shape fails to trace and the call silently leaves the JAX
+        path, so staying on it is the assertion.
         """
-
-        def body(v):
-            return RecordBatch.stack(
-                [Record("r", {"s": jnp.sum(v) * k}, name_is_auto=True) for k in (1.0, 2.0)],
-                level_name="k",
-            )
-
         vector = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="v")
-        broadcast = Function(func=body, n_broadcast_samples=8, seed=0)
-        sequential = Function(func=body, dispatch="sequential", n_broadcast_samples=8, seed=0)
-
-        np.testing.assert_array_equal(
-            np.asarray(broadcast(vector).samples), np.asarray(sequential(vector).samples)
-        )
-
-    def test_a_nonscalar_event_shape_still_vectorizes_when_the_body_allows(self):
-        """The added transform did not cost the vectorized path its shapes."""
-        vector = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="v")
-        total = Function(func=lambda v: jnp.sum(v), n_broadcast_samples=8, seed=0)
+        third = Function(func=lambda v: v[2], n_broadcast_samples=8, seed=0)
         sequential = Function(
-            func=lambda v: jnp.sum(v), dispatch="sequential", n_broadcast_samples=8, seed=0
+            func=lambda v: v[2], dispatch="sequential", n_broadcast_samples=8, seed=0
         )
 
+        with caplog.at_level(logging.INFO, logger="probpipe.core.node"):
+            mapped = third(vector)
+
+        assert not any("not JAX-traceable" in record.message for record in caplog.records)
         np.testing.assert_allclose(
-            np.asarray(total(vector).samples), np.asarray(sequential(vector).samples), rtol=1e-6
+            np.asarray(mapped.samples), np.asarray(sequential(vector).samples), rtol=1e-6
         )
 
     def test_an_aliased_argument_still_reads_as_one_variable(self):
@@ -798,12 +790,12 @@ class TestTheProbeModelsItsExecutorsTransform:
         )
 
     def test_a_batch_returning_body_survives_the_nested_regime(self, caplog):
-        """A sweep crossed with a law composes the two fallbacks.
+        """A sweep crossed with a law still produces a result.
 
-        The sweep's own probe already refuses this body, so the outer path falls
-        back before the per-row marginalization is reached — this pins that the
-        composition still produces a result, not that the mapped-draw probe is
-        what caught it.
+        Verified by spying on the executor: ``_broadcast_jax`` is not reached in
+        this regime at all — the per-row marginalization resolves to the
+        row-wise sampler — so this pins the composition rather than the
+        mapped-draw probe, which the other tests here cover directly.
         """
 
         def body(p, x):

--- a/tests/distributions/test_sequential_joint.py
+++ b/tests/distributions/test_sequential_joint.py
@@ -463,17 +463,14 @@ class TestBroadcastingReconnection:
         # z and x are jointly sampled, x ≈ z, so a - b ≈ 0
         np.testing.assert_allclose(np.array(result.samples), 0.0, atol=0.15)
 
-    def test_views_from_sequential_joint_reject_jax(self):
-        """Explicit ``dispatch="jax"`` is rejected for sequential-joint views.
+    def test_views_from_sequential_joint_accept_jax(self):
+        """Explicit ``dispatch="jax"`` runs for sequential-joint views.
 
-        A ``SequentialJointDistribution`` constructs each downstream
-        component from a Python callable (``x=lambda z: Normal(loc=z,
-        ...)``), building a fresh distribution object per draw — which
-        is not JAX-traceable. ``dispatch="jax"`` is strict (it does not
-        silently fall back), so it raises a clear error pointing the
-        user at the ``auto`` / ``sequential`` paths. The ``_loop``
-        companion above exercises the correct joint-sampled result via
-        ``dispatch="sequential"``.
+        A ``SequentialJointDistribution`` builds each downstream component from
+        a Python callable, which is indeed not traceable — but that
+        construction happens in ``_sample_broadcast_args``, concretely, before
+        the map. Only the body is traced, and ``a - b`` traces fine, so the
+        views co-sample and the mapped result matches the row-wise one.
         """
         joint = SequentialJointDistribution(
             z=Normal(loc=0.0, scale=1.0, name="z"),
@@ -483,22 +480,25 @@ class TestBroadcastingReconnection:
         def subtract(a: float, b: float) -> float:
             return a - b
 
-        wf = Function(
-            func=subtract,
-            dispatch="jax",
-            n_broadcast_samples=30,
-            seed=55,
-        )
-        with pytest.raises(ValueError, match="dispatch='jax' failed while tracing"):
-            wf(a=joint["z"], b=joint["x"])
+        def run(dispatch):
+            return Function(
+                func=subtract,
+                dispatch=dispatch,
+                n_broadcast_samples=30,
+                seed=55,
+            )(a=joint["z"], b=joint["x"])
 
-    def test_views_from_sequential_joint_auto_falls_back(self):
-        """``dispatch="auto"`` falls back to sequential and reconnects views.
+        mapped = run("jax")
 
-        Auto-detection probes JAX-traceability, finds the lambda-based
-        sequential joint isn't traceable, and falls back to sequential
-        dispatch — producing the same correct joint-sampled result as
-        the explicit ``_loop`` test (``x ≈ z`` so ``a - b ≈ 0``).
+        np.testing.assert_allclose(np.array(mapped.samples), 0.0, atol=0.15)
+        np.testing.assert_allclose(np.array(mapped.samples), np.array(run("sequential").samples))
+
+    def test_views_from_sequential_joint_reconnect_under_auto(self):
+        """``dispatch="auto"`` reconnects the views whichever path it picks.
+
+        The views co-sample through their shared root, so ``x ≈ z`` and
+        ``a - b ≈ 0`` — a property of the sampler rather than of the dispatch,
+        which is why this holds without pinning which one auto resolves to.
         """
         joint = SequentialJointDistribution(
             z=Normal(loc=0.0, scale=1.0, name="z"),


### PR DESCRIPTION
## Summary

A `Function` whose body returns a `RecordBatch`, called with a `Distribution`
argument, **crashed** instead of falling back to sequential dispatch:

```python
@function
def body(x: float) -> RecordBatch:
    return RecordBatch.stack(
        [Record("r", {"y": x * k}, name_is_auto=True) for k in (1.0, 2.0, 3.0)],
        level_name="k",
    )

body(Normal(0.0, 1.0, name="x"))
```

```
ValueError: a transform left this RecordBatch's fields with 2 batch axes where
its levels account for 1. An added axis belongs to no level, and unflattening
has no name to give one …
```

The trace probe exists so that a body which traces cleanly bare but cannot
survive the transform its executor applies is caught **while a fallback is still
available**. `Node._jax_traceability_error` modelled the transform for
`execute_sweep_rows_jax`, which maps over batch rows, but not for
`_broadcast_jax`, which also maps — over the draw axis rather than over rows.
With no batched-record argument the probe took its bare branch,
`jax.make_jaxpr(lambda kw: func(**kw))(dummy_kw)`, so the body passed and then
failed inside `jax.vmap`, past the point where anything could fall back.

Both mapping executors are now probed under a map. A plain distribution argument
is traced over a single draw taken from `_sample_broadcast_args` — the
executor's own input construction — rather than synthesized from the law's event
shape. That distinction turned out to matter: a record-valued law draws a *batch
of records*, so mapping it hands the body a record where zeros of the event
shape would hand it an array. A one-field `ProductDistribution` took the JAX
path on a body the executor could not run and crashed inside it, which is the
same failure mode again, and is now covered by a test.

Chasing that down surfaced the underlying defect: **the dispatches disagreed on
what a one-field draw even is.** Such a law draws a batch of records; the
row-wise paths presented each draw as its bare leaf via `_index_sample`, while
the `vmap` path presented the record. The record shim carries conversions and
deliberately no arithmetic, so `x * 2` succeeded under `dispatch="sequential"`
and crashed under the mapped executor.

Design II.4 leaves the choice itself open — it rides on the single-value
coercion question `Record` poses — so the rule was picked by which paths already
made it: `_broadcast_sample` and both arms of `_broadcast_enumerate` unwrap, and
only `_broadcast_jax` did not. Presenting the bare leaf everywhere changes no
behavior that worked, fixes the one that crashed, and keeps the mapped path for
these laws rather than retreating to row-wise. `_present_draw` is that single
rule; `mapped_draw_body` is the executor body the probe traces, so neither the
dispatches nor the probe and its executor are held in agreement by hand.

## Linked issue(s)

Refs #405 — that issue proposes vectorizing these bodies rather than falling
back, and describes the fallback as correct-but-slow. That holds for the sweep
executor; this is the path where it was not correct. Fixing it first means the
fallback #405 replaces is one that actually exists.

## Test plan

`tests/core/test_workflow_distribution_broadcast.py`, new class
`TestTheProbeModelsItsExecutorsTransform` — 13 tests. These fail on `main`
without the source change and pass with it:

- the regression itself: a batch-returning body over a law does not raise;
- the fallback is what ran (asserted via the dispatch log);
- the fallback's result equals explicit `dispatch="sequential"`;
- `dispatch="jax"` reports the dispatch it cannot use rather than surfacing the
  raw pytree error;
- **several distribution arguments** are all mapped, not just the first;
- a **one-field record law** presents the same value to every dispatch — the
  case that used to crash under the mapped executor and succeed row-wise;
- a **law that cannot answer `dtype`** is still probed. This is the one the
  removed preflight actually refused: `getattr(law, "dtype", None)` swallows
  only `AttributeError`, and a `SequentialJointDistribution` view raises
  `NotImplementedError`.

The rest are guards, pinning that the probe gained a transform and a real draw
without becoming a blanket refusal or disturbing neighbouring paths:

- a body that survives the transform still takes JAX dispatch;
- the mapped slice carries the declared event shape — verified by mutation:
  shortening the draw to `(1,)` kills this test and no other;
- an aliased argument still reads as one variable — `f(d, d)` is `X - X`. The
  probe now draws through `_sample_broadcast_args`, so its draws are co-sampled
  the way the executor's are;
- a **multi-field law** vectorizes — a guard, since it answers both
  `event_shape` and `dtype` and so always could;
- an **empirical law** is enumerated rather than mapped, whatever the probe
  would say, so its exact weights are preserved;
- the nested regime (a sweep crossed with a law) still composes to a result.

Full suite: 4612 passed, 54 skipped. `ruff check .` and `ruff format --check .`
clean from the repo root.

## Breaking changes

`dispatch="jax"` now accepts cases it used to reject — views of a
`SequentialJointDistribution` above all, whose mapped result is measured
identical to the row-wise one. That is strictly more permissive, and the two
tests that asserted the refusal and the matching auto-fallback were pinning an
artifact of the removed preflight; both now pin the agreement.

Otherwise none. The change moves calls that previously raised onto the
sequential path,
which the two dispatches agree on by contract.

## Documentation

CHANGELOG entry under `Unreleased → Fixed`. The probe's docstring now states the
invariant it enforces — every executor that maps is probed under a map — and
names the defect it guards, since the correspondence between probe and executor
was previously carried by a prose comment and had drifted.



