### PR TITLE
refactor(core): one Immutable mixin owns the guard and the state round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Reconstruction allocates the resolved class and restores state, so it no longer
   re-runs a constructor: an `EventTemplate` keeps the class its specs were
   resolved to instead of re-deciding the numeric promotion, and a `Record` keeps
-  the exact schema it was written with. `Function` keeps one variant — its
-  constructor assigns normally, so it opens a window over itself and delegates
-  the refusal to the mixin.
+  the exact schema it was written with. `Function` now writes its own state
+  through `object.__setattr__` like every other host, so the `_initializing`
+  window its constructor used to open is gone and one guard covers every case.
 
   **Breaking:** a pickle written by an earlier version does not load. The
   reconstruction entry points it names (`_unpickle_record`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entries below describe the batch types throughout — this is the only entry that
   names the classes being removed.
 
+### Changed
+
+- **Immutability is one mixin, and a term reconstructs from its state (#395).**
+  Four classes spelled out the same guard — three of them hardcoding a class name,
+  so `NumericRecord` reported `Record` and `NumericEventTemplate` reported
+  `EventTemplate` — and answered the round-trip that immutability forces in five
+  different ways. `Record`, `EventTemplate`, `Batch`, and `Function` now mix in
+  one `Immutable`, which owns the guard (naming the class the caller touched) and
+  the state round-trip.
+
+  What the round-trip carries comes from the attributes the object holds, not
+  from a list each class writes out: every assigned slot declared anywhere in the
+  hierarchy, a bare-string `__slots__`, and a subclass's instance dictionary
+  alike. That is what made the annotations bug (#409) possible — a hand-written
+  list cannot name a field written after construction — and it is now impossible
+  by construction rather than fixed once. A class names its memos in
+  `_transient_state` to keep a cache out of the payload (`NumericRecord`'s lazy
+  conversion cache), and a store written in place in `_decoupled_state` so a copy
+  takes its own container (the annotations channel).
+
+  Reconstruction allocates the resolved class and restores state, so it no longer
+  re-runs a constructor: an `EventTemplate` keeps the class its specs were
+  resolved to instead of re-deciding the numeric promotion, and a `Record` keeps
+  the exact schema it was written with. `Function` keeps one variant — its
+  constructor assigns normally, so it opens a window over itself and delegates
+  the refusal to the mixin.
+
+  **Breaking:** a pickle written by an earlier version does not load. The
+  reconstruction entry points it names (`_unpickle_record`,
+  `_unpickle_numeric_record`, `_unpickle_event_template`) are gone, state being
+  restored directly now. Re-generate any persisted records, templates, or
+  batches.
+
 ### Fixed
 
 - **Every dispatch presents a one-field draw the same way.** A one-field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,39 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entries below describe the batch types throughout — this is the only entry that
   names the classes being removed.
 
-### Changed
-
-- **Immutability is one mixin, and a term reconstructs from its state (#395).**
-  Four classes spelled out the same guard — three of them hardcoding a class name,
-  so `NumericRecord` reported `Record` and `NumericEventTemplate` reported
-  `EventTemplate` — and answered the round-trip that immutability forces in five
-  different ways. `Record`, `EventTemplate`, `Batch`, and `Function` now mix in
-  one `Immutable`, which owns the guard (naming the class the caller touched) and
-  the state round-trip.
-
-  What the round-trip carries comes from the attributes the object holds, not
-  from a list each class writes out: every assigned slot declared anywhere in the
-  hierarchy, a bare-string `__slots__`, and a subclass's instance dictionary
-  alike. That is what made the annotations bug (#409) possible — a hand-written
-  list cannot name a field written after construction — and it is now impossible
-  by construction rather than fixed once. A class names its memos in
-  `_transient_state` to keep a cache out of the payload (`NumericRecord`'s lazy
-  conversion cache), and a store written in place in `_decoupled_state` so a copy
-  takes its own container (the annotations channel).
-
-  Reconstruction allocates the resolved class and restores state, so it no longer
-  re-runs a constructor: an `EventTemplate` keeps the class its specs were
-  resolved to instead of re-deciding the numeric promotion, and a `Record` keeps
-  the exact schema it was written with. `Function` now writes its own state
-  through `object.__setattr__` like every other host, so the `_initializing`
-  window its constructor used to open is gone and one guard covers every case.
-
-  **Breaking:** a pickle written by an earlier version does not load. The
-  reconstruction entry points it names (`_unpickle_record`,
-  `_unpickle_numeric_record`, `_unpickle_event_template`) are gone, state being
-  restored directly now. Re-generate any persisted records, templates, or
-  batches.
-
 ### Fixed
 
 - **Every dispatch presents a one-field draw the same way.** A one-field
@@ -115,15 +82,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   written *after* construction — the documented exception to immutability — so a
   state list assembled from constructor arguments misses exactly this one.
 
-  So the constructors now accept it. `Record`, `NumericRecord`, and
-  `Distribution` take private `_provenance` and `_annotations` arguments
-  (`ProductDistribution` a `_name_is_auto` as well, since it derives that flag
-  rather than accepting it), which reconstruction passes and nothing else does.
-  A rebuilt term is therefore complete when its constructor returns, and
-  `TrackedTerm._restore_identity` — which wrote identity onto an
-  already-constructed object, bypassing both the immutability guard and the
-  write-once provenance rule for any caller who found it — **is deleted**.
-  Pickles written before this still load.
+  So reconstruction reads the term's own state instead of a list: nothing has to
+  name a field for it to survive, and `TrackedTerm._restore_identity` — which
+  wrote identity onto an already-constructed object, bypassing both the
+  immutability guard and the write-once provenance rule for any caller who found
+  it — **is deleted**.
 
   The container a reconstruction is handed is decoupled from the one it was built
   from, as `with_name` already does: entries are shared, the container is not, so
@@ -673,6 +636,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uniform everywhere.
 
 ### Changed
+
+- **Immutability is one mixin, and a term reconstructs from its state (#395).**
+  Four classes spelled out the same guard — three of them hardcoding a class name,
+  so `NumericRecord` reported `Record` and `NumericEventTemplate` reported
+  `EventTemplate` — and answered the round-trip that immutability forces in five
+  different ways. `Record`, `EventTemplate`, `Batch`, and `Function` now mix in
+  one `Immutable`, which owns the guard (naming the class the caller touched) and
+  the state round-trip.
+
+  What the round-trip carries comes from the attributes the object holds, not
+  from a list each class writes out: every assigned slot declared anywhere in the
+  hierarchy, a bare-string `__slots__`, and a subclass's instance dictionary
+  alike. That is what made the annotations bug (#409) possible — a hand-written
+  list cannot name a field written after construction — and it is now impossible
+  by construction rather than fixed once. A class names its memos in
+  `_transient_state` to keep a cache out of the payload (`NumericRecord`'s lazy
+  conversion cache), and a store written in place in `_decoupled_state` so a copy
+  takes its own container (the annotations channel).
+
+  Reconstruction allocates the resolved class and restores state, so it no longer
+  re-runs a constructor: an `EventTemplate` keeps the class its specs were
+  resolved to instead of re-deciding the numeric promotion, and a `Record` keeps
+  the exact schema it was written with. `Function` now writes its own state
+  through `object.__setattr__` like every other host, so the `_initializing`
+  window its constructor used to open is gone and one guard covers every case.
+
+  **Breaking:** a pickle written by an earlier version does not load. The
+  reconstruction entry points it names (`_unpickle_record`,
+  `_unpickle_numeric_record`, `_unpickle_event_template`) are gone, state being
+  restored directly now. Re-generate any persisted records, templates, or
+  batches.
 
 - **A joint law draws a `RecordBatch`.** `_sample` on the four joint laws —
   product, sequential, Gaussian, and empirical — returns a `NumericRecordBatch`

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -101,6 +101,7 @@ if it were user-guide reference text.
 | `FunctionBatch` / `OpaqueBatch` (the batch forms that *store* their elements, over shared object-array storage) | docstrings in `probpipe/core/_function_batch.py`, `_opaque_batch.py` (storage in `_object_batch.py`); #235 Chapter 2 |
 | `Function` & ops (`sample`, `log_prob`, …) | docstrings in `core/node.py`, `core/ops.py`, `_workflow_result.py`; #235 Chapter 3 |
 | Naming / provenance / annotations (`TrackedTerm` / `Annotated` mixins) | docstrings in `probpipe/core/tracked.py` (and `provenance.py` for `Provenance` / `ParentInfo`); the naming contract in #235 Chapter 5 |
+| Immutability (`Immutable` mixin: the assignment guard, and the `copy` / `pickle` state round-trip it forces) | docstrings in `probpipe/core/_immutable.py`; `design/02-shared-abstractions.md` §II.4 |
 
 ## Canonical variable names (use these; don't invent synonyms)
 | Concept | Name |
@@ -118,6 +119,8 @@ if it were user-guide reference text.
 | PRNG key | `key` |
 | a tracked object's own identity name (the required first arg of `Record` / a distribution) | `name` |
 | a field key within a tree / the name being assigned to a field | `field_name` / `key` |
+| attributes an immutable class keeps out of its state round-trip (memos) | `_transient_state` |
+| attributes an immutable class restores into their own container (stores written in place) | `_decoupled_state` |
 *(Extend this table whenever a new contract introduces a recurring parameter.)*
 
 ## Per-PR checklist (copy into the PR description)

--- a/design/02-shared-abstractions.md
+++ b/design/02-shared-abstractions.md
@@ -226,7 +226,13 @@ As the *type layer*, an `EventTemplate` is the explicit structure that travels w
 
 Identity, type & metadata is the cross-cutting layer that lets any object carry, alongside its raw representation, four things: a **name** (what the object is called), a **spec** (the declaration of its type, II.2), a **provenance** (how it was produced), and free-form **annotations** (auxiliary information supplied by the user or an algorithm). The structure is provided by two mixins: `TrackedTerm` (name, spec, and provenance) and `Annotated` (annotations). Every first-class object, the kind an operation consumes and produces, must be a `TrackedTerm`, while structural helpers such as templates and specs are not. We call any such object a **tracked term**: a value, distribution, conditional distribution, linear operator, or batch that carries a name, its spec, and provenance.
 
-Annotation metadata is a free-form mapping:
+Annotation metadata is a free-form mapping, and the **one exception to
+immutability**: the store is written after construction by inference backends,
+validators, and diagnostic operations, and mutated in place, so the channel is
+append-only by convention — a writer adds under its own key and never overwrites
+mathematical state or another writer's entries. Being written in place is also
+why a copy takes its own container: otherwise a write on one term would show
+through on the term it was copied from.
 
 ```python
 class Annotated:
@@ -237,6 +243,8 @@ A tracked term's name must be provided by the user when constructed explicitly (
 
 The `spec` slot is the term's type, stored once (II.2). Each kind narrows it to its own spec class and exposes convenience accessors for its properties.
 
+**A tracked term is immutable, and that is a property of being one** (`C2 – Functional interface over immutable objects`): assignment and deletion raise, naming the class the caller touched, and every transformation returns a new term. `TrackedTerm` therefore carries the immutability itself rather than each kind opting in — one guard, so a subclass cannot report a different rule than its base. Immutability obliges a second thing, since `pickle` and `copy` restore an object by assigning its state back: a term reconstructs by allocating its resolved class and restoring the state it actually holds, rather than by rebuilding through its constructor. So a reconstruction cannot re-derive a schema an explicit declaration had pinned, cannot re-decide a class from arguments the state no longer carries, and cannot omit a field — including one written after construction, which no constructor argument names. A term declares any *memo* it holds as transient, keeping a cache out of the round-trip, and any *store written in place* as decoupled, so a copy takes its own container rather than sharing one. Annotations are the one such store (below).
+
 ```python
 class TrackedTerm:
     name:         str
@@ -245,6 +253,8 @@ class TrackedTerm:
     provenance:   Provenance | None              # write-once via with_provenance(...)
     def with_name(self, name: str) -> Self: ...  # shallow copy with name_is_auto = False
     def with_provenance(self, p: Provenance) -> Self: ...
+    # immutable: __setattr__ / __delattr__ raise; state round-trips through the
+    # attributes the term holds, so copy and pickle need nothing from the class
 
 class Provenance:
     operation: str                       # the operation that produced the object

--- a/probpipe/core/_batch.py
+++ b/probpipe/core/_batch.py
@@ -68,6 +68,7 @@ from dataclasses import dataclass, replace
 from math import prod
 from typing import Any, Self, cast
 
+from ._immutable import Immutable
 from .event_template import (
     TermSpec,
     ValueSpec,
@@ -342,7 +343,7 @@ class BatchSpec(TermSpec):
         return spec == self
 
 
-class Batch[E](TrackedTerm, ABC):
+class Batch[E](Immutable, TrackedTerm, ABC):
     """A tracked nd collection of elements of a common type.
 
     The batch axes are grouped into named **levels**, and indexing them returns a
@@ -379,8 +380,9 @@ class Batch[E](TrackedTerm, ABC):
     ``shape`` / ``size`` because a bare name would ambiguously cover both the
     batch axes and the content of one element.
 
-    A batch is immutable: assignment and deletion raise, and ``pickle`` / ``copy``
-    restore the slots around that guard.
+    A batch is immutable, by :class:`~probpipe.core._immutable.Immutable`:
+    assignment and deletion raise, and ``pickle`` / ``copy`` restore its state
+    around that guard.
     """
 
     __slots__ = (
@@ -408,47 +410,6 @@ class Batch[E](TrackedTerm, ABC):
     # refuses — and every site that composes or renders a selection would carry a
     # branch for it. :meth:`with_name` re-roots a view: a user-given name replaces
     # the derivation and discards the selection accumulated before it.
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        raise AttributeError(f"{type(self).__name__} is immutable")
-
-    def __delattr__(self, name: str) -> None:
-        raise AttributeError(f"{type(self).__name__} is immutable")
-
-    def __getstate__(self) -> Any:
-        """This batch's whole state, for ``pickle`` and ``copy``.
-
-        Delegates to :meth:`object.__getstate__`, which reports every assigned
-        slot declared anywhere in the class hierarchy — a subclass's storage
-        included, without it having to say so — together with an instance
-        dictionary if the subclass has one.
-
-        Notes
-        -----
-        Only :meth:`__setstate__` needs overriding here; ``__getstate__`` is
-        defined alongside it so that the pair reads as one, and so that walking
-        the hierarchy by hand is not reintroduced. That walk is easy to get
-        subtly wrong: ``__slots__`` may be a bare string naming one slot, which
-        iterates into characters rather than into that name, and a subclass that
-        declares no ``__slots__`` keeps its attributes in a dictionary that no
-        walk over ``__slots__`` would find. Either would drop state silently,
-        since a missing attribute is indistinguishable from an unassigned slot.
-        """
-        return object.__getstate__(self)
-
-    def __setstate__(self, state: Any) -> None:
-        """Restore *state* through ``object.__setattr__``.
-
-        ``pickle`` and ``copy`` restore state by assignment, which the
-        immutability guard refuses, so the write has to go around it exactly as
-        construction does. Both halves of the state are restored: the instance
-        dictionary, where a subclass has one, and the slots.
-        """
-        instance_dict, slots = state if isinstance(state, tuple) else (state, None)
-        for attribute, value in (instance_dict or {}).items():
-            object.__setattr__(self, attribute, value)
-        for slot, value in (slots or {}).items():
-            object.__setattr__(self, slot, value)
 
     # -- construction -------------------------------------------------------
 

--- a/probpipe/core/_immutable.py
+++ b/probpipe/core/_immutable.py
@@ -1,16 +1,13 @@
-"""Immutability: the assignment guard and the state round-trip it forces.
+"""Object immutability: the assignment guard and the state round-trip.
 
-An object that refuses attribute assignment cannot be restored the way
-``pickle`` and ``copy`` restore an ordinary object, which is by assigning its
-state back. :class:`Immutable` owns both halves of that bargain — the refusal
-and the round-trip — so a class states once that it is immutable instead of
-spelling out the consequences itself.
+Provides :class:`Immutable`, the mixin a class inherits to declare that its
+instances cannot be modified after construction. It supplies the assignment
+guard and, because an object that refuses assignment cannot be restored the way
+``pickle`` and ``copy`` restore an ordinary one, the state round-trip those need.
 
 Every tracked term is immutable (``C2 – Functional interface over immutable
-objects``, and the operation contract of ``design/05-operations.md`` §V.1, which
-promises an implementer's object is never modified), so :class:`TrackedTerm`
-mixes this in and a term inherits it by being one. ``EventTemplate`` mixes it in
-directly, being immutable without being a term.
+objects``), as is :class:`~probpipe.core.event_template.EventTemplate`, which is
+immutable without being a term.
 """
 
 from __future__ import annotations
@@ -21,85 +18,90 @@ __all__ = ["Immutable"]
 
 
 def decoupled_container(container: Any) -> Any:
-    """Return a shallow copy of a mutable store: entries shared, container not.
+    """Return a shallow copy of *container*: entries shared, container not.
 
-    A store written in place — the annotations channel is the one ProbPipe has —
-    must not be shared between an object and whatever it was copied or rebuilt
-    from, or a write on one shows through on the other. Any mapping type is
-    accepted: an ``xarray.DataTree`` and the like copy themselves, and anything
-    else is rebuilt as a ``dict``.
+    Parameters
+    ----------
+    container : Mapping
+        The store to copy. Any mapping type is accepted — an ``xarray.DataTree``
+        and the like copy themselves, anything else is rebuilt as a ``dict``.
+
+    Returns
+    -------
+    Mapping
+        A copy holding the same entries, which writes to either container do not
+        share.
     """
     return container.copy() if hasattr(container, "copy") else dict(container)
 
 
 def _allocate(cls: type) -> Any:
-    """Allocate *cls* without running its ``__new__`` or ``__init__``.
+    """Allocate an instance of *cls* without running ``__new__`` or ``__init__``.
 
-    The reconstruction entry point named by :meth:`Immutable.__reduce__`, at
-    module level because a pickle has to be able to import it by name.
+    The reconstruction callable :meth:`Immutable.__reduce__` names, at module
+    level so a pickle can import it.
 
-    ``object.__new__`` rather than ``cls.__new__``: a host's own ``__new__``
-    exists to *select* a class from constructor arguments — ``Record`` promoting
-    to ``NumericRecord``, the dynamic distribution subclasses — and *cls* is
-    already the resolved class the state belongs to. Re-running that choice on
-    load would let a reconstruction land on a different class than it was
-    written from.
+    Notes
+    -----
+    ``object.__new__`` rather than ``cls.__new__``, because a host's own
+    ``__new__`` selects a class from constructor arguments — ``Record``
+    promoting to ``NumericRecord``, the dynamic distribution subclasses — and
+    *cls* is already the resolved class the state belongs to.
     """
     return object.__new__(cls)
 
 
 class Immutable:
-    """Refuses attribute assignment, and round-trips its state regardless.
+    """Mixin declaring that instances cannot be modified after construction.
 
-    A host mixes this in to declare that its instances are immutable. Assignment
-    and deletion raise :exc:`AttributeError` naming the class the caller
-    actually touched; construction writes through ``object.__setattr__``, which
-    goes around the guard because the object is not yet anyone's to hold.
+    Assignment and deletion raise :exc:`AttributeError`, naming the class of the
+    object that was touched. A constructor writes through
+    ``object.__setattr__``, which the guard does not intercept.
 
-    The round-trip
-    --------------
-    ``pickle`` and ``copy`` restore an object by assigning its state back, which
-    the guard refuses, so an immutable class has to answer for its own
-    reconstruction. Answering it here rather than per class matters because the
-    answer is easy to get subtly wrong in a way that raises nothing:
+    ``copy.copy``, ``copy.deepcopy``, and ``pickle`` return an object of the same
+    class holding the same state: every attribute the original has assigned,
+    whether it lives in a slot declared anywhere in the class hierarchy or in an
+    instance dictionary. Reconstruction restores that state directly rather than
+    calling the class's constructor, so nothing is re-derived from arguments the
+    state no longer carries. Attributes named in :attr:`_transient_state` are
+    left out and unset on the copy; those named in :attr:`_decoupled_state` are
+    restored into a container of their own.
 
-    * what to save comes from :meth:`object.__getstate__`, which reports every
-      assigned slot declared anywhere in the hierarchy **and** an instance
-      dictionary if the host has one. A hand-walk over ``__slots__`` misses a
-      subclass's storage, and iterates a bare-string ``__slots__`` into
-      characters rather than into the one name it declares;
-    * a hand-written list of state fields misses whatever was added to the class
-      later — in particular anything assigned *after* construction, which no
-      constructor argument names;
-    * a missing attribute is indistinguishable from an unassigned slot, so both
-      mistakes lose data in silence.
+    Attributes
+    ----------
+    _transient_state : tuple of str
+        Names of memos to leave out of the round-trip, rebuilt on demand by the
+        host. Read as the union over the class hierarchy, so a subclass adds to
+        its base's entries rather than restating them.
+    _decoupled_state : tuple of str
+        Names of stores that are written in place, so a copy takes its own
+        container. Same union rule.
 
-    Together with :func:`_allocate`, this makes a round-trip carry exactly the
-    state the object holds, for any storage form, without the class restating
-    what its state is.
+    Raises
+    ------
+    AttributeError
+        From any attribute assignment or deletion on an instance.
 
-    Transient state
-    ---------------
-    A host names memos in :attr:`_transient_state` to keep them out of the
-    round-trip: a cache is derived from the state that *is* saved, so carrying it
-    would bloat the pickle to no purpose and, for a cache of converted arrays,
-    duplicate the payload. The attribute is left unset on the reconstruction and
-    rebuilt on demand.
+    Notes
+    -----
+    The round-trip is defined here rather than per class because the three ways
+    to get it wrong are all silent. What to save comes from
+    :meth:`object.__getstate__`, which reports every assigned slot and an
+    instance dictionary if there is one: a walk over ``__slots__`` by hand misses
+    a subclass's storage, and iterates a bare-string ``__slots__`` into
+    characters rather than into the one name it declares. A hand-written list of
+    state fields additionally misses whatever is assigned *after* construction,
+    which no constructor argument names. A missing attribute is
+    indistinguishable from an unassigned slot, so each mistake loses data without
+    raising.
     """
 
     __slots__ = ()
 
-    #: Attribute names excluded from the state round-trip — memos, rebuilt on
-    #: demand rather than carried. Subclasses override; the union over the MRO
-    #: applies, so a subclass need not repeat its base's entries.
     _transient_state: ClassVar[tuple[str, ...]] = ()
-
-    #: Attribute names holding a store that is written in place, so a
-    #: reconstruction takes its own container rather than sharing one. Same MRO
-    #: union as :attr:`_transient_state`.
     _decoupled_state: ClassVar[tuple[str, ...]] = ()
 
-    # -- the guard -----------------------------------------------------------
+    # -- The guard -----------------------------------------------------------
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise AttributeError(f"{type(self).__name__} is immutable")
@@ -107,17 +109,24 @@ class Immutable:
     def __delattr__(self, name: str) -> None:
         raise AttributeError(f"{type(self).__name__} is immutable")
 
-    # -- the round-trip ------------------------------------------------------
+    # -- The state round-trip ------------------------------------------------
 
     @classmethod
-    def _declared_state_names(cls, attribute: str) -> frozenset[str]:
-        """The union of *attribute* over every class in this MRO."""
+    def _declared_state_names(cls, declaration: str) -> frozenset[str]:
+        """The union of the *declaration* tuple over every class in the MRO."""
         return frozenset(
-            name for klass in cls.__mro__ for name in klass.__dict__.get(attribute, ())
+            name for klass in cls.__mro__ for name in klass.__dict__.get(declaration, ())
         )
 
-    def __getstate__(self) -> Any:
-        """This object's state, minus its declared memos."""
+    def __getstate__(self) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        """Return this object's state, minus the attributes declared transient.
+
+        Returns
+        -------
+        tuple of (dict or None, dict or None)
+            The instance dictionary and the assigned slots, in the pair form
+            :meth:`object.__getstate__` uses; either half is ``None`` when empty.
+        """
         state = object.__getstate__(self)
         instance_dict, slots = state if isinstance(state, tuple) else (state, None)
         transient = self._declared_state_names("_transient_state")
@@ -127,14 +136,20 @@ class Immutable:
         return (instance_dict or None, slots or None)
 
     def __setstate__(self, state: Any) -> None:
-        """Restore *state*, writing through ``object.__setattr__``.
+        """Restore *state*, assigning through ``object.__setattr__``.
 
-        Both halves are restored — the instance dictionary, where the host has
-        one, and the slots — going around the guard exactly as construction
-        does. A store named in :attr:`_decoupled_state` is restored into its own
-        container, so a write on this object does not reach the one it was
-        rebuilt from; ``copy.copy`` is where that matters, its state being the
-        original's own attribute values.
+        Parameters
+        ----------
+        state : tuple of (dict or None, dict or None)
+            The instance dictionary and slots, as :meth:`__getstate__` returns
+            them. A bare dictionary is accepted as the instance-dictionary half.
+
+        Notes
+        -----
+        A store named in :attr:`_decoupled_state` is restored into its own
+        container. ``copy.copy`` passes the original's own attribute values as
+        the state, so restoring such a store verbatim would leave both objects
+        writing to one container.
         """
         instance_dict, slots = state if isinstance(state, tuple) else (state, None)
         decoupled = self._declared_state_names("_decoupled_state")
@@ -143,12 +158,13 @@ class Immutable:
                 value = decoupled_container(value)
             object.__setattr__(self, attribute, value)
 
-    def __reduce__(self):
-        """Reconstruct by allocating the resolved class and restoring state.
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Return the reconstruction of this object: allocate its class, restore state.
 
-        Deliberately not the constructor: an immutable object's state is exactly
-        what it holds, and rebuilding through ``__init__`` would re-derive it —
-        re-inferring a schema an explicit declaration had pinned, or re-deciding
-        a class from arguments the state no longer carries.
+        Returns
+        -------
+        tuple
+            The three-element form ``pickle`` and ``copy`` consume:
+            :func:`_allocate`, the resolved class, and :meth:`__getstate__`.
         """
         return (_allocate, (type(self),), self.__getstate__())

--- a/probpipe/core/_immutable.py
+++ b/probpipe/core/_immutable.py
@@ -8,6 +8,11 @@ guard and, because an object that refuses assignment cannot be restored the way
 Every tracked term is immutable (``C2 – Functional interface over immutable
 objects``), as is :class:`~probpipe.core.event_template.EventTemplate`, which is
 immutable without being a term.
+
+Interim: the mixin is inherited by ``Record``, ``EventTemplate``, ``Batch``, and
+``Function``, the classes that enforced immutability individually. The rest of
+the tracked terms accept assignment until :class:`TrackedTerm` inherits it, which
+also requires the terms that mutate after construction to stop.
 """
 
 from __future__ import annotations
@@ -33,22 +38,6 @@ def decoupled_container(container: Any) -> Any:
         share.
     """
     return container.copy() if hasattr(container, "copy") else dict(container)
-
-
-def _allocate(cls: type) -> Any:
-    """Allocate an instance of *cls* without running ``__new__`` or ``__init__``.
-
-    The reconstruction callable :meth:`Immutable.__reduce__` names, at module
-    level so a pickle can import it.
-
-    Notes
-    -----
-    ``object.__new__`` rather than ``cls.__new__``, because a host's own
-    ``__new__`` selects a class from constructor arguments — ``Record``
-    promoting to ``NumericRecord``, the dynamic distribution subclasses — and
-    *cls* is already the resolved class the state belongs to.
-    """
-    return object.__new__(cls)
 
 
 class Immutable:
@@ -165,6 +154,14 @@ class Immutable:
         -------
         tuple
             The three-element form ``pickle`` and ``copy`` consume:
-            :func:`_allocate`, the resolved class, and :meth:`__getstate__`.
+            ``object.__new__``, the resolved class, and :meth:`__getstate__`.
+
+        Notes
+        -----
+        ``object.__new__`` rather than the host's own ``__new__``, which selects
+        a class from constructor arguments — ``Record`` promoting to
+        ``NumericRecord``, the dynamic distribution subclasses. The class here is
+        already the resolved one the state belongs to, so that choice must not be
+        made again.
         """
-        return (_allocate, (type(self),), self.__getstate__())
+        return (object.__new__, (type(self),), self.__getstate__())

--- a/probpipe/core/_immutable.py
+++ b/probpipe/core/_immutable.py
@@ -1,0 +1,154 @@
+"""Immutability: the assignment guard and the state round-trip it forces.
+
+An object that refuses attribute assignment cannot be restored the way
+``pickle`` and ``copy`` restore an ordinary object, which is by assigning its
+state back. :class:`Immutable` owns both halves of that bargain — the refusal
+and the round-trip — so a class states once that it is immutable instead of
+spelling out the consequences itself.
+
+Every tracked term is immutable (``C2 – Functional interface over immutable
+objects``, and the operation contract of ``design/05-operations.md`` §V.1, which
+promises an implementer's object is never modified), so :class:`TrackedTerm`
+mixes this in and a term inherits it by being one. ``EventTemplate`` mixes it in
+directly, being immutable without being a term.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+__all__ = ["Immutable"]
+
+
+def decoupled_container(container: Any) -> Any:
+    """Return a shallow copy of a mutable store: entries shared, container not.
+
+    A store written in place — the annotations channel is the one ProbPipe has —
+    must not be shared between an object and whatever it was copied or rebuilt
+    from, or a write on one shows through on the other. Any mapping type is
+    accepted: an ``xarray.DataTree`` and the like copy themselves, and anything
+    else is rebuilt as a ``dict``.
+    """
+    return container.copy() if hasattr(container, "copy") else dict(container)
+
+
+def _allocate(cls: type) -> Any:
+    """Allocate *cls* without running its ``__new__`` or ``__init__``.
+
+    The reconstruction entry point named by :meth:`Immutable.__reduce__`, at
+    module level because a pickle has to be able to import it by name.
+
+    ``object.__new__`` rather than ``cls.__new__``: a host's own ``__new__``
+    exists to *select* a class from constructor arguments — ``Record`` promoting
+    to ``NumericRecord``, the dynamic distribution subclasses — and *cls* is
+    already the resolved class the state belongs to. Re-running that choice on
+    load would let a reconstruction land on a different class than it was
+    written from.
+    """
+    return object.__new__(cls)
+
+
+class Immutable:
+    """Refuses attribute assignment, and round-trips its state regardless.
+
+    A host mixes this in to declare that its instances are immutable. Assignment
+    and deletion raise :exc:`AttributeError` naming the class the caller
+    actually touched; construction writes through ``object.__setattr__``, which
+    goes around the guard because the object is not yet anyone's to hold.
+
+    The round-trip
+    --------------
+    ``pickle`` and ``copy`` restore an object by assigning its state back, which
+    the guard refuses, so an immutable class has to answer for its own
+    reconstruction. Answering it here rather than per class matters because the
+    answer is easy to get subtly wrong in a way that raises nothing:
+
+    * what to save comes from :meth:`object.__getstate__`, which reports every
+      assigned slot declared anywhere in the hierarchy **and** an instance
+      dictionary if the host has one. A hand-walk over ``__slots__`` misses a
+      subclass's storage, and iterates a bare-string ``__slots__`` into
+      characters rather than into the one name it declares;
+    * a hand-written list of state fields misses whatever was added to the class
+      later — in particular anything assigned *after* construction, which no
+      constructor argument names;
+    * a missing attribute is indistinguishable from an unassigned slot, so both
+      mistakes lose data in silence.
+
+    Together with :func:`_allocate`, this makes a round-trip carry exactly the
+    state the object holds, for any storage form, without the class restating
+    what its state is.
+
+    Transient state
+    ---------------
+    A host names memos in :attr:`_transient_state` to keep them out of the
+    round-trip: a cache is derived from the state that *is* saved, so carrying it
+    would bloat the pickle to no purpose and, for a cache of converted arrays,
+    duplicate the payload. The attribute is left unset on the reconstruction and
+    rebuilt on demand.
+    """
+
+    __slots__ = ()
+
+    #: Attribute names excluded from the state round-trip — memos, rebuilt on
+    #: demand rather than carried. Subclasses override; the union over the MRO
+    #: applies, so a subclass need not repeat its base's entries.
+    _transient_state: ClassVar[tuple[str, ...]] = ()
+
+    #: Attribute names holding a store that is written in place, so a
+    #: reconstruction takes its own container rather than sharing one. Same MRO
+    #: union as :attr:`_transient_state`.
+    _decoupled_state: ClassVar[tuple[str, ...]] = ()
+
+    # -- the guard -----------------------------------------------------------
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError(f"{type(self).__name__} is immutable")
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError(f"{type(self).__name__} is immutable")
+
+    # -- the round-trip ------------------------------------------------------
+
+    @classmethod
+    def _declared_state_names(cls, attribute: str) -> frozenset[str]:
+        """The union of *attribute* over every class in this MRO."""
+        return frozenset(
+            name for klass in cls.__mro__ for name in klass.__dict__.get(attribute, ())
+        )
+
+    def __getstate__(self) -> Any:
+        """This object's state, minus its declared memos."""
+        state = object.__getstate__(self)
+        instance_dict, slots = state if isinstance(state, tuple) else (state, None)
+        transient = self._declared_state_names("_transient_state")
+        if transient:
+            instance_dict = {k: v for k, v in (instance_dict or {}).items() if k not in transient}
+            slots = {k: v for k, v in (slots or {}).items() if k not in transient}
+        return (instance_dict or None, slots or None)
+
+    def __setstate__(self, state: Any) -> None:
+        """Restore *state*, writing through ``object.__setattr__``.
+
+        Both halves are restored — the instance dictionary, where the host has
+        one, and the slots — going around the guard exactly as construction
+        does. A store named in :attr:`_decoupled_state` is restored into its own
+        container, so a write on this object does not reach the one it was
+        rebuilt from; ``copy.copy`` is where that matters, its state being the
+        original's own attribute values.
+        """
+        instance_dict, slots = state if isinstance(state, tuple) else (state, None)
+        decoupled = self._declared_state_names("_decoupled_state")
+        for attribute, value in ((instance_dict or {}) | (slots or {})).items():
+            if attribute in decoupled and value is not None:
+                value = decoupled_container(value)
+            object.__setattr__(self, attribute, value)
+
+    def __reduce__(self):
+        """Reconstruct by allocating the resolved class and restoring state.
+
+        Deliberately not the constructor: an immutable object's state is exactly
+        what it holds, and rebuilding through ``__init__`` would re-derive it —
+        re-inferring a schema an explicit declaration had pinned, or re-deciding
+        a class from arguments the state no longer carries.
+        """
+        return (_allocate, (type(self),), self.__getstate__())

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -305,12 +305,25 @@ class NumericRecord(Record):
         val = self._tree[field_name]
         if isinstance(val, jnp.ndarray):
             return val
-        cache = self._jax_cache
+        cache = self._conversion_cache()
         arr = cache.get(field_name)
         if arr is None:
             arr = _to_jax_array(val)
             cache[field_name] = arr
         return arr
+
+    def _conversion_cache(self) -> dict[str, jnp.ndarray]:
+        """The per-leaf conversion memo, created if this instance has none.
+
+        A record that arrives from ``copy`` or ``pickle`` carries no memo — it is
+        derived from the leaves, so it is rebuilt rather than transported — and
+        the first conversion after one lands here.
+        """
+        cache = getattr(self, "_jax_cache", None)
+        if cache is None:
+            cache = {}
+            object.__setattr__(self, "_jax_cache", cache)
+        return cache
 
     def _field_as_jax(self, key: str) -> jnp.ndarray:
         """The converted ``jax.Array`` for the field at *key*, at any depth.

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -41,7 +41,6 @@ from .event_template import (
     _record_declaration_template,
 )
 from .named_tree import _PATH_SEP, _check_no_path_sep, _unflatten_paths
-from .provenance import Provenance
 from .record import Record
 
 # ``_is_numeric_leaf`` is defined in ``_array_backend`` (the shared leaf
@@ -183,6 +182,11 @@ class NumericRecord(Record):
 
     __slots__ = ("_jax_cache", "_vector_size")
 
+    #: The lazy conversion cache is a memo over the stored leaves, so it is
+    #: rebuilt on demand rather than carried through ``copy`` and ``pickle`` —
+    #: carrying it would duplicate every converted array in the payload.
+    _transient_state = ("_jax_cache",)
+
     def __init__(
         self,
         name: str,
@@ -192,8 +196,6 @@ class NumericRecord(Record):
         event_template: EventTemplate | RecordSpec | None = None,
         name_is_auto: bool = False,
         _validate_leaves: bool = True,
-        _provenance: Provenance | None = None,
-        _annotations: Mapping[str, Any] | None = None,
         **fields: ArrayLike | NumericRecord,
     ):
         # Read as a template for the child lookups below. ``event_template``
@@ -236,8 +238,6 @@ class NumericRecord(Record):
             event_template=event_template,
             name_is_auto=name_is_auto,
             _validate_leaves=_validate_leaves,
-            _provenance=_provenance,
-            _annotations=_annotations,
         )
         # Cache vector_size, reading only container metadata (shapes) — a
         # lazy / disk-backed leaf is not materialised here.
@@ -403,26 +403,6 @@ class NumericRecord(Record):
         return self
 
     # -- Single-field scalar-like coercion ---------------------------------
-
-    def __reduce__(self):
-        # Native leaves pickle themselves, so one branch suffices: the stored
-        # field dict round-trips with native types intact at every nesting
-        # level, and the authoritative template is threaded back so an
-        # explicit (non-inferred) schema survives rather than being
-        # re-inferred, and annotations ride along because they are written
-        # after construction. The conversion cache is deliberately not
-        # serialized — it is a memo, rebuilt on demand.
-        return (
-            _unpickle_numeric_record,
-            (
-                dict(self._tree),
-                self._name,
-                self._name_is_auto,
-                self._provenance,
-                self._spec,
-                getattr(self, "_annotations", None),
-            ),
-        )
 
     def _single_numeric_field(self) -> str:
         """Return the sole numeric field's name, or raise ``TypeError``."""
@@ -604,23 +584,6 @@ def _reconstruct_from_vector(
 # ---------------------------------------------------------------------------
 # Pickle helper
 # ---------------------------------------------------------------------------
-
-
-def _unpickle_numeric_record(
-    store: dict, name: str, name_is_auto: bool, provenance, spec=None, annotations=None
-) -> NumericRecord:
-    # ``store`` holds the native leaves verbatim (they pickle themselves), so
-    # reconstruction is ordinary validation-without-conversion. The threaded
-    # declaration preserves an explicit schema across the round-trip; a pickle
-    # written before it or the annotations were serialized still loads.
-    return NumericRecord(
-        name,
-        store,
-        event_template=spec,
-        name_is_auto=name_is_auto,
-        _provenance=provenance,
-        _annotations=annotations,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -1069,13 +1069,6 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
         """Subclass hook for stricter spec validation. No-op on the base."""
         return
 
-    # -- Immutability -------------------------------------------------------
-    #
-    # The guard and the state round-trip come from
-    # :class:`~probpipe.core._immutable.Immutable`. Restoring the stored specs
-    # directly keeps the resolved class, where rebuilding through the
-    # constructor would re-run the numeric promotion in ``__new__``.
-
     # -- Tree structure -----------------------------------------------------
     #
     # The mapping and path-navigation methods (``keys`` / ``values`` /

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -1071,11 +1071,10 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
 
     # -- Immutability -------------------------------------------------------
     #
-    # The assignment guard and the state round-trip come from
+    # The guard and the state round-trip come from
     # :class:`~probpipe.core._immutable.Immutable`. Restoring the stored specs
-    # directly also keeps the resolved class: rebuilding through the constructor
-    # would re-run the numeric promotion in ``__new__``, which reads the specs it
-    # is given rather than the class the state came from.
+    # directly keeps the resolved class, where rebuilding through the
+    # constructor would re-run the numeric promotion in ``__new__``.
 
     # -- Tree structure -----------------------------------------------------
     #

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -74,6 +74,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ._array_backend import _event_shape_of, _is_numeric_leaf, _numpy_dtype_of
+from ._immutable import Immutable
 from .constraints import Constraint
 from .named_tree import (
     _PATH_SEP,
@@ -905,7 +906,7 @@ def _full_array_shape_or_none(val: Any) -> tuple[int, ...] | None:
 # ---------------------------------------------------------------------------
 
 
-class EventTemplate(NamedTree[ValueSpec]):
+class EventTemplate(NamedTree[ValueSpec], Immutable):
     """Structural description of a value: its named, possibly-nested leaf structure.
 
     An ``EventTemplate`` describes the **structure** of a value as a **named
@@ -1069,15 +1070,12 @@ class EventTemplate(NamedTree[ValueSpec]):
         return
 
     # -- Immutability -------------------------------------------------------
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        raise AttributeError("EventTemplate is immutable")
-
-    def __delattr__(self, name: str) -> None:
-        raise AttributeError("EventTemplate is immutable")
-
-    def __reduce__(self):
-        return (_unpickle_event_template, (dict(self._tree),))
+    #
+    # The assignment guard and the state round-trip come from
+    # :class:`~probpipe.core._immutable.Immutable`. Restoring the stored specs
+    # directly also keeps the resolved class: rebuilding through the constructor
+    # would re-run the numeric promotion in ``__new__``, which reads the specs it
+    # is given rather than the class the state came from.
 
     # -- Tree structure -----------------------------------------------------
     #
@@ -1750,8 +1748,3 @@ def _replace_template_dimensions(
         else:
             children[name] = spec.with_bound_dims(bindings)
     return EventTemplate(children)
-
-
-def _unpickle_event_template(specs: dict) -> EventTemplate:
-    """Rebuild an EventTemplate during unpickling."""
-    return EventTemplate(specs)

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -548,16 +548,13 @@ class Function(Node, Immutable, TrackedTerm, Annotated):
         object.__setattr__(renamed, "__qualname__", name)
         return renamed
 
-    #: The construction flag is not state: it says where the constructor got to,
-    #: and a reconstruction is past that point.
+    #: Not state: the flag says where the constructor got to.
     _transient_state = ("_initializing",)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        # The one variant on the shared guard: this constructor assigns normally
-        # rather than through ``object.__setattr__``, so it opens a window over
-        # itself. Delegating the refusal keeps the message and the deletion rule
-        # shared. The window closes for good once construction is a guarded
-        # window on every tracked term, which is where the flag goes.
+        # This constructor assigns normally rather than through
+        # ``object.__setattr__``, so it opens a window over itself; the refusal
+        # outside that window is the shared one.
         if getattr(self, "_initializing", False):
             object.__setattr__(self, name, value)
             return

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -43,6 +43,7 @@ from ._function_contract import (
     _validate_function_templates,
     _wrap_declared_function_output,
 )
+from ._immutable import Immutable
 from ._record_batch import RecordBatch
 from .event_template import ArraySpec, EventTemplate, _concretize_event_template
 from .provenance import Provenance
@@ -184,7 +185,7 @@ class Node(ABC):  # noqa: B024
         return self._inputs
 
 
-class Function(Node, TrackedTerm, Annotated):
+class Function(Node, Immutable, TrackedTerm, Annotated):
     """
     An immutable, tracked executable DAG node wrapping one implementation.
 
@@ -547,14 +548,20 @@ class Function(Node, TrackedTerm, Annotated):
         object.__setattr__(renamed, "__qualname__", name)
         return renamed
 
+    #: The construction flag is not state: it says where the constructor got to,
+    #: and a reconstruction is past that point.
+    _transient_state = ("_initializing",)
+
     def __setattr__(self, name: str, value: Any) -> None:
+        # The one variant on the shared guard: this constructor assigns normally
+        # rather than through ``object.__setattr__``, so it opens a window over
+        # itself. Delegating the refusal keeps the message and the deletion rule
+        # shared. The window closes for good once construction is a guarded
+        # window on every tracked term, which is where the flag goes.
         if getattr(self, "_initializing", False):
             object.__setattr__(self, name, value)
             return
-        raise AttributeError("Function is immutable")
-
-    def __delattr__(self, name: str) -> None:
-        raise AttributeError("Function is immutable")
+        super().__setattr__(name, value)
 
     @property
     def effective_workflow_kind(self) -> WorkflowKind:

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -6,6 +6,7 @@ import math
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
+from functools import partial
 from types import MappingProxyType
 from typing import Any, Literal, cast, get_args, overload
 
@@ -172,9 +173,11 @@ class Node(ABC):  # noqa: B024
             else:
                 inputs[k] = v
 
-        # Freeze internal state (read-only)
-        self._child_nodes = MappingProxyType(child_nodes)
-        self._inputs = MappingProxyType(inputs)
+        # Freeze internal state (read-only). Written through
+        # ``object.__setattr__`` so this also serves an immutable subclass, whose
+        # guard refuses assignment even from its own constructor.
+        object.__setattr__(self, "_child_nodes", MappingProxyType(child_nodes))
+        object.__setattr__(self, "_inputs", MappingProxyType(inputs))
 
     @property
     def child_nodes(self) -> Mapping[str, Node]:
@@ -426,39 +429,41 @@ class Function(Node, Immutable, TrackedTerm, Annotated):
             construction_bindings=construction_bindings,
         )
 
-        object.__setattr__(self, "_initializing", True)
+        set_attribute = partial(object.__setattr__, self)
         self._init_tracked(name, name_is_auto=name_is_auto)
-        object.__setattr__(self, "_annotations", {})
-        self._implementation = implementation
-        self._signature_info = signature_info
-        self._workflow_kind_raw = workflow_kind
+        set_attribute("_annotations", {})
+        set_attribute("_implementation", implementation)
+        set_attribute("_signature_info", signature_info)
+        set_attribute("_workflow_kind_raw", workflow_kind)
 
         # Expose wrapped function's metadata for introspection (help(),
         # inspect.signature(), IDE tooltips, mkdocstrings).  We skip
         # __wrapped__ to prevent inspect.unwrap() from bypassing __call__.
-        self.__doc__ = getattr(metadata_source, "__doc__", None)
-        self.__name__ = self._name
-        self.__qualname__ = getattr(metadata_source, "__qualname__", self._name)
-        self.__signature__ = self._signature_info.signature
-        self.__module__ = getattr(metadata_source, "__module__", None) or type(self).__module__
-        self._module = module
-        self._n_broadcast_samples = (
+        set_attribute("__doc__", getattr(metadata_source, "__doc__", None))
+        set_attribute("__name__", self._name)
+        set_attribute("__qualname__", getattr(metadata_source, "__qualname__", self._name))
+        set_attribute("__signature__", signature_info.signature)
+        set_attribute(
+            "__module__", getattr(metadata_source, "__module__", None) or type(self).__module__
+        )
+        set_attribute("_module", module)
+        set_attribute(
+            "_n_broadcast_samples",
             n_broadcast_samples
             if n_broadcast_samples is not None
-            else self.DEFAULT_N_BROADCAST_SAMPLES
+            else self.DEFAULT_N_BROADCAST_SAMPLES,
         )
-        self._dispatch = dispatch
-        self._max_workers = max_workers
-        self._seed = seed
-        self._include_inputs = include_inputs
-        self._input_template = input_template
-        self._output_template = output_template
+        set_attribute("_dispatch", dispatch)
+        set_attribute("_max_workers", max_workers)
+        set_attribute("_seed", seed)
+        set_attribute("_include_inputs", include_inputs)
+        set_attribute("_input_template", input_template)
+        set_attribute("_output_template", output_template)
 
         # bind = "construction-time inputs" (defaults/config). kwargs are also treated as bind.
-        self._bind = MappingProxyType(construction_bindings)
+        set_attribute("_bind", MappingProxyType(construction_bindings))
 
         super().__init__()
-        object.__setattr__(self, "_initializing", False)
 
     @property
     def signature(self) -> inspect.Signature:
@@ -547,18 +552,6 @@ class Function(Node, Immutable, TrackedTerm, Annotated):
         object.__setattr__(renamed, "__name__", name)
         object.__setattr__(renamed, "__qualname__", name)
         return renamed
-
-    #: Not state: the flag says where the constructor got to.
-    _transient_state = ("_initializing",)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        # This constructor assigns normally rather than through
-        # ``object.__setattr__``, so it opens a window over itself; the refusal
-        # outside that window is the shared one.
-        if getattr(self, "_initializing", False):
-            object.__setattr__(self, name, value)
-            return
-        super().__setattr__(name, value)
 
     @property
     def effective_workflow_kind(self) -> WorkflowKind:

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -45,6 +45,7 @@ import numpy as np
 
 from ..custom_types import ArrayLike
 from ._array_backend import _metadata_of, _numpy_dtype_of, _to_numpy_array, array_backend_for
+from ._immutable import Immutable
 from .event_template import (
     EventTemplate,
     NumericEventTemplate,
@@ -55,7 +56,6 @@ from .event_template import (
     _unify_event_template_with_value,
 )
 from .named_tree import _PATH_SEP, NamedTree, _check_no_path_sep, _unflatten_paths
-from .provenance import Provenance
 from .tracked import Annotated, TrackedTerm
 
 if TYPE_CHECKING:
@@ -155,12 +155,10 @@ def _canonical_dtype_str(leaf: Any) -> str:
 #: Constructor keywords that name a construction option rather than a field, so
 #: the keyword form of ``Record(...)`` does not read them as data. The positional
 #: dict form takes a field of any name, including these.
-_RESERVED_INIT_KWARGS = frozenset(
-    {"event_template", "name_is_auto", "_validate_leaves", "_provenance", "_annotations"}
-)
+_RESERVED_INIT_KWARGS = frozenset({"event_template", "name_is_auto", "_validate_leaves"})
 
 
-class Record(NamedTree[Any], TrackedTerm, Annotated):
+class Record(NamedTree[Any], Immutable, TrackedTerm, Annotated):
     """A single structured value with metadata.
 
     A ``Record`` holds a single concrete value: an ordered, named collection
@@ -430,8 +428,6 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
         event_template: EventTemplate | RecordSpec | None = None,
         name_is_auto: bool = False,
         _validate_leaves: bool = True,
-        _provenance: Provenance | None = None,
-        _annotations: Mapping[str, Any] | None = None,
         **fields: _FieldValue,
     ):
         # Every check below reads structure, so work in templates and keep the
@@ -502,13 +498,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
                 raise ValueError(f"at {field_name!r}: {error}") from None
 
         object.__setattr__(self, "_tree", field_map)
-        # ``_provenance`` and ``_annotations`` carry state a reconstruction
-        # already holds and that construction cannot otherwise reach: provenance
-        # is write-once, and annotations are written after construction, so a
-        # rebuilt record would come back without either. Private, and the
-        # reconstruction paths at the bottom of this module are the only callers.
-        self._init_tracked(name, name_is_auto=name_is_auto, provenance=_provenance)
-        self._init_annotations(_annotations)
+        self._init_tracked(name, name_is_auto=name_is_auto)
         if event_template is None:
             event_template = EventTemplate.infer_from(field_map)
         else:
@@ -639,30 +629,13 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
         return self._spec.event_template
 
     # -- Immutability -------------------------------------------------------
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        raise AttributeError("Record is immutable")
-
-    def __delattr__(self, name: str) -> None:
-        raise AttributeError("Record is immutable")
-
-    def __reduce__(self):
-        # Serialize the authoritative spec so a pickled record keeps its exact
-        # schema (and equality) instead of re-inferring a weaker one on load —
-        # an explicit ``support`` / ``dtype`` / ``OpaqueSpec.meta`` is not
-        # recoverable by ``infer_from``. Annotations ride along too: they are
-        # written after construction, so no constructor argument carries them.
-        return (
-            _unpickle_record,
-            (
-                dict(self._tree),
-                self._name,
-                self._name_is_auto,
-                self._provenance,
-                self._spec,
-                getattr(self, "_annotations", None),
-            ),
-        )
+    #
+    # The assignment guard and the state round-trip come from
+    # :class:`~probpipe.core._immutable.Immutable`. The spec a record carries is
+    # part of that state, so a reconstruction keeps the exact schema it was
+    # written with — an explicit ``support`` / ``dtype`` / ``OpaqueSpec.meta``
+    # that ``infer_from`` could not recover — without this class restating what
+    # its state is.
 
     # -- Tree structure -----------------------------------------------------
     #
@@ -1259,22 +1232,6 @@ def _pack_fields(
 # ---------------------------------------------------------------------------
 # Pickle helpers
 # ---------------------------------------------------------------------------
-
-
-def _unpickle_record(
-    store: dict, name: str, name_is_auto: bool, provenance, spec=None, annotations=None
-) -> Record:
-    # ``spec`` and ``annotations`` are optional, and construction accepts either
-    # declaration form, so a pickle written before either was serialized still
-    # loads.
-    return Record(
-        name,
-        store,
-        event_template=spec,
-        name_is_auto=name_is_auto,
-        _provenance=provenance,
-        _annotations=annotations,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -628,14 +628,6 @@ class Record(NamedTree[Any], Immutable, TrackedTerm, Annotated):
         """
         return self._spec.event_template
 
-    # -- Immutability -------------------------------------------------------
-    #
-    # The guard and the state round-trip come from
-    # :class:`~probpipe.core._immutable.Immutable`. A record's spec is part of
-    # that state, so a reconstruction keeps the exact schema it was written with
-    # — an explicit ``support`` / ``dtype`` / ``OpaqueSpec.meta`` that
-    # ``infer_from`` could not recover.
-
     # -- Tree structure -----------------------------------------------------
     #
     # The mapping and path-navigation methods (``keys`` / ``values`` /

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -630,12 +630,11 @@ class Record(NamedTree[Any], Immutable, TrackedTerm, Annotated):
 
     # -- Immutability -------------------------------------------------------
     #
-    # The assignment guard and the state round-trip come from
-    # :class:`~probpipe.core._immutable.Immutable`. The spec a record carries is
-    # part of that state, so a reconstruction keeps the exact schema it was
-    # written with — an explicit ``support`` / ``dtype`` / ``OpaqueSpec.meta``
-    # that ``infer_from`` could not recover — without this class restating what
-    # its state is.
+    # The guard and the state round-trip come from
+    # :class:`~probpipe.core._immutable.Immutable`. A record's spec is part of
+    # that state, so a reconstruction keeps the exact schema it was written with
+    # — an explicit ``support`` / ``dtype`` / ``OpaqueSpec.meta`` that
+    # ``infer_from`` could not recover.
 
     # -- Tree structure -----------------------------------------------------
     #

--- a/probpipe/core/tracked.py
+++ b/probpipe/core/tracked.py
@@ -31,6 +31,7 @@ from collections.abc import Mapping
 # exposes; the conflict-avoidance constraint itself doesn't change.
 from typing import Any, Self, _ProtocolMeta
 
+from ._immutable import decoupled_container
 from .provenance import Provenance
 
 __all__ = ["Annotated", "TrackedTerm", "auto_name"]
@@ -68,11 +69,11 @@ def _decoupled_annotations(annotations: Mapping[str, Any]) -> Mapping[str, Any]:
     Entries are shared, the container is not, so a write on one object does not
     show through on the object it was copied or rebuilt from — the annotations
     channel is written in place (see :class:`Annotated`), which is what makes a
-    shared container observable. Any mapping type is accepted: an
-    ``xarray.DataTree`` and the like copy themselves, and anything else is
-    rebuilt as a ``dict``.
+    shared container observable. The rule itself lives with the state round-trip
+    that also applies it (:func:`~probpipe.core._immutable.decoupled_container`),
+    so a rename and a reconstruction decouple the same way.
     """
-    return annotations.copy() if hasattr(annotations, "copy") else dict(annotations)
+    return decoupled_container(annotations)
 
 
 class _TrackedTermMeta(_ProtocolMeta):
@@ -341,6 +342,10 @@ class Annotated:
     """
 
     __slots__ = ()
+
+    #: The annotations store is written in place, so a copy or a reconstruction
+    #: takes its own container (see ``Immutable._decoupled_state``).
+    _decoupled_state = ("_annotations",)
 
     def _init_annotations(self, annotations: Mapping[str, Any] | None) -> None:
         """Attach a starting annotations store (constructor helper for hosts).

--- a/tests/core/test_immutable.py
+++ b/tests/core/test_immutable.py
@@ -9,6 +9,7 @@ import copy
 import pickle
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from probpipe import NumericRecord, NumericRecordBatch, Record, RecordBatch, function
@@ -147,6 +148,37 @@ class TestTransientState:
         # Copied rather than pickled: a class defined in a function body has no
         # importable name, which is a limit of ``pickle`` and not of the mixin.
         assert not hasattr(copy.copy(Sub(1)), "_memo")
+
+
+class TestAMemoIsRebuiltAfterARoundTrip:
+    """A transient memo is left unset, so whatever reads it must rebuild it.
+
+    ``NumericRecord``'s conversion cache is the one in the tree. Only a *native*
+    leaf reaches it — a ``jax`` leaf is returned without conversion — so these
+    use numpy and xarray leaves.
+    """
+
+    @ROUND_TRIPS
+    def test_a_numpy_leaf_still_converts(self, operation):
+        record = NumericRecord("nr", {"x": np.array([1.0, 2.0])})
+        assert operation(record).to_vector().tolist() == [1.0, 2.0]
+
+    @ROUND_TRIPS
+    def test_a_converted_leaf_reconverts(self, operation):
+        # Converting first populates the memo on the original, which the copy
+        # must not depend on.
+        record = NumericRecord("nr", {"x": np.array([1.0, 2.0])})
+        record.to_vector()
+        assert operation(record).to_vector().tolist() == [1.0, 2.0]
+
+    @ROUND_TRIPS
+    def test_a_native_container_leaf_still_converts(self, operation):
+        xr = pytest.importorskip("xarray")
+        leaf = xr.DataArray([1.0, 2.0], dims=["t"], coords={"t": [10, 20]})
+        record = NumericRecord("nr", {"x": leaf})
+        assert operation(record).to_vector().tolist() == [1.0, 2.0]
+        # The native leaf itself survives; only the converted form is rebuilt.
+        assert operation(record)["x"].dims == ("t",)
 
 
 class TestDecoupledState:

--- a/tests/core/test_immutable.py
+++ b/tests/core/test_immutable.py
@@ -1,0 +1,221 @@
+"""The ``Immutable`` mixin: the assignment guard and the state round-trip.
+
+The classes that mix it in are covered by their own suites; these tests pin the
+mixin's contract directly, including the storage forms a hand-written round-trip
+got wrong before it was shared.
+"""
+
+import copy
+import pickle
+
+import jax.numpy as jnp
+import pytest
+
+from probpipe import NumericRecord, NumericRecordBatch, Record, RecordBatch, function
+from probpipe.core._immutable import Immutable
+from probpipe.core.event_template import EventTemplate
+
+# ---------------------------------------------------------------------------
+# Hosts declared here rather than reused: the point is the storage forms, and
+# each is a shape a real host takes. They are module-level so pickle can find
+# them by name.
+# ---------------------------------------------------------------------------
+
+
+class Slotted(Immutable):
+    __slots__ = ("left", "right")
+
+    def __init__(self, left, right):
+        object.__setattr__(self, "left", left)
+        object.__setattr__(self, "right", right)
+
+
+class OneBareStringSlot(Immutable):
+    # A bare string, not a tuple: iterating it yields characters, so a walk over
+    # ``__slots__`` clones this host without its storage and raises nothing.
+    __slots__ = "store"
+
+    def __init__(self, store):
+        object.__setattr__(self, "store", store)
+
+
+class DictCarrying(Immutable):
+    # No ``__slots__``, so the state lives in an instance dictionary that no walk
+    # over ``__slots__`` would find.
+    def __init__(self, value):
+        object.__setattr__(self, "value", value)
+
+
+class SlottedWithDictSubclass(Slotted):
+    def __init__(self, left, right, extra):
+        super().__init__(left, right)
+        object.__setattr__(self, "extra", extra)
+
+
+class WithMemo(Immutable):
+    __slots__ = ("_memo", "value")
+    _transient_state = ("_memo",)
+
+    def __init__(self, value):
+        object.__setattr__(self, "value", value)
+        object.__setattr__(self, "_memo", {"expensive": True})
+
+
+class WithStore(Immutable):
+    __slots__ = ("store",)
+    _decoupled_state = ("store",)
+
+    def __init__(self, store):
+        object.__setattr__(self, "store", store)
+
+
+ROUND_TRIPS = pytest.mark.parametrize(
+    "operation",
+    [
+        pytest.param(copy.copy, id="copy"),
+        pytest.param(copy.deepcopy, id="deepcopy"),
+        pytest.param(lambda o: pickle.loads(pickle.dumps(o)), id="pickle"),
+    ],
+)
+
+
+class TestTheGuard:
+    def test_assignment_names_the_class_the_caller_touched(self):
+        with pytest.raises(AttributeError, match="Slotted is immutable"):
+            Slotted(1, 2).left = 3
+
+    def test_a_subclass_reports_itself_not_its_base(self):
+        # The message a hardcoded class name got wrong for every subclass.
+        with pytest.raises(AttributeError, match="SlottedWithDictSubclass is immutable"):
+            SlottedWithDictSubclass(1, 2, 3).left = 4
+
+    def test_deletion_raises_too(self):
+        with pytest.raises(AttributeError, match="Slotted is immutable"):
+            del Slotted(1, 2).left
+
+    def test_a_new_attribute_is_refused_as_well(self):
+        with pytest.raises(AttributeError, match="DictCarrying is immutable"):
+            DictCarrying(1).added = 2
+
+
+class TestEveryStorageFormRoundTrips:
+    """The three ways a hand-written round-trip lost state in silence."""
+
+    @ROUND_TRIPS
+    def test_slots(self, operation):
+        restored = operation(Slotted(1, [2]))
+        assert (restored.left, restored.right) == (1, [2])
+
+    @ROUND_TRIPS
+    def test_a_bare_string_slots_declaration(self, operation):
+        assert operation(OneBareStringSlot([1, 2])).store == [1, 2]
+
+    @ROUND_TRIPS
+    def test_an_instance_dictionary(self, operation):
+        assert operation(DictCarrying("v")).value == "v"
+
+    @ROUND_TRIPS
+    def test_a_subclass_that_adds_a_dictionary_to_slots(self, operation):
+        restored = operation(SlottedWithDictSubclass(1, 2, "e"))
+        assert (restored.left, restored.right, restored.extra) == (1, 2, "e")
+
+    @ROUND_TRIPS
+    def test_the_reconstruction_keeps_its_class(self, operation):
+        assert type(operation(SlottedWithDictSubclass(1, 2, 3))) is SlottedWithDictSubclass
+
+    def test_an_unassigned_slot_stays_unassigned(self):
+        partial = object.__new__(Slotted)
+        object.__setattr__(partial, "left", 1)
+        restored = pickle.loads(pickle.dumps(partial))
+        assert restored.left == 1
+        assert not hasattr(restored, "right")
+
+
+class TestTransientState:
+    @ROUND_TRIPS
+    def test_a_memo_is_not_carried(self, operation):
+        assert not hasattr(operation(WithMemo(1)), "_memo")
+
+    @ROUND_TRIPS
+    def test_the_rest_of_the_state_still_is(self, operation):
+        assert operation(WithMemo(7)).value == 7
+
+    def test_a_subclass_inherits_the_declaration(self):
+        class Sub(WithMemo):
+            __slots__ = ()
+
+        # Copied rather than pickled: a class defined in a function body has no
+        # importable name, which is a limit of ``pickle`` and not of the mixin.
+        assert not hasattr(copy.copy(Sub(1)), "_memo")
+
+
+class TestDecoupledState:
+    @ROUND_TRIPS
+    def test_the_store_survives(self, operation):
+        assert operation(WithStore({"k": 1})).store == {"k": 1}
+
+    def test_a_write_on_the_copy_does_not_reach_the_original(self):
+        original = WithStore({"k": 1})
+        clone = copy.copy(original)
+        clone.store["added"] = 2
+        assert "added" not in original.store
+
+
+class TestTheHostsInTheTree:
+    """The mixin's real hosts: each reports itself, and round-trips."""
+
+    @pytest.fixture(
+        params=[
+            pytest.param(lambda: Record("r", {"x": jnp.ones(2), "tag": "m"}), id="record"),
+            pytest.param(lambda: NumericRecord("nr", {"x": jnp.ones(2)}), id="numeric-record"),
+            pytest.param(lambda: EventTemplate(x=(2,), tag=None), id="event-template"),
+            pytest.param(
+                lambda: RecordBatch.stack(
+                    [Record("r", {"x": jnp.ones(2), "tag": "m"}, name_is_auto=True)] * 2,
+                    level_name="draw",
+                ),
+                id="record-batch",
+            ),
+            pytest.param(
+                lambda: NumericRecordBatch.stack(
+                    [NumericRecord("nr", {"x": jnp.ones(2)}, name_is_auto=True)] * 2,
+                    level_name="draw",
+                ),
+                id="numeric-record-batch",
+            ),
+        ]
+    )
+    def term(self, request):
+        return request.param()
+
+    def test_it_is_immutable(self, term):
+        with pytest.raises(AttributeError, match=f"{type(term).__name__} is immutable"):
+            term.attribute = 1
+
+    def test_it_round_trips_through_pickle(self, term):
+        restored = pickle.loads(pickle.dumps(term))
+        assert type(restored) is type(term)
+        assert restored == term
+
+    def test_it_round_trips_through_copy(self, term):
+        assert copy.copy(term) == term
+        assert copy.deepcopy(term) == term
+
+    def test_a_function_is_immutable_and_names_itself(self):
+        @function
+        def double(x: float) -> float:
+            return x * 2
+
+        with pytest.raises(AttributeError, match="Function is immutable"):
+            double.attribute = 1
+
+    def test_a_function_still_constructs_through_its_own_window(self):
+        # ``Function``'s constructor assigns normally, so it opens a window over
+        # itself rather than writing through ``object.__setattr__``. The window
+        # must be shut by the time the caller has the object.
+        @function
+        def double(x: float) -> float:
+            return x * 2
+
+        assert double(2.0) is not None
+        assert not getattr(double, "_initializing", False)

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -1186,22 +1186,6 @@ class TestSpecStorage:
         rebuilt = pickle.loads(pickle.dumps(r))
         assert rebuilt.spec == spec
 
-    def test_a_pickle_carrying_a_bare_template_still_loads(self):
-        """A payload written when the declaration was serialized as a bare
-        template loads under the spec-storing reader, which accepts either form.
-
-        Exercised through the reconstructors directly: no current code emits that
-        payload, so nothing else would reach this path.
-        """
-        from probpipe.core._numeric_record import _unpickle_numeric_record
-        from probpipe.core.record import _unpickle_record
-
-        tpl = EventTemplate(x=())
-        loaded = _unpickle_record({"x": jnp.asarray(1.0)}, "r", False, None, tpl)
-        assert loaded.spec == RecordSpec(tpl)
-        loaded_numeric = _unpickle_numeric_record({"x": jnp.asarray(1.0)}, "r", False, None, tpl)
-        assert loaded_numeric.spec == RecordSpec(tpl)
-
     def test_numeric_record_accepts_a_spec_declaration(self):
         from probpipe import NumericRecord
 

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -440,12 +440,3 @@ class TestRoundTripPreservesAnnotations:
             return (set(instance_dict or {}) | set(slots or {})) - {"_jax_cache"}
 
         assert assigned(term) - assigned(roundtrip(term)) == set()
-
-    def test_pickle_without_annotations_still_loads(self):
-        # Reconstruction stays callable with the shorter argument list a pickle
-        # written before annotations were serialized carries.
-        from probpipe.core.record import _unpickle_record
-
-        r = _unpickle_record({"x": jnp.ones(3)}, "r", False, None)
-        assert r.name == "r"
-        assert r.annotations is None

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -373,11 +373,11 @@ class TestPicklePreservesTemplate:
 
 
 class TestRoundTripPreservesAnnotations:
-    """Annotations are written *after* construction — the documented exception
-    to immutability — so no constructor argument carries them and a state list
-    assembled from ``__init__`` misses them. They must survive every
-    reconstruction path (#409), which ``__reduce__`` governs for ``copy`` as
-    well as for ``pickle``.
+    """Annotations survive every reconstruction path.
+
+    They are written *after* construction — the documented exception to
+    immutability — so no constructor argument carries them, and ``__reduce__``
+    governs ``copy`` as well as ``pickle``.
     """
 
     @pytest.fixture(


### PR DESCRIPTION
## Summary

Four classes spelled out the same immutability guard and answered the round-trip it forces in five different ways. One `Immutable` mixin now owns both, and `Record`, `EventTemplate`, `Batch`, and `Function` mix it in.

**The guard names the class the caller touched.** Three of the four hardcoded a name, so `NumericRecord` reported `Record`, `NumericEventTemplate` reported `EventTemplate`, and `_ConditioningStep` reported `Function`.

**The round-trip reads the object rather than a list.** `object.__getstate__` reports every assigned slot declared anywhere in the hierarchy, a bare-string `__slots__`, and a subclass's instance dictionary alike — the three forms a hand-walk lost in silence, and the reason #386's review found `Batch.__getstate__` dropping storage. A hand-written *list* of fields has a fourth failure mode: it cannot name a field written after construction, which is exactly how #409 happened. Both are now impossible by construction rather than fixed once each.

**Reconstruction allocates the resolved class and restores state**, instead of rebuilding through a constructor. `__reduce__` names `object.__new__`, so a host's own `__new__` — which exists to *select* a class from constructor arguments — does not re-run and re-decide. An `EventTemplate` therefore keeps the class its specs resolved to rather than re-running the numeric promotion, and a `Record` keeps the exact schema it was written with, which is what its bespoke `__reduce__` existed to protect.

Two host declarations keep that generic:

- `_transient_state` names memos to leave out — `NumericRecord`'s lazy conversion cache, which its old `__reduce__` dropped by hand and which would otherwise duplicate every converted array in the payload;
- `_decoupled_state` names a store written *in place*, so a copy takes its own container. `Annotated` declares the annotations channel, which is how #412's decoupling survives the move to a shared round-trip: `copy.copy`'s state is the original's own attribute values, so restoring it verbatim would hand both objects one dict.

**`Function` has no variant of its own.** Its constructor, and `Node`'s, now assign through `object.__setattr__` the way every other immutable host initializes, so the `_initializing` flag and the `__setattr__` override that consulted it are both gone. One guard covers every case, and no state records where a constructor got to.

## Linked issue(s)

Part of #395, the first of the three changes it stages: the mixin itself, on the four classes that already refuse assignment. The second fixes the terms that mutate outside construction; the third has `TrackedTerm` inherit `Immutable`, which is what turns `C2` and the §V.1 operation contract into enforced statements rather than documented ones.

**Stacked on #412**, which fixes #409 and whose hand-written state lists this deletes. Targets that branch; will retarget to `main` when it merges.

## Breaking changes

**A pickle written by an earlier version does not load.** It names the reconstruction entry points (`_unpickle_record`, `_unpickle_numeric_record`, `_unpickle_event_template`), which are gone now that state is restored directly. Re-generate any persisted records, templates, or batches. No shim, per the pre-stable policy set by #336; the test that covered an older payload form is removed with the helpers it called.

Otherwise none. The guard's *message* changes for the three classes that reported the wrong name, which is the fix rather than a break.

## Test plan

New `tests/core/test_immutable.py` — 48 tests over the mixin's contract, each round-trip parameterized across `copy.copy`, `copy.deepcopy`, and `pickle`:

- **the guard**: assignment, deletion, and a new attribute all raise, and a subclass reports *itself*;
- **every storage form round-trips** — slots, a bare-string `__slots__`, an instance dictionary, and a subclass that adds one to a slotted base. These are declared as purpose-built hosts because they are the shapes that failed silently before;
- an unassigned slot stays unassigned, rather than being restored as something;
- **transient**: a memo is not carried, the rest of the state is, and a subclass inherits the declaration;
- **decoupled**: the store survives, and a write on the copy does not reach the original;
- **a transient memo is rebuilt, not just dropped** — `NumericRecord`'s conversion cache is only reached by a *native* leaf, so these use numpy and xarray leaves and assert `to_vector` still works after each round-trip;
- **the real hosts** — `Record`, `NumericRecord`, `EventTemplate`, `RecordBatch`, `NumericRecordBatch`, `Function` — each report their own name and round-trip to an equal object of the same class.

4723 passed, 53 skipped. `ruff format` / `ruff check` clean.

**One regression found in review and fixed here.** Excluding the conversion cache from the round-trip left `_child_field_as_jax` reading a slot a reconstruction does not have, so `to_vector` after a copy or an unpickle raised `AttributeError` for any record holding a native leaf. A jax leaf returns before the cache is touched, which is why the first round of tests missed it entirely. The memo is rebuilt on first use, which is what a transient declaration promises, and the tests above now cover it.

Two pre-existing limits on `Function`, unchanged by this PR and verified against the base branch: plain `pickle` cannot reach a decorated function (the decorator rebinds the name), and `copy.deepcopy` fails on its `MappingProxyType` bind. `cloudpickle` works, which is what the Ray and Prefect paths use.

## Documentation

- [x] Docstrings updated for changed public APIs
- [ ] User Guide / tutorials updated where relevant
- [x] CHANGELOG entry added under `Unreleased → Changed`

`design/02-shared-abstractions.md` §II.4 states the rule the code now enforces: a tracked term is immutable because it is one, it reconstructs from the state it holds, and annotations are the documented exception — written in place, hence decoupled on copy.

## Contract checklist

- [x] Contract of every touched abstraction was clear before coding; the one ambiguity found is recorded above — whether a copy shares an in-place store — and resolved by `_decoupled_state`.
- [x] The new contract is documented in `probpipe/core/_immutable.py`: what the guard raises, what a round-trip preserves, and what the two declarations do.
- [x] Docstring openings lead with the API; the three silent failure modes are deferred to a `Notes` section.
- [x] Code verified to obey the documented contract; the tests assert it per storage form, not only on the happy path.
- [x] Docstrings describe the target contract, with the interim state named: the module says which four classes inherit the mixin today rather than implying every tracked term does.
- [x] Variable names follow the canonical table, extended with the two new declarations.
- [x] `CONTRACTS.md` index updated: immutability is a cross-cutting contract with its own row.
- [x] `ruff format` and `ruff check` clean.

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`.
- [x] At least one `area:*` label is applied.
- [x] Linked to the tracking issue above.
