### PR TITLE
fix(core): carry annotations through copy and pickle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NumericRecord`, and `ProductDistribution` each reconstruct through a
   `__reduce__` that listed its state by hand, and none of them listed
   `_annotations`, so a copied or unpickled term came back with its annotations
-  gone and nothing raised. `__reduce__` governs `copy.copy` and `copy.deepcopy`
+  gone — the diagnostics and inference-backend payloads written into that store
+  among them — and nothing raised. `__reduce__` governs `copy.copy` and `copy.deepcopy`
   as well as `pickle`, so all three paths lost them.
 
   The omission was systematic rather than careless: annotations are the one field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,16 +80,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The omission was systematic rather than careless: annotations are the one field
   written *after* construction — the documented exception to immutability — so a
-  state list assembled from constructor arguments misses exactly this one. The
-  three now thread the store, and `TrackedTerm._restore_identity`, the shared
-  tail of every unpickle helper, restores it alongside `name_is_auto` and
-  provenance. Pickles written before this still load.
+  state list assembled from constructor arguments misses exactly this one.
 
-  The restored container is decoupled from the one it was rebuilt from, as
-  `with_name` already does: entries are shared, the container is not, so a write
-  on a copy does not show through on the original. Annotations still do not cross
-  a JAX transform boundary — `tree_unflatten` rebuilds a bare term, unchanged.
->>>>>>> fix(core): carry annotations through copy and pickle
+  So the constructors now accept it. `Record`, `NumericRecord`, and
+  `Distribution` take private `_provenance` and `_annotations` arguments
+  (`ProductDistribution` a `_name_is_auto` as well, since it derives that flag
+  rather than accepting it), which reconstruction passes and nothing else does.
+  A rebuilt term is therefore complete when its constructor returns, and
+  `TrackedTerm._restore_identity` — which wrote identity onto an
+  already-constructed object, bypassing both the immutability guard and the
+  write-once provenance rule for any caller who found it — **is deleted**.
+  Pickles written before this still load.
+
+  The container a reconstruction is handed is decoupled from the one it was built
+  from, as `with_name` already does: entries are shared, the container is not, so
+  a write on a copy does not show through on the original. Annotations still do
+  not cross a JAX transform boundary — `tree_unflatten` rebuilds a bare term,
+  unchanged.
 
 - **`is_concrete` no longer reports a polymorphic template as concrete (#390).**
   A symbolic dimension declared inside a term spec — a `RecordSpec`'s schema, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and then failed inside the executor, where nothing was left to fall back to.
   Both mapping executors are now probed under a map.
 
+- **`copy` and `pickle` no longer drop a term's annotations (#409).** `Record`,
+  `NumericRecord`, and `ProductDistribution` each reconstruct through a
+  `__reduce__` that listed its state by hand, and none of them listed
+  `_annotations`, so a copied or unpickled term came back with its annotations
+  gone and nothing raised. `__reduce__` governs `copy.copy` and `copy.deepcopy`
+  as well as `pickle`, so all three paths lost them.
+
+  The omission was systematic rather than careless: annotations are the one field
+  written *after* construction — the documented exception to immutability — so a
+  state list assembled from constructor arguments misses exactly this one. The
+  three now thread the store, and `TrackedTerm._restore_identity`, the shared
+  tail of every unpickle helper, restores it alongside `name_is_auto` and
+  provenance. Pickles written before this still load.
+
+  The restored container is decoupled from the one it was rebuilt from, as
+  `with_name` already does: entries are shared, the container is not, so a write
+  on a copy does not show through on the original. Annotations still do not cross
+  a JAX transform boundary — `tree_unflatten` rebuilds a bare term, unchanged.
+>>>>>>> fix(core): carry annotations through copy and pickle
+
 - **`is_concrete` no longer reports a polymorphic template as concrete (#390).**
   A symbolic dimension declared inside a term spec — a `RecordSpec`'s schema, a
   `DistributionSpec`'s event declaration, a `FunctionSpec`'s either side — was

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -9,12 +9,14 @@ Provides:
 from __future__ import annotations
 
 from abc import ABC
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..diagnostics.views import DiagnosticsView
     from ._distribution_array import DistributionArray
 
+from .provenance import Provenance
 from .tracked import Annotated, TrackedTerm
 
 # ---------------------------------------------------------------------------
@@ -82,10 +84,23 @@ class Distribution[T](TrackedTerm, Annotated, ABC):
         If *name* is not a non-empty string.
     """
 
-    def __init__(self, *, name: str, name_is_auto: bool = False):
+    def __init__(
+        self,
+        *,
+        name: str,
+        name_is_auto: bool = False,
+        _provenance: Provenance | None = None,
+        _annotations: Mapping[str, Any] | None = None,
+    ):
         if not isinstance(name, str) or not name:
             raise TypeError(f"{type(self).__name__} requires a non-empty name= argument")
-        self._init_tracked(name, name_is_auto=name_is_auto)
+        # ``_provenance`` and ``_annotations`` carry state a reconstruction
+        # already holds and that construction cannot otherwise reach: provenance
+        # is write-once, and annotations are written after construction, so a
+        # rebuilt distribution would come back without either. Private, and the
+        # reconstruction paths are the only callers.
+        self._init_tracked(name, name_is_auto=name_is_auto, provenance=_provenance)
+        self._init_annotations(_annotations)
 
     # -- keyword-form value construction ------------------------------------
 

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -41,6 +41,7 @@ from .event_template import (
     _record_declaration_template,
 )
 from .named_tree import _PATH_SEP, _check_no_path_sep, _unflatten_paths
+from .provenance import Provenance
 from .record import Record
 
 # ``_is_numeric_leaf`` is defined in ``_array_backend`` (the shared leaf
@@ -191,6 +192,8 @@ class NumericRecord(Record):
         event_template: EventTemplate | RecordSpec | None = None,
         name_is_auto: bool = False,
         _validate_leaves: bool = True,
+        _provenance: Provenance | None = None,
+        _annotations: Mapping[str, Any] | None = None,
         **fields: ArrayLike | NumericRecord,
     ):
         # Read as a template for the child lookups below. ``event_template``
@@ -233,6 +236,8 @@ class NumericRecord(Record):
             event_template=event_template,
             name_is_auto=name_is_auto,
             _validate_leaves=_validate_leaves,
+            _provenance=_provenance,
+            _annotations=_annotations,
         )
         # Cache vector_size, reading only container metadata (shapes) — a
         # lazy / disk-backed leaf is not materialised here.
@@ -608,9 +613,13 @@ def _unpickle_numeric_record(
     # reconstruction is ordinary validation-without-conversion. The threaded
     # declaration preserves an explicit schema across the round-trip; a pickle
     # written before it or the annotations were serialized still loads.
-    nr = NumericRecord(name, store, event_template=spec)
-    return nr._restore_identity(
-        name_is_auto=name_is_auto, provenance=provenance, annotations=annotations
+    return NumericRecord(
+        name,
+        store,
+        event_template=spec,
+        name_is_auto=name_is_auto,
+        _provenance=provenance,
+        _annotations=annotations,
     )
 
 
@@ -641,13 +650,13 @@ def _numeric_record_flatten(v: NumericRecord) -> tuple[list, tuple[RecordSpec, s
 def _numeric_record_unflatten(aux: tuple[RecordSpec, str, bool], children: list) -> NumericRecord:
     """Unflatten NumericRecord from JAX pytree traversal, threading the aux spec."""
     spec, name, name_is_auto = aux
-    nr = NumericRecord(
+    return NumericRecord(
         name,
         dict(zip(tuple(spec.event_template.children), children)),
         event_template=spec,
+        name_is_auto=name_is_auto,
         _validate_leaves=False,
     )
-    return nr._restore_identity(name_is_auto=name_is_auto, provenance=None)
 
 
 jax.tree_util.register_pytree_node(

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -404,8 +404,9 @@ class NumericRecord(Record):
         # field dict round-trips with native types intact at every nesting
         # level, and the authoritative template is threaded back so an
         # explicit (non-inferred) schema survives rather than being
-        # re-inferred. The conversion cache is deliberately not serialized —
-        # it is a memo, rebuilt on demand.
+        # re-inferred, and annotations ride along because they are written
+        # after construction. The conversion cache is deliberately not
+        # serialized — it is a memo, rebuilt on demand.
         return (
             _unpickle_numeric_record,
             (
@@ -414,6 +415,7 @@ class NumericRecord(Record):
                 self._name_is_auto,
                 self._provenance,
                 self._spec,
+                getattr(self, "_annotations", None),
             ),
         )
 
@@ -600,14 +602,16 @@ def _reconstruct_from_vector(
 
 
 def _unpickle_numeric_record(
-    store: dict, name: str, name_is_auto: bool, provenance, spec=None
+    store: dict, name: str, name_is_auto: bool, provenance, spec=None, annotations=None
 ) -> NumericRecord:
     # ``store`` holds the native leaves verbatim (they pickle themselves), so
     # reconstruction is ordinary validation-without-conversion. The threaded
     # declaration preserves an explicit schema across the round-trip; a pickle
-    # written before it was serialized still loads.
+    # written before it or the annotations were serialized still loads.
     nr = NumericRecord(name, store, event_template=spec)
-    return nr._restore_identity(name_is_auto=name_is_auto, provenance=provenance)
+    return nr._restore_identity(
+        name_is_auto=name_is_auto, provenance=provenance, annotations=annotations
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -55,6 +55,7 @@ from .event_template import (
     _unify_event_template_with_value,
 )
 from .named_tree import _PATH_SEP, NamedTree, _check_no_path_sep, _unflatten_paths
+from .provenance import Provenance
 from .tracked import Annotated, TrackedTerm
 
 if TYPE_CHECKING:
@@ -150,6 +151,13 @@ def _canonical_dtype_str(leaf: Any) -> str:
 # ---------------------------------------------------------------------------
 # Record
 # ---------------------------------------------------------------------------
+
+#: Constructor keywords that name a construction option rather than a field, so
+#: the keyword form of ``Record(...)`` does not read them as data. The positional
+#: dict form takes a field of any name, including these.
+_RESERVED_INIT_KWARGS = frozenset(
+    {"event_template", "name_is_auto", "_validate_leaves", "_provenance", "_annotations"}
+)
 
 
 class Record(NamedTree[Any], TrackedTerm, Annotated):
@@ -395,9 +403,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
             if len(args) > 1 and args[1] is not None:
                 source: Mapping[str, Any] = args[1]
             else:
-                source = {
-                    k: v for k, v in kwargs.items() if k not in ("event_template", "name_is_auto")
-                }
+                source = {k: v for k, v in kwargs.items() if k not in _RESERVED_INIT_KWARGS}
             # Promote when every field is numeric (the value probe — bare
             # arrays, numeric scalars, and native backend containers alike)
             # and no explicit non-numeric template vetoes it. Leaves are
@@ -424,6 +430,8 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
         event_template: EventTemplate | RecordSpec | None = None,
         name_is_auto: bool = False,
         _validate_leaves: bool = True,
+        _provenance: Provenance | None = None,
+        _annotations: Mapping[str, Any] | None = None,
         **fields: _FieldValue,
     ):
         # Every check below reads structure, so work in templates and keep the
@@ -494,7 +502,13 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
                 raise ValueError(f"at {field_name!r}: {error}") from None
 
         object.__setattr__(self, "_tree", field_map)
-        self._init_tracked(name, name_is_auto=name_is_auto)
+        # ``_provenance`` and ``_annotations`` carry state a reconstruction
+        # already holds and that construction cannot otherwise reach: provenance
+        # is write-once, and annotations are written after construction, so a
+        # rebuilt record would come back without either. Private, and the
+        # reconstruction paths at the bottom of this module are the only callers.
+        self._init_tracked(name, name_is_auto=name_is_auto, provenance=_provenance)
+        self._init_annotations(_annotations)
         if event_template is None:
             event_template = EventTemplate.infer_from(field_map)
         else:
@@ -1253,9 +1267,13 @@ def _unpickle_record(
     # ``spec`` and ``annotations`` are optional, and construction accepts either
     # declaration form, so a pickle written before either was serialized still
     # loads.
-    r = Record(name, store, event_template=spec)
-    return r._restore_identity(
-        name_is_auto=name_is_auto, provenance=provenance, annotations=annotations
+    return Record(
+        name,
+        store,
+        event_template=spec,
+        name_is_auto=name_is_auto,
+        _provenance=provenance,
+        _annotations=annotations,
     )
 
 
@@ -1300,9 +1318,10 @@ def _record_unflatten(aux: tuple[RecordSpec, str, bool], children: list) -> Reco
         name,
         dict(zip(tuple(spec.event_template.children), children)),
         event_template=spec,
+        name_is_auto=name_is_auto,
         _validate_leaves=False,
     )
-    return r._restore_identity(name_is_auto=name_is_auto, provenance=None)
+    return r
 
 
 jax.tree_util.register_pytree_node(Record, _record_flatten, _record_unflatten)

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -636,7 +636,8 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
         # Serialize the authoritative spec so a pickled record keeps its exact
         # schema (and equality) instead of re-inferring a weaker one on load —
         # an explicit ``support`` / ``dtype`` / ``OpaqueSpec.meta`` is not
-        # recoverable by ``infer_from``.
+        # recoverable by ``infer_from``. Annotations ride along too: they are
+        # written after construction, so no constructor argument carries them.
         return (
             _unpickle_record,
             (
@@ -645,6 +646,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
                 self._name_is_auto,
                 self._provenance,
                 self._spec,
+                getattr(self, "_annotations", None),
             ),
         )
 
@@ -1245,11 +1247,16 @@ def _pack_fields(
 # ---------------------------------------------------------------------------
 
 
-def _unpickle_record(store: dict, name: str, name_is_auto: bool, provenance, spec=None) -> Record:
-    # ``spec`` is optional, and construction accepts either form, so a pickle
-    # written before the declaration was serialized still loads.
+def _unpickle_record(
+    store: dict, name: str, name_is_auto: bool, provenance, spec=None, annotations=None
+) -> Record:
+    # ``spec`` and ``annotations`` are optional, and construction accepts either
+    # declaration form, so a pickle written before either was serialized still
+    # loads.
     r = Record(name, store, event_template=spec)
-    return r._restore_identity(name_is_auto=name_is_auto, provenance=provenance)
+    return r._restore_identity(
+        name_is_auto=name_is_auto, provenance=provenance, annotations=annotations
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/tracked.py
+++ b/probpipe/core/tracked.py
@@ -62,6 +62,19 @@ def auto_name(name: str | None, default: str) -> tuple[str, bool]:
     return name, False
 
 
+def _decoupled_annotations(annotations: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a shallow copy of an annotations container.
+
+    Entries are shared, the container is not, so a write on one object does not
+    show through on the object it was copied or rebuilt from — the annotations
+    channel is written in place (see :class:`Annotated`), which is what makes a
+    shared container observable. Any mapping type is accepted: an
+    ``xarray.DataTree`` and the like copy themselves, and anything else is
+    rebuilt as a ``dict``.
+    """
+    return annotations.copy() if hasattr(annotations, "copy") else dict(annotations)
+
+
 class _TrackedTermMeta(_ProtocolMeta):
     """Metaclass enforcing that every ``TrackedTerm`` instance has a
     non-empty ``name`` set by the time construction returns.
@@ -218,14 +231,9 @@ class TrackedTerm(metaclass=_TrackedTermMeta):
         object.__setattr__(clone, "_name", name)
         object.__setattr__(clone, "_name_is_auto", False)
         object.__setattr__(clone, "_provenance", None)
-        # Decouple the annotations container: writers add entries in place
-        # (the documented append-only channel), and a shared container would
-        # let a post-rename write show through on the original. A shallow
-        # container copy shares the entry values but not the container.
         annotations = getattr(clone, "_annotations", None)
         if annotations is not None:
-            copied = annotations.copy() if hasattr(annotations, "copy") else dict(annotations)
-            object.__setattr__(clone, "_annotations", copied)
+            object.__setattr__(clone, "_annotations", _decoupled_annotations(annotations))
         clone.with_provenance(
             Provenance.create(
                 "with_name",
@@ -271,19 +279,34 @@ class TrackedTerm(metaclass=_TrackedTermMeta):
         object.__setattr__(self, "_provenance", provenance)
         return self
 
-    def _restore_identity(self, *, name_is_auto: bool, provenance: Provenance | None) -> Self:
-        """Restore identity state on a reconstructed object, returning it.
+    def _restore_identity(
+        self,
+        *,
+        name_is_auto: bool,
+        provenance: Provenance | None,
+        annotations: Mapping[str, Any] | None = None,
+    ) -> Self:
+        """Restore identity and metadata state on a reconstructed object.
 
         The shared tail of every unpickle helper: after the constructor has
         rebuilt the object (setting ``_name`` from the stored name), this
         re-applies the stored :attr:`name_is_auto` flag and, when present,
-        the stored provenance — bypassing the write-once guard, since the
-        reconstruction is restoring recorded state rather than rewriting
-        lineage.
+        the stored provenance and annotations — bypassing the write-once guard,
+        since the reconstruction is restoring recorded state rather than
+        rewriting lineage.
+
+        Annotations need restoring here because they are written *after*
+        construction (see :class:`Annotated`), so no constructor argument
+        carries them. The container is decoupled from the one passed in for the
+        reason :meth:`with_name` gives: writers add entries in place, and a
+        shared container would let a write on the reconstruction show through
+        on whatever it was rebuilt from.
         """
         object.__setattr__(self, "_name_is_auto", bool(name_is_auto))
         if provenance is not None:
             object.__setattr__(self, "_provenance", provenance)
+        if annotations is not None:
+            object.__setattr__(self, "_annotations", _decoupled_annotations(annotations))
         return self
 
     # -- copying -------------------------------------------------------------

--- a/probpipe/core/tracked.py
+++ b/probpipe/core/tracked.py
@@ -279,36 +279,6 @@ class TrackedTerm(metaclass=_TrackedTermMeta):
         object.__setattr__(self, "_provenance", provenance)
         return self
 
-    def _restore_identity(
-        self,
-        *,
-        name_is_auto: bool,
-        provenance: Provenance | None,
-        annotations: Mapping[str, Any] | None = None,
-    ) -> Self:
-        """Restore identity and metadata state on a reconstructed object.
-
-        The shared tail of every unpickle helper: after the constructor has
-        rebuilt the object (setting ``_name`` from the stored name), this
-        re-applies the stored :attr:`name_is_auto` flag and, when present,
-        the stored provenance and annotations — bypassing the write-once guard,
-        since the reconstruction is restoring recorded state rather than
-        rewriting lineage.
-
-        Annotations need restoring here because they are written *after*
-        construction (see :class:`Annotated`), so no constructor argument
-        carries them. The container is decoupled from the one passed in for the
-        reason :meth:`with_name` gives: writers add entries in place, and a
-        shared container would let a write on the reconstruction show through
-        on whatever it was rebuilt from.
-        """
-        object.__setattr__(self, "_name_is_auto", bool(name_is_auto))
-        if provenance is not None:
-            object.__setattr__(self, "_provenance", provenance)
-        if annotations is not None:
-            object.__setattr__(self, "_annotations", _decoupled_annotations(annotations))
-        return self
-
     # -- copying -------------------------------------------------------------
 
     def _shallow_copy(self) -> Self:
@@ -371,6 +341,24 @@ class Annotated:
     """
 
     __slots__ = ()
+
+    def _init_annotations(self, annotations: Mapping[str, Any] | None) -> None:
+        """Attach a starting annotations store (constructor helper for hosts).
+
+        The counterpart to :meth:`TrackedTerm._init_tracked`, for the one case a
+        host is handed annotations up front rather than having them written into
+        it later: reconstructing a term that already carried some. ``None``
+        leaves the store unset, which is what an ordinary construction passes,
+        so :attr:`annotations` stays ``None`` until a writer attaches something.
+
+        The container is decoupled from the one passed in, for the reason
+        :meth:`TrackedTerm.with_name` gives: writers add entries in place, so a
+        shared container would let a write on this object show through on
+        whatever it was built from. Writes go through ``object.__setattr__`` so
+        an immutable host can call this from its constructor.
+        """
+        if annotations is not None:
+            object.__setattr__(self, "_annotations", _decoupled_annotations(annotations))
 
     @property
     def annotations(self) -> Mapping[str, Any] | None:

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -251,9 +251,17 @@ class ProductDistribution(
         self._event_template = _build_event_template(self._components)
 
     def __reduce__(self):
+        # Annotations are threaded explicitly: they are written after
+        # construction, so rebuilding from the components alone would drop them.
         return (
             _unpickle_product_distribution,
-            (dict(self._components), self._name, self._name_is_auto, self._provenance),
+            (
+                dict(self._components),
+                self._name,
+                self._name_is_auto,
+                self._provenance,
+                getattr(self, "_annotations", None),
+            ),
         )
 
     # -- Sampling (returns Record) ------------------------------------------
@@ -453,10 +461,16 @@ class ProductDistribution(
         return f"ProductDistribution({comp_str}{name_str})"
 
 
-def _unpickle_product_distribution(components, name, name_is_auto, provenance):
-    """Reconstruct a ProductDistribution (or dynamic subclass) from its components."""
+def _unpickle_product_distribution(components, name, name_is_auto, provenance, annotations=None):
+    """Reconstruct a ProductDistribution (or dynamic subclass) from its components.
+
+    ``annotations`` is optional so a pickle written before they were serialized
+    still loads.
+    """
     p = ProductDistribution(**components, name=name)
-    return p._restore_identity(name_is_auto=name_is_auto, provenance=provenance)
+    return p._restore_identity(
+        name_is_auto=name_is_auto, provenance=provenance, annotations=annotations
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -12,6 +12,7 @@ Provides:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any
 
@@ -217,14 +218,33 @@ class ProductDistribution(
     _sampling_cost = "low"
     _preferred_orchestration = None
 
-    def __new__(cls, *positional, name: str | None = None, **components):
+    def __new__(
+        cls,
+        *positional,
+        name: str | None = None,
+        _name_is_auto: bool | None = None,
+        _provenance: Provenance | None = None,
+        _annotations: Mapping[str, Any] | None = None,
+        **components,
+    ):
+        # ``__new__`` binds the same keywords as ``__init__``, reconstruction's
+        # included: anything left in ``**components`` is read as a component, and
+        # a stray one changes which class the probe below selects.
         components = _merge_positional_and_keyword(positional, components)
         if not components:
             return object.__new__(cls)
         actual_cls = _product_class_for_components(components)
         return object.__new__(actual_cls)
 
-    def __init__(self, *positional, name: str | None = None, **components):
+    def __init__(
+        self,
+        *positional,
+        name: str | None = None,
+        _name_is_auto: bool | None = None,
+        _provenance: Provenance | None = None,
+        _annotations: Mapping[str, Any] | None = None,
+        **components,
+    ):
         components = _merge_positional_and_keyword(positional, components)
         if not components:
             raise ValueError("ProductDistribution requires at least one component.")
@@ -247,7 +267,18 @@ class ProductDistribution(
                 )
         self._components = resolved
         name, name_is_auto = auto_name(name, "product(" + ",".join(resolved.keys()) + ")")
-        super().__init__(name=name, name_is_auto=name_is_auto)
+        # A reconstruction passes the stored flag: it always supplies *name*, so
+        # the derivation above would call a once-auto-derived name user-given.
+        # The three underscore-prefixed keywords are the reconstruction's only,
+        # and are documented on ``Distribution.__init__``.
+        if _name_is_auto is not None:
+            name_is_auto = _name_is_auto
+        super().__init__(
+            name=name,
+            name_is_auto=name_is_auto,
+            _provenance=_provenance,
+            _annotations=_annotations,
+        )
         self._event_template = _build_event_template(self._components)
 
     def __reduce__(self):
@@ -467,9 +498,12 @@ def _unpickle_product_distribution(components, name, name_is_auto, provenance, a
     ``annotations`` is optional so a pickle written before they were serialized
     still loads.
     """
-    p = ProductDistribution(**components, name=name)
-    return p._restore_identity(
-        name_is_auto=name_is_auto, provenance=provenance, annotations=annotations
+    return ProductDistribution(
+        **components,
+        name=name,
+        _name_is_auto=name_is_auto,
+        _provenance=provenance,
+        _annotations=annotations,
     )
 
 
@@ -490,8 +524,11 @@ class TFPProductDistribution(ProductDistribution):
     for interop with SBI and other TFP-dependent subsystems.
     """
 
-    def __init__(self, *positional, name: str | None = None, **components):
-        super().__init__(*positional, name=name, **components)
+    def __init__(self, *positional, **kwargs):
+        # Forwarded wholesale rather than restated: the base's keywords include
+        # the reconstruction ones, and a signature repeated here would silently
+        # swallow any it missed into ``**components``.
+        super().__init__(*positional, **kwargs)
         self._build_tfp_dist()
 
     def _build_tfp_dist(self):

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -10,6 +10,7 @@ The fix adds __reduce__ to each class, delegating reconstruction to the normal
 constructor.
 """
 
+import copy
 import pickle
 
 import jax.numpy as jnp
@@ -360,3 +361,71 @@ class TestPicklePreservesTemplate:
         back = roundtrip(nr)
         assert [float(v) for v in back["x"]] == [1.0, 2.0]
         assert float(back["y"]) == pytest.approx(3.0)
+
+
+# ---------------------------------------------------------------------------
+# Pickle preserves annotations
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripPreservesAnnotations:
+    """Annotations are written *after* construction — the documented exception
+    to immutability — so no constructor argument carries them and a state list
+    assembled from ``__init__`` misses them. They must survive every
+    reconstruction path (#409), which ``__reduce__`` governs for ``copy`` as
+    well as for ``pickle``.
+    """
+
+    @staticmethod
+    def annotated(record):
+        # The store is written through ``object.__setattr__``, as the library's
+        # own writers do: the immutability guard refuses plain assignment.
+        object.__setattr__(record, "_annotations", {"diagnostics": {"n_eff": 42}})
+        return record
+
+    @pytest.fixture(params=["record", "numeric_record"])
+    def term(self, request):
+        if request.param == "record":
+            return self.annotated(Record("r", {"x": jnp.ones(3), "tag": "meters"}))
+        return self.annotated(NumericRecord("nr", {"x": jnp.ones(3)}))
+
+    def test_pickle_preserves_annotations(self, term):
+        assert roundtrip(term).annotations == {"diagnostics": {"n_eff": 42}}
+
+    def test_cloudpickle_preserves_annotations(self, term):
+        assert cloudpickle_roundtrip(term).annotations == {"diagnostics": {"n_eff": 42}}
+
+    def test_copy_preserves_annotations(self, term):
+        assert copy.copy(term).annotations == {"diagnostics": {"n_eff": 42}}
+        assert copy.deepcopy(term).annotations == {"diagnostics": {"n_eff": 42}}
+
+    def test_copy_decouples_the_container(self, term):
+        # Writers add entries in place, so a shared container would let a write
+        # on the copy show through on the original.
+        clone = copy.copy(term)
+        clone.annotations["added"] = 1
+        assert "added" not in term.annotations
+
+    def test_unannotated_term_stays_unannotated(self):
+        assert roundtrip(Record("r", {"x": jnp.ones(3)})).annotations is None
+
+    def test_no_state_is_lost(self, term):
+        # The general form of the bug: compare every attribute the object
+        # reports, so a field added later cannot go missing silently. The
+        # conversion cache is the one documented exclusion — a memo, rebuilt on
+        # demand.
+        def assigned(obj):
+            state = object.__getstate__(obj)
+            instance_dict, slots = state if isinstance(state, tuple) else (state, {})
+            return (set(instance_dict or {}) | set(slots or {})) - {"_jax_cache"}
+
+        assert assigned(term) - assigned(roundtrip(term)) == set()
+
+    def test_pickle_without_annotations_still_loads(self):
+        # Reconstruction stays callable with the shorter argument list a pickle
+        # written before annotations were serialized carries.
+        from probpipe.core.record import _unpickle_record
+
+        r = _unpickle_record({"x": jnp.ones(3)}, "r", False, None)
+        assert r.name == "r"
+        assert r.annotations is None

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -420,6 +420,15 @@ class TestRoundTripPreservesAnnotations:
         assert roundtrip(Record("r", {"x": jnp.ones(3)})).annotations is None
         assert roundtrip(ProductDistribution(v=Normal(0.0, 1.0, name="v"))).annotations is None
 
+    def test_the_reconstruction_has_the_same_type(self, term):
+        # A term whose class is chosen from its constructor arguments — a record
+        # promoting to ``NumericRecord``, a product distribution picking up the
+        # mixins its components support — lands on a different class if the
+        # reconstruction lets one of its own keywords be read as data. The state
+        # can look complete while the interface is not.
+        assert type(roundtrip(term)) is type(term)
+        assert type(copy.copy(term)) is type(term)
+
     def test_no_state_is_lost(self, term):
         # The general form of the bug: compare every attribute the object
         # reports, so a field added later cannot go missing silently. The

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -1,8 +1,10 @@
-"""Pickle / cloudpickle round-trip tests for the Record family.
+"""Round-trip tests for the terms that reconstruct through their own ``__reduce__``.
 
 These tests ensure that Record, EventTemplate, NumericRecord, RecordBatch,
-and NumericRecordBatch can survive pickle serialization, which is required for
-Ray task distribution (Ray uses cloudpickle to ship arguments to workers).
+NumericRecordBatch, and ProductDistribution can survive pickle serialization,
+which is required for Ray task distribution (Ray uses cloudpickle to ship
+arguments to workers), and that a copy or an unpickle preserves everything the
+term was carrying.
 
 The core issue was that Record.__setattr__ raises "Record is immutable", so
 pickle's default restore mechanism (create empty instance + __setattr__) failed.
@@ -17,8 +19,10 @@ import jax.numpy as jnp
 import pytest
 
 from probpipe import (
+    Normal,
     NumericRecord,
     NumericRecordBatch,
+    ProductDistribution,
     RecordBatch,
 )
 from probpipe.core._empirical import BootstrapReplicateDistribution, EmpiricalDistribution
@@ -376,18 +380,24 @@ class TestRoundTripPreservesAnnotations:
     well as for ``pickle``.
     """
 
-    @staticmethod
-    def annotated(record):
-        # The store is written through ``object.__setattr__``, as the library's
-        # own writers do: the immutability guard refuses plain assignment.
-        object.__setattr__(record, "_annotations", {"diagnostics": {"n_eff": 42}})
-        return record
-
-    @pytest.fixture(params=["record", "numeric_record"])
+    @pytest.fixture(
+        params=[
+            # An opaque leaf keeps this one a plain ``Record`` rather than
+            # promoting it, so both classes in the family are covered.
+            pytest.param(lambda: Record("r", {"x": jnp.ones(3), "tag": "meters"}), id="record"),
+            pytest.param(lambda: NumericRecord("nr", {"x": jnp.ones(3)}), id="numeric-record"),
+            pytest.param(
+                lambda: ProductDistribution(value=Normal(0.0, 1.0, name="value"), name="joint"),
+                id="product-distribution",
+            ),
+        ]
+    )
     def term(self, request):
-        if request.param == "record":
-            return self.annotated(Record("r", {"x": jnp.ones(3), "tag": "meters"}))
-        return self.annotated(NumericRecord("nr", {"x": jnp.ones(3)}))
+        term = request.param()
+        # The store is written through ``object.__setattr__``, as the library's
+        # own writers do: an immutability guard refuses plain assignment.
+        object.__setattr__(term, "_annotations", {"diagnostics": {"n_eff": 42}})
+        return term
 
     def test_pickle_preserves_annotations(self, term):
         assert roundtrip(term).annotations == {"diagnostics": {"n_eff": 42}}
@@ -408,6 +418,7 @@ class TestRoundTripPreservesAnnotations:
 
     def test_unannotated_term_stays_unannotated(self):
         assert roundtrip(Record("r", {"x": jnp.ones(3)})).annotations is None
+        assert roundtrip(ProductDistribution(v=Normal(0.0, 1.0, name="v"))).annotations is None
 
     def test_no_state_is_lost(self, term):
         # The general form of the bug: compare every attribute the object

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import copy
-import pickle
-
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -658,36 +655,6 @@ class TestPytreeRegistration:
         assert isinstance(reconstructed, ProductDistribution)
         assert reconstructed.fields == ("x", "y")
         assert reconstructed._name == "j"
-
-
-class TestRoundTripPreservesAnnotations:
-    """Annotations are written after construction, so reconstruction has to
-    carry them explicitly — rebuilding from the components alone drops them
-    (#409). ``__reduce__`` governs ``copy`` as well as ``pickle``.
-    """
-
-    @pytest.fixture
-    def annotated_joint(self, normal_x, normal_y):
-        joint = ProductDistribution(x=normal_x, y=normal_y, name="j")
-        object.__setattr__(joint, "_annotations", {"diagnostics": {"n_eff": 42}})
-        return joint
-
-    def test_pickle_preserves_annotations(self, annotated_joint):
-        back = pickle.loads(pickle.dumps(annotated_joint))
-        assert back.annotations == {"diagnostics": {"n_eff": 42}}
-
-    def test_copy_preserves_annotations(self, annotated_joint):
-        assert copy.copy(annotated_joint).annotations == {"diagnostics": {"n_eff": 42}}
-        assert copy.deepcopy(annotated_joint).annotations == {"diagnostics": {"n_eff": 42}}
-
-    def test_copy_decouples_the_container(self, annotated_joint):
-        clone = copy.copy(annotated_joint)
-        clone.annotations["added"] = 1
-        assert "added" not in annotated_joint.annotations
-
-    def test_unannotated_joint_stays_unannotated(self, normal_x, normal_y):
-        joint = ProductDistribution(x=normal_x, y=normal_y, name="j")
-        assert pickle.loads(pickle.dumps(joint)).annotations is None
 
 
 # ===========================================================================

--- a/tests/distributions/test_product.py
+++ b/tests/distributions/test_product.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import copy
+import pickle
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -655,6 +658,36 @@ class TestPytreeRegistration:
         assert isinstance(reconstructed, ProductDistribution)
         assert reconstructed.fields == ("x", "y")
         assert reconstructed._name == "j"
+
+
+class TestRoundTripPreservesAnnotations:
+    """Annotations are written after construction, so reconstruction has to
+    carry them explicitly — rebuilding from the components alone drops them
+    (#409). ``__reduce__`` governs ``copy`` as well as ``pickle``.
+    """
+
+    @pytest.fixture
+    def annotated_joint(self, normal_x, normal_y):
+        joint = ProductDistribution(x=normal_x, y=normal_y, name="j")
+        object.__setattr__(joint, "_annotations", {"diagnostics": {"n_eff": 42}})
+        return joint
+
+    def test_pickle_preserves_annotations(self, annotated_joint):
+        back = pickle.loads(pickle.dumps(annotated_joint))
+        assert back.annotations == {"diagnostics": {"n_eff": 42}}
+
+    def test_copy_preserves_annotations(self, annotated_joint):
+        assert copy.copy(annotated_joint).annotations == {"diagnostics": {"n_eff": 42}}
+        assert copy.deepcopy(annotated_joint).annotations == {"diagnostics": {"n_eff": 42}}
+
+    def test_copy_decouples_the_container(self, annotated_joint):
+        clone = copy.copy(annotated_joint)
+        clone.annotations["added"] = 1
+        assert "added" not in annotated_joint.annotations
+
+    def test_unannotated_joint_stays_unannotated(self, normal_x, normal_y):
+        joint = ProductDistribution(x=normal_x, y=normal_y, name="j")
+        assert pickle.loads(pickle.dumps(joint)).annotations is None
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

`Record`, `NumericRecord`, and `ProductDistribution` each reconstruct through a
`__reduce__` that lists its state by hand, and none of them listed
`_annotations`, so a copied or unpickled term came back with its annotations gone
and nothing raised. `__reduce__` governs `copy.copy` and `copy.deepcopy` as well
as `pickle`, so all three paths lost them.

The omission is systematic rather than careless: annotations are the one field
written *after* construction — `tracked.py` calls it "the one documented
exception to object immutability" — so a state list assembled from constructor
arguments misses exactly this one, every time.

The three now thread the store, and **the constructors accept it**: `Record`,
`NumericRecord`, and `Distribution` take private `_provenance` and `_annotations`
arguments (`ProductDistribution` a `_name_is_auto` too, since it derives that flag
rather than accepting it), following the `_validate_leaves` precedent for a
reconstruction-only keyword. A rebuilt term is complete when its constructor
returns.

That let `TrackedTerm._restore_identity` be **deleted**. It wrote identity onto an
already-constructed object through `object.__setattr__`, bypassing both the
immutability guard and the write-once provenance rule for any caller who found it
— written for reconstruction, but scoped to nothing. Reconstruction now has no
privileged write path, and the two JAX unflatten paths pass `name_is_auto` to the
constructor, which already accepted it.

`Annotated._init_annotations` is the counterpart to `TrackedTerm._init_tracked`,
so each mixin still initializes its own state. The container it is handed is
**decoupled** from the one it was rebuilt from, as `with_name` already does: entries are shared, the container is not, so a write on
a copy does not show through on the original. That matters because the channel is
written in place by design — the shared-container case is observable, and the
copy moves into a `_decoupled_annotations` helper the two paths share.

Pickles written before this still load: the new argument is optional, following
the `spec` precedent already there for the same reason. Annotations still do not
cross a JAX transform boundary — `tree_unflatten` rebuilds a bare term,
unchanged, and that is untouched here.

## Relationship to #411

**#411 fixes the same bug and was opened first, and its test design is better than
what this branch started with** — one fixture parameterized over the three classes,
rather than the record family in one file and a near-copy of the same assertions
for `ProductDistribution` in another. That shape is adopted here, with credit on
the commit, and the extra coverage this branch carries now applies to all three
classes instead of two.

What remains are three differences in the fix itself, each verified rather than
predicted:

1. **One restore site rather than three.** #411 repeats
   `if annotations is not None: object.__setattr__(...)` at each of the three
   unpickle helpers. Here it goes into `_restore_identity`, which all three
   already call. The repetition is the shape #395 exists to remove, so landing it
   means the mixin change there has three more copies to undo.
2. **`copy.copy` shares the annotations container in #411.** Simulating its
   restore on a plain `Record`:

   ```
   copy.copy shares the container: True
   write on copy shows on original: True     # deepcopy is unaffected
   ```

   Since writers add entries in place, that write is observable on the original.
   Decoupling the container is what `with_name` already does, for this reason.
3. **#411 assigns `_annotations` directly in `_product.py`**
   (`p._annotations = annotations`) while using `object.__setattr__` in the other
   two. It works only because `ProductDistribution` carries no immutability
   guard today, and breaks as soon as one lands on `TrackedTerm` (#395).

## Linked issue(s)

Closes #409.

Refs #395 — the structural fix there (a shared state round-trip delegating to
`object.__getstate__`) makes this class of omission impossible rather than
patching one instance of it, and deletes these hand-written lists. This PR is the
narrow fix so the bug closes with a regression test that does not depend on that
work.

## Test plan

`TestRoundTripPreservesAnnotations` in `tests/core/test_record_serialization.py`,
parameterized over `Record`, `NumericRecord`, and `ProductDistribution`:

- annotations survive `pickle`, `cloudpickle`, `copy.copy`, and `copy.deepcopy`;
- the container is decoupled — a write on the copy does not reach the original;
- an unannotated term still round-trips to `annotations is None`;
- **no state is lost at all** — the keys `object.__getstate__` reports before the
  round-trip equal those after, minus the documented `_jax_cache` memo. This is
  the general form of the bug, and it is the test that would have caught it when
  `Annotated` was introduced;
- reconstruction stays callable with the shorter argument list an older pickle
  carries;
- **the reconstruction has the same type** — added after the state-key test caught
  a class-selection regression this change introduced and the targeted tests
  missed. `ProductDistribution.__new__` has its own signature, so the new private
  keywords sat in its `**components` and reached the probe that picks the
  TFP-backed subclass; a reconstruction came back on the plain class, carrying the
  right state without `_tfp_dist`. `__new__` now binds them, and
  `TFPProductDistribution.__init__` forwards its arguments wholesale rather than
  restating a signature that can fall behind its base.

**Negative control:** restoring the pre-fix `__reduce__` makes all three
assertions fail (`pickle` / `copy` / `deepcopy` → `None`), so the tests are not
vacuous.

Runs: `tests/core` + `tests/distributions` 3418 passed, 4 skipped;
`tests/diagnostics` clean. `ruff format` and `ruff check` clean on the changed
paths. Pyright not run.

## Breaking changes

None. `copy.copy` now yields an independent annotations container where it
previously yielded a term with no annotations at all.

## Documentation

- [x] Docstrings updated for changed public APIs
- [ ] User Guide / tutorials updated where relevant
- [x] CHANGELOG entry added under `Unreleased → Fixed`

## Contract checklist

- [x] Contract of every touched abstraction was clear before coding.
- [x] Changed contracts documented in docstrings: `_restore_identity` is gone, and the reconstruction keywords are documented where they are consumed.
- [x] Docstring openings lead with the API; rationale deferred.
- [x] Code verified to obey the documented contract; tests assert it, including the type a reconstruction lands on.
- [x] Variable names follow the canonical table.
- [x] `CONTRACTS.md` needs no index change — no cross-cutting contract moved.
- [x] `ruff format` and `ruff check` clean.

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`.
- [x] At least one `area:*` label is applied.
- [x] Linked to the issue above.
