### PR TITLE
feat(core): vectorize a swept body that returns a batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A sweep whose body returns a batch now vectorizes (#405).** Such a body used
+  to fail the JAX trace probe and drop to row-wise dispatch: `vmap` inserts an
+  output axis and re-enters `RecordBatch`'s unflatten hook, which has no name to
+  give the new level and refuses rather than guess — the pytree contract carries
+  neither `in_axes` nor `out_axes`, so *a shape is not a provenance*.
+
+  The refusal stands; the executor no longer routes through it. A body's
+  returned batch is taken apart into raw columns for the crossing and rebuilt on
+  the far side by the executor, which holds the level names the hook lacked. The
+  result carries the sweep's levels followed by the body's, and equals what
+  row-wise dispatch produced. The input side already worked this way, rebuilding
+  each row's record from raw columns inside the traced call; this is the same
+  move on the output side.
+
+  A raw `jax.vmap` over a batch is refused exactly as before. Only an operation
+  that knows which axis it added may name the level, which is what the executor
+  knows and a bare transform does not.
+
 - **`RecordBatch` / `NumericRecordBatch` — a batch of records, stored columnar.**
   A batch of records that all conform to one `EventTemplate`: the batched value a
   `Function` produces and consumes, such as the many draws a `sample` yields. It

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -28,7 +28,7 @@ from ._empirical import (
 )
 from ._numeric_record_batch import NumericRecordBatch
 from ._object_batch import _from_iterable, _is_object_array
-from ._record_batch import RecordBatch, _batch_class_for
+from ._record_batch import RecordBatch, _batch_class_for, _MappedBatchColumns
 from .event_template import (
     ArraySpec,
     EventTemplate,
@@ -619,6 +619,36 @@ def _make_marginal(
 DRAW_LEVEL = "draw"
 
 
+def _batch_over_swept_columns(
+    columns: dict[str, Any],
+    *,
+    batch_shape: tuple[int, ...],
+    sweep_level_names: tuple[str, ...],
+    sweep_groups: tuple[tuple[int, ...], ...],
+    element_spec: Any,
+    inner_level_names: tuple[str, ...],
+    inner_axis_groups: tuple[tuple[int, ...], ...],
+    name: str,
+) -> RecordBatch:
+    """Build the aggregate for a sweep whose rows each held a batch.
+
+    *columns* arrive stacked on a single leading axis of ``prod(batch_shape)``,
+    which the sweep's own axes replace; the levels are the sweep's followed by
+    the rows'. Both dispatches land here — the row-wise one after stacking the
+    rows itself, the mapped one with the transform's output axis already in
+    place — so the two agree by construction rather than by being maintained in
+    parallel.
+    """
+    return _batch_class_for(element_spec)(
+        {path: column.reshape(batch_shape + column.shape[1:]) for path, column in columns.items()},
+        (*sweep_level_names, *inner_level_names),
+        element_spec=element_spec,
+        axis_groups=(*sweep_groups, *inner_axis_groups),
+        name=name,
+        name_is_auto=True,
+    )
+
+
 def _make_stack(
     inner_outputs: Any,
     *,
@@ -696,6 +726,22 @@ def _make_stack(
         raise ValueError(
             f"_make_stack mints one level per group of axes: {len(sweep_groups)} groups "
             f"{sweep_groups} against {len(level_names)} names {list(level_names)}"
+        )
+
+    # --- Mapped batch-returning body -----------------------------------
+    # Before the generic pytree handling below, which would read the inner batch
+    # axis as an event axis and drop the level names with it — the same reason
+    # the batch-of-batches case precedes the Record case on the list path.
+    if isinstance(inner_outputs, _MappedBatchColumns):
+        return _batch_over_swept_columns(
+            inner_outputs.columns,
+            batch_shape=batch_shape,
+            sweep_level_names=level_names,
+            sweep_groups=sweep_groups,
+            element_spec=inner_outputs.element_spec,
+            inner_level_names=inner_outputs.level_names,
+            inner_axis_groups=inner_outputs.axis_groups,
+            name=name or field_name,
         )
 
     # --- List-of-X path (Python-loop execution) -------------------------
@@ -780,17 +826,18 @@ def _make_stack(
             for path in first.event_template:
                 cols = [o._raw_column(path) for o in outs]
                 if any(_is_object_array(c) for c in cols):
-                    stacked = np.stack(cols, axis=0)
+                    columns[path] = np.stack(cols, axis=0)
                 else:
-                    stacked = jnp.stack(cols, axis=0)
-                columns[path] = stacked.reshape(batch_shape + stacked.shape[1:])
-            return _batch_class_for(first.element_spec)(
+                    columns[path] = jnp.stack(cols, axis=0)
+            return _batch_over_swept_columns(
                 columns,
-                (*level_names, *first.level_names),
+                batch_shape=batch_shape,
+                sweep_level_names=level_names,
+                sweep_groups=sweep_groups,
                 element_spec=first.element_spec,
-                axis_groups=(*sweep_groups, *first.axis_groups),
+                inner_level_names=tuple(first.level_names),
+                inner_axis_groups=tuple(first.axis_groups),
                 name=name or field_name,
-                name_is_auto=True,
             )
 
         # All (scalar) Records → stack into one batch. NumericRecordBatch if

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -1350,3 +1350,90 @@ def _surviving_batch_shape(columns: dict[str, Any], rank: int) -> tuple[int, ...
 
 
 jax.tree_util.register_pytree_node(RecordBatch, _record_batch_flatten, _unflatten_with(RecordBatch))
+
+
+# ---------------------------------------------------------------------------
+# Carrying a batch across a transform that adds an axis
+# ---------------------------------------------------------------------------
+
+
+class _MappedBatchColumns:
+    """A batch taken apart into raw columns, to cross a mapping transform.
+
+    ``_unflatten_with`` refuses an added axis because it has no name to give the
+    level, and no reading of the arriving shapes recovers one — *a shape is not
+    a provenance*. That refusal is right for a raw transform, and this does not
+    weaken it. It is the other half of the same rule: an operation that knows
+    which axis it added, and what to call the level, does not have to guess, and
+    should not route its reconstruction through a hook that must.
+
+    So a mapping executor hands the transform this instead of the batch. It is
+    an inert carrier — its unflatten rebuilds it verbatim, checking nothing —
+    which is exactly what lets it survive a rank change that ``RecordBatch``
+    cannot. The executor holds the missing name and rebuilds the batch itself,
+    on the far side.
+
+    Private, and short-lived by construction: an executor wraps its body's
+    return and unwraps it in the same call, so this never reaches a caller.
+    """
+
+    __slots__ = ("axis_groups", "columns", "element_spec", "level_names", "name", "name_is_auto")
+
+    def __init__(
+        self,
+        columns: dict[str, Any],
+        *,
+        element_spec: RecordSpec,
+        level_names: tuple[str, ...],
+        axis_groups: tuple[tuple[int, ...], ...],
+        name: str,
+        name_is_auto: bool,
+    ):
+        self.columns = columns
+        self.element_spec = element_spec
+        self.level_names = level_names
+        self.axis_groups = axis_groups
+        self.name = name
+        self.name_is_auto = name_is_auto
+
+    @classmethod
+    def of(cls, batch: RecordBatch) -> _MappedBatchColumns:
+        """Take *batch* apart, keeping what unflattening could not have inferred."""
+        return cls(
+            {path: batch._raw_column(path) for path in batch.event_template},
+            element_spec=batch.element_spec,
+            level_names=tuple(batch.level_names),
+            axis_groups=tuple(batch.axis_groups),
+            name=batch._name,
+            name_is_auto=batch._name_is_auto,
+        )
+
+
+def _mapped_batch_columns_flatten(carried: _MappedBatchColumns):
+    return list(carried.columns.values()), (
+        tuple(carried.columns),
+        carried.element_spec,
+        carried.level_names,
+        carried.axis_groups,
+        carried.name,
+        carried.name_is_auto,
+    )
+
+
+def _mapped_batch_columns_unflatten(aux, children) -> _MappedBatchColumns:
+    paths, element_spec, level_names, axis_groups, name, name_is_auto = aux
+    # No rank check, deliberately: the added axis is the point, and the caller
+    # that added it is the one that can name it.
+    return _MappedBatchColumns(
+        dict(zip(paths, children, strict=True)),
+        element_spec=element_spec,
+        level_names=level_names,
+        axis_groups=axis_groups,
+        name=name,
+        name_is_auto=name_is_auto,
+    )
+
+
+jax.tree_util.register_pytree_node(
+    _MappedBatchColumns, _mapped_batch_columns_flatten, _mapped_batch_columns_unflatten
+)

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -255,8 +255,8 @@ def mapped_row_body(
     """The body ``jax.vmap`` runs for one sweep row, and the probe traces.
 
     Both callers use this rather than each building its own: the probe's job is
-    to trace what the executor runs, and two functions kept alike by a comment
-    is how they came apart before.
+    to trace exactly what the executor runs, which two separately maintained
+    functions cannot promise.
 
     A row's batched-record argument is rebuilt from raw leaf columns inside the
     traced call, so nothing infers a batch axis on the way in. On the way out, a

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -8,7 +8,7 @@ outer sweep layer of nested array + distribution broadcasts.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 import jax
@@ -18,6 +18,7 @@ from . import _workflow_call, _workflow_execution, _workflow_plan, _workflow_res
 from ._batch import Batch
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
+from ._record_batch import RecordBatch, _MappedBatchColumns
 from .distribution import BroadcastDistribution, Distribution
 from .event_template import EventTemplate
 from .provenance import Provenance
@@ -245,6 +246,38 @@ def execute_sweep_rows(
     return _workflow_execution.execute_many(request)
 
 
+def mapped_row_body(
+    *,
+    func: Callable[..., Any],
+    values: dict[str, Any],
+    array_args: Sequence[_workflow_call.WorkflowInputRef],
+) -> Callable[[Any], Any]:
+    """The body ``jax.vmap`` runs for one sweep row, and the probe traces.
+
+    Both callers use this rather than each building its own: the probe's job is
+    to trace what the executor runs, and two functions kept alike by a comment
+    is how they came apart before.
+
+    A row's batched-record argument is rebuilt from raw leaf columns inside the
+    traced call, so nothing infers a batch axis on the way in. On the way out, a
+    returned :class:`Batch` is taken apart into :class:`_MappedBatchColumns`,
+    because the map is about to add an axis that the batch's own unflatten hook
+    could not name — the executor names it afterwards, from the sweep's levels.
+    """
+
+    def one_row(array_slice_leaves):
+        replacements = {
+            ref: Record(ref.label, leaves, name_is_auto=True)
+            for ref, leaves in zip(array_args, array_slice_leaves)
+        }
+        out = func(**_workflow_call.replace_input_refs(values, replacements))
+        if isinstance(out, RecordBatch):
+            return _MappedBatchColumns.of(out)
+        return out
+
+    return one_row
+
+
 def execute_sweep_rows_jax(
     *,
     func: Callable[..., Any],
@@ -253,13 +286,7 @@ def execute_sweep_rows_jax(
     n_total: int,
 ) -> Any:
     """Execute the limited single-batch sweep through ``jax.vmap``."""
-
-    def single_call(array_slice_leaves):
-        replacements = {
-            ref: Record(ref.label, leaves, name_is_auto=True)
-            for ref, leaves in zip(array_args, array_slice_leaves)
-        }
-        return func(**_workflow_call.replace_input_refs(values, replacements))
+    single_call = mapped_row_body(func=func, values=values, array_args=array_args)
 
     vmap_input = []
     for ref in array_args:

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -46,7 +46,6 @@ from ._function_contract import (
 from ._record_batch import RecordBatch
 from .event_template import ArraySpec, EventTemplate, _concretize_event_template
 from .provenance import Provenance
-from .record import Record
 from .tracked import Annotated, TrackedTerm, auto_name
 
 logger = logging.getLogger(__name__)
@@ -959,14 +958,13 @@ class Function(Node, TrackedTerm, Annotated):
                     dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, replacement)
             if batched_sources:
                 refs = list(batched_sources)
-
-                def _row_call(rows_leaves):
-                    kw = dummy_kw
-                    for row_ref, leaves in zip(refs, rows_leaves):
-                        kw = _workflow_call.replace_input_ref(
-                            kw, row_ref, Record(row_ref.label, leaves, name_is_auto=True)
-                        )
-                    return func(**kw)
+                # The executor's own body, not a copy of it: what the probe
+                # traces and what runs must not be two things kept alike by
+                # hand. ``dummy_kw`` already carries the non-batched arguments,
+                # so the wrapper only has the batched refs left to replace.
+                _row_call = _workflow_sweep.mapped_row_body(
+                    func=func, values=dummy_kw, array_args=refs
+                )
 
                 probe_leaves = []
                 for source in batched_sources.values():

--- a/tests/core/test_workflow_sweep.py
+++ b/tests/core/test_workflow_sweep.py
@@ -12,6 +12,7 @@ import pytest
 from probpipe import (
     BroadcastDistribution,
     DistributionArray,
+    EventTemplate,
     Function,
     Normal,
     NumericRecord,
@@ -341,13 +342,49 @@ class TestASweptBodyThatReturnsABatch:
         assert mapped.axis_groups == sequential.axis_groups
         np.testing.assert_allclose(np.asarray(mapped["y"]), np.asarray(sequential["y"]))
 
-    def test_a_multi_axis_sweep_keeps_the_groups_apart(self):
-        """Two zip groups sweep as a product, so the aggregate carries both sweep
-        levels before the body's own.
+    def test_a_multi_axis_level_reshapes_on_the_mapped_path(self, monkeypatch):
+        """One level spanning two axes, swept under the map.
+
+        The mapped executor flattens the sweep to a single axis of
+        ``prod(batch_shape)`` and the carrier restores its shape afterwards, so
+        a sweep of rank greater than one is what exercises that reshape. It
+        takes a single argument on purpose: two array arguments make two zip
+        groups, which sets ``jax_supported`` false and would quietly measure
+        row-wise dispatch instead.
+        """
+        reached = []
+        real = _workflow_sweep.execute_sweep_rows_jax
+
+        def spy(**kwargs):
+            reached.append(1)
+            return real(**kwargs)
+
+        monkeypatch.setattr(_workflow_sweep, "execute_sweep_rows_jax", spy)
+
+        grid = RecordBatch(
+            {"x": jnp.arange(6.0).reshape(2, 3)},
+            "cell",
+            element_spec=EventTemplate(x=()),
+            axis_groups=((2, 3),),
+        )
+
+        mapped = Function(func=self._body, name="swept")(grid)
+        sequential = Function(func=self._body, name="swept", dispatch="sequential")(grid)
+
+        assert reached == [1]
+        assert mapped.level_names == ("cell", "k")
+        assert mapped.axis_groups == ((2, 3), (3,))
+        assert mapped.batch_shape == (2, 3, 3)
+        assert np.shape(mapped._raw_column("y")) == (2, 3, 3)
+        np.testing.assert_allclose(np.asarray(mapped["y"]), np.asarray(sequential["y"]))
+
+    def test_two_zip_groups_sweep_as_a_product(self):
+        """Two groups product, so the aggregate carries both sweep levels first.
 
         Group structure, not only total size: collapsing the sweep onto one flat
         leading axis agrees on ``batch_size`` and loses which axis belongs to
-        which level.
+        which level. Two array arguments take row-wise dispatch, so this pins
+        the aggregation rather than the mapped path.
         """
 
         def body(p, q):

--- a/tests/core/test_workflow_sweep.py
+++ b/tests/core/test_workflow_sweep.py
@@ -281,8 +281,8 @@ class TestASweptBodyThatReturnsABatch:
     ``vmap`` adds an output axis that ``RecordBatch``'s unflatten hook cannot
     name — *a shape is not a provenance* — so the executor hands the transform
     raw columns and rebuilds the batch itself afterwards, from the levels it
-    swept. The sequential path is the oracle throughout: it always produced the
-    right answer, only slowly.
+    swept. The sequential path is the oracle throughout: it builds the same
+    aggregate one row at a time.
     """
 
     @staticmethod
@@ -300,7 +300,12 @@ class TestASweptBodyThatReturnsABatch:
         )
 
     def test_the_sweep_takes_the_mapped_path(self, monkeypatch):
-        """The point of the exercise: this used to fail the probe and fall back."""
+        """The mapped executor runs, with no fall back to row-wise dispatch.
+
+        The discriminating assertion: every other test in this class passes on
+        the sequential path too, so only this one distinguishes vectorizing from
+        agreeing with the oracle.
+        """
         reached = []
         real = _workflow_sweep.execute_sweep_rows_jax
 
@@ -337,11 +342,12 @@ class TestASweptBodyThatReturnsABatch:
         np.testing.assert_allclose(np.asarray(mapped["y"]), np.asarray(sequential["y"]))
 
     def test_a_multi_axis_sweep_keeps_the_groups_apart(self):
-        """Group structure, not only flat shape: ((2, 3), (2,)) is not ((2,), (3, 2)).
+        """Two zip groups sweep as a product, so the aggregate carries both sweep
+        levels before the body's own.
 
-        Two zip groups sweep as a product, so the aggregate carries two sweep
-        levels before the body's own — the case a reshape to a flat leading axis
-        would silently get wrong.
+        Group structure, not only total size: collapsing the sweep onto one flat
+        leading axis agrees on ``batch_size`` and loses which axis belongs to
+        which level.
         """
 
         def body(p, q):
@@ -391,11 +397,11 @@ class TestASweptBodyThatReturnsABatch:
         assert isinstance(out, RecordBatch)
 
     def test_a_raw_vmap_returning_a_batch_is_still_refused(self):
-        """The hook is routed around, not softened — issue 406 rests on it.
+        """The hook is routed around, not softened.
 
-        Only the executor, which knows the level it swept, may rebuild across an
-        added axis. A raw ``vmap`` still has no name to give one and still says
-        so.
+        Only a caller that knows which axis it added, and what to call the level
+        it stands for, may rebuild across one. The executor knows both; a raw
+        ``vmap`` knows neither, and is refused.
         """
         with pytest.raises(ValueError, match="belongs to no level"):
             jax.vmap(

--- a/tests/core/test_workflow_sweep.py
+++ b/tests/core/test_workflow_sweep.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -11,12 +12,16 @@ import pytest
 from probpipe import (
     BroadcastDistribution,
     DistributionArray,
+    Function,
     Normal,
     NumericRecord,
     NumericRecordBatch,
+    Record,
+    RecordBatch,
     mean,
 )
 from probpipe.core import _workflow_call, _workflow_execution, _workflow_sweep
+from probpipe.core._record_batch import _MappedBatchColumns
 from probpipe.core._workflow_plan import build_broadcast_plan
 
 
@@ -268,3 +273,134 @@ class TestExecuteSweep:
         ]
         assert result.provenance.operation == "workflow.nested"
         assert result.provenance.metadata["k"] == 7
+
+
+class TestASweptBodyThatReturnsABatch:
+    """A body returning a batch vectorizes instead of falling back.
+
+    ``vmap`` adds an output axis that ``RecordBatch``'s unflatten hook cannot
+    name — *a shape is not a provenance* — so the executor hands the transform
+    raw columns and rebuilds the batch itself afterwards, from the levels it
+    swept. The sequential path is the oracle throughout: it always produced the
+    right answer, only slowly.
+    """
+
+    @staticmethod
+    def _rows(n: int, *, level_name: str = "row") -> RecordBatch:
+        return RecordBatch.stack(
+            [Record("p", {"x": jnp.asarray(float(i))}, name_is_auto=True) for i in range(n)],
+            level_name=level_name,
+        )
+
+    @staticmethod
+    def _body(p):
+        return RecordBatch.stack(
+            [Record("r", {"y": p["x"] * k}, name_is_auto=True) for k in (1.0, 2.0, 3.0)],
+            level_name="k",
+        )
+
+    def test_the_sweep_takes_the_mapped_path(self, monkeypatch):
+        """The point of the exercise: this used to fail the probe and fall back."""
+        reached = []
+        real = _workflow_sweep.execute_sweep_rows_jax
+
+        def spy(**kwargs):
+            reached.append(1)
+            return real(**kwargs)
+
+        monkeypatch.setattr(_workflow_sweep, "execute_sweep_rows_jax", spy)
+        Function(func=self._body, name="swept")(self._rows(4))
+
+        assert reached == [1]
+
+    def test_the_levels_are_the_sweeps_then_the_bodys(self):
+        out = Function(func=self._body, name="swept")(self._rows(4))
+
+        assert out.level_names == ("row", "k")
+        assert out.axis_groups == ((4,), (3,))
+
+    def test_the_shape_agrees_with_the_columns_it_holds(self):
+        """A batch whose spec its own columns contradict is the failure to avoid."""
+        out = Function(func=self._body, name="swept")(self._rows(4))
+
+        assert out.batch_shape == (4, 3)
+        assert out.batch_size == 12
+        assert np.shape(out._raw_column("y")) == (4, 3)
+
+    def test_it_matches_sequential_dispatch(self):
+        mapped = Function(func=self._body, name="swept")(self._rows(4))
+        sequential = Function(func=self._body, name="swept", dispatch="sequential")(self._rows(4))
+
+        assert mapped.element_spec == sequential.element_spec
+        assert mapped.level_names == sequential.level_names
+        assert mapped.axis_groups == sequential.axis_groups
+        np.testing.assert_allclose(np.asarray(mapped["y"]), np.asarray(sequential["y"]))
+
+    def test_a_multi_axis_sweep_keeps_the_groups_apart(self):
+        """Group structure, not only flat shape: ((2, 3), (2,)) is not ((2,), (3, 2)).
+
+        Two zip groups sweep as a product, so the aggregate carries two sweep
+        levels before the body's own — the case a reshape to a flat leading axis
+        would silently get wrong.
+        """
+
+        def body(p, q):
+            return RecordBatch.stack(
+                [Record("r", {"z": p["x"] * q["w"] * k}, name_is_auto=True) for k in (1.0, 2.0)],
+                level_name="k",
+            )
+
+        first = self._rows(2, level_name="a")
+        second = RecordBatch.stack(
+            [Record("q", {"w": jnp.asarray(float(i))}, name_is_auto=True) for i in range(3)],
+            level_name="b",
+        )
+
+        mapped = Function(func=body, name="swept")(first, second)
+        sequential = Function(func=body, name="swept", dispatch="sequential")(first, second)
+
+        assert mapped.level_names == ("a", "b", "k")
+        assert mapped.axis_groups == ((2,), (3,), (2,))
+        assert mapped.batch_shape == (2, 3, 2)
+        np.testing.assert_allclose(np.asarray(mapped["z"]), np.asarray(sequential["z"]))
+
+    def test_a_nested_element_survives_the_transform(self):
+        """Columns are leaf-keyed, so a nested record needs no special case."""
+
+        def body(p):
+            return RecordBatch.stack(
+                [Record("r", {"inner": {"y": p["x"] * k}}, name_is_auto=True) for k in (1.0, 2.0)],
+                level_name="k",
+            )
+
+        mapped = Function(func=body, name="swept")(self._rows(3))
+        sequential = Function(func=body, name="swept", dispatch="sequential")(self._rows(3))
+
+        assert mapped.level_names == ("row", "k")
+        assert mapped.element_spec == sequential.element_spec
+        np.testing.assert_allclose(
+            np.asarray(mapped._raw_column("inner/y")),
+            np.asarray(sequential._raw_column("inner/y")),
+        )
+
+    def test_the_carrier_does_not_reach_the_caller(self):
+        """It is wrapped and unwrapped inside one call, by construction."""
+        out = Function(func=self._body, name="swept")(self._rows(4))
+
+        assert not isinstance(out, _MappedBatchColumns)
+        assert isinstance(out, RecordBatch)
+
+    def test_a_raw_vmap_returning_a_batch_is_still_refused(self):
+        """The hook is routed around, not softened — issue 406 rests on it.
+
+        Only the executor, which knows the level it swept, may rebuild across an
+        added axis. A raw ``vmap`` still has no name to give one and still says
+        so.
+        """
+        with pytest.raises(ValueError, match="belongs to no level"):
+            jax.vmap(
+                lambda v: RecordBatch.stack(
+                    [Record("r", {"y": v * k}, name_is_auto=True) for k in (1.0, 2.0)],
+                    level_name="k",
+                )
+            )(jnp.arange(4.0))


### PR DESCRIPTION
## Summary

A sweep whose body returns a `RecordBatch` now runs under `jax.vmap` instead of
dropping to row-wise dispatch.

`vmap` inserts an output axis and re-enters `RecordBatch`'s unflatten hook, which
has no name to give the new level: a treedef replays the static aux and the
transformed children, and carries neither `in_axes` nor `out_axes`. **A shape is
not a provenance**, so the hook refuses rather than guess — and that refusal stays
exactly as it is.

What changes is that the executor stops routing through it. The body's returned
batch is taken apart into `_MappedBatchColumns`, an inert private carrier whose
own unflatten rebuilds it verbatim and checks nothing, which is what lets it cross
a rank change the batch cannot. The executor rebuilds the batch on the far side,
where it holds the level names the hook lacked.

This is the move the input side already makes: `execute_sweep_rows_jax` flattens
each batched argument to raw leaf columns and rebuilds a `Record` inside the
traced call, so nothing infers a batch axis on the way in. Now the same holds on
the way out.

## Structure

- **The probe and the executor share one body wrapper**
  (`_workflow_sweep.mapped_row_body`) rather than being two functions kept alike
  by a comment. That correspondence is what drifted to produce #408's bug, so it
  is now structural.
- **One reconstruction serves both dispatches.** `_batch_over_swept_columns`
  builds the aggregate: the row-wise path calls it after stacking rows itself,
  the mapped path with the transform's output axis already in place. The two
  agree by construction instead of by parallel maintenance.

## Linked issue(s)

Closes #405.

Stacked on #408, which fixed the case where the same class of body did not fall
back but crashed. This PR targets that branch and will retarget to `main` when it
merges.

## Test plan

`tests/core/test_workflow_sweep.py`, new class `TestASweptBodyThatReturnsABatch`
— 9 tests:

- **The sweep takes the mapped path** — the discriminating one, verified
  before/after by spying on `execute_sweep_rows_jax`: on #408's head it is
  reached 0 times and the log says "not JAX-traceable; using sequential
  dispatch"; here it is reached once, with no fallback.
- **The levels are the sweep's followed by the body's** — `('row', 'k')`, groups
  `((4,), (3,))`.
- **The shape agrees with the columns it holds** — `batch_shape=(4, 3)`,
  `batch_size=12`, column shape `(4, 3)`, since a batch whose spec its own
  columns contradict is the failure to avoid.
- **It matches sequential dispatch** — on element spec, levels, groups, and
  values.
- **A multi-axis level reshapes on the mapped path** — one argument carrying a
  level over two axes (`batch_shape=(2, 3)`), which is what exercises the
  carrier's flatten-to-`prod`-and-restore. It takes a single argument on
  purpose: two array arguments make two zip groups, which sets `jax_supported`
  false, so the earlier two-argument version measured row-wise dispatch and left
  this uncovered. A spy asserts the mapped executor ran.
- **Two zip groups sweep as a product** — `('a', 'b', 'k')` over
  `((2,), (3,), (2,))`. Row-wise by construction, so it pins the aggregation
  rather than the mapped path.
- **A nested element survives**, since columns are leaf-keyed.
- **The carrier does not reach the caller.**
- **A raw `jax.vmap` returning a batch is still refused** — the hook is routed
  around, not softened, which #406 depends on.

Full suite: 4621 passed, 54 skipped. `ruff check .` and `ruff format --check .`
clean from the repo root.

## Breaking changes

None. Calls that previously fell back now vectorize and produce the same result;
the two dispatches agree by contract, and the tests assert that agreement
directly rather than approximating it.

## Documentation

CHANGELOG entry under `Unreleased → Added`. `_MappedBatchColumns` carries a
docstring stating why it is inert and why that is the other half of the hook's
refusal rather than an exception to it; `mapped_row_body` states why both callers
must use it.

- [x] Docstrings updated for changed public APIs
- [ ] User Guide / tutorials updated where relevant
- [x] CHANGELOG (or release-notes entry) noted in the linked issue

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`.
- [x] At least one `area:*` label is applied.
- [x] Linked to the primary implementation issue above.


