### PR TITLE
fix(core): preserve annotations across serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Copying and pickling records and product distributions now preserve annotations (#409).**
+  `Record`, `NumericRecord`, and `ProductDistribution` previously omitted their
+  post-construction annotation store from their custom serialization state, so
+  `copy`, `deepcopy`, and pickle silently discarded diagnostic and backend metadata.
+
 - **`is_concrete` no longer reports a polymorphic template as concrete (#390).**
   A symbolic dimension declared inside a term spec — a `RecordSpec`'s schema, a
   `DistributionSpec`'s event declaration, a `FunctionSpec`'s either side — was

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -414,6 +414,7 @@ class NumericRecord(Record):
                 self._name_is_auto,
                 self._provenance,
                 self._spec,
+                self.annotations,
             ),
         )
 
@@ -600,14 +601,17 @@ def _reconstruct_from_vector(
 
 
 def _unpickle_numeric_record(
-    store: dict, name: str, name_is_auto: bool, provenance, spec=None
+    store: dict, name: str, name_is_auto: bool, provenance, spec=None, annotations=None
 ) -> NumericRecord:
     # ``store`` holds the native leaves verbatim (they pickle themselves), so
     # reconstruction is ordinary validation-without-conversion. The threaded
     # declaration preserves an explicit schema across the round-trip; a pickle
     # written before it was serialized still loads.
     nr = NumericRecord(name, store, event_template=spec)
-    return nr._restore_identity(name_is_auto=name_is_auto, provenance=provenance)
+    nr._restore_identity(name_is_auto=name_is_auto, provenance=provenance)
+    if annotations is not None:
+        object.__setattr__(nr, "_annotations", annotations)
+    return nr
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -645,6 +645,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
                 self._name_is_auto,
                 self._provenance,
                 self._spec,
+                self.annotations,
             ),
         )
 
@@ -1245,11 +1246,16 @@ def _pack_fields(
 # ---------------------------------------------------------------------------
 
 
-def _unpickle_record(store: dict, name: str, name_is_auto: bool, provenance, spec=None) -> Record:
+def _unpickle_record(
+    store: dict, name: str, name_is_auto: bool, provenance, spec=None, annotations=None
+) -> Record:
     # ``spec`` is optional, and construction accepts either form, so a pickle
     # written before the declaration was serialized still loads.
     r = Record(name, store, event_template=spec)
-    return r._restore_identity(name_is_auto=name_is_auto, provenance=provenance)
+    r._restore_identity(name_is_auto=name_is_auto, provenance=provenance)
+    if annotations is not None:
+        object.__setattr__(r, "_annotations", annotations)
+    return r
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -253,7 +253,13 @@ class ProductDistribution(
     def __reduce__(self):
         return (
             _unpickle_product_distribution,
-            (dict(self._components), self._name, self._name_is_auto, self._provenance),
+            (
+                dict(self._components),
+                self._name,
+                self._name_is_auto,
+                self._provenance,
+                self.annotations,
+            ),
         )
 
     # -- Sampling (returns Record) ------------------------------------------
@@ -453,10 +459,13 @@ class ProductDistribution(
         return f"ProductDistribution({comp_str}{name_str})"
 
 
-def _unpickle_product_distribution(components, name, name_is_auto, provenance):
+def _unpickle_product_distribution(components, name, name_is_auto, provenance, annotations=None):
     """Reconstruct a ProductDistribution (or dynamic subclass) from its components."""
     p = ProductDistribution(**components, name=name)
-    return p._restore_identity(name_is_auto=name_is_auto, provenance=provenance)
+    p._restore_identity(name_is_auto=name_is_auto, provenance=provenance)
+    if annotations is not None:
+        p._annotations = annotations
+    return p
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -10,14 +10,17 @@ The fix adds __reduce__ to each class, delegating reconstruction to the normal
 constructor.
 """
 
+import copy
 import pickle
 
 import jax.numpy as jnp
 import pytest
 
 from probpipe import (
+    Normal,
     NumericRecord,
     NumericRecordBatch,
+    ProductDistribution,
     RecordBatch,
 )
 from probpipe.core._empirical import BootstrapReplicateDistribution, EmpiricalDistribution
@@ -41,6 +44,46 @@ def roundtrip(obj):
 def cloudpickle_roundtrip(obj):
     cloudpickle = pytest.importorskip("cloudpickle")
     return pickle.loads(cloudpickle.dumps(obj))
+
+
+def state_keys(obj):
+    state = object.__getstate__(obj)
+    instance_dict, slots = state if isinstance(state, tuple) else (state, None)
+    return set(instance_dict or {}) | set(slots or {})
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(lambda: Record("r", value="opaque"), id="record"),
+        pytest.param(lambda: NumericRecord("nr", value=jnp.array([1.0, 2.0])), id="numeric-record"),
+        pytest.param(
+            lambda: ProductDistribution(value=Normal(0.0, 1.0, name="value"), name="joint"),
+            id="product-distribution",
+        ),
+    ]
+)
+def annotated_term(request):
+    term = request.param()
+    object.__setattr__(term, "_annotations", {"diagnostics": {"status": "complete"}})
+    return term
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        pytest.param(copy.copy, id="copy"),
+        pytest.param(copy.deepcopy, id="deepcopy"),
+        pytest.param(roundtrip, id="pickle"),
+    ],
+)
+def test_annotated_term_roundtrip_preserves_annotations_and_state(annotated_term, operation):
+    before = state_keys(annotated_term)
+
+    restored = operation(annotated_term)
+
+    assert restored.annotations == annotated_term.annotations
+    transient = {"_jax_cache"} if isinstance(annotated_term, NumericRecord) else set()
+    assert before - transient == state_keys(restored) - transient
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Preserve annotations when `Record`, `NumericRecord`, and `ProductDistribution` instances are copied or pickled. Their custom `__reduce__` implementations now include the post-construction annotation store, and the reconstruction helpers restore it while retaining defaulted parameters for older pickle payloads.

## Linked issue(s)

Closes #409

## Test plan

- `python -m pytest -p no:xdist -o "addopts=" tests/core/test_record_serialization.py -q` — 36 passed
- `python -m pytest -p no:xdist -o "addopts=" tests/core/test_record.py tests/core/test_numeric_record.py tests/core/test_tracked.py tests/distributions/test_product.py -q` — 390 passed
- `ruff check .` — passed
- `ruff format --check probpipe/core/record.py probpipe/core/_numeric_record.py probpipe/distributions/_product.py tests/core/test_record_serialization.py` — passed

`ruff format --check .` still reports nine pre-existing Markdown/design files outside this change; none of the modified Python files are among them.

## Breaking changes

None.

## Documentation

- [ ] Docstrings updated for changed public APIs
- [ ] User Guide / tutorials updated where relevant
- [x] CHANGELOG (or release-notes entry) noted in the linked issue

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`
- [ ] At least one `area:*` label applied (the repository labeler applies these from changed paths)
- [x] Linked to an issue above — or N/A for a small standalone fix
