### PR TITLE
fix(core): reading a distribution no longer modifies it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reading a distribution no longer modifies it.** `BroadcastDistribution`
+  assigned its marginal on the first `marginalize()`, and a backend-delegated
+  `DistributionArray` assigned its components on the first read, so a query
+  changed the object a caller was holding — against `C2` and the §V.1 promise
+  that an implementer's object is never modified. Each now fills a memo container
+  assigned at construction, so the result is still computed once and the term's
+  own fields stay as they were built. Both remain lazy.
+
 - **Every dispatch presents a one-field draw the same way.** A one-field
   record-valued law — a `ProductDistribution` over a single distribution, say —
   draws a batch of records. The row-wise paths presented each draw as its bare
@@ -636,6 +644,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uniform everywhere.
 
 ### Changed
+
+- **Terms that build a result write it before handing it over.**
+  `DistributionArray._from_backend`, `_make_distribution_array`,
+  `TFPProductDistribution`'s combined-view build, `make_posterior`'s annotations
+  store, and `SequentialJointDistribution`'s conditioning all populated a term
+  after allocating it, using plain attribute assignment. They now write through
+  `object.__setattr__`, the way a constructor does. No behavior changes — each
+  wrote before the object reached a caller — but an assignment guard on every
+  tracked term would refuse the old form, and `ApproximateDistribution`'s chain
+  concatenation moves to the same memo container as the two lazy reads above.
 
 - **Immutability is a property of being a tracked term (#395).** `TrackedTerm`
   inherits `Immutable`, so assignment and deletion raise on a record, a batch, a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -440,8 +440,8 @@ uv build packaging/probpipe   # probpipe (metapackage)
    permits both for now, because the documented emulator pattern trains a
    subclassed random function in place and fitting has no contract yet that
    returns a new fitted term. Treat the rule as binding when writing new code
-   either way. The one documented exception
-   is the `annotations` store (`_annotations`, provided by the
+   either way. Two stores are documented exceptions, both written after
+   construction. The first is the `annotations` store (`_annotations`, provided by the
    `Annotated` mixin in `probpipe.core.tracked`; a string-keyed
    mapping, typically an `xarray.DataTree`, of post-construction
    metadata): validators and diagnostic ops (e.g.,
@@ -450,14 +450,15 @@ uv build packaging/probpipe   # probpipe (metapackage)
    `annotations["loo"]`, ...). This is a deliberate carve-out — the
    alternative of returning a renamed clone for every diagnostic would
    break the provenance/identity tracking that downstream code relies
-   on. Treat `_annotations` as append-only; never mutate other state
-   post-construction.
+   on. Treat `_annotations` as append-only.
 
-   A lazily computed value is a second, narrower carve-out: it lives in a
+   The second, narrower, is a lazily computed value: it lives in a
    `_memo` dictionary the constructor assigns and the read fills in place,
    declared in `_transient_state` so a copy rebuilds it rather than
    inheriting it. Whatever reads one must tolerate its absence, since a
    copy or an unpickle arrives without it.
+
+   Those two aside, never mutate a term's state after construction.
 2. **Operations are standalone Functions** — `sample()`, `mean()`,
    `log_prob()`, `condition_on()` are `Function` instances in
    `probpipe/core/ops.py`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -452,6 +452,12 @@ uv build packaging/probpipe   # probpipe (metapackage)
    break the provenance/identity tracking that downstream code relies
    on. Treat `_annotations` as append-only; never mutate other state
    post-construction.
+
+   A lazily computed value is a second, narrower carve-out: it lives in a
+   `_memo` dictionary the constructor assigns and the read fills in place,
+   declared in `_transient_state` so a copy rebuilds it rather than
+   inheriting it. Whatever reads one must tolerate its absence, since a
+   copy or an unpickle arrives without it.
 2. **Operations are standalone Functions** — `sample()`, `mean()`,
    `log_prob()`, `condition_on()` are `Function` instances in
    `probpipe/core/ops.py`.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -801,7 +801,9 @@ do not add assignment to a distribution outside its constructor. The exemption
 lifts by removing both overrides, once fitting has that contract; removing one
 would leave a trainer that clears what it fitted still raising.
 
-**The one carve-out is the `annotations` store** (`_annotations`, provided
+Two stores are carved out of that rule, both written after construction.
+
+**The first is the `annotations` store** (`_annotations`, provided
 by the `Annotated` mixin in `probpipe.core.tracked` and carried by
 `Distribution` and `Record`): a string-keyed mapping — typically an
 `xarray.DataTree` — whose job is to collect post-construction metadata
@@ -812,7 +814,7 @@ break the provenance/identity tracking that downstream code relies on.
 Treat it as append-only and never use it as a back-channel for mutating
 parameter-like state.
 
-A second, narrower carve-out is a **memo**: a term that computes something
+**The second, narrower, is a memo**: a term that computes something
 lazily holds a `_memo` dictionary, assigned by its constructor and filled in
 place by the read that needs it (`BroadcastDistribution.marginalize`, a
 backend-delegated `DistributionArray.components`,

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -812,6 +812,16 @@ break the provenance/identity tracking that downstream code relies on.
 Treat it as append-only and never use it as a back-channel for mutating
 parameter-like state.
 
+A second, narrower carve-out is a **memo**: a term that computes something
+lazily holds a `_memo` dictionary, assigned by its constructor and filled in
+place by the read that needs it (`BroadcastDistribution.marginalize`, a
+backend-delegated `DistributionArray.components`,
+`ApproximateDistribution._concat_chains`). Filling it leaves the term's own
+attributes as construction set them, which is what the immutability guard sees.
+A class holding one declares it in `_transient_state` so no copy inherits it —
+each copy rebuilds — and whatever reads it must tolerate its absence, since a
+copy or an unpickle arrives without one.
+
 ### 9.3 Error messages
 
 When a protocol check fails, raise `TypeError` with a message that names

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -1215,9 +1215,9 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
         name, name_is_auto = auto_name(name, "broadcast")
         super().__init__(name=name, name_is_auto=name_is_auto)
         self._approximate = True
-        # A memo, filled on first read. It is a container assigned once here
-        # rather than an attribute assigned later, so reading it does not modify
-        # the distribution.
+        # A memo, filled on first read. Reading fills it in place, which leaves
+        # the term's own attributes as construction set them — what the
+        # immutability guard sees, and what a copy drops rather than inherits.
         self._memo: dict[str, MarginalizedBroadcastDistribution] = {}
 
     # -- basic properties ---------------------------------------------------

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -1210,7 +1210,10 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
         name, name_is_auto = auto_name(name, "broadcast")
         super().__init__(name=name, name_is_auto=name_is_auto)
         self._approximate = True
-        self._marginal_cache: MarginalizedBroadcastDistribution | None = None
+        # A memo, filled on first read. It is a container assigned once here
+        # rather than an attribute assigned later, so reading it does not modify
+        # the distribution.
+        self._memo: dict[str, MarginalizedBroadcastDistribution] = {}
 
     # -- basic properties ---------------------------------------------------
 
@@ -1280,16 +1283,18 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
         so the lineage is preserved without a direct reference to the
         ``BroadcastDistribution``.
         """
-        if self._marginal_cache is None:
-            self._marginal_cache = _make_marginal(
+        marginal = self._memo.get("marginal")
+        if marginal is None:
+            marginal = _make_marginal(
                 self._output_samples,
                 self._w,
                 output_distributions=self._output_distributions,
                 event_template=self._output_template,
             )
-            if self.provenance is not None and isinstance(self._marginal_cache, Distribution):
-                self._marginal_cache.with_provenance(self.provenance)
-        return self._marginal_cache
+            if self.provenance is not None and isinstance(marginal, Distribution):
+                marginal.with_provenance(self.provenance)
+            self._memo["marginal"] = marginal
+        return marginal
 
     @property
     def output(self) -> MarginalizedBroadcastDistribution:

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -26,7 +26,7 @@ from ._empirical import (
     EmpiricalDistribution,
     RecordEmpiricalDistribution,
 )
-from ._immutable import constructing
+from ._immutable import constructing, transient_memo
 from ._numeric_record_batch import NumericRecordBatch
 from ._object_batch import _from_iterable, _is_object_array
 from ._record_batch import RecordBatch, _batch_class_for, _MappedBatchColumns
@@ -1183,6 +1183,11 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
         Distribution name for provenance.
     """
 
+    #: The memo is not state: a copy recomputes rather than inheriting one. It
+    #: matters for more than size here, since a memoised value can carry the
+    #: provenance of the term that computed it.
+    _transient_state = ("_memo",)
+
     _sampling_cost: str = "low"
     _preferred_orchestration: str | None = None
 
@@ -1283,7 +1288,7 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
         so the lineage is preserved without a direct reference to the
         ``BroadcastDistribution``.
         """
-        marginal = self._memo.get("marginal")
+        marginal = transient_memo(self).get("marginal")
         if marginal is None:
             marginal = _make_marginal(
                 self._output_samples,
@@ -1293,7 +1298,7 @@ class BroadcastDistribution(Distribution[dict], SupportsSampling):
             )
             if self.provenance is not None and isinstance(marginal, Distribution):
                 marginal.with_provenance(self.provenance)
-            self._memo["marginal"] = marginal
+            transient_memo(self)["marginal"] = marginal
         return marginal
 
     @property

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -130,8 +130,10 @@ class DistributionArray[T](Distribution[T]):
     #: provenance of the term that computed it.
     _transient_state = ("_memo",)
 
-    # Storage slots. ``_components`` is ``None`` for backend-delegated
-    # arrays until :attr:`components` materialises the eager tuple
+    # Storage slots. ``_components`` holds the literal tuple an eagerly built
+    # array was given, and stays ``None`` for a backend-delegated one — which is
+    # what marks it as backend-delegated. :attr:`components` materialises that
+    # array's cells on first read into the memo rather than into this slot
     # lazily; the literal-array constructor sets it directly.
     # ``_backend`` is ``None`` for the literal path and set by
     # :meth:`_from_backend`.

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -40,6 +40,7 @@ to pull out the i-th element of a **batch** → ``DistributionArray``.
 
 from __future__ import annotations
 
+from functools import partial
 from math import prod
 from typing import TYPE_CHECKING
 
@@ -349,10 +350,12 @@ class DistributionArray[T](Distribution[T]):
         # eager component list. Initialise fields the same way
         # __init__ would, but without per-component validation (the
         # backend already vouched for shape consistency).
-        instance._components = None
-        instance._batch_shape = tuple(backend.batch_shape)
-        instance._backend = backend
-        instance._event_template = None
+        set_attribute = partial(object.__setattr__, instance)
+        set_attribute("_components", None)
+        set_attribute("_memo", {})
+        set_attribute("_batch_shape", tuple(backend.batch_shape))
+        set_attribute("_backend", backend)
+        set_attribute("_event_template", None)
         name, name_is_auto = auto_name(name, "distribution_array")
         Distribution.__init__(instance, name=name, name_is_auto=name_is_auto)
         # Approximation status flows from the backend. TFP-backed
@@ -360,7 +363,7 @@ class DistributionArray[T](Distribution[T]):
         # ``RecordEmpiricalDistribution``) will report
         # ``is_approximate=True`` on its own samples and the array
         # picks that up here.
-        instance._approximate = bool(getattr(backend, "is_approximate", False))
+        set_attribute("_approximate", bool(getattr(backend, "is_approximate", False)))
         return instance
 
     # -- structure -----------------------------------------------------------
@@ -378,11 +381,15 @@ class DistributionArray[T](Distribution[T]):
         :meth:`__getitem__` / :meth:`_flat_component` always returns a
         fresh scalar.
         """
-        if self._components is None:
-            assert self._backend is not None  # invariant
+        if self._components is not None:
+            return self._components
+        assert self._backend is not None  # invariant
+        cells = self._memo.get("components")
+        if cells is None:
             n = prod(self._batch_shape)
-            self._components = tuple(self._backend.cell(i) for i in range(n))
-        return self._components
+            cells = tuple(self._backend.cell(i) for i in range(n))
+            self._memo["components"] = cells
+        return cells
 
     @property
     def batch_shape(self) -> tuple[int, ...]:
@@ -710,7 +717,7 @@ def _make_distribution_array(
                     f"DistributionArray component {index} event_template {actual!r} "
                     f"does not match declared template {event_template!r}"
                 )
-        array._event_template = event_template
+        object.__setattr__(array, "_event_template", event_template)
     if name_is_auto is not None:
         object.__setattr__(array, "_name_is_auto", bool(name_is_auto))
     return array

--- a/probpipe/core/_distribution_array.py
+++ b/probpipe/core/_distribution_array.py
@@ -49,6 +49,7 @@ import numpy as np
 
 from .._array_utils import _slice_leading_axes
 from ._distribution_base import Distribution
+from ._immutable import transient_memo
 from .event_template import EventTemplate
 from .protocols import SupportsArrayBackend
 from .tracked import auto_name
@@ -123,6 +124,11 @@ class DistributionArray[T](Distribution[T]):
       fail at op-dispatch on the first non-supporting cell, rather
       than rejecting at construction.
     """
+
+    #: The memo is not state: a copy recomputes rather than inheriting one. It
+    #: matters for more than size here, since a memoised value can carry the
+    #: provenance of the term that computed it.
+    _transient_state = ("_memo",)
 
     # Storage slots. ``_components`` is ``None`` for backend-delegated
     # arrays until :attr:`components` materialises the eager tuple
@@ -384,11 +390,11 @@ class DistributionArray[T](Distribution[T]):
         if self._components is not None:
             return self._components
         assert self._backend is not None  # invariant
-        cells = self._memo.get("components")
+        cells = transient_memo(self).get("components")
         if cells is None:
             n = prod(self._batch_shape)
             cells = tuple(self._backend.cell(i) for i in range(n))
-            self._memo["components"] = cells
+            transient_memo(self)["components"] = cells
         return cells
 
     @property

--- a/probpipe/core/_immutable.py
+++ b/probpipe/core/_immutable.py
@@ -32,7 +32,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any, ClassVar
 
-__all__ = ["Immutable", "constructing", "declared_state_names"]
+__all__ = ["Immutable", "constructing", "declared_state_names", "transient_memo"]
 
 
 def declared_state_names(cls: type, declaration: str) -> frozenset[str]:
@@ -104,6 +104,34 @@ def constructing(instance: Any) -> Iterator[Any]:
             registry[key] = (held, depth - 1)
         else:
             del registry[key]
+
+
+def transient_memo(host: Any) -> dict[str, Any]:
+    """The host's ``_memo`` dictionary, created if it has none.
+
+    Parameters
+    ----------
+    host : object
+        A term holding its lazily computed values in a ``_memo`` dictionary
+        declared in :attr:`Immutable._transient_state`.
+
+    Returns
+    -------
+    dict
+        The memo, empty if this host has not got one yet.
+
+    Notes
+    -----
+    A transient memo is not carried across a copy or a pickle, so a term that
+    arrives by either route has none and whatever reads it must rebuild rather
+    than assume. Written through ``object.__setattr__`` so an immutable host can
+    call it from a read path.
+    """
+    memo = getattr(host, "_memo", None)
+    if memo is None:
+        memo = {}
+        object.__setattr__(host, "_memo", memo)
+    return memo
 
 
 def decoupled_container(container: Any) -> Any:
@@ -199,13 +227,6 @@ class Immutable:
 
     # -- The state round-trip ------------------------------------------------
 
-    @classmethod
-    def _declared_state_names(cls, declaration: str) -> frozenset[str]:
-        """The union of the *declaration* tuple over every class in the MRO."""
-        return frozenset(
-            name for klass in cls.__mro__ for name in klass.__dict__.get(declaration, ())
-        )
-
     def __getstate__(self) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         """Return this object's state, minus the attributes declared transient.
 
@@ -217,7 +238,7 @@ class Immutable:
         """
         state = object.__getstate__(self)
         instance_dict, slots = state if isinstance(state, tuple) else (state, None)
-        transient = self._declared_state_names("_transient_state")
+        transient = declared_state_names(type(self), "_transient_state")
         if transient:
             instance_dict = {k: v for k, v in (instance_dict or {}).items() if k not in transient}
             slots = {k: v for k, v in (slots or {}).items() if k not in transient}
@@ -240,7 +261,7 @@ class Immutable:
         writing to one container.
         """
         instance_dict, slots = state if isinstance(state, tuple) else (state, None)
-        decoupled = self._declared_state_names("_decoupled_state")
+        decoupled = declared_state_names(type(self), "_decoupled_state")
         for attribute, value in ((instance_dict or {}) | (slots or {})).items():
             if attribute in decoupled and value is not None:
                 value = decoupled_container(value)

--- a/probpipe/core/_workflow_result.py
+++ b/probpipe/core/_workflow_result.py
@@ -174,8 +174,6 @@ def _copy_result_term(
         elif isinstance(clone, Record):
             object.__setattr__(clone, "_spec", _to_record_declaration(output_template))
     object.__setattr__(clone, "_provenance", None)
-    annotations = getattr(clone, "_annotations", None)
-    if annotations is not None:
-        copied = annotations.copy() if hasattr(annotations, "copy") else dict(annotations)
-        object.__setattr__(clone, "_annotations", copied)
+    # The annotations container is already the clone's own: ``_shallow_copy``
+    # decouples what the host declares in ``_decoupled_state``.
     return clone

--- a/probpipe/core/tracked.py
+++ b/probpipe/core/tracked.py
@@ -305,22 +305,24 @@ class TrackedTerm(Immutable, metaclass=_TrackedTermMeta):
     # -- copying -------------------------------------------------------------
 
     def _shallow_copy(self) -> Self:
-        """Return a shallow copy sharing all internal state.
+        """Return a shallow copy holding the same state, entries shared.
 
-        Copies the instance ``__dict__`` (when present) and every assigned
-        slot across the class hierarchy via ``object.__setattr__``, bypassing
-        both ``__init__`` and any immutability guard on ``__setattr__``. Used
-        by :meth:`with_name`; host classes with exotic storage may override.
+        Copies through the state round-trip — :meth:`__getstate__` into
+        :meth:`__setstate__` — so the copy carries every attribute the original
+        has assigned **except** what the class declares transient, and a store
+        the class declares decoupled arrives in a container of its own. Writes
+        bypass both ``__init__`` and the immutability guard, as construction
+        does. Used by :meth:`with_name`; host classes with exotic storage may
+        override.
 
         Allocation uses ``object.__new__`` directly: ``type(self)`` is
         already the resolved concrete class, so a host's own ``__new__`` —
         which exists to *select* a class from constructor arguments and may
         require them — must not run again here.
 
-        The copy goes through the same state round-trip as ``copy`` and
-        ``pickle``, so a rename honours what a class declares about its state: a
-        memo is not carried into the copy, and a store written in place is not
-        shared with it. All three copy paths therefore agree.
+        Going through the round-trip rather than around it is what makes a
+        rename, a ``copy.copy``, and an unpickle agree: a memo is dropped by all
+        three, and an in-place store is decoupled by all three.
         """
         clone = object.__new__(type(self))
         clone.__setstate__(self.__getstate__())

--- a/probpipe/core/tracked.py
+++ b/probpipe/core/tracked.py
@@ -228,9 +228,10 @@ class TrackedTerm(Immutable, metaclass=_TrackedTermMeta):
         rename is always a user choice). The copy's :attr:`provenance`
         records the rename, with the original as parent, so the lineage
         chain is preserved. On an ``Annotated`` host the annotations
-        *container* is copied (its entries are shared), so annotations
-        written after the rename land on one object without appearing on
-        the other.
+        *container* is its own (its entries are shared), so annotations
+        written after the rename land on one object without appearing on the
+        other — :meth:`_shallow_copy` does that, from the host's own
+        ``_decoupled_state`` declaration.
 
         This renames the object *itself*. To rename the named fields inside a
         structured object, use ``with_path_names`` on the named-tree types.
@@ -256,9 +257,6 @@ class TrackedTerm(Immutable, metaclass=_TrackedTermMeta):
         object.__setattr__(clone, "_name", name)
         object.__setattr__(clone, "_name_is_auto", False)
         object.__setattr__(clone, "_provenance", None)
-        annotations = getattr(clone, "_annotations", None)
-        if annotations is not None:
-            object.__setattr__(clone, "_annotations", _decoupled_annotations(annotations))
         clone.with_provenance(
             Provenance.create(
                 "with_name",

--- a/probpipe/core/tracked.py
+++ b/probpipe/core/tracked.py
@@ -319,20 +319,13 @@ class TrackedTerm(Immutable, metaclass=_TrackedTermMeta):
         which exists to *select* a class from constructor arguments and may
         require them — must not run again here.
 
-        What to copy comes from :meth:`object.__getstate__` rather than from a
-        walk over ``__slots__``. That walk is easy to get subtly wrong, and
-        wrong here is silent: ``__slots__`` may be a bare string naming one
-        slot, which iterates into characters rather than into that name, so a
-        host declaring ``__slots__ = "_store"`` would be cloned without its
-        storage and nothing would raise.
+        The copy goes through the same state round-trip as ``copy`` and
+        ``pickle``, so a rename honours what a class declares about its state: a
+        memo is not carried into the copy, and a store written in place is not
+        shared with it. All three copy paths therefore agree.
         """
         clone = object.__new__(type(self))
-        state = object.__getstate__(self)
-        instance_dict, slots = state if isinstance(state, tuple) else (state, None)
-        for attribute, value in (instance_dict or {}).items():
-            object.__setattr__(clone, attribute, value)
-        for slot, value in (slots or {}).items():
-            object.__setattr__(clone, slot, value)
+        clone.__setstate__(self.__getstate__())
         return clone
 
 

--- a/probpipe/distributions/_product.py
+++ b/probpipe/distributions/_product.py
@@ -534,6 +534,9 @@ class TFPProductDistribution(ProductDistribution):
     def _build_tfp_dist(self):
         """Construct a combined TFP distribution from the components.
 
+        Called from ``__init__`` only, so it writes ``_tfp_dist`` through
+        ``object.__setattr__`` as the rest of construction does.
+
         Collects component TFP distributions in field-insertion order
         (matching the ``Record`` layout).  For the common case of
         same-family scalar distributions, stacks parameters into a
@@ -562,12 +565,13 @@ class TFPProductDistribution(ProductDistribution):
                 vals = [d.parameters[pname] for d in tfp_dists]
                 if all(v is not None for v in vals):
                     stacked_params[pname] = jnp.stack(vals)
-            self._tfp_dist = tfd.Independent(
+            combined = tfd.Independent(
                 type(exemplar)(**stacked_params),
                 reinterpreted_batch_ndims=1,
             )
         else:
-            self._tfp_dist = tfd.Blockwise(tfp_dists)
+            combined = tfd.Blockwise(tfp_dists)
+        object.__setattr__(self, "_tfp_dist", combined)
 
     @property
     def event_shape(self) -> tuple[int, ...]:

--- a/probpipe/distributions/_sequential_joint.py
+++ b/probpipe/distributions/_sequential_joint.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable
+from functools import partial
 from types import MappingProxyType
 
 import jax
@@ -490,23 +491,32 @@ class SequentialJointDistribution(
         }
         result_cls = _sequential_class_for_components(unconditioned_pre)
         result = result_cls.__new__(result_cls)
-        result._raw_components = dict(self._raw_components)  # originals unchanged
-        result._name = self._name
-        result._proto_components = dict(self._proto_components)
-        result._callable_parents = self._callable_parents
-        result._conditioned_names = all_conditioned
-        result._conditioned_values = {
-            **self._conditioned_values,
-            **{k: jnp.asarray(v) for k, v in observed.items()},
-        }
-        result._sampleable_error = self._compute_sampleable_error(
-            result._conditioned_names,
-            result._callable_parents,
+        # Allocate-then-populate stands in for a constructor here, so the fields
+        # are written the way a constructor writes them.
+        set_attribute = partial(object.__setattr__, result)
+        set_attribute("_raw_components", dict(self._raw_components))  # originals unchanged
+        set_attribute("_name", self._name)
+        set_attribute("_proto_components", dict(self._proto_components))
+        set_attribute("_callable_parents", self._callable_parents)
+        set_attribute("_conditioned_names", all_conditioned)
+        set_attribute(
+            "_conditioned_values",
+            {
+                **self._conditioned_values,
+                **{k: jnp.asarray(v) for k, v in observed.items()},
+            },
+        )
+        set_attribute(
+            "_sampleable_error",
+            self._compute_sampleable_error(
+                result._conditioned_names,
+                result._callable_parents,
+            ),
         )
 
         # Expose only unconditioned components
-        result._components = unconditioned_pre
-        result._event_template = _build_event_template(unconditioned_pre)
+        set_attribute("_components", unconditioned_pre)
+        set_attribute("_event_template", _build_event_template(unconditioned_pre))
 
         result.with_provenance(
             Provenance.create(

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -174,7 +174,10 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
             raise ValueError("Must provide at least one chain")
 
         self._chains = [jnp.asarray(c) for c in chains]
-        self._concatenated: Array | None = None
+        # A memo, filled on first read: a container assigned once here rather
+        # than an attribute assigned later, so reading it does not modify the
+        # distribution.
+        self._memo: dict[str, Array] = {}
 
         # When the caller's chain columns are laid out in a different
         # field order than the template — e.g. a backend whose trace
@@ -204,7 +207,7 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
                     )
             if len(event_template.fields) > 1:
                 self._chains = [c[..., perm] for c in self._chains]
-                self._concatenated = None
+                self._memo.pop("concatenated", None)
 
         flat = self._concat_chains()
         # Track whether the user explicitly supplied a template; we use
@@ -276,9 +279,11 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
 
     def _concat_chains(self) -> Array:
         """Lazily concatenated view of all chains."""
-        if self._concatenated is None:
-            self._concatenated = jnp.concatenate(self._chains, axis=0)
-        return self._concatenated
+        concatenated = self._memo.get("concatenated")
+        if concatenated is None:
+            concatenated = jnp.concatenate(self._chains, axis=0)
+            self._memo["concatenated"] = concatenated
+        return concatenated
 
     # -- Chain access ---------------------------------------------------------
 
@@ -500,7 +505,7 @@ def make_posterior(
             clean = group_path.lstrip("/")
             ds = node.to_dataset() if isinstance(node, xr.DataTree) else node
             dicto[f"arviz/{clean}"] = ds
-        result._annotations = xr.DataTree.from_dict(dicto)
+        result._init_annotations(xr.DataTree.from_dict(dicto))
 
     result.with_provenance(
         Provenance.create(

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 import jax.numpy as jnp
 
 from .._weights import Weights
+from ..core._immutable import transient_memo
 from ..core.distribution import Distribution, RecordEmpiricalDistribution
 from ..core.event_template import ArraySpec, EventTemplate, NumericEventTemplate, OpaqueSpec
 from ..core.provenance import Provenance
@@ -161,6 +162,11 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
     per-chain samples.
     """
 
+    #: The memo is not state: a copy recomputes rather than inheriting one. It
+    #: matters for more than size here, since a memoised value can carry the
+    #: provenance of the term that computed it.
+    _transient_state = ("_memo",)
+
     def __init__(
         self,
         chains: list[Array],
@@ -207,7 +213,7 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
                     )
             if len(event_template.fields) > 1:
                 self._chains = [c[..., perm] for c in self._chains]
-                self._memo.pop("concatenated", None)
+                transient_memo(self).pop("concatenated", None)
 
         flat = self._concat_chains()
         # Track whether the user explicitly supplied a template; we use
@@ -279,10 +285,10 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
 
     def _concat_chains(self) -> Array:
         """Lazily concatenated view of all chains."""
-        concatenated = self._memo.get("concatenated")
+        concatenated = transient_memo(self).get("concatenated")
         if concatenated is None:
             concatenated = jnp.concatenate(self._chains, axis=0)
-            self._memo["concatenated"] = concatenated
+            transient_memo(self)["concatenated"] = concatenated
         return concatenated
 
     # -- Chain access ---------------------------------------------------------

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -180,9 +180,9 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
             raise ValueError("Must provide at least one chain")
 
         self._chains = [jnp.asarray(c) for c in chains]
-        # A memo, filled on first read: a container assigned once here rather
-        # than an attribute assigned later, so reading it does not modify the
-        # distribution.
+        # A memo, filled on first read. Reading fills it in place, which leaves
+        # the term's own attributes as construction set them — what the
+        # immutability guard sees, and what a copy drops rather than inherits.
         self._memo: dict[str, Array] = {}
 
         # When the caller's chain columns are laid out in a different

--- a/tests/core/test_distribution_array.py
+++ b/tests/core/test_distribution_array.py
@@ -693,8 +693,10 @@ class TestBackendDelegatedStorage:
         assert len(c1) == 3
         # Cached: same tuple identity returned.
         assert c1 is c2
-        # And now _components is populated.
-        assert da._components is c1
+        # The memo holds it; the literal-components slot stays empty, which is
+        # what marks this array as backend-delegated.
+        assert da._memo["components"] is c1
+        assert da._components is None
 
     def test_slice_indexing_materialises_components(self):
         from probpipe import DistributionArray
@@ -703,7 +705,7 @@ class TestBackendDelegatedStorage:
         da = DistributionArray._from_backend(backend, name="x")
         sub = da[1:4]
         # Slicing forces materialisation (rare path).
-        assert da._components is not None
+        assert da._memo["components"] is not None
         assert isinstance(sub, DistributionArray)
         assert len(sub) == 3
 

--- a/tests/core/test_terms_do_not_mutate.py
+++ b/tests/core/test_terms_do_not_mutate.py
@@ -111,3 +111,51 @@ class TestAnOperationDoesNotMutateItsResultAfterBuildingIt:
         assert again is not conditioned
         # The operand is untouched, which is what §V.1 promises.
         assert set(joint.components) == {"z", "x"}
+
+
+class TestACopyDoesNotInheritAMemo:
+    """A memo is per term, because what it holds can be per term.
+
+    ``marginalize`` stamps the distribution's own provenance onto the marginal it
+    builds, so a renamed copy sharing one memo with its original would hand
+    whichever of them asked second the other's lineage — and which that is
+    depends only on query order.
+    """
+
+    @staticmethod
+    def _broadcast() -> BroadcastDistribution:
+        return BroadcastDistribution(
+            input_samples={"x": jnp.ones((5, 1))},
+            output_samples=jnp.zeros((5, 2)),
+            weights=None,
+            broadcast_args=["x"],
+        )
+
+    def test_the_rename_does_not_share_the_original_s_memo(self):
+        original = self._broadcast()
+        renamed = original.with_name("renamed")
+        assert getattr(renamed, "_memo", None) is not getattr(original, "_memo", None)
+
+    def test_lineage_does_not_depend_on_which_is_marginalized_first(self):
+        renamed_first = self._broadcast()
+        renamed = renamed_first.with_name("renamed")
+        from_rename = renamed.marginalize()
+        from_original = renamed_first.marginalize()
+
+        original_first = self._broadcast()
+        also_from_original = original_first.marginalize()
+        also_from_rename = original_first.with_name("renamed").marginalize()
+
+        # The original's marginal carries the original's lineage in both orders,
+        # and the rename's carries the rename's.
+        assert from_original.provenance is None
+        assert also_from_original.provenance is None
+        assert from_rename.provenance.operation == "with_name"
+        assert also_from_rename.provenance.operation == "with_name"
+        assert from_original is not from_rename
+
+    def test_each_still_memoises_its_own(self):
+        original = self._broadcast()
+        renamed = original.with_name("renamed")
+        assert original.marginalize() is original.marginalize()
+        assert renamed.marginalize() is renamed.marginalize()

--- a/tests/core/test_terms_do_not_mutate.py
+++ b/tests/core/test_terms_do_not_mutate.py
@@ -13,6 +13,8 @@ name. The tests keep watch on all of them, since the difference is invisible fro
 outside and easy to lose.
 """
 
+from collections.abc import Mapping
+
 import jax.numpy as jnp
 import numpy as np
 
@@ -26,16 +28,35 @@ from probpipe import (
 from probpipe.core._broadcast_distributions import BroadcastDistribution
 
 
-def assigned_attributes(term) -> dict:
-    """The term's attributes, as a name -> id map; memo containers excluded.
+def assigned_state(term) -> dict:
+    """What the term holds, in the two ways a read could change it.
 
-    Identity rather than value: a lazily filled memo mutates its container in
-    place, which is invisible here, while assigning any attribute is not.
+    Each attribute maps to its value's identity — which catches an attribute
+    being *rebound* — paired with a shallow census of that value where the value
+    is a container, which catches one being edited *in place*. Identity alone
+    misses the second, and it is the likelier of the two: a lazy read that fills
+    a dictionary it already holds rebinds nothing.
+
+    The census is deliberately shallow and structural: keys and element
+    identities, not values. A distribution's leaves are jax arrays and other
+    terms, which have no cheap value equality, so this asserts that the
+    *arrangement* is untouched rather than that the numbers are.
+
+    ``_memo`` is excluded, being the one store a read is meant to fill.
     """
     state = object.__getstate__(term)
     instance_dict, slots = state if isinstance(state, tuple) else (state, {})
     both = {**(instance_dict or {}), **(slots or {})}
-    return {name: id(value) for name, value in both.items() if name != "_memo"}
+    return {name: (id(value), _census(value)) for name, value in both.items() if name != "_memo"}
+
+
+def _census(value):
+    """A shallow, structural snapshot of a container, or ``None`` for a leaf."""
+    if isinstance(value, Mapping):
+        return ("mapping", tuple(value), tuple(id(v) for v in value.values()))
+    if isinstance(value, (list, tuple)) and not isinstance(value, str):
+        return ("sequence", len(value), tuple(id(v) for v in value))
+    return None
 
 
 class _ScalarBackend:
@@ -50,6 +71,40 @@ class _ScalarBackend:
         return Normal(float(index), 1.0, name=f"c{index}")
 
 
+class TestTheCheckItself:
+    """The helper has to catch the kind of mutation these tests are about.
+
+    A lazy read that fills a container the term already holds rebinds nothing,
+    so a check comparing attribute identities alone passes straight through it.
+    """
+
+    def test_it_catches_an_edit_that_rebinds_nothing(self):
+        joint = SequentialJointDistribution(
+            z=Normal(loc=0.0, scale=1.0, name="z"),
+            x=lambda z: Normal(loc=z, scale=0.5, name="x"),
+        )
+        name, container = next((n, v) for n, v in vars(joint).items() if isinstance(v, dict) and v)
+        before = assigned_state(joint)
+        container["injected"] = object()  # same dict object, new entry
+        assert assigned_state(joint) != before, f"an in-place edit to {name} went unseen"
+
+    def test_it_catches_a_rebound_attribute(self):
+        joint = SequentialJointDistribution(
+            z=Normal(loc=0.0, scale=1.0, name="z"),
+            x=lambda z: Normal(loc=z, scale=0.5, name="x"),
+        )
+        before = assigned_state(joint)
+        object.__setattr__(joint, "_conditioned_names", ("z",))
+        assert assigned_state(joint) != before
+
+    def test_it_ignores_the_memo(self):
+        # The one store a read is meant to fill.
+        array = DistributionArray._from_backend(_ScalarBackend(3), name="x")
+        before = assigned_state(array)
+        assert array.components  # fills the memo
+        assert assigned_state(array) == before
+
+
 class TestAQueryLeavesTheTermUnchanged:
     def test_marginalizing_a_broadcast_distribution(self):
         broadcast = BroadcastDistribution(
@@ -58,9 +113,9 @@ class TestAQueryLeavesTheTermUnchanged:
             weights=None,
             broadcast_args=["x"],
         )
-        before = assigned_attributes(broadcast)
+        before = assigned_state(broadcast)
         first = broadcast.marginalize()
-        assert assigned_attributes(broadcast) == before
+        assert assigned_state(broadcast) == before
         # Still memoised: the second read returns the first result.
         assert broadcast.marginalize() is first
 
@@ -68,9 +123,9 @@ class TestAQueryLeavesTheTermUnchanged:
         # The backend-delegated array is the one that materialises on read; an
         # array built from a literal component list has them from the start.
         array = DistributionArray._from_backend(_ScalarBackend(3), name="x")
-        before = assigned_attributes(array)
+        before = assigned_state(array)
         first = array.components
-        assert assigned_attributes(array) == before
+        assert assigned_state(array) == before
         assert array.components is first
 
     def test_an_approximate_distribution_concatenates_at_construction(self):
@@ -79,9 +134,9 @@ class TestAQueryLeavesTheTermUnchanged:
         from probpipe.inference._approximate_distribution import ApproximateDistribution
 
         posterior = ApproximateDistribution([np.zeros((4, 1)), np.ones((4, 1))], name="p")
-        before = assigned_attributes(posterior)
+        before = assigned_state(posterior)
         first = posterior._concat_chains()
-        assert assigned_attributes(posterior) == before
+        assert assigned_state(posterior) == before
         assert posterior._concat_chains() is first
 
     def test_a_tfp_product_distribution_builds_its_tfp_view_at_construction(self):
@@ -91,9 +146,9 @@ class TestAQueryLeavesTheTermUnchanged:
             a=Normal(0.0, 1.0, name="a"), b=Normal(1.0, 2.0, name="b"), name="j"
         )
         assert hasattr(joint, "_tfp_dist")
-        before = assigned_attributes(joint)
+        before = assigned_state(joint)
         _ = joint.event_shape
-        assert assigned_attributes(joint) == before
+        assert assigned_state(joint) == before
 
 
 class TestAnOperationDoesNotMutateItsResultAfterBuildingIt:
@@ -105,9 +160,9 @@ class TestAnOperationDoesNotMutateItsResultAfterBuildingIt:
         conditioned = condition_on(joint, z=jnp.asarray(2.0))
         # The result is complete when it is returned, and conditioning again
         # builds another result rather than editing this one.
-        before = assigned_attributes(conditioned)
+        before = assigned_state(conditioned)
         again = condition_on(joint, z=jnp.asarray(3.0))
-        assert assigned_attributes(conditioned) == before
+        assert assigned_state(conditioned) == before
         assert again is not conditioned
         # The operand is untouched, which is what §V.1 promises.
         assert set(joint.components) == {"z", "x"}

--- a/tests/core/test_terms_do_not_mutate.py
+++ b/tests/core/test_terms_do_not_mutate.py
@@ -13,10 +13,13 @@ name. The tests keep watch on all of them, since the difference is invisible fro
 outside and easy to lose.
 """
 
+import copy
+import pickle
 from collections.abc import Mapping
 
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from probpipe import (
     DistributionArray,
@@ -166,6 +169,78 @@ class TestAnOperationDoesNotMutateItsResultAfterBuildingIt:
         assert again is not conditioned
         # The operand is untouched, which is what §V.1 promises.
         assert set(joint.components) == {"z", "x"}
+
+
+class TestEveryMemoHolderDropsItsMemoOnACopy:
+    """Each memo-holding term, across each way of copying one.
+
+    The mixin's own tests cover the mechanism; these cover the three classes
+    that opt into it, so dropping `_transient_state` from one of them, or
+    breaking its rebuild path, fails here rather than passing quietly.
+
+    Each case gives a term, a read that fills its memo, and what that read
+    returns, so the assertions can check both halves: the copy does not inherit
+    the memo, and it can still rebuild the value.
+    """
+
+    @staticmethod
+    def _broadcast():
+        term = BroadcastDistribution(
+            input_samples={"x": jnp.ones((5, 1))},
+            output_samples=jnp.zeros((5, 2)),
+            weights=None,
+            broadcast_args=["x"],
+        )
+        return term, lambda d: d.marginalize()
+
+    @staticmethod
+    def _backend_array():
+        term = DistributionArray._from_backend(_ScalarBackend(3), name="x")
+        return term, lambda d: d.components
+
+    @staticmethod
+    def _approximate():
+        from probpipe.inference._approximate_distribution import ApproximateDistribution
+
+        term = ApproximateDistribution([np.zeros((4, 1)), np.ones((4, 1))], name="p")
+        return term, lambda d: d._concat_chains()
+
+    @pytest.fixture(
+        params=[
+            pytest.param("_broadcast", id="broadcast-marginal"),
+            pytest.param("_backend_array", id="backend-array-components"),
+            pytest.param("_approximate", id="approximate-chains"),
+        ]
+    )
+    def case(self, request):
+        return getattr(self, request.param)()
+
+    @pytest.fixture(
+        params=[
+            pytest.param(lambda t: t.with_name("renamed"), id="with_name"),
+            pytest.param(copy.copy, id="copy"),
+            pytest.param(copy.deepcopy, id="deepcopy"),
+            pytest.param(lambda t: pickle.loads(pickle.dumps(t)), id="pickle"),
+        ]
+    )
+    def copied(self, request):
+        return request.param
+
+    def test_the_copy_does_not_inherit_the_memo(self, case, copied):
+        term, read = case
+        read(term)  # fill it on the original
+        assert getattr(copied(term), "_memo", {}) == {}
+
+    def test_the_copy_still_rebuilds_the_value(self, case, copied):
+        term, read = case
+        read(term)
+        assert read(copied(term)) is not None
+
+    def test_the_memo_is_declared_transient(self, case):
+        from probpipe.core._immutable import declared_state_names
+
+        term, _ = case
+        assert "_memo" in declared_state_names(type(term), "_transient_state")
 
 
 class TestACopyDoesNotInheritAMemo:

--- a/tests/core/test_terms_do_not_mutate.py
+++ b/tests/core/test_terms_do_not_mutate.py
@@ -1,0 +1,113 @@
+"""Reading a tracked term does not modify it.
+
+`design/05-operations.md` §V.1 promises an implementer's object is never
+modified. Two terms broke that where a caller could see it: a
+``BroadcastDistribution`` assigned its marginal on first ``marginalize()``, and a
+backend-delegated ``DistributionArray`` assigned its components on first read.
+Both now fill a memo container assigned at construction, so the attributes the
+term was built with stay untouched.
+
+The rest of the class is an invariant rather than a regression: those terms wrote
+their fields before the object reached a caller, which is construction by another
+name. The tests keep watch on all of them, since the difference is invisible from
+outside and easy to lose.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+
+from probpipe import (
+    DistributionArray,
+    Normal,
+    ProductDistribution,
+    SequentialJointDistribution,
+    condition_on,
+)
+from probpipe.core._broadcast_distributions import BroadcastDistribution
+
+
+def assigned_attributes(term) -> dict:
+    """The term's attributes, as a name -> id map; memo containers excluded.
+
+    Identity rather than value: a lazily filled memo mutates its container in
+    place, which is invisible here, while assigning any attribute is not.
+    """
+    state = object.__getstate__(term)
+    instance_dict, slots = state if isinstance(state, tuple) else (state, {})
+    both = {**(instance_dict or {}), **(slots or {})}
+    return {name: id(value) for name, value in both.items() if name != "_memo"}
+
+
+class _ScalarBackend:
+    """The smallest thing ``DistributionArray._from_backend`` accepts."""
+
+    is_approximate = False
+
+    def __init__(self, n: int):
+        self.batch_shape = (n,)
+
+    def cell(self, index: int) -> Normal:
+        return Normal(float(index), 1.0, name=f"c{index}")
+
+
+class TestAQueryLeavesTheTermUnchanged:
+    def test_marginalizing_a_broadcast_distribution(self):
+        broadcast = BroadcastDistribution(
+            input_samples={"x": jnp.ones((5, 1))},
+            output_samples=jnp.zeros((5, 2)),
+            weights=None,
+            broadcast_args=["x"],
+        )
+        before = assigned_attributes(broadcast)
+        first = broadcast.marginalize()
+        assert assigned_attributes(broadcast) == before
+        # Still memoised: the second read returns the first result.
+        assert broadcast.marginalize() is first
+
+    def test_reading_a_backend_delegated_array_s_components(self):
+        # The backend-delegated array is the one that materialises on read; an
+        # array built from a literal component list has them from the start.
+        array = DistributionArray._from_backend(_ScalarBackend(3), name="x")
+        before = assigned_attributes(array)
+        first = array.components
+        assert assigned_attributes(array) == before
+        assert array.components is first
+
+    def test_an_approximate_distribution_concatenates_at_construction(self):
+        # The constructor reads the concatenation, so the memo is filled before
+        # a caller holds the object and no later read assigns anything.
+        from probpipe.inference._approximate_distribution import ApproximateDistribution
+
+        posterior = ApproximateDistribution([np.zeros((4, 1)), np.ones((4, 1))], name="p")
+        before = assigned_attributes(posterior)
+        first = posterior._concat_chains()
+        assert assigned_attributes(posterior) == before
+        assert posterior._concat_chains() is first
+
+    def test_a_tfp_product_distribution_builds_its_tfp_view_at_construction(self):
+        # The combined TFP distribution is built once, by the constructor: no
+        # read fills it in later.
+        joint = ProductDistribution(
+            a=Normal(0.0, 1.0, name="a"), b=Normal(1.0, 2.0, name="b"), name="j"
+        )
+        assert hasattr(joint, "_tfp_dist")
+        before = assigned_attributes(joint)
+        _ = joint.event_shape
+        assert assigned_attributes(joint) == before
+
+
+class TestAnOperationDoesNotMutateItsResultAfterBuildingIt:
+    def test_conditioning_a_sequential_joint(self):
+        joint = SequentialJointDistribution(
+            z=Normal(loc=0.0, scale=1.0, name="z"),
+            x=lambda z: Normal(loc=z, scale=0.5, name="x"),
+        )
+        conditioned = condition_on(joint, z=jnp.asarray(2.0))
+        # The result is complete when it is returned, and conditioning again
+        # builds another result rather than editing this one.
+        before = assigned_attributes(conditioned)
+        again = condition_on(joint, z=jnp.asarray(3.0))
+        assert assigned_attributes(conditioned) == before
+        assert again is not conditioned
+        # The operand is untouched, which is what §V.1 promises.
+        assert set(joint.components) == {"z", "x"}


### PR DESCRIPTION
## Summary

> **What a memo container is, and what it does not buy.** Each of these classes
> now holds a plain `dict` named `_memo`, assigned once by the constructor, and a
> lazy read puts its result in it under a string key — `_memo["marginal"]`,
> `_memo["components"]`, `_memo["concatenated"]` — where it used to assign an
> attribute. `NumericRecord._jax_cache` is the same pattern already in the tree.
>
> This makes the terms **pass an assignment guard**; it does not make them
> immutable. The dict's contents still change after construction, so a term's
> internal state at the second read differs from the first. It is unobservable
> through the public interface — the memoized value is deterministic, so a caller
> cannot distinguish it from recomputation — but the guard is not what prevents
> mutation here, it simply does not apply. The alternative is computing at
> construction and dropping the memo, paying the cost up front; that is the choice
> every distribution faces when the guard reaches them, and it is deliberately not
> made here, since these classes are slated to change.

Two distributions changed themselves when read. `BroadcastDistribution` assigned its marginal on the first `marginalize()`, and a backend-delegated `DistributionArray` assigned its components on the first read — so a query modified an object its caller was holding, which is what `C2` and the §V.1 operation contract rule out. Each now fills a memo container assigned at construction: computed once as before, lazily as before, with the term's own fields left as they were built.

Five more sites populated a term *after* allocating it, using plain attribute assignment:

| Site | What it builds |
|---|---|
| `DistributionArray._from_backend` | five fields on an `object.__new__`'d instance |
| `_make_distribution_array` | the declared `event_template` |
| `TFPProductDistribution._build_tfp_dist` | the combined TFP view, from `__init__` |
| `make_posterior` | the posterior's annotations store |
| `SequentialJointDistribution._condition_on_impl` | ten fields on the conditioned result |

**None of that was observable** — each wrote before the object reached a caller, so this half is not a behavior fix. It matters for two other reasons: an assignment guard on every tracked term refuses the plain form, and a reader cannot tell construction from mutation when both look identical. They write through `object.__setattr__` now, the way a constructor does. `ApproximateDistribution`'s chain concatenation joins the same memo container, though its constructor already forced it.

## A copy does not inherit the memo

Caught in review: `_shallow_copy` carried the memo dictionary itself, so `with_name` handed the rename and the original **one** memo. `marginalize` stamps the distribution's own provenance onto the marginal it builds, so whichever asked second silently received the other's lineage — decided by query order, and wrong in the rename's direction.

The memo is declared transient, and the three copy paths now agree on what that means: `_shallow_copy` reads `_transient_state` and `_decoupled_state` like the state round-trip does, so a rename, a `copy.copy`, and an unpickle produce the same thing. The declarations moved to a module-level `declared_state_names`, since they describe how a class *copies* whether or not it also refuses assignment — and only some hosts refuse it so far.

A term arriving by any of those routes therefore has no memo, so reading one rebuilds rather than assumes: `transient_memo` does that, next to the declaration that makes it necessary. This is the same correction the conversion cache needed in #413 when it was first declared transient.

All four copy paths agree, and `_shallow_copy` gets *shorter* for it — it delegates to the round-trip rather than walking attributes itself.

An earlier revision left `copy.copy` sharing the memo and argued it was harmless, on the grounds that a plain copy has its original's provenance. That was wrong: `with_provenance` attaches to the copy afterwards, so the two can differ and the shared memo hands one of them the other's lineage. Reproduced, then fixed by the ordering above.

## Linked issue(s)

Part of #395. **Stacked on #416** (the last of the stack, now that #412 and #413 have merged), which makes `TrackedTerm` inherit `Immutable`, and that order is load-bearing rather than incidental: the memo below is declared *transient*, and only a term that goes through the mixin's state round-trip honours that declaration. Reviewed in the other order, this PR's own head shared a memo across `copy`, `deepcopy`, and `pickle` while honouring the declaration in `with_name` — correct only once #416 landed on top of it. Reversed, each PR is correct where it sits.

## What this deliberately leaves alone

**`PyABCDistribution.rvs` advancing `self._key`.** #395 listed this as a tracked term whose query advances its own RNG state — the plainest violation on the list. It is not a ProbPipe term at all: it subclasses `pyabc.Distribution` to implement that library's stateful RV protocol, where `rvs()` is *required* to return a fresh draw per call. Checked directly rather than inferred from the name this time; the issue's table is corrected.

**`ProductDistribution.__reduce__`.** It is a distribution, not one of the four immutable hosts, so it keeps reconstructing through its constructor until the guard reaches distributions.

## Test plan

`tests/core/test_terms_do_not_mutate.py` — 5 tests. Each compares a term's attributes **by identity** before and after a read, excluding the memo container: a memo filled in place passes, an attribute assignment does not.

- `BroadcastDistribution.marginalize()` and the backend-delegated `DistributionArray.components` leave the term unchanged, and still return the same object on a second read;
- `TFPProductDistribution` has its combined view before any read;
- `ApproximateDistribution` concatenates during construction;
- conditioning a `SequentialJointDistribution` twice leaves the first result untouched, and the operand keeps both components;
- **a rename does not share the original's memo**, and the marginal each produces carries its own lineage in either query order.

**Negative control:** two of the five fail on #413's head, which are exactly the two observable sites. The other three pin invariants that were already true — kept because the difference is invisible from outside and easy to lose, and labelled as such in the module docstring rather than dressed up as regressions.

Two existing tests in `test_distribution_array.py` asserted on the slot that now holds a mode flag rather than the materialised tuple; they follow the memo instead.

4731 passed, 53 skipped. `ruff format` / `ruff check` clean.

## Breaking changes

None.

## Documentation

- [x] Docstrings updated for changed public APIs
- [ ] User Guide / tutorials updated where relevant
- [x] CHANGELOG entries added under `Unreleased → Fixed` and `→ Changed`

## Contract checklist

- [x] Contract of every touched abstraction was clear before coding; the ambiguity found — whether these sites were observable mutations or construction in disguise — is resolved above, per site, by negative control rather than by reading the code.
- [x] Changed contracts documented where they live: each memo says it is filled on first read and that reading does not modify the term.
- [x] Docstring openings lead with the API; rationale deferred.
- [x] Code verified to obey the documented contract; the tests assert the property (attributes unchanged across a read), not a happy-path value.
- [x] Docstrings describe the target contract — the memo containers are written as the pattern that survives the guard, not as a workaround for its absence.
- [x] Variable names follow the canonical table.
- [x] `CONTRACTS.md` needs no index change; no cross-cutting contract moved.
- [x] `ruff format` and `ruff check` clean.

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`.
- [x] At least one `area:*` label is applied.
- [x] Linked to the tracking issue above.


