### PR TITLE
refactor(core): make immutability a property of being a tracked term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -663,8 +663,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where the rule lives — in the term hierarchy rather than in four class bodies —
   and that turning it on for the rest is now a deletion.
 
-### Changed
-
 - **Immutability is one mixin, and a term reconstructs from its state (#395).**
   Four classes spelled out the same guard — three of them hardcoding a class name,
   so `NumericRecord` reported `Record` and `NumericEventTemplate` reported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -637,6 +637,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Immutability is a property of being a tracked term (#395).** `TrackedTerm`
+  inherits `Immutable`, so assignment and deletion raise on a record, a batch, a
+  function, or a template once its constructor has returned — the design's `C2`
+  and the §V.1 promise that an implementer's object is never modified, enforced
+  rather than documented. Four classes enforced it individually before.
+
+  **The distribution layer is exempt for now.** `Distribution` permits
+  assignment, because the documented way to build an emulator is to subclass a
+  random function and train it in place, and fitting has no contract yet that
+  returns a new term instead. That is one method with one docstring, and deleting
+  it turns the guard on for the other seventy-two classes; a test asserts it is
+  the *only* exemption, so a second cannot appear quietly.
+
+  Construction is unaffected: it runs inside a per-instance window the
+  `TrackedTerm` metaclass opens, so a host's `__init__` assigns normally and no
+  constructor needed converting. The window closes when `__init__` returns, and
+  also when it raises, so a half-built term left behind by a failure is as
+  immutable as a finished one. Code that allocates with `object.__new__` and then
+  calls a constructor by hand opens the window itself — three sites in the
+  package do.
+
+  Nothing changes for a caller: the classes that refuse assignment are the same
+  four families as before, and a distribution still accepts it. What changes is
+  where the rule lives — in the term hierarchy rather than in four class bodies —
+  and that turning it on for the rest is now a deletion.
+
+### Changed
+
 - **Immutability is one mixin, and a term reconstructs from its state (#395).**
   Four classes spelled out the same guard — three of them hardcoding a class name,
   so `NumericRecord` reported `Record` and `NumericEventTemplate` reported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -643,12 +643,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the §V.1 promise that an implementer's object is never modified, enforced
   rather than documented. Four classes enforced it individually before.
 
-  **The distribution layer is exempt for now.** `Distribution` permits
-  assignment, because the documented way to build an emulator is to subclass a
+  **The distribution layer is exempt for now.** `Distribution` permits assignment
+  and deletion, because the documented way to build an emulator is to subclass a
   random function and train it in place, and fitting has no contract yet that
-  returns a new term instead. That is one method with one docstring, and deleting
-  it turns the guard on for the other seventy-two classes; a test asserts it is
-  the *only* exemption, so a second cannot appear quietly.
+  returns a new term instead. That is two overrides — `__setattr__` and
+  `__delattr__` — and removing both turns the guard on for the other
+  seventy-two classes; removing one would leave half an exemption. A test
+  asserts `Distribution` is the *only* exempt class, so a second cannot appear
+  quietly.
 
   Construction is unaffected: it runs inside a per-instance window the
   `TrackedTerm` metaclass opens, so a host's `__init__` assigns normally and no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -659,7 +659,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   package do.
 
   Nothing changes for a caller: the classes that refuse assignment are the same
-  four families as before, and a distribution still accepts it. What changes is
+  four families as before, and a distribution still accepts assignment *and*
+  deletion, the exemption covering both. What changes is
   where the rule lives — in the term hierarchy rather than in four class bodies —
   and that turning it on for the rest is now a deletion.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -435,7 +435,12 @@ uv build packaging/probpipe   # probpipe (metapackage)
 ### Design principles
 
 1. **Distributions are immutable** — parameters fixed at construction;
-   operations return new distributions. The one documented exception
+   operations return new distributions. Records, batches, functions, and
+   templates enforce this (assignment and deletion raise); `Distribution`
+   permits both for now, because the documented emulator pattern trains a
+   subclassed random function in place and fitting has no contract yet that
+   returns a new fitted term. Treat the rule as binding when writing new code
+   either way. The one documented exception
    is the `annotations` store (`_annotations`, provided by the
    `Annotated` mixin in `probpipe.core.tracked`; a string-keyed
    mapping, typically an `xarray.DataTree`, of post-construction

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -789,6 +789,18 @@ Distribution and `Function` objects are immutable. Parameters, Function
 signatures, templates, controls, and implementations are fixed at construction;
 operations return new terms rather than mutating state.
 
+Records, batches, functions, and templates **enforce** this: assignment and
+deletion raise `AttributeError`, naming the class touched.
+
+**Distributions do not enforce it yet.** `Distribution` overrides both
+`__setattr__` and `__delattr__` to permit them, because the documented way to
+build an emulator is to subclass a random function and train it in place, and
+fitting has no contract yet that returns a new fitted term instead. Write new
+code as though the guard were on — an operation returns a new distribution — and
+do not add assignment to a distribution outside its constructor. The exemption
+lifts by removing both overrides, once fitting has that contract; removing one
+would leave a trainer that clears what it fitted still raising.
+
 **The one carve-out is the `annotations` store** (`_annotations`, provided
 by the `Annotated` mixin in `probpipe.core.tracked` and carried by
 `Distribution` and `Record`): a string-keyed mapping — typically an

--- a/probpipe/converters/_probpipe.py
+++ b/probpipe/converters/_probpipe.py
@@ -687,9 +687,11 @@ class ProbPipeConverter(Converter):
                 with contextlib.suppress(AttributeError):
                     check(source)
 
-        # Mark approximate if source is approximate or conversion used sampling
+        # Mark approximate if source is approximate or conversion used sampling.
+        # Written through ``object.__setattr__``: the result is a tracked term,
+        # and this is the conversion finishing it rather than a later edit.
         if source.is_approximate or not isinstance(source, target_type):
-            result._approximate = True
+            object.__setattr__(result, "_approximate", True)
 
         return result
 

--- a/probpipe/core/_batch.py
+++ b/probpipe/core/_batch.py
@@ -68,7 +68,6 @@ from dataclasses import dataclass, replace
 from math import prod
 from typing import Any, Self, cast
 
-from ._immutable import Immutable
 from .event_template import (
     TermSpec,
     ValueSpec,
@@ -343,7 +342,7 @@ class BatchSpec(TermSpec):
         return spec == self
 
 
-class Batch[E](Immutable, TrackedTerm, ABC):
+class Batch[E](TrackedTerm, ABC):
     """A tracked nd collection of elements of a common type.
 
     The batch axes are grouped into named **levels**, and indexing them returns a

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -26,6 +26,7 @@ from ._empirical import (
     EmpiricalDistribution,
     RecordEmpiricalDistribution,
 )
+from ._immutable import constructing
 from ._numeric_record_batch import NumericRecordBatch
 from ._object_batch import _from_iterable, _is_object_array
 from ._record_batch import RecordBatch, _batch_class_for, _MappedBatchColumns
@@ -287,13 +288,16 @@ def _make_mixture_marginal(
 
     cls = _mixture_class_cache[cache_key]
     obj = object.__new__(cls)
-    _MixtureMarginal.__init__(
-        obj,
-        components,
-        weights,
-        name=name,
-        event_template=event_template,
-    )
+    # Allocated here rather than through the class, so the construction window
+    # the metaclass would have opened is opened explicitly.
+    with constructing(obj):
+        _MixtureMarginal.__init__(
+            obj,
+            components,
+            weights,
+            name=name,
+            event_template=event_template,
+        )
     return obj
 
 

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -84,6 +84,22 @@ class Distribution[T](TrackedTerm, Annotated, ABC):
         If *name* is not a non-empty string.
     """
 
+    # -- Immutability: deferred for this layer ------------------------------
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Permit assignment, which :class:`TrackedTerm` otherwise refuses.
+
+        Interim, and the only exemption from the rule that a tracked term is
+        immutable. It stands because the contract for a *fitted* mapping is not
+        settled: the documented way to build an emulator is to subclass a random
+        function and train it in place, and until fitting has a contract that
+        produces a new term instead, enforcing immutability here would break that
+        pattern without offering a replacement.
+
+        Deleting this method turns the guard on for the whole distribution layer.
+        """
+        object.__setattr__(self, name, value)
+
     def __init__(
         self,
         *,

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -86,6 +86,10 @@ class Distribution[T](TrackedTerm, Annotated, ABC):
 
     # -- Immutability: deferred for this layer ------------------------------
 
+    def __delattr__(self, name: str) -> None:
+        """Permit deletion, for the reason :meth:`__setattr__` gives."""
+        object.__delattr__(self, name)
+
     def __setattr__(self, name: str, value: Any) -> None:
         """Permit assignment, which :class:`TrackedTerm` otherwise refuses.
 

--- a/probpipe/core/_distribution_base.py
+++ b/probpipe/core/_distribution_base.py
@@ -87,7 +87,10 @@ class Distribution[T](TrackedTerm, Annotated, ABC):
     # -- Immutability: deferred for this layer ------------------------------
 
     def __delattr__(self, name: str) -> None:
-        """Permit deletion, for the reason :meth:`__setattr__` gives."""
+        """Permit deletion, for the reason :meth:`__setattr__` gives.
+
+        Goes with that method: removing the exemption means removing both.
+        """
         object.__delattr__(self, name)
 
     def __setattr__(self, name: str, value: Any) -> None:
@@ -100,7 +103,9 @@ class Distribution[T](TrackedTerm, Annotated, ABC):
         produces a new term instead, enforcing immutability here would break that
         pattern without offering a replacement.
 
-        Deleting this method turns the guard on for the whole distribution layer.
+        Deleting this method **and** :meth:`__delattr__` turns the guard on for
+        the whole distribution layer. Both, or the layer keeps half an
+        exemption: a trainer that clears what it fitted would still raise.
         """
         object.__setattr__(self, name, value)
 

--- a/probpipe/core/_immutable.py
+++ b/probpipe/core/_immutable.py
@@ -58,13 +58,14 @@ def declared_state_names(cls: type, declaration: str) -> frozenset[str]:
     return frozenset(name for klass in cls.__mro__ for name in klass.__dict__.get(declaration, ()))
 
 
-# Instances whose constructor is running on this thread, keyed by ``id``. The
-# instance is the value, not just the key: holding it keeps the id from being
-# reused by another object while the constructor is still on the stack.
+# Instances whose constructor is running on this thread, keyed by ``id``, each
+# with the number of windows open on it. The instance is held rather than just
+# its id, which keeps the id from being reused by another object while the
+# constructor is still on the stack; the count is what makes a window nest.
 _under_construction = threading.local()
 
 
-def _constructing_now() -> dict[int, Any]:
+def _constructing_now() -> dict[int, tuple[Any, int]]:
     registry = getattr(_under_construction, "registry", None)
     if registry is None:
         registry = {}
@@ -81,6 +82,9 @@ def constructing(instance: Any) -> Iterator[Any]:
     instance and per thread, and closed even if the constructor raises, so a
     half-built object left behind by a failure is as immutable as a finished one.
 
+    Windows on one instance nest: an inner block leaves the outer one open, since
+    what closes a window is the last exit rather than the first.
+
     :class:`~probpipe.core.tracked.TrackedTerm`'s metaclass opens this around
     every construction, so a term's ``__init__`` assigns normally. Code that
     allocates with ``object.__new__`` and then calls a constructor by hand has to
@@ -88,11 +92,16 @@ def constructing(instance: Any) -> Iterator[Any]:
     """
     registry = _constructing_now()
     key = id(instance)
-    registry[key] = instance
+    _, depth = registry.get(key, (instance, 0))
+    registry[key] = (instance, depth + 1)
     try:
         yield instance
     finally:
-        registry.pop(key, None)
+        held, depth = registry[key]
+        if depth > 1:
+            registry[key] = (held, depth - 1)
+        else:
+            del registry[key]
 
 
 def decoupled_container(container: Any) -> Any:

--- a/probpipe/core/_immutable.py
+++ b/probpipe/core/_immutable.py
@@ -131,6 +131,16 @@ class Immutable:
     left out and unset on the copy; those named in :attr:`_decoupled_state` are
     restored into a container of their own.
 
+    ``pickle`` additionally requires the object's class to be **importable by
+    name**, since that is what a pickle stores. A class built at runtime — the
+    per-capability subclasses some distribution families generate — is not, and
+    pickling an instance of one raises :exc:`pickle.PicklingError`. This is a
+    property of the class, not of this mixin: the default protocol names the
+    class too, so such an object was already unpicklable. ``copy`` and
+    ``deepcopy`` hold the class object itself rather than its name and are
+    unaffected; ``cloudpickle``, which serializes a class by value, also handles
+    them.
+
     Attributes
     ----------
     _transient_state : tuple of str

--- a/probpipe/core/_immutable.py
+++ b/probpipe/core/_immutable.py
@@ -5,21 +5,94 @@ instances cannot be modified after construction. It supplies the assignment
 guard and, because an object that refuses assignment cannot be restored the way
 ``pickle`` and ``copy`` restore an ordinary one, the state round-trip those need.
 
-Every tracked term is immutable (``C2 – Functional interface over immutable
-objects``), as is :class:`~probpipe.core.event_template.EventTemplate`, which is
+:class:`~probpipe.core.tracked.TrackedTerm` inherits it, so a term is immutable by
+being one (``C2 – Functional interface over immutable objects``);
+:class:`~probpipe.core.event_template.EventTemplate` mixes it in directly, being
 immutable without being a term.
 
-Interim: the mixin is inherited by ``Record``, ``EventTemplate``, ``Batch``, and
-``Function``, the classes that enforced immutability individually. The rest of
-the tracked terms accept assignment until :class:`TrackedTerm` inherits it, which
-also requires the terms that mutate after construction to stop.
+One layer is exempt for now:
+:class:`~probpipe.core._distribution_base.Distribution` permits assignment, since
+the documented way to build an emulator is to subclass a random function and
+train it in place, and fitting has no contract yet that returns a new term
+instead. Deleting that one method turns the guard on for the layer.
+
+A constructor still has to write, so construction runs inside
+:func:`constructing`, a per-instance window in which assignment is allowed.
+``TrackedTerm``'s metaclass opens it around every construction; code that
+allocates with ``object.__new__`` and calls a constructor by hand opens it
+itself.
 """
 
 from __future__ import annotations
 
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any, ClassVar
 
-__all__ = ["Immutable"]
+__all__ = ["Immutable", "constructing", "declared_state_names"]
+
+
+def declared_state_names(cls: type, declaration: str) -> frozenset[str]:
+    """The union of a state declaration over every class in *cls*'s MRO.
+
+    Parameters
+    ----------
+    cls : type
+        The class whose hierarchy is read.
+    declaration : str
+        ``"_transient_state"`` or ``"_decoupled_state"``.
+
+    Returns
+    -------
+    frozenset of str
+        Every attribute name any class in the hierarchy declares, so a subclass
+        adds to its base's entries rather than restating them.
+
+    Notes
+    -----
+    At module level rather than on :class:`Immutable` because the declarations
+    describe how a class *copies*, which holds whether or not it also refuses
+    assignment: :meth:`__getstate__` reads them, and so may any other copy path.
+    """
+    return frozenset(name for klass in cls.__mro__ for name in klass.__dict__.get(declaration, ()))
+
+
+# Instances whose constructor is running on this thread, keyed by ``id``. The
+# instance is the value, not just the key: holding it keeps the id from being
+# reused by another object while the constructor is still on the stack.
+_under_construction = threading.local()
+
+
+def _constructing_now() -> dict[int, Any]:
+    registry = getattr(_under_construction, "registry", None)
+    if registry is None:
+        registry = {}
+        _under_construction.registry = registry
+    return registry
+
+
+@contextmanager
+def constructing(instance: Any) -> Iterator[Any]:
+    """Allow attribute assignment on *instance* for the duration of the block.
+
+    The window construction runs in: an immutable object is built by assigning to
+    it, and it belongs to nobody until its constructor returns. Opened per
+    instance and per thread, and closed even if the constructor raises, so a
+    half-built object left behind by a failure is as immutable as a finished one.
+
+    :class:`~probpipe.core.tracked.TrackedTerm`'s metaclass opens this around
+    every construction, so a term's ``__init__`` assigns normally. Code that
+    allocates with ``object.__new__`` and then calls a constructor by hand has to
+    open it itself.
+    """
+    registry = _constructing_now()
+    key = id(instance)
+    registry[key] = instance
+    try:
+        yield instance
+    finally:
+        registry.pop(key, None)
 
 
 def decoupled_container(container: Any) -> Any:
@@ -44,8 +117,10 @@ class Immutable:
     """Mixin declaring that instances cannot be modified after construction.
 
     Assignment and deletion raise :exc:`AttributeError`, naming the class of the
-    object that was touched. A constructor writes through
-    ``object.__setattr__``, which the guard does not intercept.
+    object that was touched — except inside :func:`constructing`, the window an
+    object is built in, which a host's constructor may assign freely within.
+    Writing through ``object.__setattr__`` also goes around the guard, and is
+    what code outside a constructor uses when it has to.
 
     ``copy.copy``, ``copy.deepcopy``, and ``pickle`` return an object of the same
     class holding the same state: every attribute the original has assigned,
@@ -93,6 +168,9 @@ class Immutable:
     # -- The guard -----------------------------------------------------------
 
     def __setattr__(self, name: str, value: Any) -> None:
+        if id(self) in _constructing_now():
+            object.__setattr__(self, name, value)
+            return
         raise AttributeError(f"{type(self).__name__} is immutable")
 
     def __delattr__(self, name: str) -> None:

--- a/probpipe/core/_immutable.py
+++ b/probpipe/core/_immutable.py
@@ -11,10 +11,12 @@ being one (``C2 – Functional interface over immutable objects``);
 immutable without being a term.
 
 One layer is exempt for now:
-:class:`~probpipe.core._distribution_base.Distribution` permits assignment, since
-the documented way to build an emulator is to subclass a random function and
-train it in place, and fitting has no contract yet that returns a new term
-instead. Deleting that one method turns the guard on for the layer.
+:class:`~probpipe.core._distribution_base.Distribution` permits assignment and
+deletion, since the documented way to build an emulator is to subclass a random
+function and train it in place, and fitting has no contract yet that returns a
+new term instead. Deleting **both** of its overrides — ``__setattr__`` and
+``__delattr__`` — turns the guard on for the layer; dropping one leaves half an
+exemption, which is how it was first written.
 
 A constructor still has to write, so construction runs inside
 :func:`constructing`, a per-instance window in which assignment is allowed.

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -44,7 +44,6 @@ from ._function_contract import (
     _validate_function_templates,
     _wrap_declared_function_output,
 )
-from ._immutable import Immutable
 from ._record_batch import RecordBatch
 from .event_template import ArraySpec, EventTemplate, _concretize_event_template
 from .provenance import Provenance
@@ -188,7 +187,7 @@ class Node(ABC):  # noqa: B024
         return self._inputs
 
 
-class Function(Node, Immutable, TrackedTerm, Annotated):
+class Function(Node, TrackedTerm, Annotated):
     """
     An immutable, tracked executable DAG node wrapping one implementation.
 

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -45,7 +45,6 @@ import numpy as np
 
 from ..custom_types import ArrayLike
 from ._array_backend import _metadata_of, _numpy_dtype_of, _to_numpy_array, array_backend_for
-from ._immutable import Immutable
 from .event_template import (
     EventTemplate,
     NumericEventTemplate,
@@ -158,7 +157,7 @@ def _canonical_dtype_str(leaf: Any) -> str:
 _RESERVED_INIT_KWARGS = frozenset({"event_template", "name_is_auto", "_validate_leaves"})
 
 
-class Record(NamedTree[Any], Immutable, TrackedTerm, Annotated):
+class Record(NamedTree[Any], TrackedTerm, Annotated):
     """A single structured value with metadata.
 
     A ``Record`` holds a single concrete value: an ordered, named collection

--- a/probpipe/core/tracked.py
+++ b/probpipe/core/tracked.py
@@ -31,7 +31,7 @@ from collections.abc import Mapping
 # exposes; the conflict-avoidance constraint itself doesn't change.
 from typing import Any, Self, _ProtocolMeta
 
-from ._immutable import decoupled_container
+from ._immutable import Immutable, constructing, decoupled_container
 from .provenance import Provenance
 
 __all__ = ["Annotated", "TrackedTerm", "auto_name"]
@@ -77,8 +77,13 @@ def _decoupled_annotations(annotations: Mapping[str, Any]) -> Mapping[str, Any]:
 
 
 class _TrackedTermMeta(_ProtocolMeta):
-    """Metaclass enforcing that every ``TrackedTerm`` instance has a
-    non-empty ``name`` set by the time construction returns.
+    """Metaclass running construction in a window, and enforcing a non-empty name.
+
+    A tracked term is immutable, so it can only be built by assigning to it
+    before anyone holds it. This runs ``__init__`` inside
+    :func:`~probpipe.core._immutable.constructing`, which is what lets a
+    constructor assign normally while assignment anywhere else raises. The window
+    is per instance and per thread, and closes even when ``__init__`` raises.
 
     The check runs after ``__init__`` so it covers every construction
     path: classes that call ``super().__init__(name=...)``, classes that
@@ -95,7 +100,19 @@ class _TrackedTermMeta(_ProtocolMeta):
     """
 
     def __call__(cls, *args: Any, **kwargs: Any) -> Any:
-        instance = super().__call__(*args, **kwargs)
+        # ``type.__call__``, split so the window can be opened between the two
+        # halves: allocation first, then ``__init__`` inside it. A host's
+        # ``__new__`` may resolve to a subclass, and as ``type.__call__`` does,
+        # ``__init__`` runs only when it returns an instance of *cls*.
+        if cls.__new__ is object.__new__:
+            instance = cls.__new__(cls)
+        else:
+            instance = cls.__new__(cls, *args, **kwargs)
+        if isinstance(instance, cls):
+            with constructing(instance):
+                returned = instance.__init__(*args, **kwargs)
+            if returned is not None:
+                raise TypeError(f"__init__() should return None, not {type(returned).__name__!r}")
         name = getattr(instance, "_name", None)
         if not isinstance(name, str) or not name:
             raise TypeError(
@@ -107,7 +124,7 @@ class _TrackedTermMeta(_ProtocolMeta):
         return instance
 
 
-class TrackedTerm(metaclass=_TrackedTermMeta):
+class TrackedTerm(Immutable, metaclass=_TrackedTermMeta):
     """Identity mixin: a :attr:`name` and a write-once :attr:`provenance`.
 
     A ``TrackedTerm`` object carries, alongside its mathematical content, the two
@@ -130,6 +147,13 @@ class TrackedTerm(metaclass=_TrackedTermMeta):
     :meth:`with_provenance`, and a subsequent attempt raises. Transformations
     that build a new object attach fresh provenance to the result instead of
     rewriting the input's.
+
+    A tracked term is **immutable**
+    (:class:`~probpipe.core._immutable.Immutable`): assignment and deletion raise
+    once its constructor has returned, and an operation that changes anything
+    returns a new term. Construction assigns inside the window the metaclass
+    opens, so a host's ``__init__`` is written normally. The distribution layer
+    is exempt for now, for the reason its ``__setattr__`` gives.
 
     Attributes
     ----------

--- a/tests/core/test_immutable.py
+++ b/tests/core/test_immutable.py
@@ -304,15 +304,26 @@ class TestEveryTrackedTermIsImmutable:
         ]
         assert exempt == [Distribution.__name__]
 
-    def test_a_distribution_still_accepts_assignment(self):
+    def test_a_distribution_still_accepts_assignment_and_deletion(self):
         # The interim exemption, asserted rather than assumed: training an
         # emulator in place is the documented pattern until fitting has a
-        # contract that returns a new term instead.
+        # contract that returns a new term instead. Both operations, since an
+        # exemption covering only assignment would still break a trainer that
+        # clears what it fitted.
         from probpipe import Normal
 
         term = Normal(0.0, 1.0, name="x")
         term._trained = True
         assert term._trained is True
+        del term._trained
+        assert not hasattr(term, "_trained")
+
+    def test_a_term_outside_that_layer_refuses_both(self):
+        term = Record("r", {"x": jnp.ones(2)})
+        with pytest.raises(AttributeError, match="Record is immutable"):
+            term.attribute = 1
+        with pytest.raises(AttributeError, match="Record is immutable"):
+            del term._name
 
     def test_a_term_outside_that_layer_refuses_assignment_and_names_itself(self):
         term = RecordBatch.stack(
@@ -340,24 +351,35 @@ class TestTheConstructionWindow:
         with pytest.raises(TypeError, match="should return None"):
             Returning()
 
-    def test_it_closes_when_the_constructor_raises(self):
+    def test_it_closes_when_a_constructor_raises(self):
+        # Through the metaclass rather than by opening the window by hand: what
+        # is under test is that ``_TrackedTermMeta.__call__`` closes the window
+        # on the way out of a failing ``__init__``. The half-built object is
+        # kept from ``__new__``, since the failed call returns nothing.
         from probpipe.core._immutable import _constructing_now
+        from probpipe.core.tracked import TrackedTerm
 
-        class Failing(Immutable):
-            __slots__ = ("value",)
+        built = []
+
+        class Failing(TrackedTerm):
+            def __new__(cls):
+                instance = super().__new__(cls)
+                built.append(instance)
+                return instance
 
             def __init__(self):
-                object.__setattr__(self, "value", 1)
+                self._init_tracked("failing")
+                self.partial = 1
                 raise ValueError("no")
 
-        from probpipe.core._immutable import constructing
+        with pytest.raises(ValueError, match="no"):
+            Failing()
 
-        instance = object.__new__(Failing)
-        with pytest.raises(ValueError), constructing(instance):
-            instance.__init__()
+        (half_built,) = built
+        assert half_built.partial == 1  # the constructor got that far
         assert _constructing_now() == {}
         with pytest.raises(AttributeError, match="Failing is immutable"):
-            instance.value = 2
+            half_built.partial = 2
 
     def test_it_covers_one_instance_and_not_another(self):
         from probpipe.core._immutable import constructing

--- a/tests/core/test_immutable.py
+++ b/tests/core/test_immutable.py
@@ -369,13 +369,33 @@ class TestTheConstructionWindow:
             with pytest.raises(AttributeError, match="Slotted is immutable"):
                 inner.left = 1  # and on this one it is not
 
-    def test_a_nested_construction_leaves_the_outer_window_open(self):
+    def test_a_window_on_one_instance_nests(self):
+        # An inner block must leave the outer one open: what closes a window is
+        # the last exit, not the first. Reached whenever a constructor that
+        # already runs in a window opens one on itself — through a helper that
+        # allocates and initializes, say.
+        from probpipe.core._immutable import _constructing_now, constructing
+
+        instance = object.__new__(Slotted)
+        with constructing(instance):
+            with constructing(instance):
+                instance.left = 1
+            instance.right = 2  # still inside the outer window
+        assert (instance.left, instance.right) == (1, 2)
+        assert _constructing_now() == {}
+        with pytest.raises(AttributeError, match="Slotted is immutable"):
+            instance.left = 3
+
+    def test_constructing_a_term_inside_another_leaves_both_correct(self):
         from probpipe import Normal, ProductDistribution
 
-        # The joint's constructor builds nothing itself, but component
-        # construction runs inside it, and its window must survive theirs.
+        # Different instances rather than one nested in itself: the components
+        # are built first, and the joint's own window is unaffected by theirs.
+        # (A distribution accepts assignment either way — see the exemption
+        # above — so what is asserted is that both terms came out intact.)
         joint = ProductDistribution(a=Normal(0.0, 1.0, name="a"), name="j")
         assert joint.name == "j"
+        assert joint.components["a"].name == "a"
 
 
 class TestAClassBuiltAtRuntime:

--- a/tests/core/test_immutable.py
+++ b/tests/core/test_immutable.py
@@ -251,3 +251,128 @@ class TestTheHostsInTheTree:
 
         assert double(2.0) is not None
         assert not getattr(double, "_initializing", False)
+
+
+class TestEveryTrackedTermIsImmutable:
+    """The guarantee, over every tracked term the package defines.
+
+    Discovered rather than listed: a term added later is covered without anyone
+    remembering to add it here, which is what keeps the rule from decaying back
+    into the per-class opt-in it replaced.
+    """
+
+    @staticmethod
+    def every_tracked_class() -> list[type]:
+        import importlib
+        import pkgutil
+
+        import probpipe
+        from probpipe.core.tracked import TrackedTerm
+
+        for module in pkgutil.walk_packages(probpipe.__path__, "probpipe."):
+            try:
+                importlib.import_module(module.name)
+            except ImportError:
+                continue  # an optional backend that is not installed
+
+        seen: set[type] = set()
+
+        def collect(cls: type) -> None:
+            for subclass in cls.__subclasses__():
+                if subclass not in seen:
+                    seen.add(subclass)
+                    collect(subclass)
+
+        collect(TrackedTerm)
+        return sorted(seen, key=lambda c: c.__name__)
+
+    def test_the_mixin_is_in_every_tracked_term_s_mro(self):
+        offenders = [c.__name__ for c in self.every_tracked_class() if not issubclass(c, Immutable)]
+        assert offenders == []
+
+    def test_the_only_exemption_is_the_distribution_layer(self):
+        # A class defining its own ``__setattr__`` is back to the per-class rule,
+        # and free to disagree with the message or the exception. Exactly one
+        # does, deliberately and temporarily, and this is what stops a second
+        # from appearing quietly.
+        from probpipe.core._distribution_base import Distribution
+
+        exempt = [
+            c.__name__
+            for c in self.every_tracked_class()
+            if "__setattr__" in c.__dict__ or "__delattr__" in c.__dict__
+        ]
+        assert exempt == [Distribution.__name__]
+
+    def test_a_distribution_still_accepts_assignment(self):
+        # The interim exemption, asserted rather than assumed: training an
+        # emulator in place is the documented pattern until fitting has a
+        # contract that returns a new term instead.
+        from probpipe import Normal
+
+        term = Normal(0.0, 1.0, name="x")
+        term._trained = True
+        assert term._trained is True
+
+    def test_a_term_outside_that_layer_refuses_assignment_and_names_itself(self):
+        term = RecordBatch.stack(
+            [Record("r", {"x": jnp.ones(2)}, name_is_auto=True)] * 2, level_name="draw"
+        )
+        with pytest.raises(AttributeError, match="RecordBatch is immutable"):
+            term.attribute = 1
+
+
+class TestTheConstructionWindow:
+    def test_it_closes_when_the_constructor_returns(self):
+        term = Record("r", {"x": jnp.ones(2)})
+        with pytest.raises(AttributeError):
+            term.attribute = 1
+
+    def test_an_init_that_returns_a_value_is_refused(self):
+        # ``type.__call__`` raises on this, and splitting it must not lose that.
+        from probpipe.core.tracked import TrackedTerm
+
+        class Returning(TrackedTerm):
+            def __init__(self):
+                self._init_tracked("t")
+                return "oops"
+
+        with pytest.raises(TypeError, match="should return None"):
+            Returning()
+
+    def test_it_closes_when_the_constructor_raises(self):
+        from probpipe.core._immutable import _constructing_now
+
+        class Failing(Immutable):
+            __slots__ = ("value",)
+
+            def __init__(self):
+                object.__setattr__(self, "value", 1)
+                raise ValueError("no")
+
+        from probpipe.core._immutable import constructing
+
+        instance = object.__new__(Failing)
+        with pytest.raises(ValueError), constructing(instance):
+            instance.__init__()
+        assert _constructing_now() == {}
+        with pytest.raises(AttributeError, match="Failing is immutable"):
+            instance.value = 2
+
+    def test_it_covers_one_instance_and_not_another(self):
+        from probpipe.core._immutable import constructing
+
+        inner = object.__new__(Slotted)
+        outer = object.__new__(Slotted)
+        with constructing(outer):
+            outer.left = 1  # the window is open on this one
+            with pytest.raises(AttributeError, match="Slotted is immutable"):
+                inner.left = 1  # and on this one it is not
+
+    def test_a_nested_construction_leaves_the_outer_window_open(self):
+        from probpipe import Normal, ProductDistribution
+
+        # The joint's constructor builds nothing itself, but component
+        # construction runs inside it, and its window must survive theirs.
+        joint = ProductDistribution(a=Normal(0.0, 1.0, name="a"), name="j")
+        assert joint.name == "j"

--- a/tests/core/test_immutable.py
+++ b/tests/core/test_immutable.py
@@ -376,3 +376,74 @@ class TestTheConstructionWindow:
         # construction runs inside it, and its window must survive theirs.
         joint = ProductDistribution(a=Normal(0.0, 1.0, name="a"), name="j")
         assert joint.name == "j"
+
+
+class TestAClassBuiltAtRuntime:
+    """What the round-trip does for a class that has no importable name.
+
+    Some distribution families build a subclass per capability set, so the class
+    an instance reports exists only in memory. ``pickle`` stores a class by name
+    and therefore cannot store these; the mixin does not change that, since the
+    default protocol names the class too. These pin the behavior so a change to
+    it is deliberate.
+    """
+
+    @staticmethod
+    def _sequential_joint():
+        from probpipe import Normal, SequentialJointDistribution
+
+        return SequentialJointDistribution(
+            z=Normal(loc=0.0, scale=1.0, name="z"),
+            x=lambda z: Normal(loc=z, scale=0.5, name="x"),
+        )
+
+    @staticmethod
+    def _flattened_view():
+        from probpipe import Normal, ProductDistribution
+
+        joint = ProductDistribution(
+            a=Normal(0.0, 1.0, name="a"), b=Normal(1.0, 2.0, name="b"), name="j"
+        )
+        return joint.as_flat_distribution()
+
+    @pytest.fixture(
+        params=[
+            pytest.param("_sequential_joint", id="sequential-joint"),
+            pytest.param("_flattened_view", id="flattened-view"),
+        ]
+    )
+    def runtime_classed(self, request):
+        return getattr(self, request.param)()
+
+    def test_its_class_is_not_importable_by_name(self, runtime_classed):
+        import importlib
+
+        cls = type(runtime_classed)
+        module = importlib.import_module(cls.__module__)
+        assert getattr(module, cls.__qualname__, None) is not cls
+
+    def test_standard_pickle_refuses_it(self, runtime_classed):
+        with pytest.raises(pickle.PicklingError):
+            pickle.dumps(runtime_classed)
+
+    def test_copy_and_deepcopy_still_work(self, runtime_classed):
+        # They hold the class object rather than its name.
+        assert type(copy.copy(runtime_classed)) is type(runtime_classed)
+        assert type(copy.deepcopy(runtime_classed)) is type(runtime_classed)
+
+    def test_cloudpickle_handles_it(self, runtime_classed):
+        # It serializes the class by value, which is what the Ray and Prefect
+        # paths rely on.
+        cloudpickle = pytest.importorskip("cloudpickle")
+        restored = pickle.loads(cloudpickle.dumps(runtime_classed))
+        assert type(restored).__name__ == type(runtime_classed).__name__
+
+    def test_a_family_that_reconstructs_through_a_factory_pickles(self):
+        # ``ProductDistribution`` keeps its own ``__reduce__`` naming a
+        # module-level rebuild, so its runtime class is never named in a pickle.
+        from probpipe import Normal, ProductDistribution
+
+        joint = ProductDistribution(
+            a=Normal(0.0, 1.0, name="a"), b=Normal(1.0, 2.0, name="b"), name="j"
+        )
+        assert type(pickle.loads(pickle.dumps(joint))).__name__ == type(joint).__name__


### PR DESCRIPTION
## Summary

`TrackedTerm` inherits `Immutable`, so a record, a batch, a function, or a template is immutable **by being a term** rather than by mixing the guard in itself. `Record`, `Function`, and `Batch` drop it from their base lists, where inheriting it twice would be an MRO conflict.

Construction runs inside a per-instance window the metaclass opens, so a host's `__init__` assigns normally and **no constructor needed converting**. The metaclass already wrapped construction to check the name; it now splits `type.__call__` to open the window between allocation and initialisation, keeping both rules that split has to preserve — `__init__` runs only when `__new__` returns an instance of the class (which every host selecting a subclass from its arguments relies on), and an `__init__` returning anything but `None` raises as it would through `type.__call__`. The window closes when `__init__` returns **and when it raises**, so a half-built term left by a failure is as immutable as a finished one.

**Nothing changes for a caller.** The same four families refuse assignment as before, and a distribution still accepts it — verified side by side against #414's head. What changes is where the rule lives, and that extending it becomes a deletion rather than seventy-two edits.

## The distribution layer is exempt, deliberately

`Distribution` permits assignment and deletion. The documented way to build an emulator is to subclass a random function and train it in place — `GPEmulator.fit()` and `FittedPolynomial.fit()` in `docs/user_guide/10_random_functions_and_emulators.ipynb` assign `self._X_train`, `self._K_inv`, `self._weights` — and fitting has no contract yet that returns a new term instead. Enforcing here would break that pattern without offering a replacement, and the replacement is what #370 ("define a controlled fitted-mapping producer contract") is for.

It is two overrides — `__setattr__` and `__delattr__`, since a trainer that clears what it fitted needs both. Removing **both** turns the guard on for the other **72** classes, which is 72 of the 84 tracked terms; the 12 outside the distribution branch are exactly the families already guarded, and removing only one would leave half an exemption. A test asserts `Distribution` is the *only* exempt class, so a second cannot appear quietly.

## Linked issue(s)

Part of #395, landing the mechanism and the structural rule while the distribution layer waits on #370.

**#412 and #413 have merged**, so this now targets `main` directly. It still comes *before* the memo work in #414 rather than after. That ordering is the fix for a defect review found: #414 declares its memo transient, and only a term that goes through `Immutable`'s state round-trip honours that declaration — which is what this PR gives the distribution layer. With the old order, #414's own head shared a memo across `copy`, `deepcopy`, and `pickle` while honouring the declaration in `with_name`, so it violated its own contract until this landed on top. Reversed, each PR is correct where it sits.

(Opened in place of #415, which GitHub closed when the branch rewrite put its commit inside the old base.)

**#395 stays open** for the exemption's removal.

## What a pickle needs from a class

Raised in review: the round-trip this documents cannot serialize a class built at runtime, which is what several distribution families generate. Compared against `main` — those classes already raise `PicklingError` there, since the default protocol names the class too — so the limit is pre-existing and the mixin neither causes nor fixes it. The contract wording was the defect, and now states it, along with what is unaffected: `copy` and `deepcopy` hold the class object rather than its name, and `cloudpickle` serializes it by value, which is the path Ray and Prefect take. `TestAClassBuiltAtRuntime` pins all four behaviors. Reconstruction for those families is #417.

## Breaking changes

None. (An earlier revision of this branch enforced the guard everywhere; that broke the emulator workflow and is what this scope replaces.)

## Test plan

`tests/core/test_immutable.py` gains 18 tests:

- **the conformance tests the rule rests on** — every `TrackedTerm` subclass, *discovered by walking the package* rather than listed, inherits `Immutable`; `Distribution` is the only class with its own `__setattr__`; a distribution accepts assignment and a batch does not, both asserted rather than assumed;
- **the window**: closes when the constructor returns; closes when it *raises*, leaving the half-built object immutable and the registry empty; covers one instance and not another built alongside it; a nested construction leaves the outer window open; an `__init__` that returns a value raises `TypeError`.

4740 passed, 53 skipped. `ruff format` / `ruff check` clean. **The `notebooks (user_guide)` job is the one that matters here** — the emulator notebook executes cleanly against this branch (exit 0), which is what the earlier revision broke.

## Documentation

- [x] Docstrings updated for changed public APIs
- [ ] User Guide / tutorials updated where relevant
- [x] CHANGELOG entry added under `Unreleased → Changed`

`TrackedTerm`'s docstring states the guarantee and names the exemption; `_immutable.py` says which layer is exempt and what removes it. `design/02` §II.4 describes the target and needs no change — per `CONTRACTS.md` directive 5, the interim state is labelled in the code rather than written into the design.

## Contract checklist

- [x] Contract of every touched abstraction was clear before coding; the one that was not — what a fitted mapping does to its term — is the reason for the exemption rather than something guessed at.
- [x] The changed contract is documented where it lives: `TrackedTerm` says a term is immutable and that construction assigns inside the window; `constructing` says what the window is and who opens it; `Distribution.__setattr__` says why it is exempt and what removes it.
- [x] Docstring openings lead with the API; rationale deferred.
- [x] Code verified to obey the documented contract; the conformance test asserts it over the whole package rather than a sample.
- [x] Docstrings describe the target contract, with the interim state labelled as such.
- [x] Variable names follow the canonical table.
- [x] `CONTRACTS.md` index already carries the immutability row (added in #413).
- [x] `ruff format` and `ruff check` clean.

## Checklist

- [x] PR title follows `<type>(<scope>): <subject>`.
- [x] At least one `area:*` label is applied.
- [x] Linked to the tracking issue above.




