### PR TITLE
feat(core): add NumericArray and NumericArrayBatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,11 +86,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   later change.
 
   `NumericArray` holds one array and carries no batch axes, so its `shape` is the
-  event shape. It carries the full array surface, and **arithmetic on it yields a
-  bare array** — identity is attached by operations, and arithmetic is not one.
-  It is a registered pytree, which is what lets it cross a `jit` or `vmap`
-  boundary; its spec is re-derived from the array that arrives, since a shape and
-  a dtype state it exactly.
+  event shape. Construction **validates without converting** — the value is stored
+  in its native form and materialises at most once, at the compute boundary — the
+  rule `NumericRecord` already follows for its leaves. It carries the full array
+  surface, and **arithmetic yields a bare value of the stored type**: identity is
+  attached by operations, and arithmetic is not one. It is a registered pytree,
+  which is what lets it cross a `jit` or `vmap` boundary; the boundary presents a
+  bare array, and its spec is re-derived from what arrives, since a shape and a
+  dtype state it exactly.
 
   `NumericArrayBatch` stores one array with the batch axes leading and splits
   them from the event axes by its element spec. Selection yields a `NumericArray`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   `NumericArrayBatch` stores one array with the batch axes leading and splits
   them from the event axes by its element spec, which it validates the stored
-  dtype against at construction — the batch asserts that spec of every element.
+  dtype against at construction — the batch asserts that spec of every element,
+  so a store that reports no single dtype cannot carry a pinned one either.
   Selection yields a `NumericArray` under the derived name, as `RecordBatch`
   yields a `Record`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call, retain the resulting joint distribution, or materialize and reuse
   samples explicitly when a shared realization is required.
 
+### Added
+
+- **`NumericArray` and `NumericArrayBatch` (#398).** The tracked class of the
+  numeric-array kind and its batch form, so `NumericArraySpec` has the pair every
+  other value spec has. Nothing returns them yet; the operations switch over in a
+  later change.
+
+  `NumericArray` holds one array and carries no batch axes, so its `shape` is the
+  event shape. It carries the full array surface, and **arithmetic on it yields a
+  bare array** — identity is attached by operations, and arithmetic is not one.
+  It is a registered pytree, which is what lets it cross a `jit` or `vmap`
+  boundary; its spec is re-derived from the array that arrives, since a shape and
+  a dtype state it exactly.
+
+  `NumericArrayBatch` stores one array with the batch axes leading and splits
+  them from the event axes by its element spec. Selection yields a `NumericArray`
+  under the derived name, as `RecordBatch` yields a `Record`.
+
+### Changed
+
+- **`ArraySpec` is renamed `NumericArraySpec` (#398).** The spec now agrees with
+  the class it names, as `RecordSpec`/`Record` does. `Array` remains the type
+  alias for a bare backend array.
+
 ### Changed
 
 - **Design: every value spec has a tracked class (#398).** `ArraySpec` gains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,8 +96,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dtype state it exactly.
 
   `NumericArrayBatch` stores one array with the batch axes leading and splits
-  them from the event axes by its element spec. Selection yields a `NumericArray`
-  under the derived name, as `RecordBatch` yields a `Record`.
+  them from the event axes by its element spec, which it validates the stored
+  dtype against at construction — the batch asserts that spec of every element.
+  Selection yields a `NumericArray` under the derived name, as `RecordBatch`
+  yields a `Record`.
+
+- **`ArrayBackend.take` — positional selection for a native container.** `[]` is
+  positional on a numpy-protocol container and reads *labels* on a `pandas` one,
+  so a batch stored as a `DataFrame` could not address its own elements. Backends
+  now declare how to select by position, defaulting to `obj[index]`; the built-in
+  `pandas` backends select through `.iloc`.
 
 ### Changed
 

--- a/docs/api/records.md
+++ b/docs/api/records.md
@@ -93,7 +93,7 @@ keeps its dims / coords / attrs, a `pandas` object its index / columns /
 dtypes) and converts to `jax.Array` lazily at the compute boundary.
 Containers speaking the numpy protocol need no registration; registering an
 `ArrayBackend` makes any other container type a first-class numeric leaf —
-recognised by template inference and `ArraySpec.is_valid`, promoted,
+recognised by template inference and `NumericArraySpec.is_valid`, promoted,
 converted at the boundary, and fingerprinted by content.
 
 ::: probpipe.register_array_backend

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -92,10 +92,10 @@ from probpipe.core.distribution import (
     set_return_approx_dist,
 )
 from probpipe.core.event_template import (
-    ArraySpec,
     DistributionSpec,
     EventTemplate,
     FunctionSpec,
+    NumericArraySpec,
     NumericEventTemplate,
     OpaqueSpec,
     RecordSpec,
@@ -213,7 +213,6 @@ __all__ = [
     "ApproximateDistribution",
     "ArrayBackend",
     "ArrayRandomFunction",
-    "ArraySpec",
     "Batch",
     "BatchSpec",
     # Array-backend registry
@@ -277,6 +276,7 @@ __all__ = [
     "NegativeBinomial",
     # Continuous
     "Normal",
+    "NumericArraySpec",
     "NumericEventTemplate",
     "NumericJointEmpirical",
     "NumericRandomMeasure",

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -40,6 +40,8 @@ from probpipe.core._array_backend import (
 from probpipe.core._batch import Batch, BatchSpec
 from probpipe.core._distribution_array import DistributionArray
 from probpipe.core._function_batch import FunctionBatch
+from probpipe.core._numeric_array import NumericArray
+from probpipe.core._numeric_array_batch import NumericArrayBatch
 from probpipe.core._numeric_record import NumericRecord
 from probpipe.core._numeric_record_batch import NumericRecordBatch
 from probpipe.core._opaque_batch import OpaqueBatch
@@ -276,6 +278,8 @@ __all__ = [
     "NegativeBinomial",
     # Continuous
     "Normal",
+    "NumericArray",
+    "NumericArrayBatch",
     "NumericArraySpec",
     "NumericEventTemplate",
     "NumericJointEmpirical",

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -147,6 +147,14 @@ class ArrayBackend:
     to_numpy : callable, optional
         ``to_numpy(obj) -> np.ndarray`` — the fingerprint materialisation.
         Defaults to ``np.asarray(obj)``.
+    take : callable, optional
+        ``take(obj, index) -> Any`` — **positional** selection along the
+        leading axes, where *index* is a tuple of ints and slices, one per
+        leading axis. Defaults to ``obj[index]``, which is positional for a
+        numpy-protocol container. A container whose ``[]`` means something else
+        must override it: ``pandas`` reads labels there, so its backend selects
+        through ``.iloc``. This is what lets a batch address its elements by
+        position without materialising the whole store.
     metadata : callable, optional
         ``metadata(obj) -> Any`` — the container's **identity-bearing
         metadata beyond its values** (an ``xarray`` array's dims / coords /
@@ -167,6 +175,7 @@ class ArrayBackend:
     is_numeric: Callable[[Any], bool] = field(kw_only=True, default=lambda obj: True)
     to_jax: Callable[[Any], jax.Array] = field(kw_only=True, default=_default_to_jax)
     to_numpy: Callable[[Any], np.ndarray] = field(kw_only=True, default=_default_to_numpy)
+    take: Callable[[Any, tuple], Any] = field(kw_only=True, default=lambda obj, index: obj[index])
     metadata: Callable[[Any], Any] = field(kw_only=True, default=lambda obj: None)
 
 
@@ -315,6 +324,20 @@ def _numpy_dtype_of(value: Any) -> np.dtype | None:
     if nd is None:
         nd = np.asarray(value).dtype
     return nd
+
+
+def _take_at(value: Any, index: tuple) -> Any:
+    """Select positionally along *value*'s leading axes.
+
+    The one place positional selection happens, so a container whose ``[]``
+    means something other than position — a ``pandas`` object, where it reads
+    labels — is addressed through its backend rather than by a caller that
+    happens to know.
+    """
+    backend = array_backend_for(value)
+    if backend is not None:
+        return backend.take(value, index)
+    return value[index]
 
 
 def _to_numpy_array(value: Any) -> np.ndarray:
@@ -483,6 +506,7 @@ def _register_pandas() -> None:
             is_numeric=lambda s: _column_numeric(s.dtype),
             to_jax=lambda s: jnp.asarray(_dense(s, (s.dtype,))),
             to_numpy=lambda s: _dense(s, (s.dtype,)),
+            take=lambda obj, index: obj.iloc[index],
             metadata=_series_metadata,
         ),
     )
@@ -511,6 +535,7 @@ def _register_pandas() -> None:
             is_numeric=_frame_is_numeric,
             to_jax=lambda df: jnp.asarray(_dense(df, df.dtypes)),
             to_numpy=lambda df: _dense(df, df.dtypes),
+            take=lambda obj, index: obj.iloc[index],
             metadata=_frame_metadata,
         ),
     )

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -21,7 +21,7 @@ type, how to answer the four questions every numeric gate asks:
 * ``to_jax(obj)`` / ``to_numpy(obj)`` — materialising conversions, used at
   the compute boundary and for content fingerprints.
 
-Every consumer — template inference and ``ArraySpec.is_valid``, the
+Every consumer — template inference and ``NumericArraySpec.is_valid``, the
 ``Record`` → ``NumericRecord`` promotion probe, the ``NumericRecord``
 conversion cache, batch stacking, and ``fingerprint()`` — resolves
 **registry first, duck-typing second**, so registering one backend makes a
@@ -179,7 +179,7 @@ def register_array_backend(leaf_type: type, backend: ArrayBackend) -> None:
     """Register *backend* as the array-backend hooks for *leaf_type*.
 
     Registering a type makes its instances first-class numeric leaves
-    everywhere at once: template inference and ``ArraySpec.is_valid``
+    everywhere at once: template inference and ``NumericArraySpec.is_valid``
     recognise them, all-numeric records holding them auto-promote to
     ``NumericRecord``, the compute boundary converts them through
     ``backend.to_jax``, batch stacking coerces them per element, and

--- a/probpipe/core/_batch.py
+++ b/probpipe/core/_batch.py
@@ -136,7 +136,7 @@ class BatchSpec(TermSpec):
     batch of opaque values carry a term spec of its own.
 
     An axis size may be a **symbolic dimension name** instead of an integer, as
-    an ``ArraySpec`` shape entry may, so that a declaration can fix the number of
+    an ``NumericArraySpec`` shape entry may, so that a declaration can fix the number of
     levels while deferring how many elements each holds — "returns a batch of
     ``S`` draws" before ``S`` is known. The names share one scope with the
     element's schema, so a batch of ``("n",)`` over arrays of shape ``("n",)`` is
@@ -1021,7 +1021,7 @@ class Batch[E](TrackedTerm, ABC):
 def _axis_size(size: Any) -> int | str:
     """An axis size as an ``int``, or a symbolic dimension name as a ``str``.
 
-    The two spellings ``ArraySpec.shape`` accepts, for the same reason: a
+    The two spellings ``NumericArraySpec.shape`` accepts, for the same reason: a
     declaration may defer a size while fixing the rank. A name must be a
     non-empty identifier, as a level name must be.
     """

--- a/probpipe/core/_batch.py
+++ b/probpipe/core/_batch.py
@@ -136,7 +136,7 @@ class BatchSpec(TermSpec):
     batch of opaque values carry a term spec of its own.
 
     An axis size may be a **symbolic dimension name** instead of an integer, as
-    an ``NumericArraySpec`` shape entry may, so that a declaration can fix the number of
+    a ``NumericArraySpec`` shape entry may, so that a declaration can fix the number of
     levels while deferring how many elements each holds — "returns a batch of
     ``S`` draws" before ``S`` is known. The names share one scope with the
     element's schema, so a batch of ``("n",)`` over arrays of shape ``("n",)`` is

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -31,8 +31,8 @@ from ._numeric_record_batch import NumericRecordBatch
 from ._object_batch import _from_iterable, _is_object_array
 from ._record_batch import RecordBatch, _batch_class_for, _MappedBatchColumns
 from .event_template import (
-    ArraySpec,
     EventTemplate,
+    NumericArraySpec,
     NumericEventTemplate,
     _full_array_shape_or_none,
 )
@@ -393,7 +393,7 @@ def _stack_declared_columns(
             # of two objects, not a numeric column whose second axis is another
             # multiplicity — reading it off the runtime shape states a batch
             # geometry the levels never described.
-            if isinstance(template[path], ArraySpec):
+            if isinstance(template[path], NumericArraySpec):
                 batched = jnp.stack(
                     [
                         _to_jax_array(value)
@@ -411,7 +411,7 @@ def _stack_declared_columns(
             # shape its values happened to have. The declared kind decides here
             # too, or that shape is read as a second multiplicity.
             batched = records[path]
-            if not isinstance(template[path], ArraySpec):
+            if not isinstance(template[path], NumericArraySpec):
                 batched = _packed_object_column(list(batched))
 
         shape = getattr(batched, "shape", ())
@@ -450,7 +450,7 @@ def _empty_declared_stack(
     """
     columns: dict[str, Any] = {}
     for path, spec in template.items():
-        if isinstance(spec, ArraySpec) and all(isinstance(size, int) for size in spec.shape):
+        if isinstance(spec, NumericArraySpec) and all(isinstance(size, int) for size in spec.shape):
             dtype = spec.dtype if spec.dtype is not None else jnp.zeros(()).dtype
             columns[path] = jnp.zeros((*batch_shape, *spec.shape), dtype=dtype)
         else:

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -362,9 +362,9 @@ def _update_value_spec(
     """Hash a built-in ValueSpec by the declaration fields that define it."""
     from ._batch import BatchSpec
     from .event_template import (
-        ArraySpec,
         DistributionSpec,
         FunctionSpec,
+        NumericArraySpec,
         OpaqueSpec,
         RecordSpec,
     )
@@ -375,7 +375,7 @@ def _update_value_spec(
     h.update(b".")
     h.update(spec_type.__qualname__.encode())
     h.update(b":")
-    if isinstance(spec, ArraySpec):
+    if isinstance(spec, NumericArraySpec):
         _update(h, spec.shape, depth + 1, max_array_bytes, state)
         h.update(b":dtype=")
         _update(

--- a/probpipe/core/_function_contract.py
+++ b/probpipe/core/_function_contract.py
@@ -16,8 +16,8 @@ from ._distribution_base import Distribution
 from ._record_batch import RecordBatch
 from .constraints import _supports_compatible
 from .event_template import (
-    ArraySpec,
     EventTemplate,
+    NumericArraySpec,
     ValueSpec,
     _concretize_event_template,
     _full_array_shape_or_none,
@@ -364,7 +364,7 @@ def _validate_batched_function_output_values(
     batch_shape = value.batch_shape
     batch_rank = len(batch_shape)
     for path, spec in template.items():
-        if not isinstance(spec, ArraySpec):
+        if not isinstance(spec, NumericArraySpec):
             continue
         leaf = value[path]
         actual_shape = _full_array_shape_or_none(leaf)
@@ -405,8 +405,8 @@ def _validate_function_output_template_supports(
     for path, declared_spec in declared_template.items():
         actual_spec = actual_template[path]
         if (
-            isinstance(declared_spec, ArraySpec)
-            and isinstance(actual_spec, ArraySpec)
+            isinstance(declared_spec, NumericArraySpec)
+            and isinstance(actual_spec, NumericArraySpec)
             and declared_spec.support is not None
             and actual_spec.support is not None
             and not _supports_compatible(actual_spec.support, declared_spec.support)
@@ -423,7 +423,7 @@ def _validate_function_output_supports(
     template: EventTemplate,
     value: Any,
 ) -> None:
-    """Validate declared ArraySpec supports at an eager execution boundary."""
+    """Validate declared NumericArraySpec supports at an eager execution boundary."""
     if isinstance(value, RecordBatch):
         # A batch is a collection, not a named tree: its columns are keyed by leaf
         # path and each carries the batch axes in front of its event shape, which a
@@ -482,8 +482,8 @@ def _validate_function_output_leaf_support(
     spec: ValueSpec,
     value: Any,
 ) -> None:
-    """Validate one declared ArraySpec support at an eager execution boundary."""
-    if not isinstance(spec, ArraySpec) or spec.support is None:
+    """Validate one declared NumericArraySpec support at an eager execution boundary."""
+    if not isinstance(spec, NumericArraySpec) or spec.support is None:
         return
     support = spec.support
     membership = jnp.all(support.check(value))

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -18,7 +18,6 @@ from ._array_backend import (
     _to_jax_array,
     _to_numpy_array,
 )
-from ._immutable import Immutable
 from .event_template import NumericArraySpec
 from .provenance import Provenance
 from .tracked import Annotated, TrackedTerm, auto_name
@@ -26,7 +25,7 @@ from .tracked import Annotated, TrackedTerm, auto_name
 __all__ = ["NumericArray"]
 
 
-class NumericArray(Immutable, TrackedTerm, Annotated):
+class NumericArray(TrackedTerm, Annotated):
     """One numeric array value, with identity.
 
     The tracked class of the numeric-array kind, as :class:`~probpipe.Record` is
@@ -38,11 +37,10 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
     Parameters
     ----------
     value : array-like
-        The array this names. **Stored verbatim in its native form** — a bare
-        array, an ``xarray`` / ``pandas`` container, or any registered backend —
-        so a lazy or disk-backed value is not materialised to be named. A bare
-        Python scalar carries no metadata and is normalised to a 0-d
-        ``jax.Array``.
+        The array this names, stored verbatim in its native form: a bare array,
+        an ``xarray`` / ``pandas`` container, or any registered backend, so a
+        lazy or disk-backed value stays lazy. A bare Python scalar carries no
+        metadata to read and is normalised to a 0-d ``jax.Array``.
     name : str, optional
         The value's name. Defaults to ``"numericarray"``, marked auto-derived.
     name_is_auto : bool, default False
@@ -64,21 +62,16 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
 
     Notes
     -----
-    Construction **validates without converting**, reading container metadata
-    only. Conversion to ``jax.Array`` happens at the compute boundary — the
-    pytree flatten that ``jit`` / ``vmap`` / ``grad`` traverse, and the explicit
-    conversion hooks — through a set-once cache, so the value materialises at
-    most once per instance. This is the storage rule
+    Construction validates against metadata alone, so the value materialises at
+    most once per instance and only at a compute boundary — the storage rule
     :class:`~probpipe.NumericRecord` follows for its leaves.
 
-    **Arithmetic yields a bare array**, not a ``NumericArray``. Identity is
-    attached by operations, and arithmetic is not one: a ``NumericArray`` is
-    what an operation hands back and what a caller computes *from*. The full
-    array surface is here — arithmetic, comparison, and the conversion hooks —
-    because with no fields and no field count ``arr + 1`` has exactly one
-    meaning, which is what lets :class:`~probpipe.Record` stay a container and
-    carry none of it. The operators forward to the stored value, so they return
-    **its** type: arithmetic on a numpy-backed one yields ``numpy``.
+    It carries the full array surface: arithmetic, comparison, and the
+    conversion hooks. With one value and no fields, ``arr + 1`` has a single
+    meaning, which is what lets :class:`~probpipe.Record` stay a container.
+    The operators forward to the stored value and return what it returns, so
+    arithmetic on a numpy-backed one yields ``numpy``, and identity stays with
+    the operations that attach it.
 
     Examples
     --------
@@ -147,9 +140,9 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
     def as_jax(self) -> Any:
         """The value as a ``jax.Array`` — the single conversion point.
 
-        A value already stored as one (a tracer inside a transform included)
-        passes through; a native container converts through its registered
-        backend exactly once, memoised for this instance.
+        A value already stored as one passes through, tracers included; a
+        native container converts through its registered backend once and is
+        memoised for this instance.
         """
         if isinstance(self._value, jax.Array):
             return self._value
@@ -173,13 +166,10 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
     def dtype(self) -> Any:
         """The stored value's dtype, or ``None`` when it has no single one.
 
-        The **value's**, not the declaration's, as for a single-field
-        ``NumericRecord``. These two can differ: ``is_valid`` admits a same-kind
-        cast, so a float32 value satisfies a float64 declaration. This shim
-        exists so a ``NumericArray`` can stand in for an array, and on an array
-        ``.dtype`` describes the data — a caller sizing a buffer or branching on
-        it must not be told the declaration instead. The declaration is
-        :attr:`spec`, and comparing the two is what makes the tolerance visible.
+        The value's rather than the declaration's, as for a single-field
+        ``NumericRecord``: a caller sizing a buffer or branching on the dtype is
+        asking about the data. The two can differ, since ``is_valid`` admits a
+        same-kind cast; :attr:`spec` carries the declaration.
         """
         return _numpy_dtype_of(self._value)
 
@@ -194,21 +184,14 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
         return f"NumericArray({self._value!r}, name={self.name!r})"
 
     # -- the array surface --------------------------------------------------
-    #
-    # Every operator returns what the underlying array returns, which is a bare
-    # array. ``_unwrap`` lets a NumericArray appear on either side.
-
-    @staticmethod
-    def _unwrap(other: Any) -> Any:
-        return other._value if isinstance(other, NumericArray) else other
 
     def __array__(self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
         arr = _to_numpy_array(self._value)
         arr = np.asarray(arr, dtype=dtype) if dtype is not None else arr
         return arr.copy() if copy else arr
 
-    # JAX reads ``__jax_array__`` for ``jnp.asarray``; without it the numpy
-    # hook above would win and tracing support would be lost.
+    # JAX reads this for ``jnp.asarray``; the numpy hook above would win
+    # otherwise and drop tracing.
     def __jax_array__(self) -> Any:
         return self.as_jax()
 
@@ -231,14 +214,16 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
         return iter(self._value)
 
 
+def _unwrap(other: Any) -> Any:
+    """The array inside a ``NumericArray``, or *other* unchanged."""
+    return other._value if isinstance(other, NumericArray) else other
+
+
 def _install_array_operators() -> None:
     """Forward the array operators to the held array, returning what it returns.
 
-    Written once rather than spelled out per operator: there are some forty of
-    them, they all do the same thing, and a hand-written list is where one gets
-    forgotten. The reflected and in-place forms come from the same table — an
-    in-place operator on an immutable term is the out-of-place one, and returns
-    a bare array like the rest.
+    Installed from a table so the forty of them stay one rule. An in-place
+    operator on an immutable term is the out-of-place one.
     """
     binary = [
         "add", "sub", "mul", "matmul", "truediv", "floordiv", "mod", "divmod",
@@ -249,14 +234,14 @@ def _install_array_operators() -> None:
 
     def _binary(name: str):
         def method(self: NumericArray, other: Any) -> Any:
-            return getattr(self._value, f"__{name}__")(NumericArray._unwrap(other))
+            return getattr(self._value, f"__{name}__")(_unwrap(other))
 
         method.__name__ = f"__{name}__"
         return method
 
     def _reflected(name: str):
         def method(self: NumericArray, other: Any) -> Any:
-            return getattr(self._value, f"__r{name}__")(NumericArray._unwrap(other))
+            return getattr(self._value, f"__r{name}__")(_unwrap(other))
 
         method.__name__ = f"__r{name}__"
         return method
@@ -271,8 +256,6 @@ def _install_array_operators() -> None:
     for op in binary:
         setattr(NumericArray, f"__{op}__", _binary(op))
         setattr(NumericArray, f"__r{op}__", _reflected(op))
-        # An in-place operator rebinds the caller's name to the bare result; the
-        # term itself is immutable and unchanged.
         setattr(NumericArray, f"__i{op}__", _binary(op))
     for op in comparison:
         setattr(NumericArray, f"__{op}__", _binary(op))
@@ -282,8 +265,7 @@ def _install_array_operators() -> None:
 
 _install_array_operators()
 
-# ``__eq__`` is elementwise, so the inherited ``__hash__`` would be a false
-# promise: two values comparing "equal" produce an array, not a bool.
+# ``__eq__`` is elementwise, so a hash would promise more than it can keep.
 NumericArray.__hash__ = None  # type: ignore[assignment]
 
 
@@ -292,40 +274,35 @@ NumericArray.__hash__ = None  # type: ignore[assignment]
 # ---------------------------------------------------------------------------
 
 
-def _numeric_array_flatten(value: NumericArray) -> tuple[list, tuple[str, bool, Any]]:
-    """Flatten for JAX traversal: the array, keyed by the identity and support.
+def _numeric_array_flatten(
+    value: NumericArray,
+) -> tuple[list, tuple[NumericArraySpec, str, bool]]:
+    """Flatten for JAX traversal: the array, keyed by the declaration and identity.
 
-    The **shape and dtype are not aux**, unlike a ``Record``'s template. A
-    ``NumericArray``'s spec is exactly its array's shape and dtype, so a
-    transform that changes either leaves the spec re-derivable from what
-    arrives — an exact reading, not the guess the record types must refuse.
-    What cannot be re-derived is the declared ``support``, which rides along.
+    The aux triple every tracked class flattens to. The declaration rides along
+    rather than being re-read off the child, because it is not recoverable from
+    one: ``is_valid`` admits a same-kind cast, so a float32 value under a
+    float64 declaration would come back declaring float32.
     """
     # The boundary presents a bare array, as a ``NumericRecord``'s does: this
     # is one of the compute boundaries native form converts at.
-    return [value.as_jax()], (value._name, value._name_is_auto, value._spec.support)
+    return [value.as_jax()], (value._spec, value._name, value._name_is_auto)
 
 
-def _numeric_array_unflatten(aux: tuple[str, bool, Any], children: list) -> NumericArray:
+def _numeric_array_unflatten(
+    aux: tuple[NumericArraySpec, str, bool], children: list
+) -> NumericArray:
     """Rebuild without converting or validating the child.
 
-    JAX unflattens with whatever it is carrying, which is not always an array:
-    ``tree_map(lambda x: None, value)`` builds a skeleton, and internal
-    traversals pass sentinel objects. Running the constructor here would convert
-    and validate, so those raise instead of rebuilding — the reason ``Record``
-    and ``RecordBatch`` take ``_validate_leaves=False`` on this same path. The
-    spec is derived only when the child can state one, and is left to the
-    constructor's own rule otherwise.
+    JAX unflattens with whatever it carries, and a skeleton from
+    ``tree_map(lambda x: None, value)`` or an internal sentinel is not an array
+    — the reason ``Record`` and ``RecordBatch`` take ``_validate_leaves=False``
+    on this path. A transform may also have resized the value, which is why the
+    spec a rebuilt value carries is the one it was declared with rather than one
+    read off the child: on this path a shape is transform-relative.
     """
-    name, name_is_auto, support = aux
+    spec, name, name_is_auto = aux
     (array,) = children
-    shape = getattr(array, "shape", None)
-    dtype = getattr(array, "dtype", None)
-    if shape is None or dtype is None:
-        # Not an array: a skeleton or a sentinel, which carries no spec to state.
-        spec = None
-    else:
-        spec = NumericArraySpec(shape=tuple(shape), dtype=dtype, support=support)
     value = object.__new__(NumericArray)
     object.__setattr__(value, "_value", array)
     object.__setattr__(value, "_spec", spec)

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -166,16 +166,26 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """The event shape, read from metadata. No batch axes are carried."""
-        return tuple(self._spec.shape)
+        """The event shape, read from the value's metadata. No batch axes."""
+        return _event_shape_of(self._value)
 
     @property
     def dtype(self) -> Any:
-        return self._spec.dtype
+        """The stored value's dtype, or ``None`` when it has no single one.
+
+        The **value's**, not the declaration's, as for a single-field
+        ``NumericRecord``. These two can differ: ``is_valid`` admits a same-kind
+        cast, so a float32 value satisfies a float64 declaration. This shim
+        exists so a ``NumericArray`` can stand in for an array, and on an array
+        ``.dtype`` describes the data — a caller sizing a buffer or branching on
+        it must not be told the declaration instead. The declaration is
+        :attr:`spec`, and comparing the two is what makes the tolerance visible.
+        """
+        return _numpy_dtype_of(self._value)
 
     @property
     def ndim(self) -> int:
-        return len(self._spec.shape)
+        return len(self.shape)
 
     def __len__(self) -> int:
         return len(self._value)

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import operator
 from typing import Any
 
+import jax
 import numpy as np
 
 from ._array_backend import _to_jax_array
@@ -236,3 +237,32 @@ _install_array_operators()
 # ``__eq__`` is elementwise, so the inherited ``__hash__`` would be a false
 # promise: two values comparing "equal" produce an array, not a bool.
 NumericArray.__hash__ = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# JAX PyTree registration
+# ---------------------------------------------------------------------------
+
+
+def _numeric_array_flatten(value: NumericArray) -> tuple[list, tuple[str, bool, Any]]:
+    """Flatten for JAX traversal: the array, keyed by the identity and support.
+
+    The **shape and dtype are not aux**, unlike a ``Record``'s template. A
+    ``NumericArray``'s spec is exactly its array's shape and dtype, so a
+    transform that changes either leaves the spec re-derivable from what
+    arrives — an exact reading, not the guess the record types must refuse.
+    What cannot be re-derived is the declared ``support``, which rides along.
+    """
+    return [value._value], (value._name, value._name_is_auto, value._spec.support)
+
+
+def _numeric_array_unflatten(aux: tuple[str, bool, Any], children: list) -> NumericArray:
+    name, name_is_auto, support = aux
+    (array,) = children
+    spec = None
+    if support is not None and hasattr(array, "shape") and hasattr(array, "dtype"):
+        spec = NumericArraySpec(shape=tuple(array.shape), dtype=array.dtype, support=support)
+    return NumericArray(array, name=name, name_is_auto=name_is_auto, spec=spec)
+
+
+jax.tree_util.register_pytree_node(NumericArray, _numeric_array_flatten, _numeric_array_unflatten)

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -1,0 +1,238 @@
+"""NumericArray — the tracked class of the numeric-array kind.
+
+See design III.1.
+"""
+
+from __future__ import annotations
+
+import operator
+from typing import Any
+
+import numpy as np
+
+from ._array_backend import _to_jax_array
+from ._immutable import Immutable
+from .event_template import NumericArraySpec
+from .provenance import Provenance
+from .tracked import Annotated, TrackedTerm, auto_name
+
+__all__ = ["NumericArray"]
+
+
+class NumericArray(Immutable, TrackedTerm, Annotated):
+    """One numeric array value, with identity.
+
+    The tracked class of the numeric-array kind, as :class:`~probpipe.Record` is
+    of the record kind: what an operation returns when its declared kind is a
+    :class:`~probpipe.NumericArraySpec`. It holds a single array and carries no
+    batch axes, so :attr:`shape` is the **event** shape; multiplicity lives in
+    :class:`~probpipe.NumericArrayBatch`.
+
+    Parameters
+    ----------
+    value : array-like
+        The array this names. Converted through the registered backend, so a
+        native leaf becomes a ``jax.Array`` at the same boundary every other
+        numeric conversion uses.
+    name : str, optional
+        The value's name. Defaults to ``"numericarray"``, marked auto-derived.
+    name_is_auto : bool, default False
+        Whether *name* is auto-derived rather than user-given. A value left
+        unnamed is auto-named regardless.
+    spec : NumericArraySpec, optional
+        What this value satisfies. Derived from the array's shape and dtype when
+        omitted, with an unconstrained support.
+    provenance : Provenance, optional
+        How this value was produced.
+
+    Raises
+    ------
+    TypeError
+        If *spec* is not a :class:`NumericArraySpec`, or if *value* does not
+        convert to an array.
+    ValueError
+        If *value*'s shape or dtype does not satisfy *spec*.
+
+    Notes
+    -----
+    **Arithmetic yields a bare array**, not a ``NumericArray``. Identity is
+    attached by operations, and arithmetic is not one: a ``NumericArray`` is
+    what an operation hands back and what a caller computes *from*. The full
+    array surface is here — arithmetic, comparison, and the conversion hooks —
+    because with no fields and no field count ``arr + 1`` has exactly one
+    meaning, which is what lets :class:`~probpipe.Record` stay a container and
+    carry none of it.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> value = NumericArray(jnp.arange(3.0), name="draw")
+    >>> value.shape
+    (3,)
+    >>> value + 1          # a bare array, not a NumericArray
+    Array([1., 2., 3.], dtype=float32)
+    """
+
+    __slots__ = (
+        "_annotations",
+        "_name",
+        "_name_is_auto",
+        "_provenance",
+        "_spec",
+        "_value",
+    )
+
+    def __init__(
+        self,
+        value: Any,
+        *,
+        name: str | None = None,
+        name_is_auto: bool = False,
+        spec: NumericArraySpec | None = None,
+        provenance: Provenance | None = None,
+    ) -> None:
+        if spec is not None and not isinstance(spec, NumericArraySpec):
+            raise TypeError(
+                f"NumericArray spec must be a NumericArraySpec, got {type(spec).__name__}"
+            )
+        try:
+            array = _to_jax_array(value)
+        except Exception as exc:
+            raise TypeError(
+                f"NumericArray holds one numeric array; {type(value).__name__} does not convert"
+            ) from exc
+        if spec is None:
+            spec = NumericArraySpec(shape=tuple(array.shape), dtype=array.dtype)
+        elif not spec.is_valid(array):
+            raise ValueError(
+                f"the array does not satisfy its declaration: shape {tuple(array.shape)} and "
+                f"dtype {array.dtype} against {spec}"
+            )
+        if name is None:
+            name, name_is_auto = auto_name(name, "numericarray")
+        object.__setattr__(self, "_value", array)
+        object.__setattr__(self, "_spec", spec)
+        self._init_tracked(name, name_is_auto=name_is_auto, provenance=provenance)
+
+    # -- what it holds ------------------------------------------------------
+
+    @property
+    def value(self) -> Any:
+        """The array itself, untracked."""
+        return self._value
+
+    @property
+    def spec(self) -> NumericArraySpec:
+        """This value's own declaration."""
+        return self._spec
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """The event shape. A ``NumericArray`` carries no batch axes."""
+        return tuple(self._value.shape)
+
+    @property
+    def dtype(self) -> Any:
+        return self._value.dtype
+
+    @property
+    def ndim(self) -> int:
+        return int(self._value.ndim)
+
+    def __len__(self) -> int:
+        return len(self._value)
+
+    def __repr__(self) -> str:
+        return f"NumericArray({self._value!r}, name={self.name!r})"
+
+    # -- the array surface --------------------------------------------------
+    #
+    # Every operator returns what the underlying array returns, which is a bare
+    # array. ``_unwrap`` lets a NumericArray appear on either side.
+
+    @staticmethod
+    def _unwrap(other: Any) -> Any:
+        return other._value if isinstance(other, NumericArray) else other
+
+    def __array__(self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
+        arr = np.asarray(self._value, dtype=dtype) if dtype is not None else np.asarray(self._value)
+        return arr.copy() if copy else arr
+
+    # JAX reads ``__jax_array__`` for ``jnp.asarray``; without it the numpy
+    # hook above would win and tracing support would be lost.
+    def __jax_array__(self) -> Any:
+        return self._value
+
+    def __float__(self) -> float:
+        return float(self._value)
+
+    def __int__(self) -> int:
+        return int(self._value)
+
+    def __bool__(self) -> bool:
+        return bool(self._value)
+
+    def __index__(self) -> int:
+        return operator.index(self._value)
+
+    def __getitem__(self, key: Any) -> Any:
+        return self._value[key]
+
+    def __iter__(self):
+        return iter(self._value)
+
+
+def _install_array_operators() -> None:
+    """Forward the array operators to the held array, returning what it returns.
+
+    Written once rather than spelled out per operator: there are some forty of
+    them, they all do the same thing, and a hand-written list is where one gets
+    forgotten. The reflected and in-place forms come from the same table — an
+    in-place operator on an immutable term is the out-of-place one, and returns
+    a bare array like the rest.
+    """
+    binary = [
+        "add", "sub", "mul", "matmul", "truediv", "floordiv", "mod", "divmod",
+        "pow", "lshift", "rshift", "and", "xor", "or",
+    ]  # fmt: skip
+    comparison = ["lt", "le", "eq", "ne", "gt", "ge"]
+    unary = ["neg", "pos", "abs", "invert"]
+
+    def _binary(name: str):
+        def method(self: NumericArray, other: Any) -> Any:
+            return getattr(self._value, f"__{name}__")(NumericArray._unwrap(other))
+
+        method.__name__ = f"__{name}__"
+        return method
+
+    def _reflected(name: str):
+        def method(self: NumericArray, other: Any) -> Any:
+            return getattr(self._value, f"__r{name}__")(NumericArray._unwrap(other))
+
+        method.__name__ = f"__r{name}__"
+        return method
+
+    def _unary(name: str):
+        def method(self: NumericArray) -> Any:
+            return getattr(self._value, f"__{name}__")()
+
+        method.__name__ = f"__{name}__"
+        return method
+
+    for op in binary:
+        setattr(NumericArray, f"__{op}__", _binary(op))
+        setattr(NumericArray, f"__r{op}__", _reflected(op))
+        # An in-place operator rebinds the caller's name to the bare result; the
+        # term itself is immutable and unchanged.
+        setattr(NumericArray, f"__i{op}__", _binary(op))
+    for op in comparison:
+        setattr(NumericArray, f"__{op}__", _binary(op))
+    for op in unary:
+        setattr(NumericArray, f"__{op}__", _unary(op))
+
+
+_install_array_operators()
+
+# ``__eq__`` is elementwise, so the inherited ``__hash__`` would be a false
+# promise: two values comparing "equal" produce an array, not a bool.
+NumericArray.__hash__ = None  # type: ignore[assignment]

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -11,7 +11,13 @@ from typing import Any
 import jax
 import numpy as np
 
-from ._array_backend import _to_jax_array
+from ._array_backend import (
+    _event_shape_of,
+    _is_numeric_leaf,
+    _numpy_dtype_of,
+    _to_jax_array,
+    _to_numpy_array,
+)
 from ._immutable import Immutable
 from .event_template import NumericArraySpec
 from .provenance import Provenance
@@ -32,9 +38,11 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
     Parameters
     ----------
     value : array-like
-        The array this names. Converted through the registered backend, so a
-        native leaf becomes a ``jax.Array`` at the same boundary every other
-        numeric conversion uses.
+        The array this names. **Stored verbatim in its native form** — a bare
+        array, an ``xarray`` / ``pandas`` container, or any registered backend —
+        so a lazy or disk-backed value is not materialised to be named. A bare
+        Python scalar carries no metadata and is normalised to a 0-d
+        ``jax.Array``.
     name : str, optional
         The value's name. Defaults to ``"numericarray"``, marked auto-derived.
     name_is_auto : bool, default False
@@ -49,20 +57,28 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
     Raises
     ------
     TypeError
-        If *spec* is not a :class:`NumericArraySpec`, or if *value* does not
-        convert to an array.
+        If *spec* is not a :class:`NumericArraySpec`, or if *value* is not a
+        numeric leaf.
     ValueError
         If *value*'s shape or dtype does not satisfy *spec*.
 
     Notes
     -----
+    Construction **validates without converting**, reading container metadata
+    only. Conversion to ``jax.Array`` happens at the compute boundary — the
+    pytree flatten that ``jit`` / ``vmap`` / ``grad`` traverse, and the explicit
+    conversion hooks — through a set-once cache, so the value materialises at
+    most once per instance. This is the storage rule
+    :class:`~probpipe.NumericRecord` follows for its leaves.
+
     **Arithmetic yields a bare array**, not a ``NumericArray``. Identity is
     attached by operations, and arithmetic is not one: a ``NumericArray`` is
     what an operation hands back and what a caller computes *from*. The full
     array surface is here — arithmetic, comparison, and the conversion hooks —
     because with no fields and no field count ``arr + 1`` has exactly one
     meaning, which is what lets :class:`~probpipe.Record` stay a container and
-    carry none of it.
+    carry none of it. The operators forward to the stored value, so they return
+    **its** type: arithmetic on a numpy-backed one yields ``numpy``.
 
     Examples
     --------
@@ -76,12 +92,16 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
 
     __slots__ = (
         "_annotations",
+        "_jax_cache",
         "_name",
         "_name_is_auto",
         "_provenance",
         "_spec",
         "_value",
     )
+
+    #: Derived from the value rather than transported, as for ``NumericRecord``.
+    _transient_state = ("_jax_cache",)
 
     def __init__(
         self,
@@ -96,22 +116,24 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
             raise TypeError(
                 f"NumericArray spec must be a NumericArraySpec, got {type(spec).__name__}"
             )
-        try:
-            array = _to_jax_array(value)
-        except Exception as exc:
+        if not _is_numeric_leaf(value):
             raise TypeError(
-                f"NumericArray holds one numeric array; {type(value).__name__} does not convert"
-            ) from exc
+                f"NumericArray holds one numeric array; {type(value).__name__} is not a numeric leaf"
+            )
+        # A bare Python scalar carries no metadata to read, so it is the one
+        # thing normalised at construction — as ``NumericRecord`` normalises it.
+        stored = _to_jax_array(value) if isinstance(value, (int, float, complex, bool)) else value
+        shape, dtype = _event_shape_of(stored), _numpy_dtype_of(stored)
         if spec is None:
-            spec = NumericArraySpec(shape=tuple(array.shape), dtype=array.dtype)
-        elif not spec.is_valid(array):
+            spec = NumericArraySpec(shape=shape, dtype=dtype)
+        elif not spec.is_valid(stored):
             raise ValueError(
-                f"the array does not satisfy its declaration: shape {tuple(array.shape)} and "
-                f"dtype {array.dtype} against {spec}"
+                f"the array does not satisfy its declaration: shape {shape} and "
+                f"dtype {dtype} against {spec}"
             )
         if name is None:
             name, name_is_auto = auto_name(name, "numericarray")
-        object.__setattr__(self, "_value", array)
+        object.__setattr__(self, "_value", stored)
         object.__setattr__(self, "_spec", spec)
         self._init_tracked(name, name_is_auto=name_is_auto, provenance=provenance)
 
@@ -119,8 +141,23 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
 
     @property
     def value(self) -> Any:
-        """The array itself, untracked."""
+        """The stored value, in the form it was given. Untracked."""
         return self._value
+
+    def as_jax(self) -> Any:
+        """The value as a ``jax.Array`` — the single conversion point.
+
+        A value already stored as one (a tracer inside a transform included)
+        passes through; a native container converts through its registered
+        backend exactly once, memoised for this instance.
+        """
+        if isinstance(self._value, jax.Array):
+            return self._value
+        cached = getattr(self, "_jax_cache", None)
+        if cached is None:
+            cached = _to_jax_array(self._value)
+            object.__setattr__(self, "_jax_cache", cached)
+        return cached
 
     @property
     def spec(self) -> NumericArraySpec:
@@ -129,16 +166,16 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """The event shape. A ``NumericArray`` carries no batch axes."""
-        return tuple(self._value.shape)
+        """The event shape, read from metadata. No batch axes are carried."""
+        return tuple(self._spec.shape)
 
     @property
     def dtype(self) -> Any:
-        return self._value.dtype
+        return self._spec.dtype
 
     @property
     def ndim(self) -> int:
-        return int(self._value.ndim)
+        return len(self._spec.shape)
 
     def __len__(self) -> int:
         return len(self._value)
@@ -156,25 +193,26 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
         return other._value if isinstance(other, NumericArray) else other
 
     def __array__(self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
-        arr = np.asarray(self._value, dtype=dtype) if dtype is not None else np.asarray(self._value)
+        arr = _to_numpy_array(self._value)
+        arr = np.asarray(arr, dtype=dtype) if dtype is not None else arr
         return arr.copy() if copy else arr
 
     # JAX reads ``__jax_array__`` for ``jnp.asarray``; without it the numpy
     # hook above would win and tracing support would be lost.
     def __jax_array__(self) -> Any:
-        return self._value
+        return self.as_jax()
 
     def __float__(self) -> float:
-        return float(self._value)
+        return float(self.as_jax())
 
     def __int__(self) -> int:
-        return int(self._value)
+        return int(self.as_jax())
 
     def __bool__(self) -> bool:
-        return bool(self._value)
+        return bool(self.as_jax())
 
     def __index__(self) -> int:
-        return operator.index(self._value)
+        return operator.index(self.as_jax())
 
     def __getitem__(self, key: Any) -> Any:
         return self._value[key]
@@ -253,16 +291,36 @@ def _numeric_array_flatten(value: NumericArray) -> tuple[list, tuple[str, bool, 
     arrives — an exact reading, not the guess the record types must refuse.
     What cannot be re-derived is the declared ``support``, which rides along.
     """
-    return [value._value], (value._name, value._name_is_auto, value._spec.support)
+    # The boundary presents a bare array, as a ``NumericRecord``'s does: this
+    # is one of the compute boundaries native form converts at.
+    return [value.as_jax()], (value._name, value._name_is_auto, value._spec.support)
 
 
 def _numeric_array_unflatten(aux: tuple[str, bool, Any], children: list) -> NumericArray:
+    """Rebuild without converting or validating the child.
+
+    JAX unflattens with whatever it is carrying, which is not always an array:
+    ``tree_map(lambda x: None, value)`` builds a skeleton, and internal
+    traversals pass sentinel objects. Running the constructor here would convert
+    and validate, so those raise instead of rebuilding — the reason ``Record``
+    and ``RecordBatch`` take ``_validate_leaves=False`` on this same path. The
+    spec is derived only when the child can state one, and is left to the
+    constructor's own rule otherwise.
+    """
     name, name_is_auto, support = aux
     (array,) = children
-    spec = None
-    if support is not None and hasattr(array, "shape") and hasattr(array, "dtype"):
-        spec = NumericArraySpec(shape=tuple(array.shape), dtype=array.dtype, support=support)
-    return NumericArray(array, name=name, name_is_auto=name_is_auto, spec=spec)
+    shape = getattr(array, "shape", None)
+    dtype = getattr(array, "dtype", None)
+    if shape is None or dtype is None:
+        # Not an array: a skeleton or a sentinel, which carries no spec to state.
+        spec = None
+    else:
+        spec = NumericArraySpec(shape=tuple(shape), dtype=dtype, support=support)
+    value = object.__new__(NumericArray)
+    object.__setattr__(value, "_value", array)
+    object.__setattr__(value, "_spec", spec)
+    value._init_tracked(name, name_is_auto=name_is_auto)
+    return value
 
 
 jax.tree_util.register_pytree_node(NumericArray, _numeric_array_flatten, _numeric_array_unflatten)

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -8,9 +8,17 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Self
 
+import jax
 import numpy as np
 
-from ._array_backend import _event_shape_of, _is_numeric_leaf, _numpy_dtype_of, _take_at
+from ._array_backend import (
+    _event_shape_of,
+    _is_numeric_leaf,
+    _numpy_dtype_of,
+    _take_at,
+    _to_jax_array,
+    _to_numpy_array,
+)
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._numeric_array import NumericArray
 from .event_template import NumericArraySpec
@@ -40,10 +48,15 @@ class NumericArrayBatch(Batch[NumericArray]):
     axis_groups : iterable of iterable of int, optional
         The axis sizes each level holds, in order, tiling ``batch_shape``.
         Defaults to one axis per level.
-    name : str, optional
-        The batch's name; defaults to ``"numericarraybatch"``, marked auto.
+    name : str
+        The batch's name, **required**, as a :class:`~probpipe.Record`'s and an
+        :class:`~probpipe.Opaque`'s are. A batch is what an operation hands back,
+        and the name is what says which one it is; a class-name default would name
+        every batch in a pipeline alike. A caller that derives one says so with
+        *name_is_auto*.
     name_is_auto : bool, default False
-        Whether *name* is auto-derived rather than user-given.
+        Whether *name* is auto-derived rather than user-given — set by an
+        operation that derives one, as a view does for a selected sub-batch.
     provenance : Provenance, optional
         How this batch was produced.
 
@@ -54,7 +67,9 @@ class NumericArrayBatch(Batch[NumericArray]):
         not convert to an array.
     TypeError
         Also if the stored array's dtype is one the declared element does not
-        admit — a cross-kind conversion.
+        admit — a cross-kind conversion — or if the store reports no single
+        dtype while the element declares one, which leaves the claim
+        unsubstantiated.
     ValueError
         If *values* has fewer axes than the event shape it must end with, which
         would leave no batch axis; if its trailing axes are not that event
@@ -79,7 +94,7 @@ class NumericArrayBatch(Batch[NumericArray]):
         *,
         element_spec: NumericArraySpec,
         axis_groups: Iterable[Iterable[int]] | None = None,
-        name: str | None = None,
+        name: str,
         name_is_auto: bool = False,
         provenance: Provenance | None = None,
     ) -> None:
@@ -105,12 +120,18 @@ class NumericArrayBatch(Batch[NumericArray]):
                 f"the stored array ends with {stored[len(stored) - n_event :]} where its "
                 f"elements declare the event shape {event_shape}"
             )
-        # The batch asserts *element_spec* of every element, so a column whose
-        # dtype the declaration does not admit makes that assertion false. Caught
-        # here rather than at the first selection, which is where NumericArray
-        # would otherwise raise — one layer too late to name the batch.
+        # The batch asserts *element_spec* of every element, so the store's own
+        # dtype has to satisfy it.
         dtype = _numpy_dtype_of(values)
-        if element_spec.dtype is not None and dtype is not None:
+        if element_spec.dtype is not None:
+            if dtype is None:
+                # A heterogeneous store has no single dtype to check a pinned
+                # one against, so the claim is unsupportable either way.
+                raise TypeError(
+                    f"the stored array reports no single dtype, so the declared element "
+                    f"{np.dtype(element_spec.dtype)} cannot be shown to hold of it; declare "
+                    f"no dtype, or store a container that has one"
+                )
             if not np.can_cast(dtype, element_spec.dtype, casting="same_kind"):
                 raise TypeError(
                     f"the stored array has dtype {dtype}, which the declared element "
@@ -127,8 +148,6 @@ class NumericArrayBatch(Batch[NumericArray]):
 
         names = (level_names,) if isinstance(level_names, str) else tuple(level_names)
         groups = _axis_groups_for(batch_shape, names, axis_groups, kind="NumericArrayBatch")
-        if name is None:
-            name, name_is_auto = "numericarraybatch", True
         object.__setattr__(self, "_values", values)
         self._init_batch(
             BatchSpec(element_spec, groups, names),
@@ -151,9 +170,31 @@ class NumericArrayBatch(Batch[NumericArray]):
         """The stored array, batch axes leading, in native form. Untracked."""
         return self._values
 
+    # -- the array shim, as ``NumericRecordBatch`` carries from its sole field.
+    # ``batch_shape`` / ``batch_size`` stay the names for the batch axes alone.
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """The store's full shape, ``(*batch_shape, *event_shape)``."""
+        return tuple(_event_shape_of(self._values))
+
     @property
     def dtype(self) -> Any:
-        return self.element_spec.dtype
+        """The store's dtype — the value's, as a :class:`NumericArray`'s is."""
+        return _numpy_dtype_of(self._values)
+
+    @property
+    def ndim(self) -> int:
+        """The rank of the store, batch axes included."""
+        return len(self.shape)
+
+    def __array__(self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
+        arr = _to_numpy_array(self._values)
+        arr = np.asarray(arr, dtype=dtype) if dtype is not None else arr
+        return arr.copy() if copy else arr
+
+    def __jax_array__(self) -> Any:
+        return _to_jax_array(self._values)
 
     def __repr__(self) -> str:
         return (
@@ -166,14 +207,11 @@ class NumericArrayBatch(Batch[NumericArray]):
     def _element_at(self, index: tuple[int, ...], *, name: str) -> NumericArray:
         """The array at a fully-integer positional *index*, as a `NumericArray`.
 
-        Selection is positional and goes through the value's backend, since
-        ``[]`` reads labels rather than positions on a ``pandas`` container.
-
-        Indexing a stored array does not produce the element on its own — the
-        element is the *tracked* value around it — so this is the materializing
-        side of both rules :meth:`~probpipe.core._batch.Batch._element_at`
-        states: it takes the derived *name*, marked auto, and inherits this
-        batch's provenance.
+        The materializing side of both rules
+        :meth:`~probpipe.core._batch.Batch._element_at` states: the element
+        takes the derived *name*, marked auto, and inherits this batch's
+        provenance. Selection goes through the backend, since ``[]`` is
+        positional only on a numpy-protocol container.
         """
         return self._inherit_provenance(
             NumericArray(
@@ -198,3 +236,57 @@ class NumericArrayBatch(Batch[NumericArray]):
         object.__setattr__(view, "_values", _take_at(self._values, index))
         view._init_batch(spec, name=name, name_is_auto=True)
         return view
+
+
+# ---------------------------------------------------------------------------
+# JAX PyTree registration
+# ---------------------------------------------------------------------------
+
+
+def _numeric_array_batch_flatten(batch: NumericArrayBatch):
+    """Flatten for JAX traversal: the store, keyed by the aux spec."""
+    return [batch._values], (batch._spec, batch._name, batch._name_is_auto)
+
+
+def _numeric_array_batch_unflatten(aux, children):
+    """Rebuild over the transformations a batch can state honestly.
+
+    The contract ``RecordBatch`` states, over one column instead of many. A
+    treedef carries neither ``in_axes`` nor ``out_axes``, so which level a
+    transform consumed is unrecoverable — *a shape is not a provenance* — and
+    two transformations are supported:
+
+    - **Every batch axis preserved**, the ordinary round trip, reusing the spec.
+    - **Every batch axis removed**: the value is one element, so a
+      :class:`NumericArray` is returned.
+    """
+    spec, name, name_is_auto = aux
+    (values,) = children
+    element_spec = spec.element_spec
+    event_rank = len(element_spec.shape)
+    shape = getattr(values, "shape", None)
+    if shape is None:
+        # A skeleton or sentinel has no shape to measure; rebuilt verbatim.
+        view = object.__new__(NumericArrayBatch)
+        object.__setattr__(view, "_values", values)
+        view._init_batch(spec, name=name, name_is_auto=name_is_auto)
+        return view
+    surviving = tuple(shape)[: len(shape) - event_rank] if event_rank else tuple(shape)
+    if surviving == tuple(spec.batch_shape):
+        view = object.__new__(NumericArrayBatch)
+        object.__setattr__(view, "_values", values)
+        view._init_batch(spec, name=name, name_is_auto=name_is_auto)
+        return view
+    if not surviving:
+        return NumericArray(values, name=name, name_is_auto=name_is_auto, spec=element_spec)
+    raise ValueError(
+        f"a transform left this NumericArrayBatch over {surviving} where its levels account "
+        f"for {tuple(spec.batch_shape)}. A batch keeps every batch axis or removes all of "
+        f"them, since an added or resized axis belongs to no level and unflattening has no "
+        f"name to give one; build the batch where the axis is added, or map over its store"
+    )
+
+
+jax.tree_util.register_pytree_node(
+    NumericArrayBatch, _numeric_array_batch_flatten, _numeric_array_batch_unflatten
+)

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Self
 
-from ._array_backend import _event_shape_of, _is_numeric_leaf
+import numpy as np
+
+from ._array_backend import _event_shape_of, _is_numeric_leaf, _numpy_dtype_of, _take_at
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._numeric_array import NumericArray
 from .event_template import NumericArraySpec
@@ -50,6 +52,9 @@ class NumericArrayBatch(Batch[NumericArray]):
     TypeError
         If *element_spec* is not a :class:`NumericArraySpec`, or *values* does
         not convert to an array.
+    TypeError
+        Also if the stored array's dtype is one the declared element does not
+        admit — a cross-kind conversion.
     ValueError
         If *values* has fewer axes than the event shape it must end with, which
         would leave no batch axis; if its trailing axes are not that event
@@ -100,6 +105,18 @@ class NumericArrayBatch(Batch[NumericArray]):
                 f"the stored array ends with {stored[len(stored) - n_event :]} where its "
                 f"elements declare the event shape {event_shape}"
             )
+        # The batch asserts *element_spec* of every element, so a column whose
+        # dtype the declaration does not admit makes that assertion false. Caught
+        # here rather than at the first selection, which is where NumericArray
+        # would otherwise raise — one layer too late to name the batch.
+        dtype = _numpy_dtype_of(values)
+        if element_spec.dtype is not None and dtype is not None:
+            if not np.can_cast(dtype, element_spec.dtype, casting="same_kind"):
+                raise TypeError(
+                    f"the stored array has dtype {dtype}, which the declared element "
+                    f"{np.dtype(element_spec.dtype)} does not admit; a widening or a "
+                    f"within-kind narrowing passes, a cross-kind conversion does not"
+                )
         batch_shape = stored[: len(stored) - n_event] if n_event else stored
         if not batch_shape:
             raise ValueError(
@@ -149,6 +166,9 @@ class NumericArrayBatch(Batch[NumericArray]):
     def _element_at(self, index: tuple[int, ...], *, name: str) -> NumericArray:
         """The array at a fully-integer positional *index*, as a `NumericArray`.
 
+        Selection is positional and goes through the value's backend, since
+        ``[]`` reads labels rather than positions on a ``pandas`` container.
+
         Indexing a stored array does not produce the element on its own — the
         element is the *tracked* value around it — so this is the materializing
         side of both rules :meth:`~probpipe.core._batch.Batch._element_at`
@@ -157,7 +177,7 @@ class NumericArrayBatch(Batch[NumericArray]):
         """
         return self._inherit_provenance(
             NumericArray(
-                self._values[index],
+                _take_at(self._values, index),
                 name=name,
                 name_is_auto=True,
                 spec=self.element_spec,
@@ -168,12 +188,13 @@ class NumericArrayBatch(Batch[NumericArray]):
         """A view over the same array, indexed on the batch axes as given.
 
         *index* addresses the leading axes only, so the event axes are untouched
-        and array indexing yields a view rather than a copy. Built without
+        and selection yields a view rather than a copy. It goes through the
+        value's backend, since ``[]`` is not positional on every container. Built without
         ``__init__`` for the reason ``RecordBatch`` gives: the spec and the name
         are already decided, and re-deriving them from the view's own shape
         would lose the levels a dropped axis came from.
         """
         view = object.__new__(self._view_type)
-        object.__setattr__(view, "_values", self._values[index])
+        object.__setattr__(view, "_values", _take_at(self._values, index))
         view._init_batch(spec, name=name, name_is_auto=True)
         return view

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Self
 
-from ._array_backend import _to_jax_array
+from ._array_backend import _event_shape_of, _is_numeric_leaf
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._numeric_array import NumericArray
 from .event_template import NumericArraySpec
@@ -28,6 +28,8 @@ class NumericArrayBatch(Batch[NumericArray]):
     ----------
     values : array-like
         One array holding every element, shaped ``(*batch_shape, *event_shape)``.
+        Stored verbatim in its native form, as a :class:`NumericArray`'s value
+        is, so a lazy or disk-backed column is not materialised to be batched.
     level_names : str or iterable of str
         One name per level, outermost first; a single string names one level.
     element_spec : NumericArraySpec
@@ -87,14 +89,11 @@ class NumericArrayBatch(Batch[NumericArray]):
                 f"a symbolic dimension gives the event shape no size to split the stored "
                 f"axes by; bind {element_spec.shape} with with_dims before batching"
             )
-        try:
-            array = _to_jax_array(values)
-        except Exception as exc:
+        if not _is_numeric_leaf(values):
             raise TypeError(
-                f"NumericArrayBatch stores one array; {type(values).__name__} does not convert"
-            ) from exc
-
-        stored = tuple(array.shape)
+                f"NumericArrayBatch stores one array; {type(values).__name__} is not a numeric leaf"
+            )
+        stored = _event_shape_of(values)
         n_event = len(event_shape)
         if n_event and stored[len(stored) - n_event :] != event_shape:
             raise ValueError(
@@ -113,7 +112,7 @@ class NumericArrayBatch(Batch[NumericArray]):
         groups = _axis_groups_for(batch_shape, names, axis_groups, kind="NumericArrayBatch")
         if name is None:
             name, name_is_auto = "numericarraybatch", True
-        object.__setattr__(self, "_values", array)
+        object.__setattr__(self, "_values", values)
         self._init_batch(
             BatchSpec(element_spec, groups, names),
             name=name,
@@ -132,12 +131,12 @@ class NumericArrayBatch(Batch[NumericArray]):
 
     @property
     def values(self) -> Any:
-        """The stored array, batch axes leading. Untracked."""
+        """The stored array, batch axes leading, in native form. Untracked."""
         return self._values
 
     @property
     def dtype(self) -> Any:
-        return self._values.dtype
+        return self.element_spec.dtype
 
     def __repr__(self) -> str:
         return (
@@ -174,7 +173,7 @@ class NumericArrayBatch(Batch[NumericArray]):
         are already decided, and re-deriving them from the view's own shape
         would lose the levels a dropped axis came from.
         """
-        view = object.__new__(type(self))
+        view = object.__new__(self._view_type)
         object.__setattr__(view, "_values", self._values[index])
         view._init_batch(spec, name=name, name_is_auto=True)
         return view

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -1,0 +1,180 @@
+"""NumericArrayBatch — the batch form of the numeric-array kind.
+
+See design III.1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Self
+
+from ._array_backend import _to_jax_array
+from ._batch import Batch, BatchSpec, _axis_groups_for
+from ._numeric_array import NumericArray
+from .event_template import NumericArraySpec
+from .provenance import Provenance
+
+__all__ = ["NumericArrayBatch"]
+
+
+class NumericArrayBatch(Batch[NumericArray]):
+    """A batch of numeric arrays sharing one :class:`NumericArraySpec`.
+
+    Storage is a single array with the batch axes leading — the split
+    :class:`~probpipe.RecordBatch` uses, with one column instead of many. This
+    is where a `draw` level lives for an array-valued law.
+
+    Parameters
+    ----------
+    values : array-like
+        One array holding every element, shaped ``(*batch_shape, *event_shape)``.
+    level_names : str or iterable of str
+        One name per level, outermost first; a single string names one level.
+    element_spec : NumericArraySpec
+        What every element satisfies. Its ``shape`` is the event shape, so it is
+        what splits the stored array's axes into batch and event.
+    axis_groups : iterable of iterable of int, optional
+        The axis sizes each level holds, in order, tiling ``batch_shape``.
+        Defaults to one axis per level.
+    name : str, optional
+        The batch's name; defaults to ``"numericarraybatch"``, marked auto.
+    name_is_auto : bool, default False
+        Whether *name* is auto-derived rather than user-given.
+    provenance : Provenance, optional
+        How this batch was produced.
+
+    Raises
+    ------
+    TypeError
+        If *element_spec* is not a :class:`NumericArraySpec`, or *values* does
+        not convert to an array.
+    ValueError
+        If *values* has fewer axes than the event shape it must end with, which
+        would leave no batch axis; if its trailing axes are not that event
+        shape; if a declared dimension is symbolic, which gives the event shape
+        no size to split by; or if *axis_groups* does not tile ``batch_shape``.
+
+    Notes
+    -----
+    Selection yields the element kind, as it does for every batch:
+    ``batch[i]`` is a :class:`NumericArray`. It materializes, so each element
+    takes the derived name and inherits this batch's lineage.
+    """
+
+    _values: Any
+
+    __slots__ = ("_values",)
+
+    def __init__(
+        self,
+        values: Any,
+        level_names: str | Iterable[str],
+        *,
+        element_spec: NumericArraySpec,
+        axis_groups: Iterable[Iterable[int]] | None = None,
+        name: str | None = None,
+        name_is_auto: bool = False,
+        provenance: Provenance | None = None,
+    ) -> None:
+        if not isinstance(element_spec, NumericArraySpec):
+            raise TypeError(
+                f"NumericArrayBatch element_spec must be a NumericArraySpec, "
+                f"got {type(element_spec).__name__}"
+            )
+        event_shape = tuple(element_spec.shape)
+        if any(not isinstance(axis, int) for axis in event_shape):
+            raise ValueError(
+                f"a symbolic dimension gives the event shape no size to split the stored "
+                f"axes by; bind {element_spec.shape} with with_dims before batching"
+            )
+        try:
+            array = _to_jax_array(values)
+        except Exception as exc:
+            raise TypeError(
+                f"NumericArrayBatch stores one array; {type(values).__name__} does not convert"
+            ) from exc
+
+        stored = tuple(array.shape)
+        n_event = len(event_shape)
+        if n_event and stored[len(stored) - n_event :] != event_shape:
+            raise ValueError(
+                f"the stored array ends with {stored[len(stored) - n_event :]} where its "
+                f"elements declare the event shape {event_shape}"
+            )
+        batch_shape = stored[: len(stored) - n_event] if n_event else stored
+        if not batch_shape:
+            raise ValueError(
+                f"a batch has at least one batch axis, and an array of shape {stored} over "
+                f"elements of event shape {event_shape} leaves none; a single value is a "
+                f"NumericArray"
+            )
+
+        names = (level_names,) if isinstance(level_names, str) else tuple(level_names)
+        groups = _axis_groups_for(batch_shape, names, axis_groups, kind="NumericArrayBatch")
+        if name is None:
+            name, name_is_auto = "numericarraybatch", True
+        object.__setattr__(self, "_values", array)
+        self._init_batch(
+            BatchSpec(element_spec, groups, names),
+            name=name,
+            name_is_auto=name_is_auto,
+            provenance=provenance,
+        )
+
+    # -- what it holds ------------------------------------------------------
+
+    @property
+    def element_spec(self) -> NumericArraySpec:
+        """What every element satisfies — a view on :attr:`spec`."""
+        spec = self.spec.element_spec
+        assert isinstance(spec, NumericArraySpec)
+        return spec
+
+    @property
+    def values(self) -> Any:
+        """The stored array, batch axes leading. Untracked."""
+        return self._values
+
+    @property
+    def dtype(self) -> Any:
+        return self._values.dtype
+
+    def __repr__(self) -> str:
+        return (
+            f"NumericArrayBatch(batch_shape={self.batch_shape}, "
+            f"levels={self.level_names}, event_shape={tuple(self.element_spec.shape)})"
+        )
+
+    # -- the concrete-storage seam ------------------------------------------
+
+    def _element_at(self, index: tuple[int, ...], *, name: str) -> NumericArray:
+        """The array at a fully-integer positional *index*, as a `NumericArray`.
+
+        Indexing a stored array does not produce the element on its own — the
+        element is the *tracked* value around it — so this is the materializing
+        side of both rules :meth:`~probpipe.core._batch.Batch._element_at`
+        states: it takes the derived *name*, marked auto, and inherits this
+        batch's provenance.
+        """
+        return self._inherit_provenance(
+            NumericArray(
+                self._values[index],
+                name=name,
+                name_is_auto=True,
+                spec=self.element_spec,
+            )
+        )
+
+    def _sub_batch_at(self, index: tuple[int | slice, ...], *, spec: BatchSpec, name: str) -> Self:
+        """A view over the same array, indexed on the batch axes as given.
+
+        *index* addresses the leading axes only, so the event axes are untouched
+        and array indexing yields a view rather than a copy. Built without
+        ``__init__`` for the reason ``RecordBatch`` gives: the spec and the name
+        are already decided, and re-deriving them from the view's own shape
+        would lose the levels a dropped axis came from.
+        """
+        view = object.__new__(type(self))
+        object.__setattr__(view, "_values", self._values[index])
+        view._init_batch(spec, name=name, name_is_auto=True)
+        return view

--- a/probpipe/core/_numeric_record.py
+++ b/probpipe/core/_numeric_record.py
@@ -371,7 +371,7 @@ class NumericRecord(Record):
         """Reconstruct a single record from its dense 1-D vector.
 
         The value-level inverse of :meth:`to_vector`: splits *vec* into the
-        template's per-field blocks, reshapes each to its ``ArraySpec`` shape
+        template's per-field blocks, reshapes each to its ``NumericArraySpec`` shape
         in canonical leaf order, and returns a ``NumericRecord`` carrying
         *template* as its authoritative schema under the user-given *name*.
         The reconstructed leaves are bare ``jax.Array``\\ s — a flat vector

--- a/probpipe/core/_numeric_record_batch.py
+++ b/probpipe/core/_numeric_record_batch.py
@@ -104,7 +104,7 @@ class NumericRecordBatch(RecordBatch):
         return template
 
     # ``_check_columns`` is not overridden: every field of a numeric template is
-    # an ``NumericArraySpec``, so the base already checks each column for a numeric
+    # a ``NumericArraySpec``, so the base already checks each column for a numeric
     # dtype the declaration admits.
 
     # -- single-field coercion ----------------------------------------------

--- a/probpipe/core/_numeric_record_batch.py
+++ b/probpipe/core/_numeric_record_batch.py
@@ -37,7 +37,7 @@ from ._record_batch import (
     _record_element_spec,
     _unflatten_with,
 )
-from .event_template import ArraySpec, EventTemplate, NumericEventTemplate, RecordSpec
+from .event_template import EventTemplate, NumericArraySpec, NumericEventTemplate, RecordSpec
 from .provenance import Provenance
 
 __all__ = ["NumericRecordBatch"]
@@ -104,7 +104,7 @@ class NumericRecordBatch(RecordBatch):
         return template
 
     # ``_check_columns`` is not overridden: every field of a numeric template is
-    # an ``ArraySpec``, so the base already checks each column for a numeric
+    # an ``NumericArraySpec``, so the base already checks each column for a numeric
     # dtype the declaration admits.
 
     # -- single-field coercion ----------------------------------------------
@@ -268,7 +268,7 @@ class NumericRecordBatch(RecordBatch):
             # declares its own is cast back to it — otherwise the reconstruction
             # contradicts the very template it was rebuilt from.
             declared = template[key]
-            if isinstance(declared, ArraySpec) and declared.dtype is not None:
+            if isinstance(declared, NumericArraySpec) and declared.dtype is not None:
                 block = block.astype(declared.dtype)
             columns[key] = block
             offset += size

--- a/probpipe/core/_object_batch.py
+++ b/probpipe/core/_object_batch.py
@@ -1,6 +1,6 @@
 """Object-array storage for the batch forms of values that do not stack natively.
 
-An ``ArraySpec`` value batches natively — an array with the batch axes leading —
+An ``NumericArraySpec`` value batches natively — an array with the batch axes leading —
 so no class is needed for it. A callable and an opaque object have no such form:
 there is nothing to stack them *into*. :class:`_ObjectBatch` supplies the
 storage those two batch forms share, a numpy object array, leaving each public

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -70,7 +70,7 @@ class RecordBatch(Batch[Record]):
         The field columns, keyed by **leaf path** (``"outer/a"``) or given as a
         nested mapping, which is flattened to leaf paths. Each column holds one
         field's values across the batch, shaped ``(*batch_shape, *event_shape)``
-        where the event shape is the field spec's for an ``NumericArraySpec`` and empty
+        where the event shape is the field spec's for a ``NumericArraySpec`` and empty
         otherwise — so a field that is not an array takes an object array, one
         entry per element. The keys must be exactly the fields of *element_spec*.
     level_names : str or iterable of str
@@ -1024,7 +1024,7 @@ def _batch_shape_of(
 def _stack_column(values: list[Any], spec: ValueSpec, *, kind: str) -> Any:
     """One field's values across the elements, stacked into a column.
 
-    The field's *spec* decides the form, not the values: an ``NumericArraySpec`` field
+    The field's *spec* decides the form, not the values: a ``NumericArraySpec`` field
     batches natively into an array with the batch axis leading, and every other
     leaf kind goes into an object array, one entry per element, which is the form
     the object batches present. Reading the spec rather than the values is what
@@ -1243,7 +1243,7 @@ def _refuse_a_retyped_element(
     slice shrinking the event while passing the rank check, or an object array
     arriving under a field declared numeric.
 
-    The **kind** is re-checked, not only a pinned dtype: an ``NumericArraySpec`` requires
+    The **kind** is re-checked, not only a pinned dtype: a ``NumericArraySpec`` requires
     numeric data whether or not it names a dtype, so this asks the constructor's
     own :func:`_check_array_column`, which settles kind and dtype together. That
     is the rule a batch is built under, and a transform is not a licence to

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -44,9 +44,9 @@ from ._function_batch import FunctionBatch
 from ._object_batch import _from_iterable, _frozen_object_column, _is_object_array
 from ._opaque_batch import OpaqueBatch
 from .event_template import (
-    ArraySpec,
     EventTemplate,
     FunctionSpec,
+    NumericArraySpec,
     NumericEventTemplate,
     OpaqueSpec,
     RecordSpec,
@@ -70,7 +70,7 @@ class RecordBatch(Batch[Record]):
         The field columns, keyed by **leaf path** (``"outer/a"``) or given as a
         nested mapping, which is flattened to leaf paths. Each column holds one
         field's values across the batch, shaped ``(*batch_shape, *event_shape)``
-        where the event shape is the field spec's for an ``ArraySpec`` and empty
+        where the event shape is the field spec's for an ``NumericArraySpec`` and empty
         otherwise — so a field that is not an array takes an object array, one
         entry per element. The keys must be exactly the fields of *element_spec*.
     level_names : str or iterable of str
@@ -220,7 +220,7 @@ class RecordBatch(Batch[Record]):
         the batch-axis derivation, so what is left is the dtype and the entries.
 
         An **array** field declares a dtype, so its column is checked against
-        it by the rule :meth:`~probpipe.ArraySpec.is_valid` applies to a single
+        it by the rule :meth:`~probpipe.NumericArraySpec.is_valid` applies to a single
         value: same-kind castable, so a widening or a within-kind narrowing passes
         and a cross-kind conversion does not. Any **other** field holds one entry
         per element, so its column is walked entry by entry, as ``_ObjectBatch``
@@ -237,7 +237,7 @@ class RecordBatch(Batch[Record]):
         """
         for path, column in store.items():
             spec = template[path]
-            if isinstance(spec, ArraySpec):
+            if isinstance(spec, NumericArraySpec):
                 _check_array_column(column, spec, path=path, kind=kind)
                 continue
             if not isinstance(spec, FunctionSpec | OpaqueSpec):
@@ -365,7 +365,7 @@ class RecordBatch(Batch[Record]):
     def _column_as_batch(self, key: str) -> Any:
         """One field's column, in the batch form its spec calls for.
 
-        An ``ArraySpec`` batches natively — the column *is* the array, with the
+        An ``NumericArraySpec`` batches natively — the column *is* the array, with the
         batch axes leading — so it is returned as stored. A callable or an opaque
         value has no such form, so the column is presented as the matching object
         batch over the same elements, carrying this batch's own levels.
@@ -379,7 +379,7 @@ class RecordBatch(Batch[Record]):
         """
         column = self._columns[key]
         spec = self.event_template[key]
-        if isinstance(spec, ArraySpec):
+        if isinstance(spec, NumericArraySpec):
             return column
         name = f"{self.name}[{key!r}]"
         column_spec = BatchSpec(spec, self.axis_groups, self.level_names)
@@ -927,7 +927,7 @@ def _inferred_field_spec(column: Any, event_shape: tuple[int, ...]) -> Any:
 def _event_shape(spec: ValueSpec, *, path: str, kind: str) -> tuple[int, ...]:
     """The event shape a column carries beyond the batch axes.
 
-    An ``ArraySpec`` declares one; every other leaf kind exposes no shape, so its
+    An ``NumericArraySpec`` declares one; every other leaf kind exposes no shape, so its
     column is one entry per element and the batch axes are all of it.
 
     Raises
@@ -938,7 +938,7 @@ def _event_shape(spec: ValueSpec, *, path: str, kind: str) -> tuple[int, ...]:
         refused where it can be named rather than compared against an integer
         further on.
     """
-    if not isinstance(spec, ArraySpec):
+    if not isinstance(spec, NumericArraySpec):
         return ()
     shape = tuple(spec.shape)
     symbolic = [entry for entry in shape if not isinstance(entry, int)]
@@ -1024,7 +1024,7 @@ def _batch_shape_of(
 def _stack_column(values: list[Any], spec: ValueSpec, *, kind: str) -> Any:
     """One field's values across the elements, stacked into a column.
 
-    The field's *spec* decides the form, not the values: an ``ArraySpec`` field
+    The field's *spec* decides the form, not the values: an ``NumericArraySpec`` field
     batches natively into an array with the batch axis leading, and every other
     leaf kind goes into an object array, one entry per element, which is the form
     the object batches present. Reading the spec rather than the values is what
@@ -1032,7 +1032,7 @@ def _stack_column(values: list[Any], spec: ValueSpec, *, kind: str) -> Any:
     ``OpaqueSpec`` admits — so the column comes back as the batch form its spec
     calls for and an element comes back as the object that was put in.
     """
-    if isinstance(spec, ArraySpec):
+    if isinstance(spec, NumericArraySpec):
         # Through the array backend, not ``jnp.asarray``: a registered container
         # converts by its own ``to_jax``, and the duck path cannot see it.
         return jnp.stack([_to_jax_array(value) for value in values])
@@ -1078,10 +1078,10 @@ def _one_entry_equal(left: Any, right: Any) -> bool:
         return False
 
 
-def _check_array_column(column: Any, spec: ArraySpec, *, path: str, kind: str) -> None:
+def _check_array_column(column: Any, spec: NumericArraySpec, *, path: str, kind: str) -> None:
     """Fail unless *column* is a numeric array whose dtype *spec* admits.
 
-    The dtype rule is :meth:`~probpipe.ArraySpec.is_valid`'s, applied to the
+    The dtype rule is :meth:`~probpipe.NumericArraySpec.is_valid`'s, applied to the
     column rather than to one value: same-kind castable, so a widening or a
     within-kind narrowing passes and a cross-kind conversion does not. The shape
     is already settled by the batch-axis derivation.
@@ -1243,7 +1243,7 @@ def _refuse_a_retyped_element(
     slice shrinking the event while passing the rank check, or an object array
     arriving under a field declared numeric.
 
-    The **kind** is re-checked, not only a pinned dtype: an ``ArraySpec`` requires
+    The **kind** is re-checked, not only a pinned dtype: an ``NumericArraySpec`` requires
     numeric data whether or not it names a dtype, so this asks the constructor's
     own :func:`_check_array_column`, which settles kind and dtype together. That
     is the rule a batch is built under, and a transform is not a licence to
@@ -1255,7 +1255,7 @@ def _refuse_a_retyped_element(
     for path, column in columns.items():
         shape = _column_shape(column)
         field = template[path]
-        if not isinstance(field, ArraySpec):
+        if not isinstance(field, NumericArraySpec):
             # A field with no stacked form is checked the way the constructor
             # checks it: entry by entry against its own spec. A shape-preserving
             # transform can replace a column of callables with integers and leave
@@ -1305,7 +1305,7 @@ def _surviving_batch_rank(
         if shape is None:
             return None
         field = template[path]
-        event_rank = len(field.shape) if isinstance(field, ArraySpec) else 0
+        event_rank = len(field.shape) if isinstance(field, NumericArraySpec) else 0
         if len(shape) < event_rank:
             raise ValueError(
                 f"a transform left the column {path!r} with shape {tuple(shape)}, fewer axes "

--- a/probpipe/core/_record_distribution.py
+++ b/probpipe/core/_record_distribution.py
@@ -21,7 +21,7 @@ import jax.numpy as jnp
 
 from ..custom_types import Array, PRNGKey
 from ._distribution_base import Distribution
-from .event_template import ArraySpec, EventTemplate
+from .event_template import EventTemplate, NumericArraySpec
 from .protocols import (
     SupportsCovariance,
     SupportsLogProb,
@@ -38,7 +38,7 @@ __all__ = ["RecordDistribution", "_RecordDistributionView"]
 def _field_event_shape(template: EventTemplate, name: str) -> tuple[int, ...]:
     """Event shape of one top-level field of *template*.
 
-    An :class:`ArraySpec` field returns its array ``shape``; a nested
+    An :class:`NumericArraySpec` field returns its array ``shape``; a nested
     sub-structure or non-array (opaque / distribution / function) field has no
     single event shape and returns ``()``. This is a *distribution-side* view —
     "what is the per-field event shape of one draw?" — kept here rather than on
@@ -46,7 +46,7 @@ def _field_event_shape(template: EventTemplate, name: str) -> tuple[int, ...]:
     (:attr:`~probpipe.NumericEventTemplate.leaf_shapes`).
     """
     spec = template.children[name]
-    return spec.shape if isinstance(spec, ArraySpec) else ()
+    return spec.shape if isinstance(spec, NumericArraySpec) else ()
 
 
 # ---------------------------------------------------------------------------
@@ -260,7 +260,7 @@ class _RecordDistributionView(Distribution):
     @property
     def event_shape(self) -> tuple[int, ...]:
         f = self._template_field
-        if isinstance(f, ArraySpec):
+        if isinstance(f, NumericArraySpec):
             # Numeric array leaf — its event shape is the spec shape.
             return f.shape
         # Nested template / opaque / distribution / function leaf.

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -40,7 +40,7 @@ Specs come in two families. A **raw-value spec** describes a plain value that
 names no ProbPipe kind. A **term spec** describes a tracked term, one class per
 kind, and all of them subclass the :class:`TermSpec` marker; a declaration whose
 class is a term spec therefore names a kind. The concrete specs are as follows:
-- :class:`ArraySpec`: describes a numeric array (shape, optional dtype/support)
+- :class:`NumericArraySpec`: describes a numeric array (shape, optional dtype/support)
 - :class:`RecordSpec`: describes an embedded ``Record``. Carries the event
   template of that record.
 - :class:`DistributionSpec`: describes a ``Distribution``. Carries the *event
@@ -52,7 +52,7 @@ class is a term spec therefore names a kind. The concrete specs are as follows:
 Numeric vs. Mixed
 -----------------
 
-When every field is an ``ArraySpec`` the template is all-numeric, and
+When every field is an ``NumericArraySpec`` the template is all-numeric, and
 ``EventTemplate(...)`` auto-promotes to :class:`NumericEventTemplate` — the
 specialization describing a value that is a PyTree of arrays. That subclass
 adds the flat-vector layout — ``vector_size`` and :meth:`from_vector`
@@ -84,10 +84,10 @@ from .named_tree import (
 )
 
 __all__ = [
-    "ArraySpec",
     "DistributionSpec",
     "EventTemplate",
     "FunctionSpec",
+    "NumericArraySpec",
     "NumericEventTemplate",
     "OpaqueSpec",
     "RecordSpec",
@@ -216,7 +216,7 @@ class TermSpec(ValueSpec):
     term — a ``Record``, ``Distribution``, or ``Function``. It subclasses
     :class:`ValueSpec` and adds no members of its own: the concrete subclass
     (:class:`RecordSpec`, :class:`DistributionSpec`, :class:`FunctionSpec`)
-    *is* the kind, and ``is_valid`` is inherited, not redeclared. ``ArraySpec``
+    *is* the kind, and ``is_valid`` is inherited, not redeclared. ``NumericArraySpec``
     and ``OpaqueSpec``, the raw-value leaves, are not term specs.
 
     The marker is what ``isinstance`` reads: a declaration whose class is a term
@@ -233,7 +233,7 @@ class TermSpec(ValueSpec):
 
 
 @dataclass(frozen=True, eq=False, init=False)
-class ArraySpec(ValueSpec):
+class NumericArraySpec(ValueSpec):
     """A numeric-array value spec: an event ``shape`` plus optional metadata.
 
     ``dtype`` and ``support`` are optional (default ``None``); when unset the
@@ -267,11 +267,11 @@ class ArraySpec(ValueSpec):
             (isinstance(d, int) and d >= 0) or (isinstance(d, str) and bool(d)) for d in dimensions
         ):
             raise TypeError(
-                "ArraySpec.shape must contain only non-negative ints or non-empty "
+                "NumericArraySpec.shape must contain only non-negative ints or non-empty "
                 f"symbolic dimension names, got {shape!r}"
             )
         if support is not None:
-            _require_hashable(support, context="ArraySpec.support")
+            _require_hashable(support, context="NumericArraySpec.support")
         object.__setattr__(self, "shape", dimensions)
         object.__setattr__(self, "dtype", None if dtype is None else np.dtype(dtype))
         object.__setattr__(self, "support", support)
@@ -296,7 +296,7 @@ class ArraySpec(ValueSpec):
 
     def bind_dims_from_spec(self, actual: ValueSpec, bindings: dict[str, int], path: str) -> bool:
         """Bind the symbolic entries of :attr:`shape` from *actual*'s own shape."""
-        if not isinstance(actual, ArraySpec):
+        if not isinstance(actual, NumericArraySpec):
             return False
         if any(isinstance(entry, str) for entry in actual.shape):
             raise ValueError(
@@ -308,9 +308,9 @@ class ArraySpec(ValueSpec):
                 raise ValueError(f"{path} dtype {actual.dtype} does not conform to {self.dtype}")
         return True
 
-    def with_bound_dims(self, bindings: Mapping[str, int]) -> ArraySpec:
+    def with_bound_dims(self, bindings: Mapping[str, int]) -> NumericArraySpec:
         """This spec with each bound entry of :attr:`shape` replaced by its size."""
-        return ArraySpec(
+        return NumericArraySpec(
             tuple(
                 bindings.get(entry, entry) if isinstance(entry, str) else entry
                 for entry in self.shape
@@ -325,7 +325,7 @@ class ArraySpec(ValueSpec):
         # ``False`` when both sides decline).
         if other.__class__ is not self.__class__:
             return NotImplemented
-        assert isinstance(other, ArraySpec)  # narrow for the type checker
+        assert isinstance(other, NumericArraySpec)  # narrow for the type checker
         # ``numpy.dtype`` treats ``None`` as an alias for the default dtype
         # (``np.dtype(None)`` is float64), so a plain field comparison would
         # report an unset dtype equal to a concrete one. Compare set-ness
@@ -406,7 +406,7 @@ class OpaqueSpec(ValueSpec):
         As the fallback spec, ``OpaqueSpec`` accepts any value **except** a
         ``Mapping``: a mapping denotes tree structure (a subtree), never a
         leaf. Every other value is valid, including a numeric array or scalar
-        — such a value is *typically* described by an :class:`ArraySpec`, but
+        — such a value is *typically* described by an :class:`NumericArraySpec`, but
         an explicitly-opaque field still accepts it. ``meta`` is metadata
         about the spec and is not checked against the value.
 
@@ -545,8 +545,8 @@ def _reshaped_template(
     for path, spec in template.children.items():
         if isinstance(spec, EventTemplate):
             children[path] = _reshaped_template(spec, reshape)
-        elif isinstance(spec, ArraySpec):
-            children[path] = ArraySpec(
+        elif isinstance(spec, NumericArraySpec):
+            children[path] = NumericArraySpec(
                 tuple(reshape(tuple(spec.shape))), dtype=spec.dtype, support=spec.support
             )
         else:
@@ -700,7 +700,7 @@ class FunctionSpec(TermSpec):
     meaningful, matching :class:`DistributionSpec`.
 
     The output declaration is any value specification, so a callable may
-    declare a raw-value result as well as a term: an ``ArraySpec`` output
+    declare a raw-value result as well as a term: an ``NumericArraySpec`` output
     declares one array. A term declaration names its kind by its class, while a
     raw-value declaration types the value the wrap boundary then places in a
     single-field ``Record``, keyed by the ``Function``'s name.
@@ -846,16 +846,16 @@ def _to_spec(spec: _FieldSpecInput) -> _FieldSpec:
     """Normalise a constructor input to a stored field spec.
 
     Construction-time sugar (preserved): a bare shape ``tuple`` becomes an
-    :class:`ArraySpec`, ``None`` becomes an :class:`OpaqueSpec`, and a nested
+    :class:`NumericArraySpec`, ``None`` becomes an :class:`OpaqueSpec`, and a nested
     :class:`EventTemplate` is kept as-is. Already-built specs pass through, so
-    new code may supply explicit ``ArraySpec(...)`` / ``OpaqueSpec(...)`` etc.
+    new code may supply explicit ``NumericArraySpec(...)`` / ``OpaqueSpec(...)`` etc.
     """
     if isinstance(spec, (ValueSpec, EventTemplate)):
         return spec
     if spec is None:
         return OpaqueSpec()
     if isinstance(spec, tuple):
-        return ArraySpec(shape=spec)
+        return NumericArraySpec(shape=spec)
     raise TypeError(
         f"spec must be a shape tuple, None, a ValueSpec, or an "
         f"EventTemplate, got {type(spec).__name__}"
@@ -863,7 +863,7 @@ def _to_spec(spec: _FieldSpecInput) -> _FieldSpec:
 
 
 def _is_numeric_spec(spec: Any) -> bool:
-    """A numeric leaf: an :class:`ArraySpec` or a (nested) :class:`NumericEventTemplate`.
+    """A numeric leaf: an :class:`NumericArraySpec` or a (nested) :class:`NumericEventTemplate`.
 
     A mapping spec (nested structure, not yet materialised into a nested
     template) counts as numeric iff all of its own values are — so
@@ -872,7 +872,7 @@ def _is_numeric_spec(spec: Any) -> bool:
     """
     if isinstance(spec, Mapping):
         return _all_numeric(spec.values())
-    return isinstance(spec, (ArraySpec, NumericEventTemplate))
+    return isinstance(spec, (NumericArraySpec, NumericEventTemplate))
 
 
 def _all_numeric(specs: Iterable[Any]) -> bool:
@@ -880,7 +880,7 @@ def _all_numeric(specs: Iterable[Any]) -> bool:
 
     Drives the base-class auto-promotion hook so ``EventTemplate(x=(), y=(3,))``
     returns a ``NumericEventTemplate`` without opting in explicitly. Raw inputs
-    also allow the shape-tuple sugar; ``None``, every non-``ArraySpec`` spec,
+    also allow the shape-tuple sugar; ``None``, every non-``NumericArraySpec`` spec,
     mixed nested templates, and any unsupported type are non-numeric
     (``__init__`` rejects the latter).
     """
@@ -977,7 +977,7 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
 
         - ``tuple[int | str, ...]`` — fixed or symbolic shape of a numeric array
           leaf (e.g. ``()`` for a scalar, ``(3,)`` for a 3-vector, or
-          ``("obs", 3)``); normalised to :class:`ArraySpec`.
+          ``("obs", 3)``); normalised to :class:`NumericArraySpec`.
         - ``None`` — opaque (non-array) leaf; normalised to :class:`OpaqueSpec`.
         - a :class:`ValueSpec` — an already-built spec (passed through).
         - ``EventTemplate`` — a nested sub-structure (an internal node).
@@ -1101,11 +1101,11 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
 
     @property
     def is_numeric(self) -> bool:
-        """Whether every reachable leaf is an :class:`ArraySpec`.
+        """Whether every reachable leaf is an :class:`NumericArraySpec`.
 
         Recursive: descends into nested :class:`EventTemplate` fields and
         returns ``True`` only if *all* leaves (at every depth) are numeric
-        array leaves. Any non-:class:`ArraySpec` leaf — or a nested
+        array leaves. Any non-:class:`NumericArraySpec` leaf — or a nested
         sub-template that is not itself all-numeric — makes the whole
         template non-numeric.
 
@@ -1117,10 +1117,10 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
         Returns
         -------
         bool
-            ``True`` iff every reachable leaf is an :class:`ArraySpec`.
+            ``True`` iff every reachable leaf is an :class:`NumericArraySpec`.
         """
         for spec in self._tree.values():
-            if isinstance(spec, ArraySpec):
+            if isinstance(spec, NumericArraySpec):
                 continue
             if isinstance(spec, EventTemplate):
                 if not spec.is_numeric:
@@ -1171,7 +1171,7 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
 
         Examples
         --------
-        >>> template = EventTemplate(x=ArraySpec(shape=("obs",)))
+        >>> template = EventTemplate(x=NumericArraySpec(shape=("obs",)))
         >>> template.is_concrete
         False
         >>> template.with_dims(obs=5).is_concrete
@@ -1188,11 +1188,11 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
         return _concretize_event_template(self, sizes, context=type(self).__name__)
 
     def numeric_subset(self) -> NumericEventTemplate:
-        """Project to the :class:`ArraySpec`-leaf sub-template.
+        """Project to the :class:`NumericArraySpec`-leaf sub-template.
 
         Keeps every numeric leaf, recursing into nested
         :class:`EventTemplate` fields (each contributes its own
-        ``numeric_subset()``); drops every non-:class:`ArraySpec` leaf; and
+        ``numeric_subset()``); drops every non-:class:`NumericArraySpec` leaf; and
         prunes any nested template that becomes empty. Surviving leaves keep their
         ``/``-delimited paths (the projection is path-stable). Inference uses
         this to recover the numeric leaves of a mixed template.
@@ -1215,7 +1215,7 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
         """
         specs: dict[str, _FieldSpec] = {}
         for name, spec in self._tree.items():
-            if isinstance(spec, ArraySpec):
+            if isinstance(spec, NumericArraySpec):
                 specs[name] = spec
             elif isinstance(spec, EventTemplate):
                 try:
@@ -1233,13 +1233,13 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
                 name
                 for name, spec in self._tree.items()
                 if not (
-                    isinstance(spec, ArraySpec)
+                    isinstance(spec, NumericArraySpec)
                     or (isinstance(spec, EventTemplate) and spec.is_numeric)
                 )
             )
             raise ValueError(
                 f"numeric_subset() of {type(self).__name__} is empty: no "
-                f"ArraySpec leaves survive. Dropped non-numeric fields: {dropped}."
+                f"NumericArraySpec leaves survive. Dropped non-numeric fields: {dropped}."
             )
         return NumericEventTemplate(specs)
 
@@ -1274,14 +1274,14 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
         - A **mapping** of named fields (e.g. a ``Record``'s field dict) is
           inferred field by field: a nested ``Record`` field contributes its
           own ``event_template``; a numeric array or scalar becomes an
-          :class:`ArraySpec` of its shape; anything else becomes a bare
+          :class:`NumericArraySpec` of its shape; anything else becomes a bare
           :class:`OpaqueSpec`. The result auto-promotes to a
           :class:`NumericEventTemplate` when every field is numeric.
 
         This is the **fallback** for wrapping a raw value that has no template
         yet (e.g. at a workflow boundary); for a value you already hold, read
         its authoritative ``event_template`` directly. Inference is lossy — it
-        cannot recover an :class:`ArraySpec`'s ``dtype`` / ``support``, an
+        cannot recover an :class:`NumericArraySpec`'s ``dtype`` / ``support``, an
         :class:`OpaqueSpec`'s ``meta``, or a :class:`RecordSpec` /
         :class:`DistributionSpec` / :class:`FunctionSpec`. A Python ``list`` /
         ``tuple`` leaf (no ``.shape`` / ``.dtype``) is treated as opaque even if
@@ -1326,7 +1326,7 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
                 return cls.infer_from(val)
             # Any numeric array-like — bare arrays and native containers
             # (xarray / pandas / registered backends) alike — infers an
-            # ``ArraySpec``; leaves are stored in native form, so nothing is
+            # ``NumericArraySpec``; leaves are stored in native form, so nothing is
             # lost by classing them numeric.
             return _full_array_shape_or_none(val)
 
@@ -1340,7 +1340,7 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
         for name, spec in self._tree.items():
             if isinstance(spec, EventTemplate):
                 parts.append(f"{name}={spec!r}")
-            elif isinstance(spec, ArraySpec) and spec.dtype is None and spec.support is None:
+            elif isinstance(spec, NumericArraySpec) and spec.dtype is None and spec.support is None:
                 # Bare specs render as their sugar form (shape tuple / None).
                 parts.append(f"{name}={spec.shape}")
             elif isinstance(spec, OpaqueSpec) and spec.meta is None:
@@ -1389,7 +1389,7 @@ class NumericEventTemplate(EventTemplate):
             # Any non-array leaf — OpaqueSpec, RecordSpec, DistributionSpec, or FunctionSpec.
             raise TypeError(
                 f"NumericEventTemplate: field {name!r} is a {type(spec).__name__}; "
-                f"only ArraySpec leaves (or a nested NumericEventTemplate) are "
+                f"only NumericArraySpec leaves (or a nested NumericEventTemplate) are "
                 f"allowed — use EventTemplate if you need a mixed template."
             )
 
@@ -1408,7 +1408,7 @@ class NumericEventTemplate(EventTemplate):
 
         Maps each leaf's ``/``-delimited path to its array ``shape``. Defined
         only on :class:`NumericEventTemplate` — where every leaf is an
-        :class:`ArraySpec` and therefore *has* a shape — because a shape is an
+        :class:`NumericArraySpec` and therefore *has* a shape — because a shape is an
         array notion; on a general (mixed) :class:`EventTemplate` the leaves are
         a heterogeneous sum with no uniform shape, so the structural view there
         is :meth:`keys`. A nested sub-template contributes one entry per
@@ -1420,7 +1420,7 @@ class NumericEventTemplate(EventTemplate):
                 for sub_name, sub_shape in spec.leaf_shapes.items():
                     result[f"{name}{_PATH_SEP}{sub_name}"] = sub_shape
             else:
-                # ``_post_validate`` guarantees a non-nested spec is an ArraySpec.
+                # ``_post_validate`` guarantees a non-nested spec is an NumericArraySpec.
                 result[name] = spec.shape
         return result
 
@@ -1433,7 +1433,7 @@ class NumericEventTemplate(EventTemplate):
             if isinstance(spec, NumericEventTemplate):
                 total += spec.vector_size
             else:
-                # spec is an ArraySpec — validated by ``_post_validate``.
+                # spec is an NumericArraySpec — validated by ``_post_validate``.
                 total += prod(spec.shape) if spec.shape else 1
         return total
 
@@ -1589,7 +1589,7 @@ def _unify_specs(
     :meth:`ValueSpec.bind_dims_from_spec`, and an array is concretized for the
     same reason it is when bound from a value.
     """
-    if isinstance(expected, ArraySpec) and isinstance(actual, ArraySpec):
+    if isinstance(expected, NumericArraySpec) and isinstance(actual, NumericArraySpec):
         expected.bind_dims_from_spec(actual, bindings, path)
         return expected.with_bound_dims(bindings)
     if expected.free_dims and type(expected) is type(actual):
@@ -1617,7 +1617,7 @@ def _unify_spec_with_value(
     since it may bind only some of its names and the rest belong to fields this
     pass has not reached.
     """
-    if not isinstance(spec, ArraySpec):
+    if not isinstance(spec, NumericArraySpec):
         if spec.free_dims:
             return _unify_term_spec_with_value(spec, value, bindings, path)
         if not spec.is_valid(value):

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -52,7 +52,7 @@ class is a term spec therefore names a kind. The concrete specs are as follows:
 Numeric vs. Mixed
 -----------------
 
-When every field is an ``NumericArraySpec`` the template is all-numeric, and
+When every field is a ``NumericArraySpec`` the template is all-numeric, and
 ``EventTemplate(...)`` auto-promotes to :class:`NumericEventTemplate` — the
 specialization describing a value that is a PyTree of arrays. That subclass
 adds the flat-vector layout — ``vector_size`` and :meth:`from_vector`
@@ -700,7 +700,7 @@ class FunctionSpec(TermSpec):
     meaningful, matching :class:`DistributionSpec`.
 
     The output declaration is any value specification, so a callable may
-    declare a raw-value result as well as a term: an ``NumericArraySpec`` output
+    declare a raw-value result as well as a term: a ``NumericArraySpec`` output
     declares one array. A term declaration names its kind by its class, while a
     raw-value declaration types the value the wrap boundary then places in a
     single-field ``Record``, keyed by the ``Function``'s name.
@@ -1420,7 +1420,7 @@ class NumericEventTemplate(EventTemplate):
                 for sub_name, sub_shape in spec.leaf_shapes.items():
                     result[f"{name}{_PATH_SEP}{sub_name}"] = sub_shape
             else:
-                # ``_post_validate`` guarantees a non-nested spec is an NumericArraySpec.
+                # ``_post_validate`` guarantees a non-nested spec is a NumericArraySpec.
                 result[name] = spec.shape
         return result
 
@@ -1433,7 +1433,7 @@ class NumericEventTemplate(EventTemplate):
             if isinstance(spec, NumericEventTemplate):
                 total += spec.vector_size
             else:
-                # spec is an NumericArraySpec — validated by ``_post_validate``.
+                # spec is a NumericArraySpec — validated by ``_post_validate``.
                 total += prod(spec.shape) if spec.shape else 1
         return total
 

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -54,8 +54,8 @@ from ._numeric_record_batch import NumericRecordBatch
 from ._record_batch import RecordBatch
 from ._record_distribution import RecordDistribution
 from .event_template import (
-    ArraySpec,
     EventTemplate,
+    NumericArraySpec,
     NumericEventTemplate,
     _concretize_event_template,
 )
@@ -1122,7 +1122,7 @@ class Function(Node, TrackedTerm, Annotated):
     ) -> None:
         """Raise a clear error if explicit JAX dispatch cannot trace."""
         if self._output_template is not None and any(
-            isinstance(spec, ArraySpec) and spec.support is not None
+            isinstance(spec, NumericArraySpec) and spec.support is not None
             for spec in self._output_template.values()
         ):
             raise ValueError(

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -284,7 +284,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
     equal only when inference recovers the original template, for instance when
     that template was itself inferred (the record was built without an explicit
     ``event_template``). Inference is lossy: :meth:`EventTemplate.infer_from`
-    cannot recover an ``NumericArraySpec``'s ``dtype`` / ``support``, an
+    cannot recover a ``NumericArraySpec``'s ``dtype`` / ``support``, an
     ``OpaqueSpec``'s ``meta``, etc., so an identity ``map`` of a record carrying
     a richer explicit template does *not* compare equal::
 
@@ -573,7 +573,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
                     )
                 elif check_leaf_values and not spec.is_valid(value):
                     # Both leaves: each value must satisfy its spec's is_valid
-                    # (structural shape + dtype; an NumericArraySpec's support is
+                    # (structural shape + dtype; a NumericArraySpec's support is
                     # descriptive and not part of is_valid). Skipped on the
                     # pytree-unflatten path, where a leaf's shape is
                     # transform-relative (e.g. vmap strips the mapped axis) and
@@ -617,7 +617,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
 
         Notes
         -----
-        Inference is a lossy fallback (it cannot recover an ``NumericArraySpec``'s
+        Inference is a lossy fallback (it cannot recover a ``NumericArraySpec``'s
         ``dtype`` / ``support``, an ``OpaqueSpec``'s ``meta``, or a
         ``RecordSpec`` / ``DistributionSpec`` / ``FunctionSpec``), so both round
         trips out of this process carry the declaration rather than re-deriving
@@ -1026,7 +1026,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
             If the number of *values* is not the number of fields
             (``len(template)``), or a value fails its field spec's structural
             ``is_valid`` at construction — a shape mismatch, or a cross-kind
-            dtype (an ``NumericArraySpec``'s ``support`` is descriptive and not
+            dtype (a ``NumericArraySpec``'s ``support`` is descriptive and not
             checked).
         """
         values = list(values)

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -214,19 +214,19 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
     Because an :class:`EventTemplate` is itself a :class:`~probpipe.core.named_tree.NamedTree`, its tree
     mirrors the record's exactly: each nested ``Record`` corresponds to a
     nested ``EventTemplate``, and each field value corresponds to a value spec
-    (an array to an :class:`ArraySpec`, any non-array to an
+    (an array to an :class:`NumericArraySpec`, any non-array to an
     :class:`OpaqueSpec`, and so on). ::
 
         r.event_template
         # NumericEventTemplate(x=(), y=NumericEventTemplate(a=(), b=()))
-        r.event_template["y/a"]  # ArraySpec(shape=())  — the spec for r["y/a"]
+        r.event_template["y/a"]  # NumericArraySpec(shape=())  — the spec for r["y/a"]
 
         # A record's subtree and its template's subtree stay in lock-step:
         r.at_path("y").event_template == r.event_template.at_path("y")  # True
 
         # Each field value maps to a value spec by type:
         Record("r", vec=jnp.zeros(3), label="fox").event_template
-        # EventTemplate(vec=(3,), label=None)   — array -> ArraySpec, str -> OpaqueSpec
+        # EventTemplate(vec=(3,), label=None)   — array -> NumericArraySpec, str -> OpaqueSpec
 
     Metadata: identity and annotations
     ----------------------------------
@@ -284,7 +284,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
     equal only when inference recovers the original template, for instance when
     that template was itself inferred (the record was built without an explicit
     ``event_template``). Inference is lossy: :meth:`EventTemplate.infer_from`
-    cannot recover an ``ArraySpec``'s ``dtype`` / ``support``, an
+    cannot recover an ``NumericArraySpec``'s ``dtype`` / ``support``, an
     ``OpaqueSpec``'s ``meta``, etc., so an identity ``map`` of a record carrying
     a richer explicit template does *not* compare equal::
 
@@ -541,7 +541,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
         sets must match, a nested ``Record`` must align with a nested
         ``EventTemplate`` (both internal nodes), and a non-``Record`` leaf must
         satisfy its value spec's ``is_valid`` (structure: shape and dtype; an
-        ``ArraySpec``'s ``support`` is descriptive and not part of ``is_valid``).
+        ``NumericArraySpec``'s ``support`` is descriptive and not part of ``is_valid``).
         Leaf validation is skipped on the pytree-unflatten path, where a leaf's
         shape is transform-relative (e.g. ``vmap`` strips the mapped axis) and
         the record was already validated when first built.
@@ -573,7 +573,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
                     )
                 elif check_leaf_values and not spec.is_valid(value):
                     # Both leaves: each value must satisfy its spec's is_valid
-                    # (structural shape + dtype; an ArraySpec's support is
+                    # (structural shape + dtype; an NumericArraySpec's support is
                     # descriptive and not part of is_valid). Skipped on the
                     # pytree-unflatten path, where a leaf's shape is
                     # transform-relative (e.g. vmap strips the mapped axis) and
@@ -617,7 +617,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
 
         Notes
         -----
-        Inference is a lossy fallback (it cannot recover an ``ArraySpec``'s
+        Inference is a lossy fallback (it cannot recover an ``NumericArraySpec``'s
         ``dtype`` / ``support``, an ``OpaqueSpec``'s ``meta``, or a
         ``RecordSpec`` / ``DistributionSpec`` / ``FunctionSpec``), so both round
         trips out of this process carry the declaration rather than re-deriving
@@ -1026,7 +1026,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
             If the number of *values* is not the number of fields
             (``len(template)``), or a value fails its field spec's structural
             ``is_valid`` at construction — a shape mismatch, or a cross-kind
-            dtype (an ``ArraySpec``'s ``support`` is descriptive and not
+            dtype (an ``NumericArraySpec``'s ``support`` is descriptive and not
             checked).
         """
         values = list(values)
@@ -1118,7 +1118,7 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
         richer explicit template compares equal to a re-inferred rebuild of
         itself (e.g. via :meth:`map`) only when inference recovers that template,
         since :meth:`EventTemplate.infer_from` is lossy (it cannot recover an
-        ``ArraySpec``'s ``dtype`` / ``support``, etc.).
+        ``NumericArraySpec``'s ``dtype`` / ``support``, etc.).
 
         :meth:`__hash__` is a coarser, structural hash (shape only, never the
         values or metadata), so equal records always hash equal while records

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -13,7 +13,7 @@ import jax.numpy as jnp
 from .._weights import Weights
 from ..core._immutable import transient_memo
 from ..core.distribution import Distribution, RecordEmpiricalDistribution
-from ..core.event_template import ArraySpec, EventTemplate, NumericEventTemplate, OpaqueSpec
+from ..core.event_template import EventTemplate, NumericArraySpec, NumericEventTemplate, OpaqueSpec
 from ..core.provenance import Provenance
 from ..core.record import Record
 from ..custom_types import Array, ArrayLike
@@ -21,13 +21,13 @@ from ..custom_types import Array, ArrayLike
 __all__ = ["ApproximateDistribution", "make_posterior"]
 
 
-def _spec_size(spec: ArraySpec | EventTemplate) -> int:
+def _spec_size(spec: NumericArraySpec | EventTemplate) -> int:
     """Number of scalar elements one field contributes to a flat vector.
 
     Given the spec of a single field of an :class:`EventTemplate`, return how
     many scalars that field occupies in the dense 1-D vector layout (see
     :meth:`~probpipe.NumericRecord.to_vector`): ``prod(shape)`` for an
-    :class:`ArraySpec`, or :attr:`~NumericEventTemplate.vector_size` for a
+    :class:`NumericArraySpec`, or :attr:`~NumericEventTemplate.vector_size` for a
     nested :class:`NumericEventTemplate`. Summing this over a template's fields
     gives the template's own ``vector_size``; it is used here to size each
     field's contiguous column block when splitting a flat chain.
@@ -52,11 +52,11 @@ def _spec_size(spec: ArraySpec | EventTemplate) -> int:
             f"nested {type(spec).__name__} contains non-numeric leaves; "
             f"a flat size requires a NumericEventTemplate."
         )
-    if isinstance(spec, ArraySpec):
+    if isinstance(spec, NumericArraySpec):
         return prod(spec.shape) if spec.shape else 1
     raise TypeError(
         f"template field ({type(spec).__name__}) has no flat size; only numeric "
-        f"(ArraySpec) fields and nested NumericEventTemplate fields do."
+        f"(NumericArraySpec) fields and nested NumericEventTemplate fields do."
     )
 
 
@@ -261,8 +261,8 @@ class ApproximateDistribution(RecordEmpiricalDistribution):
                     # ``(*sample_shape, nested_vector_size)``.
                     fields[field_name] = chunk
                 else:
-                    # ArraySpec leaf (opaque rejected above, nested handled).
-                    assert isinstance(spec, ArraySpec)
+                    # NumericArraySpec leaf (opaque rejected above, nested handled).
+                    assert isinstance(spec, NumericArraySpec)
                     shape = spec.shape
                     fields[field_name] = chunk.reshape(*flat.shape[:-1], *shape)
                 offset += size

--- a/tests/core/test_array_backend.py
+++ b/tests/core/test_array_backend.py
@@ -18,7 +18,7 @@ import pytest
 
 from probpipe import ArrayBackend, NumericRecord, Record, array_backend_for, register_array_backend
 from probpipe.core import _array_backend
-from probpipe.core.event_template import ArraySpec, EventTemplate, NumericEventTemplate
+from probpipe.core.event_template import EventTemplate, NumericArraySpec, NumericEventTemplate
 
 xr = pytest.importorskip("xarray")
 pd = pytest.importorskip("pandas")
@@ -87,7 +87,7 @@ class TestRegistryLookup:
         assert backend.numpy_dtype(homo) == np.dtype("float64")
         # A mixed-but-all-numeric frame densifies (to_numpy / to_jax) to its
         # columns' common promotion — the dtype the leaf is actually built as —
-        # not None, so a dtype-pinned ArraySpec does not over-reject it.
+        # not None, so a dtype-pinned NumericArraySpec does not over-reject it.
         assert backend.numpy_dtype(mixed) == np.dtype("float64")
         # No single dense dtype (an empty frame) still reports None.
         assert backend.numpy_dtype(pd.DataFrame()) is None
@@ -96,7 +96,7 @@ class TestRegistryLookup:
         # Regression: an int64 + float64 frame validates against a float64-pinned
         # NumericEventTemplate (previously rejected because numpy_dtype was None).
         df = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
-        tpl = NumericEventTemplate({"x": ArraySpec((2, 2), dtype=np.dtype("float64"))})
+        tpl = NumericEventTemplate({"x": NumericArraySpec((2, 2), dtype=np.dtype("float64"))})
         nr = NumericRecord("r", x=df, event_template=tpl)
         assert nr["x"] is df
 
@@ -331,7 +331,7 @@ class TestLazyConversion:
         leaf = _LazyLeaf()
         nr = NumericRecord("nr", lazy=leaf, x=1.0)
         assert nr["lazy"] is leaf
-        assert nr.event_template["lazy"] == ArraySpec((3,))
+        assert nr.event_template["lazy"] == NumericArraySpec((3,))
         assert nr.vector_size == 4
         assert leaf.materialisations == 0
 
@@ -439,7 +439,7 @@ def _fake_backend() -> ArrayBackend:
 class TestBackendRegistrationEndToEnd:
     def test_unregistered_fake_tensor_is_rejected(self):
         t = _FakeTensor([1.0, 2.0])
-        assert EventTemplate.infer_from({"t": t})["t"] != ArraySpec((2,))
+        assert EventTemplate.infer_from({"t": t})["t"] != NumericArraySpec((2,))
         with pytest.raises(TypeError, match="must be a numeric"):
             NumericRecord("nr", t=t)
 
@@ -450,10 +450,10 @@ class TestBackendRegistrationEndToEnd:
         # Recognition: template inference and spec validation.
         tpl = EventTemplate.infer_from({"t": t})
         assert isinstance(tpl, NumericEventTemplate)
-        assert tpl["t"] == ArraySpec((2,))
-        assert ArraySpec((2,)).is_valid(t)
-        assert ArraySpec((2,), dtype=np.float32).is_valid(t)
-        assert not ArraySpec((3,)).is_valid(t)
+        assert tpl["t"] == NumericArraySpec((2,))
+        assert NumericArraySpec((2,)).is_valid(t)
+        assert NumericArraySpec((2,), dtype=np.float32).is_valid(t)
+        assert not NumericArraySpec((3,)).is_valid(t)
 
         # Promotion: an all-numeric record holding the tensor promotes.
         r = Record("r", t=t)

--- a/tests/core/test_batch.py
+++ b/tests/core/test_batch.py
@@ -796,7 +796,7 @@ class TestSpecValidation:
             _spec([(2.7,)], ["draw"])
 
     def test_an_identifier_is_a_symbolic_axis_size(self):
-        """A name defers a size, as an `NumericArraySpec` shape entry may."""
+        """A name defers a size, as a `NumericArraySpec` shape entry may."""
         assert _spec([("draws",)], ["draw"]).axis_groups == (("draws",),)
 
     def test_a_symbolic_axis_size_must_be_an_identifier(self):
@@ -1532,7 +1532,7 @@ class TestAStoredElementKeepsItsOwnIdentity:
 
 
 class TestSymbolicMultiplicity:
-    """An axis size may be a name, as an `NumericArraySpec` shape entry may.
+    """An axis size may be a name, as a `NumericArraySpec` shape entry may.
 
     A *declaration* may defer how many elements a level holds — "returns a batch
     of `S` draws" before `S` is known. A live batch may not: it holds elements at

--- a/tests/core/test_batch.py
+++ b/tests/core/test_batch.py
@@ -16,7 +16,7 @@ from typing import get_type_hints
 
 import pytest
 
-from probpipe import ArraySpec, EventTemplate, OpaqueSpec, TermSpec
+from probpipe import EventTemplate, NumericArraySpec, OpaqueSpec, TermSpec
 from probpipe.core._batch import Batch, BatchSpec
 from probpipe.core._fingerprint import fingerprint
 from probpipe.core.provenance import Provenance
@@ -319,8 +319,8 @@ class TestSpec:
 
     def test_an_element_spec_naming_no_kind_is_well_formed(self):
         """The case ``BatchSpec`` exists to cover: a batch of raw values."""
-        bare = _BareBatch(range(3), _spec([(3,)], ["draw"], ArraySpec(shape=())))
-        assert bare.element_spec == ArraySpec(shape=())
+        bare = _BareBatch(range(3), _spec([(3,)], ["draw"], NumericArraySpec(shape=())))
+        assert bare.element_spec == NumericArraySpec(shape=())
         assert isinstance(bare.spec, BatchSpec)
 
     def test_axis_groups_are_normalized_to_tuples(self):
@@ -578,7 +578,7 @@ class TestElementIdentity:
         assert nested[1].with_name("inner")[2].name == "inner[draw=2]"
 
     def test_bare_elements_carry_no_identity(self):
-        bare = _BareBatch(range(3), _spec([(3,)], ["draw"], ArraySpec(shape=())))
+        bare = _BareBatch(range(3), _spec([(3,)], ["draw"], NumericArraySpec(shape=())))
         assert bare[1] == 1
         assert not isinstance(bare[1], TrackedTerm)
 
@@ -736,7 +736,7 @@ class TestViewProvenance:
         assert produced[1][2].provenance is produced.provenance
 
     def test_a_bare_element_has_nowhere_to_carry_it(self, full_provenance_mode):
-        bare = _BareBatch(range(3), _spec([(3,)], ["draw"], ArraySpec(shape=())))
+        bare = _BareBatch(range(3), _spec([(3,)], ["draw"], NumericArraySpec(shape=())))
         produced = self._from_an_operation(bare)
 
         assert produced[1] == 1
@@ -796,7 +796,7 @@ class TestSpecValidation:
             _spec([(2.7,)], ["draw"])
 
     def test_an_identifier_is_a_symbolic_axis_size(self):
-        """A name defers a size, as an `ArraySpec` shape entry may."""
+        """A name defers a size, as an `NumericArraySpec` shape entry may."""
         assert _spec([("draws",)], ["draw"]).axis_groups == (("draws",),)
 
     def test_a_symbolic_axis_size_must_be_an_identifier(self):
@@ -974,19 +974,25 @@ class TestRenamingAView:
 
 class TestBatchSpecFingerprint:
     def test_equal_specs_fingerprint_alike(self):
-        one = _spec([(3,)], ["draw"], ArraySpec(shape=(2,)))
-        two = _spec([(3,)], ["draw"], ArraySpec(shape=(2,)))
+        one = _spec([(3,)], ["draw"], NumericArraySpec(shape=(2,)))
+        two = _spec([(3,)], ["draw"], NumericArraySpec(shape=(2,)))
         assert fingerprint(one) == fingerprint(two)
 
     def test_the_multiplicity_is_part_of_the_digest(self):
-        base = _spec([(3,)], ["draw"], ArraySpec(shape=(2,)))
-        assert fingerprint(base) != fingerprint(_spec([(4,)], ["draw"], ArraySpec(shape=(2,))))
-        assert fingerprint(base) != fingerprint(_spec([(3,)], ["chain"], ArraySpec(shape=(2,))))
-        assert fingerprint(base) != fingerprint(_spec([(3,)], ["draw"], ArraySpec(shape=(5,))))
+        base = _spec([(3,)], ["draw"], NumericArraySpec(shape=(2,)))
+        assert fingerprint(base) != fingerprint(
+            _spec([(4,)], ["draw"], NumericArraySpec(shape=(2,)))
+        )
+        assert fingerprint(base) != fingerprint(
+            _spec([(3,)], ["chain"], NumericArraySpec(shape=(2,)))
+        )
+        assert fingerprint(base) != fingerprint(
+            _spec([(3,)], ["draw"], NumericArraySpec(shape=(5,)))
+        )
 
     def test_a_spec_in_a_template_fingerprints_by_content(self):
-        one = EventTemplate(post=_spec([(3,)], ["draw"], ArraySpec(shape=(2,))), y=(2,))
-        two = EventTemplate(post=_spec([(3,)], ["draw"], ArraySpec(shape=(2,))), y=(2,))
+        one = EventTemplate(post=_spec([(3,)], ["draw"], NumericArraySpec(shape=(2,))), y=(2,))
+        two = EventTemplate(post=_spec([(3,)], ["draw"], NumericArraySpec(shape=(2,))), y=(2,))
         assert fingerprint(one) == fingerprint(two)
 
 
@@ -1526,7 +1532,7 @@ class TestAStoredElementKeepsItsOwnIdentity:
 
 
 class TestSymbolicMultiplicity:
-    """An axis size may be a name, as an `ArraySpec` shape entry may.
+    """An axis size may be a name, as an `NumericArraySpec` shape entry may.
 
     A *declaration* may defer how many elements a level holds — "returns a batch
     of `S` draws" before `S` is known. A live batch may not: it holds elements at
@@ -1541,20 +1547,20 @@ class TestSymbolicMultiplicity:
 
     def test_free_dims_unions_the_element_schema_and_the_multiplicity(self):
         """Distinct names, so neither operand can pass for the union."""
-        spec = BatchSpec(ArraySpec(shape=("d",)), [("S",)], ["draw"])
+        spec = BatchSpec(NumericArraySpec(shape=("d",)), [("S",)], ["draw"])
 
         assert spec.free_dims == frozenset({"S", "d"})
         assert spec.free_axis_dims == frozenset({"S"})
 
     def test_a_shared_name_declares_a_square_batch(self):
         """One scope: `("n",)` of arrays of shape `("n",)` is square by declaration."""
-        spec = BatchSpec(ArraySpec(shape=("n",)), [("n",)], ["row"])
+        spec = BatchSpec(NumericArraySpec(shape=("n",)), [("n",)], ["row"])
 
         assert spec.free_dims == frozenset({"n"})
 
     def test_only_the_multiplicity_must_be_concrete_for_a_live_batch(self):
         """How many elements there are is a different question from what one is."""
-        spec = BatchSpec(ArraySpec(shape=("d",)), [(4,)], ["draw"])
+        spec = BatchSpec(NumericArraySpec(shape=("d",)), [(4,)], ["draw"])
 
         assert spec.free_axis_dims == frozenset()
         assert spec.batch_size == 4
@@ -1599,18 +1605,18 @@ class TestSymbolicMultiplicity:
 
     def test_an_axis_and_an_element_dimension_share_one_scope(self):
         """A batch of `("n",)` over arrays of shape `("n",)` binds `n` once."""
-        declared = BatchSpec(ArraySpec(shape=("n",)), [("n",)], ["row"])
+        declared = BatchSpec(NumericArraySpec(shape=("n",)), [("n",)], ["row"])
         bindings: dict[str, int] = {}
 
         assert declared.bind_dims_from_spec(
-            BatchSpec(ArraySpec(shape=(3,)), [(3,)], ["row"]), bindings, "path"
+            BatchSpec(NumericArraySpec(shape=(3,)), [(3,)], ["row"]), bindings, "path"
         )
         assert bindings == {"n": 3}
 
     def test_a_batch_that_is_not_square_is_refused(self):
         """The other half of declaring it square: 3 elements of length 5 is not."""
-        declared = BatchSpec(ArraySpec(shape=("n",)), [("n",)], ["row"])
-        actual = BatchSpec(ArraySpec(shape=(5,)), [(3,)], ["row"])
+        declared = BatchSpec(NumericArraySpec(shape=("n",)), [("n",)], ["row"])
+        actual = BatchSpec(NumericArraySpec(shape=(5,)), [(3,)], ["row"])
 
         with pytest.raises(ValueError, match=r"symbolic dimension 'n' to 5, .*already bound to 3"):
             declared.bind_dims_from_spec(actual, {}, "path")
@@ -1675,8 +1681,8 @@ class TestSymbolicMultiplicity:
 
     def test_an_element_dimension_binds_through_the_element_spec(self):
         """The element's own schema binds by the same rule one level in."""
-        declared = BatchSpec(ArraySpec(shape=("d",)), [("n",)], ["item"])
-        actual = BatchSpec(ArraySpec(shape=(7,)), [(3,)], ["item"])
+        declared = BatchSpec(NumericArraySpec(shape=("d",)), [("n",)], ["item"])
+        actual = BatchSpec(NumericArraySpec(shape=(7,)), [(3,)], ["item"])
         bindings: dict[str, int] = {}
 
         declared.bind_dims_from_spec(actual, bindings, "path")

--- a/tests/core/test_bootstrap_replicate.py
+++ b/tests/core/test_bootstrap_replicate.py
@@ -18,7 +18,7 @@ from probpipe import (
     expectation,
     sample,
 )
-from probpipe.core.event_template import ArraySpec
+from probpipe.core.event_template import NumericArraySpec
 
 # ---------------------------------------------------------------------------
 # Construction
@@ -502,8 +502,8 @@ class TestValuesEmpiricalDistribution:
         emp = EmpiricalDistribution(values_data, name="x")
         tpl = emp.event_template
         assert tpl is not None
-        assert tpl["X"] == ArraySpec((3,))
-        assert tpl["y"] == ArraySpec(())
+        assert tpl["X"] == NumericArraySpec((3,))
+        assert tpl["y"] == NumericArraySpec(())
 
     def test_fields(self, values_data):
         emp = EmpiricalDistribution(values_data, name="x")
@@ -595,8 +595,8 @@ class TestValuesBootstrapReplicateDistribution:
     def test_event_template(self, bootstrap):
         tpl = bootstrap.event_template
         assert tpl is not None
-        assert tpl["X"] == ArraySpec((20, 3))
-        assert tpl["y"] == ArraySpec((20,))
+        assert tpl["X"] == NumericArraySpec((20, 3))
+        assert tpl["y"] == NumericArraySpec((20,))
 
     def test_fields(self, bootstrap):
         assert bootstrap.fields == ("X", "y")

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -877,17 +877,17 @@ class TestMakeStack:
 
     def test_bfloat16_field_inferred_numeric_not_opaque(self):
         """The broadcast-template builder shares the numeric-dtype gate, so an
-        ml_dtypes (bfloat16) field stacks into an ArraySpec column rather than
+        ml_dtypes (bfloat16) field stacks into an NumericArraySpec column rather than
         being mislabeled opaque (#343)."""
         from probpipe import Record, RecordBatch
         from probpipe.core._broadcast_distributions import _make_stack
-        from probpipe.core.event_template import ArraySpec, OpaqueSpec
+        from probpipe.core.event_template import NumericArraySpec, OpaqueSpec
 
         records = [Record("r", x=jnp.ones(2, dtype=jnp.bfloat16), label=f"r{i}") for i in range(3)]
         out = _make_stack(records, n=3, field_name="demo", level_names=("sweep",))
         assert isinstance(out, RecordBatch)
         assert out["x"].dtype == jnp.bfloat16
-        assert out.event_template["x"] == ArraySpec((2,))  # numeric, not None/opaque
+        assert out.event_template["x"] == NumericArraySpec((2,))  # numeric, not None/opaque
         assert out.event_template["label"] == OpaqueSpec()
 
     def test_list_of_distributions_gives_distribution_array(self):

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -877,7 +877,7 @@ class TestMakeStack:
 
     def test_bfloat16_field_inferred_numeric_not_opaque(self):
         """The broadcast-template builder shares the numeric-dtype gate, so an
-        ml_dtypes (bfloat16) field stacks into an NumericArraySpec column rather than
+        ml_dtypes (bfloat16) field stacks into a NumericArraySpec column rather than
         being mislabeled opaque (#343)."""
         from probpipe import Record, RecordBatch
         from probpipe.core._broadcast_distributions import _make_stack

--- a/tests/core/test_distribution_base.py
+++ b/tests/core/test_distribution_base.py
@@ -14,7 +14,7 @@ from probpipe import (
     RecordEmpiricalDistribution,
     TransformedDistribution,
 )
-from probpipe.core.event_template import ArraySpec
+from probpipe.core.event_template import NumericArraySpec
 from probpipe.core.provenance import Provenance, provenance_ancestors
 from probpipe.distributions.kde import KDEDistribution
 
@@ -152,9 +152,9 @@ class TestWithNameEventTemplate:
 
     def test_template_shape_preserved(self):
         mvn = MultivariateNormal(loc=jnp.zeros(3), cov=jnp.eye(3), name="a")
-        assert mvn.event_template["a"] == ArraySpec((3,))
+        assert mvn.event_template["a"] == NumericArraySpec((3,))
         b = mvn.with_name("b")
-        assert b.event_template["b"] == ArraySpec((3,))
+        assert b.event_template["b"] == NumericArraySpec((3,))
 
 
 class TestNoBatchShape:

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -1075,7 +1075,7 @@ class TestConstructionSpecs:
 
 
 # ---------------------------------------------------------------------------
-# Auto-promotion to NumericEventTemplate (iff every leaf is an NumericArraySpec)
+# Auto-promotion to NumericEventTemplate (iff every leaf is a NumericArraySpec)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -13,10 +13,10 @@ from probpipe.core._batch import BatchSpec
 from probpipe.core._numeric_record_batch import NumericRecordBatch
 from probpipe.core._opaque_batch import OpaqueBatch
 from probpipe.core.event_template import (
-    ArraySpec,
     DistributionSpec,
     EventTemplate,
     FunctionSpec,
+    NumericArraySpec,
     NumericEventTemplate,
     OpaqueSpec,
     RecordSpec,
@@ -91,13 +91,13 @@ class TestConstruction:
     def test_none_spec(self):
         tpl = EventTemplate(label=None, x=())
         assert tpl["label"] == OpaqueSpec()
-        assert tpl["x"] == ArraySpec(())
+        assert tpl["x"] == NumericArraySpec(())
 
     def test_nested(self):
         inner = EventTemplate(force=(), mass=())
         outer = EventTemplate(physics=inner, obs=())
         assert isinstance(outer.at_path("physics"), EventTemplate)
-        assert outer["physics/force"] == ArraySpec(())
+        assert outer["physics/force"] == NumericArraySpec(())
 
     def test_invalid_spec_raises(self):
         with pytest.raises(TypeError, match="spec must be"):
@@ -123,9 +123,9 @@ class TestFieldAccess:
         return EventTemplate(a=(), b=(3,), c=(2, 4))
 
     def test_getitem(self, tpl):
-        assert tpl["a"] == ArraySpec(())
-        assert tpl["b"] == ArraySpec((3,))
-        assert tpl["c"] == ArraySpec((2, 4))
+        assert tpl["a"] == NumericArraySpec(())
+        assert tpl["b"] == NumericArraySpec((3,))
+        assert tpl["c"] == NumericArraySpec((2, 4))
 
     def test_contains(self, tpl):
         assert "a" in tpl
@@ -151,9 +151,9 @@ class TestNamedTreeSurfaceOnEventTemplate:
         return EventTemplate(theta=EventTemplate(loc=(2,), scale=()), sigma=(3,))
 
     def test_path_indexing_returns_leaf_spec(self, nested):
-        assert nested["theta/loc"] == ArraySpec((2,))
-        assert nested["theta/scale"] == ArraySpec(())
-        assert nested["sigma"] == ArraySpec((3,))
+        assert nested["theta/loc"] == NumericArraySpec((2,))
+        assert nested["theta/scale"] == NumericArraySpec(())
+        assert nested["sigma"] == NumericArraySpec((3,))
 
     def test_tuple_indexing_matches_slash_path(self, nested):
         assert nested["theta", "loc"] == nested["theta/loc"]
@@ -185,7 +185,7 @@ class TestNamedTreeSurfaceOnEventTemplate:
 
     def test_values_and_items(self, nested):
         values = list(nested.values())
-        assert values == [ArraySpec((2,)), ArraySpec(()), ArraySpec((3,))]
+        assert values == [NumericArraySpec((2,)), NumericArraySpec(()), NumericArraySpec((3,))]
         assert list(nested.items()) == list(zip(nested.keys(), values))
 
 
@@ -299,7 +299,7 @@ class TestFlatSize:
             _ = tpl.vector_size
 
     def test_rejects_opaque_leaf(self):
-        with pytest.raises(TypeError, match="only ArraySpec"):
+        with pytest.raises(TypeError, match="only NumericArraySpec"):
             NumericEventTemplate(label=None, x=(3,))
 
     def test_rejects_non_numeric_nested(self):
@@ -395,8 +395,8 @@ class TestInferFrom:
         r = Record("r", a=1.0, b=2.0)
         tpl = EventTemplate.infer_from(r)
         assert tpl.fields == ("a", "b")
-        assert tpl["a"] == ArraySpec(())
-        assert tpl["b"] == ArraySpec(())
+        assert tpl["a"] == NumericArraySpec(())
+        assert tpl["b"] == NumericArraySpec(())
 
     def test_nested_mapping_is_structure_not_opaque(self):
         # A mapping is never a leaf: a nested dict value is inferred as a
@@ -413,10 +413,10 @@ class TestInferFrom:
             {"a": 1.0, "x": jnp.zeros(3), "params": Record("r", m=jnp.zeros(2))}
         )
         assert tuple(tpl.children) == ("a", "x", "params")
-        assert tpl["a"] == ArraySpec(())
-        assert tpl["x"] == ArraySpec((3,))
+        assert tpl["a"] == NumericArraySpec(())
+        assert tpl["x"] == NumericArraySpec((3,))
         assert isinstance(tpl.at_path("params"), EventTemplate)
-        assert tpl["params/m"] == ArraySpec((2,))
+        assert tpl["params/m"] == NumericArraySpec((2,))
 
     def test_empty_mapping_raises(self):
         with pytest.raises(ValueError, match="at least one field"):
@@ -425,17 +425,17 @@ class TestInferFrom:
     def test_array_fields(self):
         r = Record("r", x=jnp.zeros(5), y=jnp.zeros((2, 3)))
         tpl = EventTemplate.infer_from(r)
-        assert tpl["x"] == ArraySpec((5,))
-        assert tpl["y"] == ArraySpec((2, 3))
+        assert tpl["x"] == NumericArraySpec((5,))
+        assert tpl["y"] == NumericArraySpec((2, 3))
 
     def test_nested_record(self):
         inner = Record("r", x=1.0, y=jnp.zeros(3))
         outer = Record("r", params=inner, z=2.0)
         tpl = EventTemplate.infer_from(outer)
         assert isinstance(tpl.at_path("params"), EventTemplate)
-        assert tpl["params/x"] == ArraySpec(())
-        assert tpl["params/y"] == ArraySpec((3,))
-        assert tpl["z"] == ArraySpec(())
+        assert tpl["params/x"] == NumericArraySpec(())
+        assert tpl["params/y"] == NumericArraySpec((3,))
+        assert tpl["z"] == NumericArraySpec(())
 
     def test_roundtrip_vector_size(self):
         from probpipe.core._numeric_record import NumericRecord
@@ -484,7 +484,7 @@ class TestInferFrom:
 
         r = Record("r", xs=np.asarray([1.0, 2.0, 3.0]))
         tpl = EventTemplate.infer_from(r)
-        assert tpl["xs"] == ArraySpec((3,))
+        assert tpl["xs"] == NumericArraySpec((3,))
 
 
 # ---------------------------------------------------------------------------
@@ -520,9 +520,9 @@ class TestRepr:
         # A spec carrying dtype/support is not bare, so repr falls back to the
         # full dataclass repr rather than the bare-shape shorthand. The dtype
         # renders in its normalised ``numpy.dtype`` form.
-        tpl = EventTemplate(x=ArraySpec((3,), dtype="float32"))
+        tpl = EventTemplate(x=NumericArraySpec((3,), dtype="float32"))
         r = repr(tpl)
-        assert "ArraySpec(" in r
+        assert "NumericArraySpec(" in r
         assert "dtype=dtype('float32')" in r
 
     def test_populated_opaque_spec_shows_full_repr(self):
@@ -532,33 +532,33 @@ class TestRepr:
 
 
 # ---------------------------------------------------------------------------
-# Value specs — the ValueSpec base and its concrete subclasses (ArraySpec /
+# Value specs — the ValueSpec base and its concrete subclasses (NumericArraySpec /
 # OpaqueSpec / DistributionSpec / FunctionSpec)
 # ---------------------------------------------------------------------------
 
 
 class TestValueSpecs:
     def test_array_spec_defaults(self):
-        spec = ArraySpec((3,))
+        spec = NumericArraySpec((3,))
         assert spec.shape == (3,)
         assert spec.dtype is None
         assert spec.support is None
 
     def test_array_spec_coerces_shape_to_tuple(self):
         # A list shape is normalised to a tuple so the spec stays hashable.
-        spec = ArraySpec([2, 4])
+        spec = NumericArraySpec([2, 4])
         assert spec.shape == (2, 4)
         assert isinstance(spec.shape, tuple)
 
     def test_array_spec_rejects_negative_dims(self):
         with pytest.raises(TypeError, match="non-negative ints"):
-            ArraySpec((-1,))
+            NumericArraySpec((-1,))
 
     def test_specs_are_frozen(self):
         from dataclasses import FrozenInstanceError
 
         for spec in (
-            ArraySpec((3,)),
+            NumericArraySpec((3,)),
             OpaqueSpec(),
             RecordSpec(EventTemplate(x=())),
             DistributionSpec(event_spec=EventTemplate(x=())),
@@ -570,7 +570,7 @@ class TestValueSpecs:
     def test_specs_are_hashable(self):
         # Usable as dict keys / set members — required for treedef caching.
         specs = {
-            ArraySpec((3,)): 1,
+            NumericArraySpec((3,)): 1,
             OpaqueSpec(): 2,
             DistributionSpec(event_spec=EventTemplate(x=())): 3,
             FunctionSpec(input_template=EventTemplate(x=()), output_spec=EventTemplate(y=())): 4,
@@ -583,8 +583,8 @@ class TestValueSpecs:
             OpaqueSpec(meta=[])  # type: ignore[arg-type]
 
     def test_array_spec_rejects_unhashable_support_at_construction(self):
-        with pytest.raises(TypeError, match=r"ArraySpec\.support must be hashable"):
-            ArraySpec((), support=[])  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match=r"NumericArraySpec\.support must be hashable"):
+            NumericArraySpec((), support=[])  # type: ignore[arg-type]
 
     def test_template_rejects_unhashable_custom_value_spec_at_construction(self):
         spec = _UnhashableValueSpec(metadata=["mutable"])
@@ -601,10 +601,10 @@ class TestValueSpecs:
         assert hash(template) == hash(EventTemplate(custom=_TaggedValueSpec(tag="custom")))
 
     def test_specs_value_equality(self):
-        assert ArraySpec((3,)) == ArraySpec((3,))
-        assert ArraySpec((3,), dtype="float32") == ArraySpec((3,), dtype="float32")
-        assert ArraySpec((3,)) != ArraySpec((2,))
-        assert ArraySpec((3,)) != ArraySpec((3,), dtype="float32")
+        assert NumericArraySpec((3,)) == NumericArraySpec((3,))
+        assert NumericArraySpec((3,), dtype="float32") == NumericArraySpec((3,), dtype="float32")
+        assert NumericArraySpec((3,)) != NumericArraySpec((2,))
+        assert NumericArraySpec((3,)) != NumericArraySpec((3,), dtype="float32")
         assert OpaqueSpec() == OpaqueSpec()
         assert OpaqueSpec(meta="a") == OpaqueSpec(meta="a")
         assert OpaqueSpec(meta="a") != OpaqueSpec(meta="b")
@@ -618,10 +618,10 @@ class TestValueSpecs:
         ) == FunctionSpec(input_template=EventTemplate(x=()), output_spec=EventTemplate(y=()))
 
     def test_array_and_opaque_specs_are_distinct(self):
-        assert ArraySpec(()) != OpaqueSpec()
+        assert NumericArraySpec(()) != OpaqueSpec()
 
     def test_value_spec_is_abstract_base(self):
-        for cls in (ArraySpec, OpaqueSpec, DistributionSpec, FunctionSpec):
+        for cls in (NumericArraySpec, OpaqueSpec, DistributionSpec, FunctionSpec):
             assert issubclass(cls, ValueSpec)
         with pytest.raises(TypeError, match="abstract"):
             ValueSpec()  # type: ignore[abstract]
@@ -635,16 +635,16 @@ class TestValueSpecs:
         assert "LeafSpec" not in probpipe.__all__
 
     def test_equal_specs_hash_equal(self):
-        # ``ArraySpec.__hash__`` is hand-written; pin the eq/hash contract for
-        # every spec kind, including a populated ArraySpec.
+        # ``NumericArraySpec.__hash__`` is hand-written; pin the eq/hash contract for
+        # every spec kind, including a populated NumericArraySpec.
         from probpipe.core.constraints import positive
 
         inner_a, inner_b = EventTemplate(x=()), EventTemplate(x=())
         pairs = [
-            (ArraySpec((3,)), ArraySpec((3,))),
+            (NumericArraySpec((3,)), NumericArraySpec((3,))),
             (
-                ArraySpec((2,), dtype="float32", support=positive),
-                ArraySpec((2,), dtype=jnp.float32, support=positive),
+                NumericArraySpec((2,), dtype="float32", support=positive),
+                NumericArraySpec((2,), dtype=jnp.float32, support=positive),
             ),
             (OpaqueSpec(meta="a"), OpaqueSpec(meta="a")),
             (DistributionSpec(event_spec=inner_a), DistributionSpec(event_spec=inner_b)),
@@ -667,16 +667,16 @@ class TestValueSpecs:
         # numpy treats ``np.dtype(None)`` as the default dtype, so a naive
         # field comparison would report these equal (while the eq/hash
         # contract requires equal objects to hash equal).
-        assert ArraySpec(()) != ArraySpec((), dtype=jnp.float64)
-        assert ArraySpec((), dtype=jnp.float64) != ArraySpec(())
+        assert NumericArraySpec(()) != NumericArraySpec((), dtype=jnp.float64)
+        assert NumericArraySpec((), dtype=jnp.float64) != NumericArraySpec(())
 
     def test_array_spec_dtype_spellings_normalise(self):
         # Any numpy-coercible dtype spelling yields the same (equal, and
         # equal-hashing) spec.
         specs = [
-            ArraySpec((), dtype="float32"),
-            ArraySpec((), dtype=jnp.float32),
-            ArraySpec((), dtype=np.dtype("float32")),
+            NumericArraySpec((), dtype="float32"),
+            NumericArraySpec((), dtype=jnp.float32),
+            NumericArraySpec((), dtype=np.dtype("float32")),
         ]
         assert len(set(specs)) == 1
         assert all(s.dtype == np.dtype("float32") for s in specs)
@@ -684,7 +684,7 @@ class TestValueSpecs:
     def test_array_spec_pickle_round_trip(self):
         import pickle
 
-        spec = ArraySpec((3,), dtype="float32")
+        spec = NumericArraySpec((3,), dtype="float32")
         restored = pickle.loads(pickle.dumps(spec))
         assert restored == spec
         assert hash(restored) == hash(spec)
@@ -694,24 +694,26 @@ class TestValueSpecs:
         import pickle
 
         tpl = EventTemplate(
-            x=ArraySpec((2,), dtype="float32"),
+            x=NumericArraySpec((2,), dtype="float32"),
             label=OpaqueSpec(meta="tag"),
             d=DistributionSpec(event_spec=EventTemplate(a=())),
-            f=FunctionSpec(EventTemplate(inp=ArraySpec(())), EventTemplate(out=ArraySpec(()))),
-            r=RecordSpec(EventTemplate(c=ArraySpec(()))),
+            f=FunctionSpec(
+                EventTemplate(inp=NumericArraySpec(())), EventTemplate(out=NumericArraySpec(()))
+            ),
+            r=RecordSpec(EventTemplate(c=NumericArraySpec(()))),
         )
         restored = pickle.loads(pickle.dumps(tpl))
         assert restored == tpl
         assert hash(restored) == hash(tpl)
 
     def test_array_spec_zero_dim_allowed(self):
-        spec = ArraySpec((0,))
+        spec = NumericArraySpec((0,))
         assert spec.shape == (0,)
         assert spec.is_valid(jnp.ones(0))
         assert not spec.is_valid(jnp.ones(1))
 
     def test_array_spec_symbolic_dimensions(self):
-        spec = ArraySpec(("obs", 3, "obs"))
+        spec = NumericArraySpec(("obs", 3, "obs"))
 
         assert spec.is_valid(np.zeros((4, 3, 4)))
         assert not spec.is_valid(np.zeros((4, 3, 5)))
@@ -719,14 +721,14 @@ class TestValueSpecs:
     @pytest.mark.parametrize("dimension", ["", -1, 1.5, None])
     def test_array_spec_rejects_invalid_symbolic_dimensions(self, dimension):
         with pytest.raises(TypeError, match="symbolic dimension"):
-            ArraySpec((dimension,))
+            NumericArraySpec((dimension,))
 
     def test_distribution_spec_requires_record_declaration(self):
         with pytest.raises(TypeError, match="must be an EventTemplate or a RecordSpec"):
             DistributionSpec(event_spec=(3,))  # type: ignore[arg-type]
         # A raw-value spec is not a declaration: it names no kind.
         with pytest.raises(TypeError, match="must be an EventTemplate or a RecordSpec"):
-            DistributionSpec(event_spec=ArraySpec(()))  # type: ignore[arg-type]
+            DistributionSpec(event_spec=NumericArraySpec(()))  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -736,14 +738,14 @@ class TestValueSpecs:
 
 class TestArraySpecIsValid:
     def test_shape_match(self):
-        spec = ArraySpec((3,))
+        spec = NumericArraySpec((3,))
         assert spec.is_valid(jnp.ones(3))
         assert spec.is_valid(np.ones(3))
         assert not spec.is_valid(jnp.ones(2))
         assert not spec.is_valid(jnp.ones((3, 1)))
 
     def test_scalar_shape(self):
-        spec = ArraySpec(())
+        spec = NumericArraySpec(())
         assert spec.is_valid(1.5)
         assert spec.is_valid(2)
         assert spec.is_valid(True)
@@ -751,7 +753,7 @@ class TestArraySpecIsValid:
         assert not spec.is_valid(jnp.ones(1))
 
     def test_non_numeric_values_invalid(self):
-        spec = ArraySpec(())
+        spec = NumericArraySpec(())
         assert not spec.is_valid("text")
         assert not spec.is_valid([1.0, 2.0])
         assert not spec.is_valid((1.0, 2.0))
@@ -760,49 +762,49 @@ class TestArraySpecIsValid:
         assert not spec.is_valid(np.asarray(["a"]))
 
     def test_dtype_checked_when_set(self):
-        spec = ArraySpec((2,), dtype=jnp.float32)
+        spec = NumericArraySpec((2,), dtype=jnp.float32)
         assert spec.is_valid(jnp.ones(2, dtype=jnp.float32))
         # A same-kind cast satisfies the spec (numpy treats int->float as
         # same_kind); a cross-kind cast (a float value against an int-dtype
         # spec) does not.
         assert spec.is_valid(jnp.ones(2, dtype=jnp.int32))
-        assert not ArraySpec((2,), dtype=jnp.int32).is_valid(jnp.ones(2, dtype=jnp.float32))
+        assert not NumericArraySpec((2,), dtype=jnp.int32).is_valid(jnp.ones(2, dtype=jnp.float32))
 
     def test_dtype_unset_accepts_any_numeric_dtype(self):
-        spec = ArraySpec((2,))
+        spec = NumericArraySpec((2,))
         assert spec.is_valid(jnp.ones(2, dtype=jnp.float32))
         assert spec.is_valid(np.ones(2, dtype=np.int64))
 
     def test_ml_dtypes_are_numeric(self):
         # bfloat16 / float8 report numpy kind "V" but are numeric JAX arrays;
-        # they satisfy ArraySpec (shape-only and dtype-pinned). infer_from
+        # they satisfy NumericArraySpec (shape-only and dtype-pinned). infer_from
         # therefore routes them to the array side (see the infer_from test).
         bf16 = jnp.ones(2, dtype=jnp.bfloat16)
-        assert ArraySpec((2,)).is_valid(bf16)
-        assert ArraySpec((2,), dtype=jnp.bfloat16).is_valid(bf16)
+        assert NumericArraySpec((2,)).is_valid(bf16)
+        assert NumericArraySpec((2,), dtype=jnp.bfloat16).is_valid(bf16)
         # bf16 -> float32 is a safe widening (same-kind), so it satisfies a
         # float32 spec; a cross-kind int spec does not.
-        assert ArraySpec((2,), dtype=jnp.float32).is_valid(bf16)
-        assert not ArraySpec((2,), dtype=jnp.int32).is_valid(bf16)
+        assert NumericArraySpec((2,), dtype=jnp.float32).is_valid(bf16)
+        assert not NumericArraySpec((2,), dtype=jnp.int32).is_valid(bf16)
         f8 = jnp.ones((), dtype=jnp.float8_e4m3fn)
-        assert ArraySpec(()).is_valid(f8)
+        assert NumericArraySpec(()).is_valid(f8)
 
     def test_structured_dtype_stays_non_numeric(self):
         # numpy structured dtypes are also kind "V" but are not numeric:
-        # they fail ArraySpec, so infer_from routes them to OpaqueSpec.
+        # they fail NumericArraySpec, so infer_from routes them to OpaqueSpec.
         rec = np.zeros(2, dtype=[("a", "f4")])
-        assert not ArraySpec((2,)).is_valid(rec)
+        assert not NumericArraySpec((2,)).is_valid(rec)
         assert EventTemplate.infer_from({"r": rec})["r"] == OpaqueSpec()
 
     def test_infer_from_bfloat16_is_numeric(self):
         tpl = EventTemplate.infer_from({"x": jnp.ones((2, 3), dtype=jnp.bfloat16)})
         assert isinstance(tpl, NumericEventTemplate)
-        assert tpl["x"] == ArraySpec((2, 3))
+        assert tpl["x"] == NumericArraySpec((2, 3))
 
     def test_python_scalar_dtype_is_numpy_default(self):
         # A bare Python scalar reports the dtype ``np.asarray`` gives it.
-        assert ArraySpec((), dtype=np.asarray(1.0).dtype).is_valid(1.0)
-        assert not ArraySpec((), dtype=jnp.int32).is_valid(1.0)
+        assert NumericArraySpec((), dtype=np.asarray(1.0).dtype).is_valid(1.0)
+        assert not NumericArraySpec((), dtype=jnp.int32).is_valid(1.0)
 
     def test_support_not_checked_by_is_valid(self):
         # ``support`` is descriptive metadata on the spec; ``is_valid`` validates
@@ -811,7 +813,7 @@ class TestArraySpecIsValid:
         # and is_valid runs at Record construction, which happens under trace.)
         from probpipe.core.constraints import positive
 
-        spec = ArraySpec((2,), support=positive)
+        spec = NumericArraySpec((2,), support=positive)
         assert spec.support is positive  # still stored on the spec
         assert spec.is_valid(jnp.asarray([1.0, 2.0]))
         assert spec.is_valid(jnp.asarray([1.0, -2.0]))  # support not enforced
@@ -823,11 +825,11 @@ class TestArraySpecIsValid:
         # Python bool as a scalar Array, hence bool(...).)
         from probpipe.core.constraints import positive
 
-        spec = ArraySpec((3,), dtype=jnp.float32)
+        spec = NumericArraySpec((3,), dtype=jnp.float32)
         assert bool(jax.jit(spec.is_valid)(jnp.ones(3, dtype=jnp.float32))) is True
         assert bool(jax.jit(spec.is_valid)(jnp.ones(2, dtype=jnp.float32))) is False
         # even with a support set, no concretization is forced:
-        assert bool(jax.jit(ArraySpec((3,), support=positive).is_valid)(jnp.ones(3))) is True
+        assert bool(jax.jit(NumericArraySpec((3,), support=positive).is_valid)(jnp.ones(3))) is True
 
 
 class TestOpaqueSpecIsValid:
@@ -840,7 +842,7 @@ class TestOpaqueSpecIsValid:
 
     def test_numeric_values_valid(self):
         # As the fallback spec, OpaqueSpec accepts any non-mapping value,
-        # including numerics (though infer_from routes those to ArraySpec).
+        # including numerics (though infer_from routes those to NumericArraySpec).
         spec = OpaqueSpec()
         assert spec.is_valid(1.5)
         assert spec.is_valid(jnp.ones(2))
@@ -976,7 +978,7 @@ class TestFunctionSpecTemplatesRequired:
         # a bare ValueSpec is not wrapped into one. The output side is a
         # declaration and accepts any value specification.
         with pytest.raises(TypeError, match="input_template must be None or an EventTemplate"):
-            FunctionSpec(ArraySpec(()), EventTemplate(b=()))  # type: ignore[arg-type]
+            FunctionSpec(NumericArraySpec(()), EventTemplate(b=()))  # type: ignore[arg-type]
 
         assert FunctionSpec(EventTemplate(a=()), OpaqueSpec()).output_spec == OpaqueSpec()
 
@@ -1004,10 +1006,10 @@ class TestFunctionSpecOptionalTemplates:
         assert not spec.is_valid(3.0)
 
     def test_one_side_specified(self):
-        spec = FunctionSpec(output_spec=EventTemplate(out=ArraySpec(())))
+        spec = FunctionSpec(output_spec=EventTemplate(out=NumericArraySpec(())))
         assert spec.input_template is None
         # A record output is stored as its declaration (the storage rule).
-        assert spec.output_spec == RecordSpec(EventTemplate(out=ArraySpec(())))
+        assert spec.output_spec == RecordSpec(EventTemplate(out=NumericArraySpec(())))
 
     def test_none_specs_are_hashable_and_equal(self):
         assert FunctionSpec() == FunctionSpec()
@@ -1039,7 +1041,7 @@ class TestFunctionSpecOptionalTemplates:
 class TestConstructionSpecs:
     def test_tuple_becomes_array_spec(self):
         tpl = EventTemplate(x=(3,))
-        assert tpl["x"] == ArraySpec((3,))
+        assert tpl["x"] == NumericArraySpec((3,))
 
     def test_none_becomes_opaque_spec(self):
         tpl = EventTemplate(label=None)
@@ -1051,7 +1053,7 @@ class TestConstructionSpecs:
         assert tpl.at_path("sub") is inner
 
     def test_explicit_array_spec_accepted(self):
-        spec = ArraySpec((2,), dtype="float32")
+        spec = NumericArraySpec((2,), dtype="float32")
         tpl = EventTemplate(x=spec)
         assert tpl["x"] is spec
 
@@ -1073,13 +1075,13 @@ class TestConstructionSpecs:
 
 
 # ---------------------------------------------------------------------------
-# Auto-promotion to NumericEventTemplate (iff every leaf is an ArraySpec)
+# Auto-promotion to NumericEventTemplate (iff every leaf is an NumericArraySpec)
 # ---------------------------------------------------------------------------
 
 
 class TestAutoPromotionSpecs:
     def test_explicit_array_specs_promote(self):
-        tpl = EventTemplate(x=ArraySpec(()), y=ArraySpec((3,)))
+        tpl = EventTemplate(x=NumericArraySpec(()), y=NumericArraySpec((3,)))
         assert isinstance(tpl, NumericEventTemplate)
 
     def test_nested_numeric_promotes(self):
@@ -1106,19 +1108,19 @@ class TestAutoPromotionSpecs:
         assert type(tpl) is EventTemplate
 
     def test_numeric_rejects_opaque_spec(self):
-        with pytest.raises(TypeError, match="only ArraySpec"):
+        with pytest.raises(TypeError, match="only NumericArraySpec"):
             NumericEventTemplate(x=(), label=OpaqueSpec())
 
     def test_numeric_rejects_distribution_spec(self):
-        with pytest.raises(TypeError, match="only ArraySpec"):
+        with pytest.raises(TypeError, match="only NumericArraySpec"):
             NumericEventTemplate(x=(), d=DistributionSpec(event_spec=EventTemplate(a=())))
 
     def test_numeric_rejects_record_spec(self):
-        with pytest.raises(TypeError, match="only ArraySpec"):
+        with pytest.raises(TypeError, match="only NumericArraySpec"):
             NumericEventTemplate(x=(), r=RecordSpec(EventTemplate(a=())))
 
     def test_numeric_rejects_function_spec(self):
-        with pytest.raises(TypeError, match="only ArraySpec"):
+        with pytest.raises(TypeError, match="only NumericArraySpec"):
             NumericEventTemplate(
                 x=(),
                 f=FunctionSpec(input_template=EventTemplate(a=()), output_spec=EventTemplate(b=())),
@@ -1247,7 +1249,7 @@ class TestNumericSubset:
 
     def test_raises_when_no_numeric_leaves(self):
         tpl = EventTemplate(label=None, tag=None)
-        with pytest.raises(ValueError, match="ArraySpec leaves survive"):
+        with pytest.raises(ValueError, match="NumericArraySpec leaves survive"):
             tpl.numeric_subset()
 
     def test_raises_names_dropped_fields(self):
@@ -1409,7 +1411,7 @@ class TestTermSpecTaxonomy:
 
     def test_raw_value_specs_are_not_term_specs(self):
 
-        assert not isinstance(ArraySpec(()), TermSpec)
+        assert not isinstance(NumericArraySpec(()), TermSpec)
         assert not isinstance(OpaqueSpec(), TermSpec)
 
     # --- the storage rule: a declaration is stored as a ValueSpec ---
@@ -1439,7 +1441,7 @@ class TestTermSpecTaxonomy:
         """
         assert get_type_hints(DistributionSpec)["event_spec"] is RecordSpec
         assert get_type_hints(FunctionSpec)["output_spec"] == ValueSpec | None
-        assert get_type_hints(ArraySpec)["dtype"] == np.dtype | None
+        assert get_type_hints(NumericArraySpec)["dtype"] == np.dtype | None
 
     def test_the_old_parameter_names_are_gone(self):
         """Positional construction survives the rename; keyword construction does not.
@@ -1492,7 +1494,7 @@ class TestTermSpecTaxonomy:
         field name is invented here.
         """
         tau = EventTemplate(x=())
-        for raw in (ArraySpec((3,)), OpaqueSpec(meta="m")):
+        for raw in (NumericArraySpec((3,)), OpaqueSpec(meta="m")):
             assert FunctionSpec(tau, raw).output_spec is raw
 
     def test_unspecified_output_stays_none(self):
@@ -1540,11 +1542,11 @@ class TestRecordSpec:
     def test_requires_event_template(self):
 
         with pytest.raises(TypeError):
-            RecordSpec(ArraySpec(()))  # not an EventTemplate
+            RecordSpec(NumericArraySpec(()))  # not an EventTemplate
 
     def test_requires_event_template_message(self):
         with pytest.raises(TypeError, match="must be an EventTemplate"):
-            RecordSpec(ArraySpec(()))
+            RecordSpec(NumericArraySpec(()))
 
     def test_is_valid_accepts_matching_record_only(self):
 
@@ -1620,12 +1622,12 @@ class TestFreeDimsReachThroughTermSpecs:
 
     @staticmethod
     def _symbolic():
-        return EventTemplate(x=ArraySpec(shape=("obs",)))
+        return EventTemplate(x=NumericArraySpec(shape=("obs",)))
 
     @pytest.mark.parametrize(
         "declare",
         [
-            lambda sym: EventTemplate(x=ArraySpec(shape=("obs",))),
+            lambda sym: EventTemplate(x=NumericArraySpec(shape=("obs",))),
             lambda sym: EventTemplate(r=RecordSpec(sym)),
             lambda sym: EventTemplate(law=DistributionSpec(sym)),
             lambda sym: EventTemplate(f=FunctionSpec(sym, None)),
@@ -1643,7 +1645,7 @@ class TestFreeDimsReachThroughTermSpecs:
     def test_one_scope_across_a_term_spec_boundary(self):
         """The same name inside and outside a term spec is one dimension."""
         template = EventTemplate(
-            data=ArraySpec(shape=("obs",)),
+            data=NumericArraySpec(shape=("obs",)),
             law=DistributionSpec(self._symbolic()),
         )
 
@@ -1654,13 +1656,13 @@ class TestFreeDimsReachThroughTermSpecs:
 
     def test_a_spec_declaring_no_dimensions_reports_none(self):
         assert OpaqueSpec().free_dims == frozenset()
-        assert ArraySpec(shape=(3,)).free_dims == frozenset()
+        assert NumericArraySpec(shape=(3,)).free_dims == frozenset()
 
 
 class TestWithDims:
     def test_binding_reaches_through_a_term_spec(self):
-        sym = EventTemplate(x=ArraySpec(shape=("obs",)))
-        template = EventTemplate(law=DistributionSpec(sym), data=ArraySpec(shape=("obs",)))
+        sym = EventTemplate(x=NumericArraySpec(shape=("obs",)))
+        template = EventTemplate(law=DistributionSpec(sym), data=NumericArraySpec(shape=("obs",)))
 
         bound = template.with_dims(obs=4)
 
@@ -1669,19 +1671,21 @@ class TestWithDims:
         assert bound["law"].event_spec.event_template["x"].shape == (4,)
 
     def test_binding_returns_a_new_template(self):
-        template = EventTemplate(x=ArraySpec(shape=("obs",)))
+        template = EventTemplate(x=NumericArraySpec(shape=("obs",)))
 
         assert template.with_dims(obs=2) is not template
         assert not template.is_concrete
 
     def test_an_all_numeric_bound_template_gains_its_flat_layout(self):
-        bound = EventTemplate(x=ArraySpec(shape=("n",))).with_dims(n=3)
+        bound = EventTemplate(x=NumericArraySpec(shape=("n",))).with_dims(n=3)
 
         assert isinstance(bound, NumericEventTemplate)
         assert bound.vector_size == 3
 
     def test_an_unbound_dimension_is_named(self):
-        template = EventTemplate(x=ArraySpec(shape=("obs",)), y=ArraySpec(shape=("features",)))
+        template = EventTemplate(
+            x=NumericArraySpec(shape=("obs",)), y=NumericArraySpec(shape=("features",))
+        )
 
         with pytest.raises(ValueError, match="unbound symbolic dimensions: features, obs"):
             template.with_dims()
@@ -1690,7 +1694,7 @@ class TestWithDims:
         """It is reported by `free_dims`, so it must be substitutable."""
         from probpipe import BatchSpec
 
-        template = EventTemplate(b=BatchSpec(ArraySpec(shape=(3,)), [("S",)], ["draw"]))
+        template = EventTemplate(b=BatchSpec(NumericArraySpec(shape=(3,)), [("S",)], ["draw"]))
 
         bound = template.with_dims(S=4)
 
@@ -1699,20 +1703,20 @@ class TestWithDims:
 
     def test_a_size_must_be_an_integer(self):
         """A string would be read as a dimension *name*, silently renaming it."""
-        template = EventTemplate(x=ArraySpec(shape=("n",)))
+        template = EventTemplate(x=NumericArraySpec(shape=("n",)))
 
         for size in ("m", 2.0, None):
             with pytest.raises(TypeError, match="must be an integer"):
                 template.with_dims(n=size)
 
     def test_binding_some_names_reports_only_the_rest(self):
-        template = EventTemplate(x=ArraySpec(shape=("a",)), y=ArraySpec(shape=("b",)))
+        template = EventTemplate(x=NumericArraySpec(shape=("a",)), y=NumericArraySpec(shape=("b",)))
 
         with pytest.raises(ValueError, match=r"unbound symbolic dimensions: b$"):
             template.with_dims(a=2)
 
     def test_binding_an_already_concrete_template_is_a_no_op_copy(self):
-        template = EventTemplate(x=ArraySpec(shape=(3,)))
+        template = EventTemplate(x=NumericArraySpec(shape=(3,)))
 
         bound = template.with_dims()
 
@@ -1721,7 +1725,7 @@ class TestWithDims:
 
     def test_a_name_the_template_does_not_declare_is_ignored(self):
         """So one mapping can bind several templates."""
-        assert EventTemplate(x=ArraySpec(shape=("n",))).with_dims(n=2, other=9).is_concrete
+        assert EventTemplate(x=NumericArraySpec(shape=("n",))).with_dims(n=2, other=9).is_concrete
 
 
 class TestBindingAFunctionSpec:
@@ -1734,7 +1738,7 @@ class TestBindingAFunctionSpec:
 
     @staticmethod
     def _sym():
-        return EventTemplate(x=ArraySpec(shape=("obs",)))
+        return EventTemplate(x=NumericArraySpec(shape=("obs",)))
 
     def test_a_bare_callable_leaves_the_dimensions_free(self):
         """It declares nothing, so there is nothing to bind from — and no refusal."""
@@ -1747,7 +1751,7 @@ class TestBindingAFunctionSpec:
     def test_the_input_side_binds_from_the_callable_declaration(self):
         declared = EventTemplate(f=FunctionSpec(self._sym(), None))
         typed = Function(
-            func=lambda x: x, name="g", input_template=EventTemplate(x=ArraySpec(shape=(7,)))
+            func=lambda x: x, name="g", input_template=EventTemplate(x=NumericArraySpec(shape=(7,)))
         )
 
         record = Record("r", f=typed, event_template=declared)
@@ -1756,10 +1760,12 @@ class TestBindingAFunctionSpec:
 
     def test_the_output_side_binds_from_the_callable_declaration(self):
         declared = EventTemplate(
-            f=FunctionSpec(None, RecordSpec(EventTemplate(y=ArraySpec(("m",)))))
+            f=FunctionSpec(None, RecordSpec(EventTemplate(y=NumericArraySpec(("m",)))))
         )
         typed = Function(
-            func=lambda x: x, name="g", output_template=EventTemplate(y=ArraySpec(shape=(5,)))
+            func=lambda x: x,
+            name="g",
+            output_template=EventTemplate(y=NumericArraySpec(shape=(5,))),
         )
 
         record = Record("r", f=typed, event_template=declared)
@@ -1776,7 +1782,7 @@ class TestBindingAFunctionSpec:
 class TestInferenceThroughTermSpecs:
     """Sizes are bound from the term a spec is matched against, as for an array.
 
-    `ArraySpec` has always accepted a concrete value against a symbolic shape and
+    `NumericArraySpec` has always accepted a concrete value against a symbolic shape and
     left the binding to the one pass; these tests hold the term specs to the same
     rule.
     """
@@ -1790,7 +1796,7 @@ class TestInferenceThroughTermSpecs:
         return MultivariateNormal(jnp.zeros(size), jnp.eye(size), name="x")
 
     def test_a_distribution_binds_the_declared_dimension(self):
-        sym = EventTemplate(x=ArraySpec(shape=("obs",)))
+        sym = EventTemplate(x=NumericArraySpec(shape=("obs",)))
         record = Record(
             "r", law=self._law(3), event_template=EventTemplate(law=DistributionSpec(sym))
         )
@@ -1800,8 +1806,8 @@ class TestInferenceThroughTermSpecs:
 
     def test_a_name_shared_across_the_boundary_binds_once(self):
         declared = EventTemplate(
-            data=ArraySpec(shape=("obs",)),
-            law=DistributionSpec(EventTemplate(x=ArraySpec(shape=("obs",)))),
+            data=NumericArraySpec(shape=("obs",)),
+            law=DistributionSpec(EventTemplate(x=NumericArraySpec(shape=("obs",)))),
         )
         record = Record("r", data=jnp.zeros(3), law=self._law(3), event_template=declared)
 
@@ -1817,8 +1823,8 @@ class TestInferenceThroughTermSpecs:
         inward — so this is the case that pins one scope rather than two.
         """
         declared = EventTemplate(
-            law=DistributionSpec(EventTemplate(x=ArraySpec(shape=("obs",)))),
-            data=ArraySpec(shape=("obs",)),
+            law=DistributionSpec(EventTemplate(x=NumericArraySpec(shape=("obs",)))),
+            data=NumericArraySpec(shape=("obs",)),
         )
 
         with pytest.raises(
@@ -1829,12 +1835,12 @@ class TestInferenceThroughTermSpecs:
     def test_field_order_does_not_change_the_outcome(self):
         """The same declaration either way round: one scope, one answer."""
         term_first = EventTemplate(
-            law=DistributionSpec(EventTemplate(x=ArraySpec(shape=("obs",)))),
-            data=ArraySpec(shape=("obs",)),
+            law=DistributionSpec(EventTemplate(x=NumericArraySpec(shape=("obs",)))),
+            data=NumericArraySpec(shape=("obs",)),
         )
         array_first = EventTemplate(
-            data=ArraySpec(shape=("obs",)),
-            law=DistributionSpec(EventTemplate(x=ArraySpec(shape=("obs",)))),
+            data=NumericArraySpec(shape=("obs",)),
+            law=DistributionSpec(EventTemplate(x=NumericArraySpec(shape=("obs",)))),
         )
 
         for declared in (term_first, array_first):
@@ -1845,8 +1851,8 @@ class TestInferenceThroughTermSpecs:
     def test_a_disagreement_across_the_boundary_raises(self):
         """The point of one scope: 5 outside and 3 inside is a contradiction."""
         declared = EventTemplate(
-            data=ArraySpec(shape=("obs",)),
-            law=DistributionSpec(EventTemplate(x=ArraySpec(shape=("obs",)))),
+            data=NumericArraySpec(shape=("obs",)),
+            law=DistributionSpec(EventTemplate(x=NumericArraySpec(shape=("obs",)))),
         )
 
         with pytest.raises(
@@ -1863,7 +1869,7 @@ class TestInferenceThroughTermSpecs:
         """
         law = self._law(3)
         record = Record("w", x=jnp.zeros(3))
-        sym = EventTemplate(x=ArraySpec(shape=("obs",)))
+        sym = EventTemplate(x=NumericArraySpec(shape=("obs",)))
 
         for declared, value in (
             (RecordSpec(sym), law),
@@ -1876,21 +1882,27 @@ class TestInferenceThroughTermSpecs:
 
     def test_a_callable_declaration_refuses_a_non_callable_in_the_pass(self):
         """Likewise for the FunctionSpec branch, which has its own refusal."""
-        declared = EventTemplate(f=FunctionSpec(EventTemplate(x=ArraySpec(shape=("obs",))), None))
+        declared = EventTemplate(
+            f=FunctionSpec(EventTemplate(x=NumericArraySpec(shape=("obs",))), None)
+        )
 
         with pytest.raises(ValueError, match="does not conform to its field spec"):
             _unify_event_template_with_value(declared, {"f": 3}, context="v")
 
     def test_a_value_carrying_no_schema_says_so(self):
         """A polymorphic schema needs one to bind against."""
-        declared = EventTemplate(law=DistributionSpec(EventTemplate(x=ArraySpec(shape=("obs",)))))
+        declared = EventTemplate(
+            law=DistributionSpec(EventTemplate(x=NumericArraySpec(shape=("obs",))))
+        )
 
         with pytest.raises(ValueError, match="exposes no schema to bind it against"):
             Record("r", law=object(), event_template=declared)
 
     def test_a_concrete_declaration_still_requires_an_exact_match(self):
         """Inference is for the symbolic case; a fixed size is still a fixed size."""
-        declared = EventTemplate(law=DistributionSpec(EventTemplate(x=ArraySpec(shape=(4,)))))
+        declared = EventTemplate(
+            law=DistributionSpec(EventTemplate(x=NumericArraySpec(shape=(4,))))
+        )
 
         with pytest.raises(ValueError, match="does not conform"):
             Record("r", law=self._law(3), event_template=declared)
@@ -1911,17 +1923,19 @@ class TestAFunctionOutputBindsWhateverItDeclares:
         return Function(
             func=lambda x: jnp.zeros(output_size),
             name="f",
-            input_template=EventTemplate(x=ArraySpec(shape=(input_size,))),
-            output_template=EventTemplate(out=ArraySpec(shape=(output_size,))),
+            input_template=EventTemplate(x=NumericArraySpec(shape=(input_size,))),
+            output_template=EventTemplate(out=NumericArraySpec(shape=(output_size,))),
         )
 
     @staticmethod
     def _declared(output_spec):
-        return EventTemplate(f=FunctionSpec(EventTemplate(x=ArraySpec(shape=("n",))), output_spec))
+        return EventTemplate(
+            f=FunctionSpec(EventTemplate(x=NumericArraySpec(shape=("n",))), output_spec)
+        )
 
     def test_a_shared_name_binds_from_a_non_record_output(self):
         """`n` on both sides binds once when the two agree."""
-        declared = self._declared(ArraySpec(shape=("n",)))
+        declared = self._declared(NumericArraySpec(shape=("n",)))
 
         record = Record("r", f=self._function(4, 4), event_template=declared)
 
@@ -1935,14 +1949,14 @@ class TestAFunctionOutputBindsWhateverItDeclares:
         `(3,)` for a callable that returns `(5,)` — a schema that is not merely
         unbound but wrong.
         """
-        declared = self._declared(ArraySpec(shape=("n",)))
+        declared = self._declared(NumericArraySpec(shape=("n",)))
 
         with pytest.raises(ValueError, match=r"symbolic dimension 'n' to 5, .*already bound to 3"):
             Record("r", f=self._function(3, 5), event_template=declared)
 
     def test_a_record_output_that_disagrees_raises_the_same_way(self):
         """The route that already worked, asserted beside the one that did not."""
-        declared = self._declared(RecordSpec(EventTemplate(out=ArraySpec(shape=("n",)))))
+        declared = self._declared(RecordSpec(EventTemplate(out=NumericArraySpec(shape=("n",)))))
 
         with pytest.raises(ValueError, match=r"symbolic dimension 'n' to 5, .*already bound to 3"):
             Record("r", f=self._function(3, 5), event_template=declared)
@@ -1952,17 +1966,19 @@ class TestAFunctionOutputBindsWhateverItDeclares:
         function = Function(
             func=lambda x: x,
             name="f",
-            input_template=EventTemplate(x=ArraySpec(shape=(3,))),
-            output_template=EventTemplate(a=ArraySpec(shape=(3,)), b=ArraySpec(shape=(4,))),
+            input_template=EventTemplate(x=NumericArraySpec(shape=(3,))),
+            output_template=EventTemplate(
+                a=NumericArraySpec(shape=(3,)), b=NumericArraySpec(shape=(4,))
+            ),
         )
-        declared = self._declared(ArraySpec(shape=("n",)))
+        declared = self._declared(NumericArraySpec(shape=("n",)))
 
         with pytest.raises(ValueError, match=r"declares one output value.*output fields"):
             Record("r", f=function, event_template=declared)
 
     def test_a_bare_callable_still_binds_nothing_from_its_output(self):
         """No declaration to read, so the output stays free rather than raising."""
-        declared = self._declared(ArraySpec(shape=("k",)))
+        declared = self._declared(NumericArraySpec(shape=("k",)))
 
         record = Record("r", f=lambda x: x, event_template=declared)
 
@@ -1996,7 +2012,7 @@ class TestMultiplicityBindsFromAValue:
     def _declared(axis="n", field=None):
         fields: dict[str, Any] = {}
         if field is not None:
-            fields["data"] = ArraySpec(shape=(field,))
+            fields["data"] = NumericArraySpec(shape=(field,))
         fields["b"] = BatchSpec(OpaqueSpec(), [(axis,)], ["item"])
         return EventTemplate(fields)
 
@@ -2027,10 +2043,10 @@ class TestMultiplicityBindsFromAValue:
         other, so both directions are asserted.
         """
         array_first = EventTemplate(
-            data=ArraySpec(shape=("n",)), b=BatchSpec(OpaqueSpec(), [("n",)], ["item"])
+            data=NumericArraySpec(shape=("n",)), b=BatchSpec(OpaqueSpec(), [("n",)], ["item"])
         )
         batch_first = EventTemplate(
-            b=BatchSpec(OpaqueSpec(), [("n",)], ["item"]), data=ArraySpec(shape=("n",))
+            b=BatchSpec(OpaqueSpec(), [("n",)], ["item"]), data=NumericArraySpec(shape=("n",))
         )
 
         for declared in (array_first, batch_first):
@@ -2051,7 +2067,7 @@ class TestMultiplicityBindsFromAValue:
     def test_the_disagreement_raises_in_either_order(self):
         """The batch-first direction, which a copied scope would let through."""
         declared = EventTemplate(
-            b=BatchSpec(OpaqueSpec(), [("n",)], ["item"]), data=ArraySpec(shape=("n",))
+            b=BatchSpec(OpaqueSpec(), [("n",)], ["item"]), data=NumericArraySpec(shape=("n",))
         )
 
         with pytest.raises(
@@ -2135,7 +2151,7 @@ class TestMultiplicityBindsFromAValue:
         template that is neither concrete nor refused.
         """
         declared = EventTemplate(
-            f=FunctionSpec(EventTemplate(x=ArraySpec(shape=("k",))), None),
+            f=FunctionSpec(EventTemplate(x=NumericArraySpec(shape=("k",))), None),
             b=BatchSpec(OpaqueSpec(), [("n",)], ["item"]),
         )
 
@@ -2170,7 +2186,7 @@ class TestEverySpecBindsWhatItDeclares:
         """The walk finds the specs it is meant to hold."""
         found = set(self._concrete_specs())
 
-        assert {ArraySpec, OpaqueSpec, RecordSpec, DistributionSpec, FunctionSpec} <= found
+        assert {NumericArraySpec, OpaqueSpec, RecordSpec, DistributionSpec, FunctionSpec} <= found
         assert BatchSpec in found
 
     @pytest.mark.parametrize("method", ["bind_dims_from_value", "bind_dims_from_spec"])
@@ -2200,9 +2216,9 @@ class TestEverySpecBindsWhatItDeclares:
             _DimlessButClaiming().bind_dims_from_value(object(), {}, "p")
 
     def test_an_array_binds_its_own_shape(self):
-        """`ArraySpec` owns its binding rather than being special-cased by the pass."""
+        """`NumericArraySpec` owns its binding rather than being special-cased by the pass."""
         bindings: dict[str, int] = {}
 
-        ArraySpec(shape=("n", "m")).bind_dims_from_value(jnp.zeros((2, 5)), bindings, "p")
+        NumericArraySpec(shape=("n", "m")).bind_dims_from_value(jnp.zeros((2, 5)), bindings, "p")
 
         assert bindings == {"n": 2, "m": 5}

--- a/tests/core/test_fingerprint.py
+++ b/tests/core/test_fingerprint.py
@@ -13,11 +13,11 @@ import numpy as np
 import pytest
 
 from probpipe import (
-    ArraySpec,
     DistributionSpec,
     EventTemplate,
     FunctionSpec,
     Normal,
+    NumericArraySpec,
     OpaqueSpec,
     Record,
     RecordSpec,
@@ -951,7 +951,7 @@ class TestValueSpecFingerprints:
     def test_every_spec_kind_is_reachable_by_the_hasher(self, tau):
         """Each kind hashes by declaration; none falls through to identity."""
         for spec in (
-            ArraySpec(()),
+            NumericArraySpec(()),
             OpaqueSpec(),
             RecordSpec(tau),
             DistributionSpec(tau),

--- a/tests/core/test_first_class_function.py
+++ b/tests/core/test_first_class_function.py
@@ -18,7 +18,6 @@ import pytest
 import probpipe
 from probpipe import (
     Annotated,
-    ArraySpec,
     Distribution,
     DistributionArray,
     EventTemplate,
@@ -26,6 +25,7 @@ from probpipe import (
     FunctionSpec,
     Gamma,
     Normal,
+    NumericArraySpec,
     NumericRecord,
     NumericRecordBatch,
     Provenance,
@@ -169,7 +169,7 @@ class TestApplyContract:
             wrapped.apply(2)
 
     def test_dtype_pinned_output_accepts_bare_and_inferred_record(self):
-        template = EventTemplate(y=ArraySpec((), dtype="float32"))
+        template = EventTemplate(y=NumericArraySpec((), dtype="float32"))
         value = jnp.asarray(3.0, dtype=jnp.float32)
         returned = Record("returned", y=value)
         bare = Function(func=lambda: value, output_template=template)
@@ -188,7 +188,7 @@ class TestApplyContract:
 
     def test_declared_output_accepts_record_batch_as_a_batched_event(self):
         intrinsic = EventTemplate(y=())
-        declared = EventTemplate(y=ArraySpec((), dtype="float32"))
+        declared = EventTemplate(y=NumericArraySpec((), dtype="float32"))
         returned = NumericRecordBatch(
             {"y": jnp.asarray([1.0, 2.0], dtype=jnp.float32)},
             level_names="draw",
@@ -242,7 +242,7 @@ class TestApplyContract:
             wrapped.apply()
 
     def test_declared_output_checks_record_batch_dtype_and_support(self):
-        dtype_template = EventTemplate(y=ArraySpec((), dtype="int32"))
+        dtype_template = EventTemplate(y=NumericArraySpec((), dtype="int32"))
         float_array = RecordBatch(
             {"y": jnp.asarray([1.0, 2.0], dtype=jnp.float32)},
             level_names="draw",
@@ -253,7 +253,7 @@ class TestApplyContract:
         with pytest.raises(ValueError, match=r"output/y dtype float32 does not conform"):
             Function(func=lambda: float_array, output_template=dtype_template).apply()
 
-        support_template = EventTemplate(y=ArraySpec((), support=positive))
+        support_template = EventTemplate(y=NumericArraySpec((), support=positive))
         invalid_array = NumericRecordBatch(
             {"y": jnp.asarray([1.0, -2.0])},
             level_names="draw",
@@ -279,7 +279,7 @@ class TestApplyContract:
         declared_dtype,
     ):
         value = np.asarray(3, dtype=actual_dtype)
-        template = EventTemplate(y=ArraySpec((), dtype=declared_dtype))
+        template = EventTemplate(y=NumericArraySpec((), dtype=declared_dtype))
 
         Function(func=lambda: value, output_template=template).apply()
         Function(func=lambda: Record("returned", y=value), output_template=template).apply()
@@ -290,14 +290,14 @@ class TestApplyContract:
         returned = Record("returned", y=value) if structured else value
         wrapped = Function(
             func=lambda: returned,
-            output_template=EventTemplate(y=ArraySpec((), dtype="int32")),
+            output_template=EventTemplate(y=NumericArraySpec((), dtype="int32")),
         )
 
         with pytest.raises(ValueError, match=r"output/y.*dtype|output at 'y'"):
             wrapped.apply()
 
     def test_support_pinned_scalar_output_is_enforced(self):
-        template = EventTemplate(y=ArraySpec((), support=positive))
+        template = EventTemplate(y=NumericArraySpec((), support=positive))
 
         assert Function(func=lambda: jnp.asarray(3.0), output_template=template).apply() == 3.0
         with pytest.raises(ValueError, match=r"output at 'y'.*support positive"):
@@ -305,7 +305,7 @@ class TestApplyContract:
 
     def test_support_pinned_nested_mapping_output_is_enforced(self):
         template = EventTemplate(
-            stats=EventTemplate(y=ArraySpec((2,), support=positive)),
+            stats=EventTemplate(y=NumericArraySpec((2,), support=positive)),
         )
         wrapped = Function(
             func=lambda value: {"stats": {"y": value}},
@@ -318,7 +318,7 @@ class TestApplyContract:
 
     def test_support_pinned_nested_record_output_is_enforced(self):
         template = EventTemplate(
-            stats=EventTemplate(y=ArraySpec((2,), support=positive)),
+            stats=EventTemplate(y=NumericArraySpec((2,), support=positive)),
         )
         valid = Record("returned", stats=Record("stats", y=jnp.asarray([1.0, 2.0])))
         invalid = Record("returned", stats=Record("stats", y=jnp.asarray([1.0, -2.0])))
@@ -331,11 +331,11 @@ class TestApplyContract:
         returned = Record(
             "returned",
             y=jnp.asarray(3.0),
-            event_template=EventTemplate(y=ArraySpec((), support=real)),
+            event_template=EventTemplate(y=NumericArraySpec((), support=real)),
         )
         wrapped = Function(
             func=lambda: returned,
-            output_template=EventTemplate(y=ArraySpec((), support=positive)),
+            output_template=EventTemplate(y=NumericArraySpec((), support=positive)),
         )
 
         with pytest.raises(ValueError, match=r"output/y support real does not conform to positive"):
@@ -375,8 +375,8 @@ class TestApplyContract:
             def supports(self):
                 raise AssertionError("Function must not read Distribution.supports")
 
-        intrinsic = EventTemplate(y=ArraySpec((), dtype="float32", support=positive))
-        declared = EventTemplate(y=ArraySpec((), dtype="float32", support=positive))
+        intrinsic = EventTemplate(y=NumericArraySpec((), dtype="float32", support=positive))
+        declared = EventTemplate(y=NumericArraySpec((), dtype="float32", support=positive))
         returned = SchemaCompleteDistribution(intrinsic)
         wrapped = Function(func=lambda: returned, output_template=declared)
 
@@ -393,11 +393,11 @@ class TestApplyContract:
         cases = [
             (
                 Normal(0, 1, name="y"),
-                EventTemplate(y=ArraySpec((), dtype="float32")),
+                EventTemplate(y=NumericArraySpec((), dtype="float32")),
             ),
             (
                 Gamma(1, 1, name="y"),
-                EventTemplate(y=ArraySpec((), support=real)),
+                EventTemplate(y=NumericArraySpec((), support=real)),
             ),
         ]
 
@@ -423,7 +423,7 @@ class TestApplyContract:
         ],
     )
     def test_output_support_reductions_are_enforced(self, support, valid, invalid):
-        template = EventTemplate(y=ArraySpec(valid.shape, support=support))
+        template = EventTemplate(y=NumericArraySpec(valid.shape, support=support))
 
         Function(func=lambda: valid, output_template=template).apply()
         with pytest.raises(ValueError, match=r"output at 'y'.*declared support"):
@@ -432,7 +432,7 @@ class TestApplyContract:
     def test_support_validation_rejects_direct_jax_jit(self):
         wrapped = Function(
             func=lambda x: x + 1,
-            output_template=EventTemplate(y=ArraySpec((), support=positive)),
+            output_template=EventTemplate(y=NumericArraySpec((), support=positive)),
         )
 
         with pytest.raises(jax.errors.TracerBoolConversionError):
@@ -442,11 +442,11 @@ class TestApplyContract:
         class SupportAnnotatedNormal(Normal):
             @property
             def event_template(self):
-                return EventTemplate(x=ArraySpec((), support=real))
+                return EventTemplate(x=NumericArraySpec((), support=real))
 
         wrapped = Function(
             func=lambda x: x,
-            input_template=EventTemplate(x=ArraySpec((), support=positive)),
+            input_template=EventTemplate(x=NumericArraySpec((), support=positive)),
             dispatch="sequential",
             n_broadcast_samples=5,
         )
@@ -764,7 +764,7 @@ class TestSymbolicCalls:
         wrapped = Function(
             func=lambda row: row["value"],
             input_template=EventTemplate(row=EventTemplate(value=())),
-            output_template=EventTemplate(value=ArraySpec((), support=positive)),
+            output_template=EventTemplate(value=NumericArraySpec((), support=positive)),
             dispatch="sequential",
         )
 
@@ -775,7 +775,7 @@ class TestSymbolicCalls:
         wrapped = Function(
             func=lambda x: x**2 + 1,
             input_template=EventTemplate(x=()),
-            output_template=EventTemplate(y=ArraySpec((), support=positive)),
+            output_template=EventTemplate(y=NumericArraySpec((), support=positive)),
             dispatch="auto",
             n_broadcast_samples=8,
         )
@@ -784,14 +784,14 @@ class TestSymbolicCalls:
             result = wrapped(Normal(0, 1, name="x"))
 
         assert result.provenance.metadata["dispatch"] == "sequential"
-        assert result.event_template == EventTemplate(y=ArraySpec((), support=positive))
+        assert result.event_template == EventTemplate(y=NumericArraySpec((), support=positive))
         assert bool(jnp.all(result.samples["y"] > 0))
 
     def test_support_pinned_broadcast_explicit_jax_reports_traceability_error(self):
         wrapped = Function(
             func=lambda x: x**2 + 1,
             input_template=EventTemplate(x=()),
-            output_template=EventTemplate(y=ArraySpec((), support=positive)),
+            output_template=EventTemplate(y=NumericArraySpec((), support=positive)),
             dispatch="jax",
             n_broadcast_samples=8,
         )
@@ -806,7 +806,7 @@ class TestSymbolicCalls:
         rows = NumericRecordBatch.stack(
             [NumericRecord("row", value=jnp.asarray(float(i))) for i in range(3)], level_name="draw"
         )
-        template = EventTemplate(y=ArraySpec((), support=positive))
+        template = EventTemplate(y=NumericArraySpec((), support=positive))
         wrapped = Function(
             func=lambda row: row["value"] + 1,
             input_template=EventTemplate(row=EventTemplate(value=())),
@@ -826,7 +826,7 @@ class TestSymbolicCalls:
         wrapped = Function(
             func=lambda row: row["value"] + 1,
             input_template=EventTemplate(row=EventTemplate(value=())),
-            output_template=EventTemplate(y=ArraySpec((), support=positive)),
+            output_template=EventTemplate(y=NumericArraySpec((), support=positive)),
             dispatch="jax",
         )
 
@@ -924,7 +924,7 @@ class TestSymbolicCalls:
         wrapped = Function(
             func=lambda x: Normal(x, 1, name="y"),
             input_template=EventTemplate(x=()),
-            output_template=EventTemplate(y=ArraySpec((), support=real)),
+            output_template=EventTemplate(y=NumericArraySpec((), support=real)),
             dispatch="sequential",
             n_broadcast_samples=8,
         )
@@ -1441,7 +1441,7 @@ class TestDeclaredSupportOnABatchedOutput:
         from probpipe import NumericRecordBatch
 
         template = EventTemplate(
-            a=ArraySpec((), support=positive), b=ArraySpec((), support=positive)
+            a=NumericArraySpec((), support=positive), b=NumericArraySpec((), support=positive)
         )
         valid = NumericRecordBatch(
             {"a": jnp.ones(3), "b": jnp.ones(3) * 2},
@@ -1457,7 +1457,7 @@ class TestDeclaredSupportOnABatchedOutput:
         from probpipe import NumericRecordBatch
 
         template = EventTemplate(
-            a=ArraySpec((), support=positive), b=ArraySpec((), support=positive)
+            a=NumericArraySpec((), support=positive), b=NumericArraySpec((), support=positive)
         )
         invalid = NumericRecordBatch(
             {"a": jnp.ones(3), "b": jnp.asarray([1.0, -2.0, 3.0])},

--- a/tests/core/test_function_opaque_batch.py
+++ b/tests/core/test_function_opaque_batch.py
@@ -17,12 +17,12 @@ import numpy as np
 import pytest
 
 from probpipe import (
-    ArraySpec,
     Batch,
     BatchSpec,
     EventTemplate,
     FunctionBatch,
     FunctionSpec,
+    NumericArraySpec,
     OpaqueBatch,
     OpaqueSpec,
     Record,
@@ -160,8 +160,8 @@ class TestConstructionRefusals:
     @pytest.mark.parametrize(
         ("cls", "spec", "match"),
         [
-            (FunctionBatch, ArraySpec(()), "must be a FunctionSpec"),
-            (OpaqueBatch, ArraySpec(()), "must be an OpaqueSpec"),
+            (FunctionBatch, NumericArraySpec(()), "must be a FunctionSpec"),
+            (OpaqueBatch, NumericArraySpec(()), "must be an OpaqueSpec"),
         ],
     )
     def test_the_element_spec_must_be_its_own_kind(self, cls, spec, match):

--- a/tests/core/test_named_collection.py
+++ b/tests/core/test_named_collection.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 
 from probpipe import EventTemplate, NumericRecord, NumericRecordBatch, Record
-from probpipe.core.event_template import ArraySpec, NumericEventTemplate, OpaqueSpec
+from probpipe.core.event_template import NumericArraySpec, NumericEventTemplate, OpaqueSpec
 
 # ---------------------------------------------------------------------------
 # Construction: path-keyed unflattening and its error cases
@@ -83,7 +83,7 @@ class TestConditionalRoundTrip:
 
     def test_value_only_dict_is_lossy_for_dtype(self):
         # A template carrying dtype is not recoverable from a value-only dict.
-        tpl = EventTemplate(x=ArraySpec((), dtype=jnp.dtype("float32")))
+        tpl = EventTemplate(x=NumericArraySpec((), dtype=jnp.dtype("float32")))
         r = Record("r", {"x": jnp.float32(1.0)}, event_template=tpl)
         assert Record("r", dict(r)) != r  # re-inferred template drops the dtype
 
@@ -109,7 +109,7 @@ class TestSubtreeTemplateInvariant:
 
     def test_supplied_template_via_path_keys(self):
         tpl = EventTemplate(
-            physics=EventTemplate(force=ArraySpec((), dtype=jnp.dtype("float32")), mass=()),
+            physics=EventTemplate(force=NumericArraySpec((), dtype=jnp.dtype("float32")), mass=()),
             obs=(),
         )
         r = Record(
@@ -124,7 +124,7 @@ class TestSubtreeTemplateInvariant:
         # A pre-built child Record whose own template differs from the supplied
         # slice must adopt the slice's specs.
         tpl = EventTemplate(
-            physics=EventTemplate(force=ArraySpec((), dtype=jnp.dtype("float64")), mass=()),
+            physics=EventTemplate(force=NumericArraySpec((), dtype=jnp.dtype("float64")), mass=()),
             obs=(),
         )
         child = Record("r", {"force": 1.0, "mass": 2.0})  # bare-shape inferred template
@@ -211,8 +211,8 @@ class TestConvenienceConstructors:
 class TestEditTemplateThreading:
     def _rich(self):
         tpl = EventTemplate(
-            physics=EventTemplate(force=ArraySpec((), dtype=jnp.dtype("float32")), mass=()),
-            obs=ArraySpec((), dtype=jnp.dtype("float32")),
+            physics=EventTemplate(force=NumericArraySpec((), dtype=jnp.dtype("float32")), mass=()),
+            obs=NumericArraySpec((), dtype=jnp.dtype("float32")),
         )
         return Record(
             "r",
@@ -232,7 +232,7 @@ class TestEditTemplateThreading:
         right = Record(
             "r",
             {"obs": jnp.float32(9.0)},
-            event_template=EventTemplate(obs=ArraySpec((), dtype=jnp.dtype("float32"))),
+            event_template=EventTemplate(obs=NumericArraySpec((), dtype=jnp.dtype("float32"))),
         )
         m = left.merge(right)
         assert m.event_template.at_path("physics/force").dtype == jnp.dtype("float32")
@@ -282,7 +282,7 @@ class TestEditTemplateThreading:
         t = EventTemplate(x=(), y=(3,))
         t2 = t.replace(x=OpaqueSpec())
         assert type(t2) is EventTemplate
-        assert isinstance(t2.replace(x=ArraySpec(())), NumericEventTemplate)
+        assert isinstance(t2.replace(x=NumericArraySpec(())), NumericEventTemplate)
 
     def test_edits_reuse_untouched_children_verbatim(self):
         # An untouched nested child already named by its field key survives
@@ -309,7 +309,9 @@ class TestEditTemplateThreading:
             with pytest.raises(ValueError, match="overlap"):
                 r.replace(updates)
         with pytest.raises(ValueError, match="overlap"):
-            r.event_template.replace({"physics": ArraySpec((2,)), "physics/mass": ArraySpec((5,))})
+            r.event_template.replace(
+                {"physics": NumericArraySpec((2,)), "physics/mass": NumericArraySpec((5,))}
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -335,7 +337,7 @@ class TestEventTemplateOps:
     def test_map_to_numeric_promotes(self):
         tpl = EventTemplate(a=None, b=())  # mixed -> base EventTemplate
         assert not isinstance(tpl, NumericEventTemplate)
-        mapped = tpl.map(lambda s: ArraySpec((2,)))  # every spec numeric now
+        mapped = tpl.map(lambda s: NumericArraySpec((2,)))  # every spec numeric now
         assert isinstance(mapped, NumericEventTemplate)
 
 

--- a/tests/core/test_named_tree.py
+++ b/tests/core/test_named_tree.py
@@ -11,7 +11,12 @@ import jax.numpy as jnp
 import pytest
 
 from probpipe import EventTemplate, NumericRecord, Record
-from probpipe.core.event_template import ArraySpec, NumericEventTemplate, OpaqueSpec, ValueSpec
+from probpipe.core.event_template import (
+    NumericArraySpec,
+    NumericEventTemplate,
+    OpaqueSpec,
+    ValueSpec,
+)
 from probpipe.core.named_tree import NamedTree
 
 # ===========================================================================
@@ -173,7 +178,7 @@ class TestWithPathNames:
         assert renamed_named.name_is_auto is False
 
     def test_explicit_template_metadata_survives(self):
-        spec = ArraySpec((), dtype=jnp.float32)
+        spec = NumericArraySpec((), dtype=jnp.float32)
         r = Record("r", a=jnp.array(1.0, dtype=jnp.float32), event_template=EventTemplate(a=spec))
         renamed = r.with_path_names(a="alpha")
         assert renamed.event_template["alpha"] == spec
@@ -250,7 +255,7 @@ class TestPytreeAuxSplit:
     def test_template_and_identity_survive_roundtrip(self):
         import jax
 
-        spec = ArraySpec((), dtype=jnp.float32)
+        spec = NumericArraySpec((), dtype=jnp.float32)
         r = Record(
             "mine",
             a=jnp.array(1.0, dtype=jnp.float32),
@@ -304,7 +309,7 @@ class TestPytreeAuxSplit:
         richer = Record(
             "r",
             a=jnp.array(1.0, dtype=jnp.float32),
-            event_template=EventTemplate(a=ArraySpec((), dtype=jnp.float32)),
+            event_template=EventTemplate(a=NumericArraySpec((), dtype=jnp.float32)),
         )
         # Treedef equality is stricter than record equality: a richer explicit
         # template distinguishes the treedefs even when the data is equal.

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -45,6 +45,51 @@ class TestNumericArrayHoldsOneValue:
             NumericArray(jnp.arange(3.0), spec="not a spec")
 
 
+class TestNumericArrayStoresNativeForm:
+    """Construction validates without converting, as `NumericRecord` does.
+
+    A lazy or disk-backed value is not materialised merely to be named, and a
+    container's own metadata is not discarded.
+    """
+
+    def test_an_array_is_stored_verbatim(self):
+        raw = np.arange(3.0)
+
+        assert NumericArray(raw).value is raw
+
+    def test_a_container_keeps_its_own_metadata(self):
+        xr = pytest.importorskip("xarray")
+        data = xr.DataArray(np.arange(3.0), dims=["t"], coords={"t": [10, 20, 30]})
+
+        stored = NumericArray(data).value
+
+        assert isinstance(stored, xr.DataArray)
+        assert list(stored.coords) == ["t"]
+
+    def test_the_spec_is_read_from_metadata(self):
+        assert NumericArray(np.arange(3.0)).shape == (3,)
+
+    def test_a_bare_scalar_is_normalised(self):
+        """It carries no metadata to read, so it is the one thing converted."""
+        assert isinstance(NumericArray(2.5).value, jax.Array)
+
+    def test_conversion_happens_once_and_is_memoised(self):
+        value = NumericArray(np.arange(3.0))
+
+        assert isinstance(value.as_jax(), jax.Array)
+        assert value.as_jax() is value.as_jax()
+
+    def test_the_pytree_boundary_presents_a_bare_array(self):
+        """One of the compute boundaries native form converts at."""
+        (leaf,) = jax.tree_util.tree_leaves(NumericArray(np.arange(3.0)))
+
+        assert isinstance(leaf, jax.Array)
+
+    def test_a_non_numeric_value_is_refused(self):
+        with pytest.raises(TypeError, match="is not a numeric leaf"):
+            NumericArray("not numeric")
+
+
 class TestNumericArrayCarriesIdentity:
     def test_a_name_is_kept_and_marked_user_given(self):
         value = NumericArray(jnp.arange(3.0), name="draw")
@@ -98,6 +143,13 @@ class TestNumericArrayComputesAsAnArray:
 
         assert not isinstance(result, NumericArray)
         assert isinstance(result, jax.Array)
+
+    def test_arithmetic_returns_the_stored_types_own_result(self):
+        """The operators forward to the value, so a numpy-backed one stays numpy."""
+        result = NumericArray(np.arange(3.0)) + 1
+
+        assert isinstance(result, np.ndarray)
+        assert not isinstance(result, jax.Array)
 
     def test_it_computes_the_same_values_as_the_array_it_holds(self):
         raw = jnp.arange(3.0)
@@ -220,6 +272,28 @@ class TestNumericArrayBatchSelection:
     def test_an_element_carries_the_batch_element_spec(self):
         assert _batch()[1].spec == _batch().element_spec
 
+    def test_a_sub_batch_takes_the_declared_view_type(self):
+        """`Batch._view_type` is the hook a subclass overrides to shed its state.
+
+        Reaching for ``type(self)`` instead would hand such a subclass a view
+        claiming to answer for state the view never received.
+        """
+
+        class _Derived(NumericArrayBatch):
+            __slots__ = ()
+
+            @property
+            def _view_type(self) -> type:
+                return NumericArrayBatch
+
+        derived = _Derived(
+            jnp.arange(12.0).reshape(4, 3),
+            "draw",
+            element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+        )
+
+        assert type(derived[1:3]) is NumericArrayBatch
+
     def test_a_slice_is_a_sub_batch(self):
         sub = _batch(name="posterior")[1:3]
 
@@ -311,6 +385,27 @@ class TestNumericArrayIsAPyTree:
         rebuilt = jax.tree_util.tree_map(lambda x: x, value)
 
         assert rebuilt.spec.support == positive
+
+    def test_a_skeleton_rebuilds_rather_than_raising(self):
+        """JAX unflattens with whatever it carries, which is not always an array.
+
+        Mapping a tree to ``None`` builds a skeleton, and internal traversals
+        pass sentinels. Constructing here would convert and validate, so both
+        would raise instead of rebuilding.
+        """
+        value = NumericArray(jnp.arange(3.0), name="draw")
+
+        skeleton = jax.tree_util.tree_map(lambda x: None, value)
+
+        assert isinstance(skeleton, NumericArray)
+        assert skeleton.name == "draw"
+
+    def test_a_sentinel_child_rebuilds(self):
+        _, treedef = jax.tree_util.tree_flatten(NumericArray(jnp.arange(3.0)))
+
+        rebuilt = jax.tree_util.tree_unflatten(treedef, [object()])
+
+        assert isinstance(rebuilt, NumericArray)
 
     def test_provenance_does_not_survive_the_boundary(self):
         """As for `Record`: lineage rides on the function layer, not the treedef."""

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -15,6 +15,7 @@ def _batch(values=None, level_names="draw", **kwargs) -> NumericArrayBatch:
     if values is None:
         values = jnp.arange(12.0).reshape(4, 3)
     kwargs.setdefault("element_spec", NumericArraySpec(shape=(3,), dtype=jnp.float32))
+    kwargs.setdefault("name", "draws")
     return NumericArrayBatch(values, level_names, **kwargs)
 
 
@@ -70,7 +71,7 @@ class TestNumericArrayStoresNativeForm:
         assert NumericArray(np.arange(3.0)).shape == (3,)
 
     def test_a_bare_scalar_is_normalised(self):
-        """It carries no metadata to read, so it is the one thing converted."""
+        """It carries no metadata to read, so it is normalised."""
         assert isinstance(NumericArray(2.5).value, jax.Array)
 
     def test_conversion_happens_once_and_is_memoised(self):
@@ -80,16 +81,15 @@ class TestNumericArrayStoresNativeForm:
         assert value.as_jax() is value.as_jax()
 
     def test_the_pytree_boundary_presents_a_bare_array(self):
-        """One of the compute boundaries native form converts at."""
+        """A compute boundary, where native form converts."""
         (leaf,) = jax.tree_util.tree_leaves(NumericArray(np.arange(3.0)))
 
         assert isinstance(leaf, jax.Array)
 
     def test_dtype_reports_the_value_not_the_declaration(self):
-        """The shim stands in for an array, and an array's dtype is its data's.
+        """An array's dtype describes its data; ``.spec`` carries the declaration.
 
-        ``is_valid`` admits a same-kind cast, so the two can differ; the
-        declaration stays reachable as ``.spec``.
+        ``is_valid`` admits a same-kind cast, so the two can differ.
         """
         value = NumericArray(
             jnp.zeros(3, dtype=jnp.float32),
@@ -130,7 +130,7 @@ class TestNumericArrayCarriesIdentity:
         assert NumericArray(raw).value is raw
 
     def test_it_is_unhashable(self):
-        """`__eq__` is elementwise, so a hash would be a false promise."""
+        """`__eq__` is elementwise, so a hash would promise more than it keeps."""
         with pytest.raises(TypeError):
             hash(NumericArray(jnp.arange(3.0)))
 
@@ -152,14 +152,14 @@ class TestNumericArrayComputesAsAnArray:
         ],
     )
     def test_arithmetic_yields_a_bare_array(self, compute):
-        """Identity is attached by operations, and arithmetic is not one."""
+        """Identity is attached by operations; arithmetic is not one."""
         result = compute(NumericArray(jnp.arange(3.0)))
 
         assert not isinstance(result, NumericArray)
         assert isinstance(result, jax.Array)
 
     def test_arithmetic_returns_the_stored_types_own_result(self):
-        """The operators forward to the value, so a numpy-backed one stays numpy."""
+        """The operators forward to the value, so numpy stays numpy."""
         result = NumericArray(np.arange(3.0)) + 1
 
         assert isinstance(result, np.ndarray)
@@ -190,7 +190,7 @@ class TestNumericArrayComputesAsAnArray:
         assert isinstance(jnp.asarray(value), jax.Array)
 
     def test_it_traces_under_jit(self):
-        """``__jax_array__`` is why the numpy hook does not win and drop tracing."""
+        """Registration is what carries it into a trace."""
 
         @jax.jit
         def double(x):
@@ -229,7 +229,10 @@ class TestNumericArrayBatchHoldsTheMultiplicity:
 
     def test_scalar_elements_leave_every_axis_to_the_batch(self):
         batch = NumericArrayBatch(
-            jnp.arange(4.0), "draw", element_spec=NumericArraySpec(shape=(), dtype=jnp.float32)
+            jnp.arange(4.0),
+            "draw",
+            element_spec=NumericArraySpec(shape=(), dtype=jnp.float32),
+            name="draws",
         )
 
         assert batch.batch_shape == (4,)
@@ -263,7 +266,7 @@ class TestNumericArrayBatchHoldsTheMultiplicity:
 
 
 class TestNumericArrayBatchSelection:
-    """Selection yields the element kind, as it does for every batch."""
+    """Selection yields the element kind, as for every batch."""
 
     def test_an_element_is_a_numeric_array(self):
         element = _batch()[1]
@@ -278,7 +281,7 @@ class TestNumericArrayBatchSelection:
         assert element.name_is_auto is True
 
     def test_an_element_inherits_the_batch_lineage(self):
-        """Selecting computes nothing, so the element carries the batch's own."""
+        """Selecting computes nothing, so the element carries the batch's lineage."""
         batch = _batch().with_provenance(Provenance.create("sample", parents=[]))
 
         assert batch[1].provenance is batch.provenance
@@ -287,11 +290,7 @@ class TestNumericArrayBatchSelection:
         assert _batch()[1].spec == _batch().element_spec
 
     def test_a_sub_batch_takes_the_declared_view_type(self):
-        """`Batch._view_type` is the hook a subclass overrides to shed its state.
-
-        Reaching for ``type(self)`` instead would hand such a subclass a view
-        claiming to answer for state the view never received.
-        """
+        """`Batch._view_type` is the hook a subclass overrides to shed its state."""
 
         class _Derived(NumericArrayBatch):
             __slots__ = ()
@@ -304,6 +303,7 @@ class TestNumericArrayBatchSelection:
             jnp.arange(12.0).reshape(4, 3),
             "draw",
             element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+            name="derived",
         )
 
         assert type(derived[1:3]) is NumericArrayBatch
@@ -328,9 +328,12 @@ class TestNumericArrayBatchOverNativeContainers:
         return pd.DataFrame(np.arange(12.0).reshape(4, 3))
 
     def test_an_element_selects_by_position_not_by_label(self):
-        """``df[0]`` is a column; the element is the row at position 0."""
+        """``df[0]`` is a column, while the element is the row at position 0."""
         batch = NumericArrayBatch(
-            self._frame(), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+            self._frame(),
+            "draw",
+            element_spec=NumericArraySpec(shape=(3,), dtype=np.float64),
+            name="draws",
         )
 
         element = batch[1]
@@ -341,7 +344,10 @@ class TestNumericArrayBatchOverNativeContainers:
 
     def test_a_sub_batch_selects_by_position(self):
         batch = NumericArrayBatch(
-            self._frame(), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+            self._frame(),
+            "draw",
+            element_spec=NumericArraySpec(shape=(3,), dtype=np.float64),
+            name="draws",
         )
 
         sub = batch[1:3]
@@ -354,7 +360,7 @@ class TestNumericArrayBatchOverNativeContainers:
         frame = self._frame()
 
         batch = NumericArrayBatch(
-            frame, "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+            frame, "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64), name="draws"
         )
 
         assert isinstance(batch.values, pd.DataFrame)
@@ -362,10 +368,13 @@ class TestNumericArrayBatchOverNativeContainers:
 
 class TestNumericArrayBatchRefusals:
     def test_a_stored_array_with_no_batch_axis_is_refused(self):
-        """One value is a NumericArray; a batch has at least one batch axis."""
+        """A batch has at least one batch axis; one value is a NumericArray."""
         with pytest.raises(ValueError, match="at least one batch axis"):
             NumericArrayBatch(
-                jnp.zeros(3), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32)
+                jnp.zeros(3),
+                "draw",
+                element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+                name="draws",
             )
 
     def test_trailing_axes_that_are_not_the_event_shape_are_refused(self):
@@ -374,49 +383,85 @@ class TestNumericArrayBatchRefusals:
                 jnp.zeros((4, 5)),
                 "draw",
                 element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+                name="draws",
             )
 
     def test_a_symbolic_event_dimension_is_refused(self):
-        """A symbolic size gives the stored axes nothing to split by."""
+        """A symbolic size leaves the stored axes no split point."""
         with pytest.raises(ValueError, match="symbolic dimension"):
             NumericArrayBatch(
                 jnp.zeros((4, 3)),
                 "draw",
                 element_spec=NumericArraySpec(shape=("n",), dtype=jnp.float32),
+                name="draws",
             )
 
     def test_values_that_are_not_an_array_are_refused(self):
         with pytest.raises(TypeError, match="stores one array"):
             NumericArrayBatch(
-                object(), "draw", element_spec=NumericArraySpec(shape=(), dtype=jnp.float32)
+                object(),
+                "draw",
+                element_spec=NumericArraySpec(shape=(), dtype=jnp.float32),
+                name="draws",
             )
 
     def test_a_dtype_the_declaration_does_not_admit_is_refused(self):
-        """The batch asserts the spec of every element, so it checks at build.
-
-        Left to the first selection, ``NumericArray`` raises one layer too late
-        to name the batch that made the false claim.
-        """
+        """The batch asserts the spec of every element, so it checks at build."""
         with pytest.raises(TypeError, match="does not admit"):
             NumericArrayBatch(
                 jnp.zeros((2, 3), dtype=jnp.float32),
                 "draw",
                 element_spec=NumericArraySpec(shape=(3,), dtype=jnp.int32),
+                name="draws",
             )
 
+    def test_a_store_with_no_single_dtype_cannot_carry_a_pinned_one(self):
+        """A backend may report no single dtype, which supports no pinned one."""
+        from probpipe import ArrayBackend, register_array_backend
+
+        class _NoSingleDtype:
+            def __init__(self, array):
+                self.array = array
+
+        register_array_backend(
+            _NoSingleDtype,
+            ArrayBackend(
+                event_shape=lambda o: o.array.shape,
+                numpy_dtype=lambda o: None,
+                to_jax=lambda o: jnp.asarray(o.array),
+                to_numpy=lambda o: np.asarray(o.array),
+                take=lambda o, index: _NoSingleDtype(o.array[index]),
+            ),
+        )
+        store = _NoSingleDtype(np.zeros((4, 3)))
+
+        with pytest.raises(TypeError, match="reports no single dtype"):
+            NumericArrayBatch(
+                store,
+                "draw",
+                element_spec=NumericArraySpec(shape=(3,), dtype=np.int32),
+                name="draws",
+            )
+
+        # Declaring no dtype leaves nothing to substantiate, so it still builds.
+        assert NumericArrayBatch(
+            store, "draw", element_spec=NumericArraySpec(shape=(3,)), name="draws"
+        ).batch_shape == (4,)
+
     def test_a_same_kind_dtype_is_admitted(self):
-        """A widening or within-kind narrowing passes, as it does for a record."""
+        """A widening or within-kind narrowing passes, as for a record."""
         batch = NumericArrayBatch(
             jnp.zeros((2, 3), dtype=jnp.float32),
             "draw",
             element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float64),
+            name="draws",
         )
 
         assert batch.batch_shape == (2,)
 
     def test_an_element_spec_of_another_kind_is_refused(self):
         with pytest.raises(TypeError, match="must be a NumericArraySpec"):
-            NumericArrayBatch(jnp.zeros((4, 3)), "draw", element_spec="not a spec")
+            NumericArrayBatch(jnp.zeros((4, 3)), "draw", element_spec="not a spec", name="draws")
 
     def test_axis_groups_must_tile_the_batch_shape(self):
         with pytest.raises(ValueError):
@@ -426,9 +471,8 @@ class TestNumericArrayBatchRefusals:
 class TestNumericArrayIsAPyTree:
     """Registration is what lets it cross a transform boundary at all.
 
-    JAX no longer converts through ``__jax_array__`` during abstractification,
-    so a value that is not a registered pytree cannot be passed to a traced
-    function.
+    A traced function reaches its arguments through the pytree registry, so
+    registration is what carries a value into one.
     """
 
     def test_it_round_trips_through_flatten_and_unflatten(self):
@@ -441,18 +485,40 @@ class TestNumericArrayIsAPyTree:
         assert (rebuilt.name, rebuilt.name_is_auto) == ("draw", False)
         np.testing.assert_array_equal(np.asarray(rebuilt), np.arange(3.0))
 
-    def test_a_transform_that_changes_the_shape_re_derives_the_spec(self):
-        """Its spec *is* its shape and dtype, so what arrives states it exactly.
+    def test_a_transform_that_changes_the_shape_keeps_the_declaration(self):
+        """On this path a shape is transform-relative, so it states nothing.
 
-        This is why no rank has to be inferred here the way a batch's must be.
+        The value reports what it now holds; the spec keeps saying what was
+        declared, which is the only thing the round trip can be faithful to.
         """
         stacked = jax.tree_util.tree_map(lambda x: jnp.stack([x, x]), NumericArray(jnp.arange(3.0)))
 
         assert stacked.shape == (2, 3)
-        assert stacked.spec == NumericArraySpec(shape=(2, 3), dtype=jnp.float32)
+        assert stacked.spec == NumericArraySpec(shape=(3,), dtype=jnp.float32)
+
+    def test_a_declared_dtype_is_not_re_read_off_the_value(self):
+        """`is_valid` admits a same-kind cast, so the two can differ.
+
+        Deriving the spec from what arrives would quietly restate a float64
+        declaration as float32 — the declaration is what the aux carries.
+        """
+        value = NumericArray(
+            jnp.arange(3.0, dtype=jnp.float32),
+            spec=NumericArraySpec(shape=(3,), dtype=np.float64),
+        )
+
+        leaves, treedef = jax.tree_util.tree_flatten(value)
+
+        assert jax.tree_util.tree_unflatten(treedef, leaves).spec.dtype == np.float64
+
+    def test_a_skeleton_still_carries_its_declaration(self):
+        """`spec` is typed as one, so a rebuilt value has to have one."""
+        skeleton = jax.tree_util.tree_map(lambda x: None, NumericArray(jnp.arange(3.0)))
+
+        assert skeleton.spec == NumericArraySpec(shape=(3,), dtype=jnp.float32)
 
     def test_a_declared_support_rides_along(self):
-        """Shape and dtype re-derive; a support could not, so it is aux."""
+        """The declaration is the aux, support included."""
         from probpipe import positive
 
         value = NumericArray(
@@ -465,12 +531,7 @@ class TestNumericArrayIsAPyTree:
         assert rebuilt.spec.support == positive
 
     def test_a_skeleton_rebuilds_rather_than_raising(self):
-        """JAX unflattens with whatever it carries, which is not always an array.
-
-        Mapping a tree to ``None`` builds a skeleton, and internal traversals
-        pass sentinels. Constructing here would convert and validate, so both
-        would raise instead of rebuilding.
-        """
+        """JAX unflattens with whatever it carries, and a skeleton is not an array."""
         value = NumericArray(jnp.arange(3.0), name="draw")
 
         skeleton = jax.tree_util.tree_map(lambda x: None, value)
@@ -494,3 +555,101 @@ class TestNumericArrayIsAPyTree:
         rebuilt = jax.tree_util.tree_map(lambda x: x, value)
 
         assert rebuilt.provenance is None
+
+
+class TestABatchIsNamed:
+    """A batch's name is required, as a `Record`'s and an `Opaque`'s are."""
+
+    def test_a_name_is_required(self):
+        with pytest.raises(TypeError, match="name"):
+            NumericArrayBatch(
+                jnp.arange(12.0).reshape(4, 3),
+                "draw",
+                element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+            )
+
+    def test_a_given_name_is_marked_user_given(self):
+        batch = _batch(name="posterior")
+
+        assert (batch.name, batch.name_is_auto) == ("posterior", False)
+
+    def test_a_derived_name_says_so(self):
+        """A view derives its name, and marks it, rather than defaulting."""
+        sub = _batch(name="posterior")[1:3]
+
+        assert (sub.name, sub.name_is_auto) == ("posterior[draw=1:3]", True)
+
+
+class TestNumericArrayBatchIsAPyTree:
+    """The two-transformation contract `RecordBatch` states, over one column.
+
+    Registration is what lets a batch reach a traced function.
+    """
+
+    def test_it_round_trips_unchanged(self):
+        batch = _batch(name="posterior")
+
+        rebuilt = jax.tree_util.tree_map(lambda x: x, batch)
+
+        assert isinstance(rebuilt, NumericArrayBatch)
+        assert rebuilt.batch_shape == (4,)
+        assert rebuilt.level_names == ("draw",)
+
+    def test_removing_every_batch_axis_yields_the_element(self):
+        """The value is one element, so it comes back as one.
+
+        Observed through ``tree_map``: a ``vmap`` restacks, so the removal is
+        visible only on the way in, inside the trace.
+        """
+        out = jax.tree_util.tree_map(lambda x: x[0], _batch())
+
+        assert isinstance(out, NumericArray)
+        assert out.shape == (3,)
+
+    def test_a_vmap_hands_the_body_an_element_and_stacks_what_it_returns(self):
+        """Which is why the batch's own levels are read rather than inferred.
+
+        Unflattening a slice removes every batch axis, so the body receives a
+        `NumericArray`, and returning it stacks into one with the mapped axis
+        prepended. That value carries no levels, so its spec re-derives exactly
+        from the arriving shape.
+        """
+        out = jax.vmap(lambda element: element)(_batch())
+
+        assert isinstance(out, NumericArray)
+        assert out.shape == (4, 3)
+
+    def test_a_partial_or_resized_rank_is_refused(self):
+        """A shape is not a provenance: no reading says which level survived."""
+        with pytest.raises(ValueError, match="belongs to no level"):
+            jax.tree_util.tree_map(lambda x: jnp.stack([x, x]), _batch())
+
+    def test_a_skeleton_rebuilds_rather_than_raising(self):
+        skeleton = jax.tree_util.tree_map(lambda x: None, _batch())
+
+        assert isinstance(skeleton, NumericArrayBatch)
+
+    def test_it_reaches_a_traced_function(self):
+        total = jax.jit(lambda b: jnp.sum(b))(_batch())
+
+        assert float(total) == float(jnp.sum(jnp.arange(12.0)))
+
+
+class TestNumericArrayBatchArrayShim:
+    """Single-column, so it forwards from its store."""
+
+    def test_shape_is_the_whole_store(self):
+        batch = _batch()
+
+        assert batch.shape == (4, 3)
+        assert batch.ndim == 2
+        assert batch.batch_shape == (4,)
+
+    def test_it_converts_through_both_hooks(self):
+        batch = _batch()
+
+        assert np.asarray(batch).shape == (4, 3)
+        assert isinstance(jnp.asarray(batch), jax.Array)
+
+    def test_dtype_reports_the_store(self):
+        assert _batch().dtype == jnp.float32

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -1,0 +1,323 @@
+"""Tests for NumericArray and NumericArrayBatch — the numeric-array kind."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import NumericArray, NumericArrayBatch, NumericArraySpec
+from probpipe.core.provenance import Provenance
+
+
+def _batch(values=None, level_names="draw", **kwargs) -> NumericArrayBatch:
+    if values is None:
+        values = jnp.arange(12.0).reshape(4, 3)
+    kwargs.setdefault("element_spec", NumericArraySpec(shape=(3,), dtype=jnp.float32))
+    return NumericArrayBatch(values, level_names, **kwargs)
+
+
+class TestNumericArrayHoldsOneValue:
+    def test_shape_is_the_event_shape(self):
+        """A NumericArray carries no batch axes, so its shape is the event's."""
+        value = NumericArray(jnp.zeros((2, 5)))
+
+        assert value.shape == (2, 5)
+        assert value.ndim == 2
+        assert len(value) == 2
+
+    def test_the_spec_is_derived_when_omitted(self):
+        value = NumericArray(jnp.arange(3.0))
+
+        assert value.spec == NumericArraySpec(shape=(3,), dtype=jnp.float32)
+
+    def test_a_supplied_spec_is_checked(self):
+        with pytest.raises(ValueError, match="does not satisfy its declaration"):
+            NumericArray(jnp.arange(3.0), spec=NumericArraySpec(shape=(2,), dtype=jnp.float32))
+
+    def test_a_value_that_is_not_an_array_is_refused(self):
+        with pytest.raises(TypeError, match="holds one numeric array"):
+            NumericArray(object())
+
+    def test_a_spec_of_another_kind_is_refused(self):
+        with pytest.raises(TypeError, match="must be a NumericArraySpec"):
+            NumericArray(jnp.arange(3.0), spec="not a spec")
+
+
+class TestNumericArrayCarriesIdentity:
+    def test_a_name_is_kept_and_marked_user_given(self):
+        value = NumericArray(jnp.arange(3.0), name="draw")
+
+        assert (value.name, value.name_is_auto) == ("draw", False)
+
+    def test_an_omitted_name_is_auto_derived(self):
+        assert NumericArray(jnp.arange(3.0)).name_is_auto is True
+
+    def test_provenance_is_write_once(self):
+        value = NumericArray(jnp.arange(3.0)).with_provenance(Provenance.create("test", parents=[]))
+
+        assert value.provenance.operation == "test"
+        with pytest.raises(RuntimeError, match="already set"):
+            value.with_provenance(Provenance.create("again", parents=[]))
+
+    def test_it_is_immutable(self):
+        with pytest.raises(AttributeError, match="immutable"):
+            NumericArray(jnp.arange(3.0))._value = jnp.zeros(3)
+
+    def test_the_array_is_reachable_untracked(self):
+        raw = jnp.arange(3.0)
+
+        assert NumericArray(raw).value is raw
+
+    def test_it_is_unhashable(self):
+        """`__eq__` is elementwise, so a hash would be a false promise."""
+        with pytest.raises(TypeError):
+            hash(NumericArray(jnp.arange(3.0)))
+
+
+class TestNumericArrayComputesAsAnArray:
+    """The full array surface, because with no fields `arr + 1` has one meaning."""
+
+    @pytest.mark.parametrize(
+        "compute",
+        [
+            lambda v: v + 1,
+            lambda v: 1 + v,
+            lambda v: v * v,
+            lambda v: v - 1.0,
+            lambda v: 2.0 / (v + 1),
+            lambda v: -v,
+            lambda v: abs(v),
+            lambda v: v**2,
+        ],
+    )
+    def test_arithmetic_yields_a_bare_array(self, compute):
+        """Identity is attached by operations, and arithmetic is not one."""
+        result = compute(NumericArray(jnp.arange(3.0)))
+
+        assert not isinstance(result, NumericArray)
+        assert isinstance(result, jax.Array)
+
+    def test_it_computes_the_same_values_as_the_array_it_holds(self):
+        raw = jnp.arange(3.0)
+
+        np.testing.assert_array_equal(
+            np.asarray(NumericArray(raw) * 2 + 1), np.asarray(raw * 2 + 1)
+        )
+
+    def test_two_numeric_arrays_combine(self):
+        pair = NumericArray(jnp.arange(3.0)) + NumericArray(jnp.ones(3))
+
+        assert not isinstance(pair, NumericArray)
+        np.testing.assert_array_equal(np.asarray(pair), np.asarray(jnp.arange(1.0, 4.0)))
+
+    def test_comparison_is_elementwise(self):
+        np.testing.assert_array_equal(
+            np.asarray(NumericArray(jnp.arange(3.0)) == 1.0), np.array([False, True, False])
+        )
+
+    def test_it_converts_through_both_hooks(self):
+        value = NumericArray(jnp.arange(3.0))
+
+        np.testing.assert_array_equal(np.asarray(value), np.arange(3.0))
+        assert isinstance(jnp.asarray(value), jax.Array)
+
+    def test_it_traces_under_jit(self):
+        """``__jax_array__`` is why the numpy hook does not win and drop tracing."""
+
+        @jax.jit
+        def double(x):
+            return x * 2
+
+        np.testing.assert_allclose(
+            np.asarray(double(NumericArray(jnp.arange(3.0)))), np.arange(3.0) * 2
+        )
+
+    def test_a_scalar_converts_to_a_number(self):
+        assert float(NumericArray(jnp.asarray(2.5))) == 2.5
+        assert int(NumericArray(jnp.asarray(2))) == 2
+
+    def test_a_scalar_is_truthy_by_its_value(self):
+        assert bool(NumericArray(jnp.asarray(1.0))) is True
+        assert bool(NumericArray(jnp.asarray(0.0))) is False
+
+    def test_an_integer_scalar_indexes(self):
+        """``__index__`` is what lets one stand in for a position."""
+        assert [10, 20, 30][NumericArray(jnp.asarray(1))] == 20
+
+    def test_indexing_and_iteration_reach_the_array(self):
+        value = NumericArray(jnp.arange(3.0))
+
+        assert float(value[1]) == 1.0
+        assert [float(x) for x in value] == [0.0, 1.0, 2.0]
+
+
+class TestNumericArrayBatchHoldsTheMultiplicity:
+    def test_the_element_spec_splits_batch_axes_from_event_axes(self):
+        batch = _batch()
+
+        assert batch.batch_shape == (4,)
+        assert batch.batch_size == 4
+        assert tuple(batch.element_spec.shape) == (3,)
+
+    def test_scalar_elements_leave_every_axis_to_the_batch(self):
+        batch = NumericArrayBatch(
+            jnp.arange(4.0), "draw", element_spec=NumericArraySpec(shape=(), dtype=jnp.float32)
+        )
+
+        assert batch.batch_shape == (4,)
+
+    def test_levels_tile_the_batch_shape(self):
+        batch = _batch(
+            jnp.arange(24.0).reshape(2, 4, 3),
+            ("chain", "draw"),
+        )
+
+        assert batch.level_names == ("chain", "draw")
+        assert batch.axis_groups == ((2,), (4,))
+        assert batch.batch_shape == (2, 4)
+
+    def test_the_stored_array_and_its_dtype_are_reachable(self):
+        batch = _batch()
+
+        assert batch.values.shape == (4, 3)
+        assert batch.dtype == jnp.float32
+
+    def test_the_repr_states_the_split(self):
+        assert repr(_batch()) == (
+            "NumericArrayBatch(batch_shape=(4,), levels=('draw',), event_shape=(3,))"
+        )
+
+    def test_one_level_may_span_several_axes(self):
+        batch = _batch(jnp.arange(24.0).reshape(2, 4, 3), "cell", axis_groups=((2, 4),))
+
+        assert batch.level_names == ("cell",)
+        assert batch.axis_groups == ((2, 4),)
+
+
+class TestNumericArrayBatchSelection:
+    """Selection yields the element kind, as it does for every batch."""
+
+    def test_an_element_is_a_numeric_array(self):
+        element = _batch()[1]
+
+        assert isinstance(element, NumericArray)
+        np.testing.assert_array_equal(np.asarray(element), np.array([3.0, 4.0, 5.0]))
+
+    def test_an_element_takes_the_derived_name(self):
+        element = _batch(name="posterior")[1]
+
+        assert element.name == "posterior[draw=1]"
+        assert element.name_is_auto is True
+
+    def test_an_element_inherits_the_batch_lineage(self):
+        """Selecting computes nothing, so the element carries the batch's own."""
+        batch = _batch().with_provenance(Provenance.create("sample", parents=[]))
+
+        assert batch[1].provenance is batch.provenance
+
+    def test_an_element_carries_the_batch_element_spec(self):
+        assert _batch()[1].spec == _batch().element_spec
+
+    def test_a_slice_is_a_sub_batch(self):
+        sub = _batch(name="posterior")[1:3]
+
+        assert isinstance(sub, NumericArrayBatch)
+        assert sub.batch_shape == (2,)
+        assert sub.name == "posterior[draw=1:3]"
+
+    def test_iteration_yields_elements(self):
+        assert [type(e) for e in _batch()] == [NumericArray] * 4
+
+
+class TestNumericArrayBatchRefusals:
+    def test_a_stored_array_with_no_batch_axis_is_refused(self):
+        """One value is a NumericArray; a batch has at least one batch axis."""
+        with pytest.raises(ValueError, match="at least one batch axis"):
+            NumericArrayBatch(
+                jnp.zeros(3), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32)
+            )
+
+    def test_trailing_axes_that_are_not_the_event_shape_are_refused(self):
+        with pytest.raises(ValueError, match="where its elements declare the event shape"):
+            NumericArrayBatch(
+                jnp.zeros((4, 5)),
+                "draw",
+                element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+            )
+
+    def test_a_symbolic_event_dimension_is_refused(self):
+        """A symbolic size gives the stored axes nothing to split by."""
+        with pytest.raises(ValueError, match="symbolic dimension"):
+            NumericArrayBatch(
+                jnp.zeros((4, 3)),
+                "draw",
+                element_spec=NumericArraySpec(shape=("n",), dtype=jnp.float32),
+            )
+
+    def test_values_that_are_not_an_array_are_refused(self):
+        with pytest.raises(TypeError, match="stores one array"):
+            NumericArrayBatch(
+                object(), "draw", element_spec=NumericArraySpec(shape=(), dtype=jnp.float32)
+            )
+
+    def test_an_element_spec_of_another_kind_is_refused(self):
+        with pytest.raises(TypeError, match="must be a NumericArraySpec"):
+            NumericArrayBatch(jnp.zeros((4, 3)), "draw", element_spec="not a spec")
+
+    def test_axis_groups_must_tile_the_batch_shape(self):
+        with pytest.raises(ValueError):
+            _batch(jnp.arange(24.0).reshape(2, 4, 3), "cell", axis_groups=((2, 3),))
+
+
+class TestNumericArrayIsAPyTree:
+    """Registration is what lets it cross a transform boundary at all.
+
+    JAX no longer converts through ``__jax_array__`` during abstractification,
+    so a value that is not a registered pytree cannot be passed to a traced
+    function.
+    """
+
+    def test_it_round_trips_through_flatten_and_unflatten(self):
+        value = NumericArray(jnp.arange(3.0), name="draw")
+
+        leaves, treedef = jax.tree_util.tree_flatten(value)
+        rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+
+        assert isinstance(rebuilt, NumericArray)
+        assert (rebuilt.name, rebuilt.name_is_auto) == ("draw", False)
+        np.testing.assert_array_equal(np.asarray(rebuilt), np.arange(3.0))
+
+    def test_a_transform_that_changes_the_shape_re_derives_the_spec(self):
+        """Its spec *is* its shape and dtype, so what arrives states it exactly.
+
+        This is why no rank has to be inferred here the way a batch's must be.
+        """
+        stacked = jax.tree_util.tree_map(lambda x: jnp.stack([x, x]), NumericArray(jnp.arange(3.0)))
+
+        assert stacked.shape == (2, 3)
+        assert stacked.spec == NumericArraySpec(shape=(2, 3), dtype=jnp.float32)
+
+    def test_a_declared_support_rides_along(self):
+        """Shape and dtype re-derive; a support could not, so it is aux."""
+        from probpipe import positive
+
+        value = NumericArray(
+            jnp.arange(1.0, 4.0),
+            spec=NumericArraySpec(shape=(3,), dtype=jnp.float32, support=positive),
+        )
+
+        rebuilt = jax.tree_util.tree_map(lambda x: x, value)
+
+        assert rebuilt.spec.support == positive
+
+    def test_provenance_does_not_survive_the_boundary(self):
+        """As for `Record`: lineage rides on the function layer, not the treedef."""
+        value = NumericArray(jnp.arange(3.0)).with_provenance(
+            Provenance.create("sample", parents=[])
+        )
+
+        rebuilt = jax.tree_util.tree_map(lambda x: x, value)
+
+        assert rebuilt.provenance is None

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -85,6 +85,20 @@ class TestNumericArrayStoresNativeForm:
 
         assert isinstance(leaf, jax.Array)
 
+    def test_dtype_reports_the_value_not_the_declaration(self):
+        """The shim stands in for an array, and an array's dtype is its data's.
+
+        ``is_valid`` admits a same-kind cast, so the two can differ; the
+        declaration stays reachable as ``.spec``.
+        """
+        value = NumericArray(
+            jnp.zeros(3, dtype=jnp.float32),
+            spec=NumericArraySpec(shape=(3,), dtype=jnp.float64),
+        )
+
+        assert value.dtype == jnp.float32
+        assert value.spec.dtype == jnp.float64
+
     def test_a_non_numeric_value_is_refused(self):
         with pytest.raises(TypeError, match="is not a numeric leaf"):
             NumericArray("not numeric")
@@ -305,6 +319,47 @@ class TestNumericArrayBatchSelection:
         assert [type(e) for e in _batch()] == [NumericArray] * 4
 
 
+class TestNumericArrayBatchOverNativeContainers:
+    """Selection is positional, which `[]` is not on every container."""
+
+    @staticmethod
+    def _frame():
+        pd = pytest.importorskip("pandas")
+        return pd.DataFrame(np.arange(12.0).reshape(4, 3))
+
+    def test_an_element_selects_by_position_not_by_label(self):
+        """``df[0]`` is a column; the element is the row at position 0."""
+        batch = NumericArrayBatch(
+            self._frame(), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+        )
+
+        element = batch[1]
+
+        assert isinstance(element, NumericArray)
+        assert element.shape == (3,)
+        np.testing.assert_array_equal(np.asarray(element), np.array([3.0, 4.0, 5.0]))
+
+    def test_a_sub_batch_selects_by_position(self):
+        batch = NumericArrayBatch(
+            self._frame(), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+        )
+
+        sub = batch[1:3]
+
+        assert isinstance(sub, NumericArrayBatch)
+        assert sub.batch_shape == (2,)
+
+    def test_the_container_is_still_stored_verbatim(self):
+        pd = pytest.importorskip("pandas")
+        frame = self._frame()
+
+        batch = NumericArrayBatch(
+            frame, "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+        )
+
+        assert isinstance(batch.values, pd.DataFrame)
+
+
 class TestNumericArrayBatchRefusals:
     def test_a_stored_array_with_no_batch_axis_is_refused(self):
         """One value is a NumericArray; a batch has at least one batch axis."""
@@ -335,6 +390,29 @@ class TestNumericArrayBatchRefusals:
             NumericArrayBatch(
                 object(), "draw", element_spec=NumericArraySpec(shape=(), dtype=jnp.float32)
             )
+
+    def test_a_dtype_the_declaration_does_not_admit_is_refused(self):
+        """The batch asserts the spec of every element, so it checks at build.
+
+        Left to the first selection, ``NumericArray`` raises one layer too late
+        to name the batch that made the false claim.
+        """
+        with pytest.raises(TypeError, match="does not admit"):
+            NumericArrayBatch(
+                jnp.zeros((2, 3), dtype=jnp.float32),
+                "draw",
+                element_spec=NumericArraySpec(shape=(3,), dtype=jnp.int32),
+            )
+
+    def test_a_same_kind_dtype_is_admitted(self):
+        """A widening or within-kind narrowing passes, as it does for a record."""
+        batch = NumericArrayBatch(
+            jnp.zeros((2, 3), dtype=jnp.float32),
+            "draw",
+            element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float64),
+        )
+
+        assert batch.batch_shape == (2,)
 
     def test_an_element_spec_of_another_kind_is_refused(self):
         with pytest.raises(TypeError, match="must be a NumericArraySpec"):

--- a/tests/core/test_numeric_record.py
+++ b/tests/core/test_numeric_record.py
@@ -199,10 +199,11 @@ class TestConstruction:
         # common float across the mixed-dtype fields, and from_vector casts each
         # block back to its declared dtype. Before the cast + skeleton fix, the
         # int32 template made from_vector raise on the float32 placeholder.
-        from probpipe.core.event_template import ArraySpec, EventTemplate
+        from probpipe.core.event_template import EventTemplate, NumericArraySpec
 
         tpl = EventTemplate(
-            k=ArraySpec(shape=(3,), dtype=jnp.int32), x=ArraySpec(shape=(2,), dtype=jnp.float32)
+            k=NumericArraySpec(shape=(3,), dtype=jnp.int32),
+            x=NumericArraySpec(shape=(2,), dtype=jnp.float32),
         )
         nr = NumericRecord(
             "nr", k=jnp.array([1, 2, 3], dtype=jnp.int32), x=jnp.zeros(2), event_template=tpl

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -363,15 +363,15 @@ class TestStorage:
         assert v.replace(z=jnp.array(2.0))["y"] is da
 
     def test_backend_leaf_gives_numeric_template(self):
-        # A native backend leaf infers an ArraySpec, so the template is
+        # A native backend leaf infers an NumericArraySpec, so the template is
         # numeric and stays in step with the record's promoted class.
-        from probpipe.core.event_template import ArraySpec, NumericEventTemplate
+        from probpipe.core.event_template import NumericArraySpec, NumericEventTemplate
 
         xr = pytest.importorskip("xarray")
         da = xr.DataArray([1.0, 2.0, 3.0], dims=["t"])
         v = Record("r", y=da)
         assert isinstance(v.event_template, NumericEventTemplate)
-        assert v.event_template["y"] == ArraySpec((3,))
+        assert v.event_template["y"] == NumericArraySpec((3,))
 
 
 class TestNumericAPIOnRecord:
@@ -1177,11 +1177,11 @@ class TestSpecStorage:
     def test_the_spec_survives_a_pickle_roundtrip(self):
         import pickle
 
-        from probpipe.core.event_template import ArraySpec
+        from probpipe.core.event_template import NumericArraySpec
 
         # An explicit dtype is not recoverable by inference, so the spec must
         # be the thing that was serialized.
-        spec = RecordSpec(EventTemplate(x=ArraySpec(shape=(), dtype=jnp.float32)))
+        spec = RecordSpec(EventTemplate(x=NumericArraySpec(shape=(), dtype=jnp.float32)))
         r = Record("r", {"x": jnp.asarray(1.0, dtype=jnp.float32)}, event_template=spec)
         rebuilt = pickle.loads(pickle.dumps(r))
         assert rebuilt.spec == spec
@@ -1214,9 +1214,9 @@ class TestEventTemplateStorage:
         assert r.event_template is r.event_template
 
     def test_explicit_template_returned_verbatim(self):
-        from probpipe.core.event_template import ArraySpec, EventTemplate
+        from probpipe.core.event_template import EventTemplate, NumericArraySpec
 
-        tpl = EventTemplate(x=ArraySpec(shape=(), dtype=jnp.float32))
+        tpl = EventTemplate(x=NumericArraySpec(shape=(), dtype=jnp.float32))
         r = Record("r", {"x": jnp.asarray(1.0)}, event_template=tpl)
         assert r.event_template is tpl
 
@@ -1238,24 +1238,28 @@ class TestEventTemplateStorage:
         assert vec.shape[0] == nr.event_template.vector_size
 
     def test_equality_distinguishes_structurally_different_templates(self):
-        from probpipe.core.event_template import ArraySpec, EventTemplate
+        from probpipe.core.event_template import EventTemplate, NumericArraySpec
 
         # float32 data is same-kind valid against both a float32 spec (exact)
         # and a float64 spec (a widening), so both records construct; their
         # templates differ, so the records are unequal despite identical data.
         data = {"x": jnp.asarray(1.0, dtype=jnp.float32)}
         r_f32 = Record(
-            "r", dict(data), event_template=EventTemplate(x=ArraySpec(shape=(), dtype=jnp.float32))
+            "r",
+            dict(data),
+            event_template=EventTemplate(x=NumericArraySpec(shape=(), dtype=jnp.float32)),
         )
         r_f64 = Record(
-            "r", dict(data), event_template=EventTemplate(x=ArraySpec(shape=(), dtype=jnp.float64))
+            "r",
+            dict(data),
+            event_template=EventTemplate(x=NumericArraySpec(shape=(), dtype=jnp.float64)),
         )
         assert r_f32 != r_f64
         # Same data, both inferred -> equal templates -> equal records.
         assert Record("r", x=jnp.asarray(1.0)) == Record("r", x=jnp.asarray(1.0))
 
     def test_construction_enforces_leaf_shape_and_dtype(self):
-        from probpipe.core.event_template import ArraySpec, EventTemplate
+        from probpipe.core.event_template import EventTemplate, NumericArraySpec
 
         # A cross-kind dtype (a float value against an int-dtype spec) fails the
         # spec's is_valid -> construction raises.
@@ -1263,17 +1267,21 @@ class TestEventTemplateStorage:
             Record(
                 "r",
                 {"x": jnp.asarray(1.0, dtype=jnp.float32)},
-                event_template=EventTemplate(x=ArraySpec(shape=(), dtype=jnp.int32)),
+                event_template=EventTemplate(x=NumericArraySpec(shape=(), dtype=jnp.int32)),
             )
         # A shape mismatch also raises.
         with pytest.raises(ValueError, match="does not conform"):
-            Record("r", {"x": jnp.zeros(3)}, event_template=EventTemplate(x=ArraySpec(shape=(2,))))
+            Record(
+                "r",
+                {"x": jnp.zeros(3)},
+                event_template=EventTemplate(x=NumericArraySpec(shape=(2,))),
+            )
         # A same-kind cast (int value against a float spec) satisfies is_valid,
         # so construction succeeds.
         Record(
             "r",
             {"x": jnp.ones(2, dtype=jnp.int32)},
-            event_template=EventTemplate(x=ArraySpec(shape=(2,), dtype=jnp.float32)),
+            event_template=EventTemplate(x=NumericArraySpec(shape=(2,), dtype=jnp.float32)),
         )
 
     def test_pytree_roundtrip_threads_the_declaration(self):

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -363,7 +363,7 @@ class TestStorage:
         assert v.replace(z=jnp.array(2.0))["y"] is da
 
     def test_backend_leaf_gives_numeric_template(self):
-        # A native backend leaf infers an NumericArraySpec, so the template is
+        # A native backend leaf infers a NumericArraySpec, so the template is
         # numeric and stays in step with the record's promoted class.
         from probpipe.core.event_template import NumericArraySpec, NumericEventTemplate
 

--- a/tests/core/test_record_batch.py
+++ b/tests/core/test_record_batch.py
@@ -21,10 +21,10 @@ import pytest
 
 from probpipe import (
     ArrayBackend,
-    ArraySpec,
     EventTemplate,
     FunctionBatch,
     FunctionSpec,
+    NumericArraySpec,
     NumericRecord,
     OpaqueBatch,
     Record,
@@ -176,7 +176,7 @@ class TestConstruction:
 
     def test_element_spec_must_be_a_record_declaration(self):
         with pytest.raises(TypeError, match="RecordSpec or an EventTemplate"):
-            NumericRecordBatch({"x": jnp.zeros(3)}, "draw", element_spec=ArraySpec(shape=()))
+            NumericRecordBatch({"x": jnp.zeros(3)}, "draw", element_spec=NumericArraySpec(shape=()))
 
     def test_numeric_batch_refuses_a_non_numeric_element_spec(self):
         with pytest.raises(TypeError, match="carries a NumericEventTemplate"):
@@ -428,7 +428,7 @@ class TestColumnSpecConformance:
             NumericRecordBatch(
                 {"x": jnp.zeros(3, dtype=jnp.float32)},
                 "draw",
-                element_spec=EventTemplate(x=ArraySpec(shape=(), dtype=jnp.int32)),
+                element_spec=EventTemplate(x=NumericArraySpec(shape=(), dtype=jnp.int32)),
             )
 
     @pytest.mark.parametrize(
@@ -442,7 +442,7 @@ class TestColumnSpecConformance:
         ids=["float-widening", "float-narrowing", "int-widening", "int-narrowing"],
     )
     def test_a_same_kind_cast_is_admitted(self, column_dtype, declared):
-        # The rule ``ArraySpec.is_valid`` applies to one value: a widening or a
+        # The rule ``NumericArraySpec.is_valid`` applies to one value: a widening or a
         # within-kind narrowing passes.
         #
         # The pairs stay inside 32 bits deliberately. ``jax_enable_x64`` is off by
@@ -457,7 +457,7 @@ class TestColumnSpecConformance:
         NumericRecordBatch(
             {"x": column},
             "draw",
-            element_spec=EventTemplate(x=ArraySpec(shape=(), dtype=declared)),
+            element_spec=EventTemplate(x=NumericArraySpec(shape=(), dtype=declared)),
         )
 
     @pytest.mark.parametrize("spec", [FunctionSpec(), None], ids=["function", "opaque"])
@@ -992,8 +992,8 @@ class TestFlatLayout:
         from. Equality would not catch it: values compare, dtypes do not."""
         template = EventTemplate(
             {
-                "i": ArraySpec(shape=(), dtype=jnp.int32),
-                "f": ArraySpec(shape=(), dtype=jnp.float32),
+                "i": NumericArraySpec(shape=(), dtype=jnp.int32),
+                "f": NumericArraySpec(shape=(), dtype=jnp.float32),
             }
         )
         batch = NumericRecordBatch(
@@ -1096,7 +1096,7 @@ class TestStack:
             NumericRecord("r", {"x": jnp.zeros(2)}, event_template=EventTemplate(x=(2,))),
             NumericRecord("r", {"x": jnp.zeros(3)}, event_template=EventTemplate(x=(3,))),
         ]
-        # Declared an ArraySpec, so it stacks natively and the shapes must agree —
+        # Declared an NumericArraySpec, so it stacks natively and the shapes must agree —
         # it is not quietly demoted to an object column.
         with pytest.raises((TypeError, ValueError)):
             NumericRecordBatch.stack(records, level_name="draw", element_spec=EventTemplate(x=(2,)))
@@ -1123,7 +1123,7 @@ class TestStack:
             NumericRecordBatch.stack([], level_name="draw")
 
     def test_stack_takes_the_spec_from_the_first_record(self):
-        spec = RecordSpec(EventTemplate(x=ArraySpec(shape=(), dtype=jnp.float32)))
+        spec = RecordSpec(EventTemplate(x=NumericArraySpec(shape=(), dtype=jnp.float32)))
         records = [
             NumericRecord("r", {"x": jnp.asarray(1.0, dtype=jnp.float32)}, event_template=spec)
             for _ in range(2)
@@ -1480,7 +1480,7 @@ class TestPyTreeRebuildContract:
             jax.tree.map(lambda column: float(column.sum()), batch)
 
     def test_object_data_under_a_numeric_field_is_refused(self):
-        """An ``ArraySpec`` requires numeric data whether or not it pins a dtype,
+        """An ``NumericArraySpec`` requires numeric data whether or not it pins a dtype,
         so the kind is re-checked and not only the pinned dtype — otherwise a
         numeric batch comes back holding objects."""
         batch = self._batch((3,), "draw")
@@ -1494,7 +1494,7 @@ class TestPyTreeRebuildContract:
         batch = NumericRecordBatch(
             {"x": jnp.zeros(3, dtype=jnp.int32)},
             "draw",
-            element_spec=EventTemplate(x=ArraySpec(shape=(), dtype=jnp.int32)),
+            element_spec=EventTemplate(x=NumericArraySpec(shape=(), dtype=jnp.int32)),
         )
         with pytest.raises(TypeError, match="does not admit"):
             jax.tree.map(lambda column: column.astype(jnp.float32), batch)

--- a/tests/core/test_record_batch.py
+++ b/tests/core/test_record_batch.py
@@ -1096,7 +1096,7 @@ class TestStack:
             NumericRecord("r", {"x": jnp.zeros(2)}, event_template=EventTemplate(x=(2,))),
             NumericRecord("r", {"x": jnp.zeros(3)}, event_template=EventTemplate(x=(3,))),
         ]
-        # Declared an NumericArraySpec, so it stacks natively and the shapes must agree —
+        # Declared a NumericArraySpec, so it stacks natively and the shapes must agree —
         # it is not quietly demoted to an object column.
         with pytest.raises((TypeError, ValueError)):
             NumericRecordBatch.stack(records, level_name="draw", element_spec=EventTemplate(x=(2,)))

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -20,10 +20,10 @@ import numpy as np
 import pytest
 
 from probpipe import (
-    ArraySpec,
     EventTemplate,
     Function,
     Normal,
+    NumericArraySpec,
     NumericRecord,
     OpaqueBatch,
     ProductDistribution,
@@ -96,7 +96,7 @@ class TestFunctionBoundary:
 
     def test_a_declared_output_template_checks_a_batch_column(self):
         batch = _draws()
-        declared = EventTemplate(a=ArraySpec((), dtype=jnp.int32), b=(2,))
+        declared = EventTemplate(a=NumericArraySpec((), dtype=jnp.int32), b=(2,))
 
         f = Function(func=lambda: batch, output_template=declared)
 
@@ -796,7 +796,7 @@ class TestATransformCannotRetypeTheElement:
         batch = NumericRecordBatch(
             {"x": jnp.zeros(3, dtype=jnp.float32)},
             "draw",
-            element_spec=EventTemplate(x=ArraySpec((), dtype=jnp.float32)),
+            element_spec=EventTemplate(x=NumericArraySpec((), dtype=jnp.float32)),
         )
 
         with pytest.raises(TypeError, match="does not admit"):
@@ -808,7 +808,7 @@ class TestATransformCannotRetypeTheElement:
         batch = NumericRecordBatch(
             {"x": jnp.zeros(3, dtype=jnp.float16)},
             "draw",
-            element_spec=EventTemplate(x=ArraySpec((), dtype=jnp.float32)),
+            element_spec=EventTemplate(x=NumericArraySpec((), dtype=jnp.float32)),
         )
 
         widened = jax.tree.map(lambda leaf: leaf.astype(jnp.float32), batch)
@@ -896,13 +896,15 @@ class TestBatchValuedRowAggregation:
     @staticmethod
     def _rows(n: int = 3):
         return NumericRecordBatch(
-            {"x": jnp.arange(float(n))}, "row", element_spec=EventTemplate(x=ArraySpec(shape=()))
+            {"x": jnp.arange(float(n))},
+            "row",
+            element_spec=EventTemplate(x=NumericArraySpec(shape=())),
         )
 
     @staticmethod
     def _inner(n: int, level: str = "inner"):
         return NumericRecordBatch(
-            {"y": jnp.zeros(n)}, level, element_spec=EventTemplate(y=ArraySpec(shape=()))
+            {"y": jnp.zeros(n)}, level, element_spec=EventTemplate(y=NumericArraySpec(shape=()))
         )
 
     def test_mixing_batch_and_non_batch_rows_is_refused(self):
@@ -931,7 +933,9 @@ class TestBatchValuedRowAggregation:
             if float(x["x"]) < 0.5:
                 return self._inner(2)
             return NumericRecordBatch(
-                {"z": jnp.zeros(2)}, "inner", element_spec=EventTemplate(z=ArraySpec(shape=()))
+                {"z": jnp.zeros(2)},
+                "inner",
+                element_spec=EventTemplate(z=NumericArraySpec(shape=())),
             )
 
         with pytest.raises(ValueError, match="returned batches that disagree"):

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -27,8 +27,8 @@ from probpipe import (
 )
 from probpipe.core._empirical import BootstrapReplicateDistribution, EmpiricalDistribution
 from probpipe.core.event_template import (
-    ArraySpec,
     EventTemplate,
+    NumericArraySpec,
     NumericEventTemplate,
     OpaqueSpec,
 )
@@ -108,7 +108,7 @@ def test_event_template_pickle_roundtrip():
     assert type(t2) is EventTemplate
     assert t2.fields == ("label", "x")
     assert t2["label"] == OpaqueSpec()
-    assert t2["x"] == ArraySpec(())
+    assert t2["x"] == NumericArraySpec(())
 
 
 def test_numeric_event_template_pickle_roundtrip():
@@ -324,7 +324,9 @@ class TestPicklePreservesTemplate:
     def test_plain_record_template_survives(self):
         from probpipe.core.constraints import positive
 
-        tpl = EventTemplate(x=ArraySpec(shape=(3,), support=positive), tag=OpaqueSpec(meta="units"))
+        tpl = EventTemplate(
+            x=NumericArraySpec(shape=(3,), support=positive), tag=OpaqueSpec(meta="units")
+        )
         r = Record("r", {"x": jnp.ones(3), "tag": "meters"}, event_template=tpl)
         assert not isinstance(r, NumericRecord)  # opaque leaf keeps it a plain Record
         back = roundtrip(r)
@@ -334,7 +336,7 @@ class TestPicklePreservesTemplate:
     def test_numeric_record_template_survives(self):
         from probpipe.core.constraints import positive
 
-        tpl = EventTemplate(x=ArraySpec(shape=(3,), support=positive))
+        tpl = EventTemplate(x=NumericArraySpec(shape=(3,), support=positive))
         nr = NumericRecord("nr", {"x": jnp.ones(3)}, event_template=tpl)
         back = roundtrip(nr)
         assert back.event_template == nr.event_template
@@ -343,7 +345,7 @@ class TestPicklePreservesTemplate:
     def test_cloudpickle_preserves_template(self):
         from probpipe.core.constraints import positive
 
-        tpl = EventTemplate(x=ArraySpec(shape=(3,), support=positive))
+        tpl = EventTemplate(x=NumericArraySpec(shape=(3,), support=positive))
         nr = NumericRecord("nr", {"x": jnp.ones(3)}, event_template=tpl)
         assert cloudpickle_roundtrip(nr).event_template == nr.event_template
 
@@ -352,7 +354,7 @@ class TestPicklePreservesTemplate:
         from probpipe.core.constraints import positive
 
         da = xr.DataArray([1.0, 2.0, 3.0], dims=["t"], coords={"t": [10, 20, 30]})
-        tpl = EventTemplate(x=ArraySpec(shape=(3,), support=positive))
+        tpl = EventTemplate(x=NumericArraySpec(shape=(3,), support=positive))
         nr = NumericRecord("nr", {"x": da}, event_template=tpl)
         back = roundtrip(nr)
         assert back.event_template == nr.event_template  # explicit template survived

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -29,7 +29,7 @@ from probpipe import (
 )
 from probpipe.core._record_batch import RecordBatch
 from probpipe.core.distribution import _RecordDistributionView
-from probpipe.core.event_template import ArraySpec
+from probpipe.core.event_template import NumericArraySpec
 from probpipe.inference import rwmh
 from probpipe.inference._approximate_distribution import make_posterior
 from probpipe.inference._inference_utils import build_mcmc_datatree
@@ -1273,7 +1273,7 @@ class TestEndToEndValuesPipeline:
         tpl = posterior.event_template
         assert tpl is not None
         assert tpl.fields == ("params",)
-        assert tpl["params"] == ArraySpec((2,))
+        assert tpl["params"] == NumericArraySpec((2,))
 
     def test_draws_are_named_values(self, posterior):
         """draws() returns Record with correct field names and shapes."""

--- a/tests/inference/test_minibatch.py
+++ b/tests/inference/test_minibatch.py
@@ -16,10 +16,10 @@ import pytest
 import tensorflow_probability.substrates.jax.glm as tfp_glm
 
 from probpipe import (
-    ArraySpec,
     EventTemplate,
     GLMLikelihood,
     MultivariateNormal,
+    NumericArraySpec,
     NumericRecordBatch,
     Record,
     random_unnormalized_log_prob,
@@ -486,7 +486,7 @@ def test_a_multi_axis_batch_is_refused_at_construction(prior, likelihood):
     grid = NumericRecordBatch(
         {"x": jnp.ones((4, 3))},
         ("n", "k"),
-        element_spec=EventTemplate(x=ArraySpec(shape=())),
+        element_spec=EventTemplate(x=NumericArraySpec(shape=())),
     )
     with pytest.raises(ValueError, match="rows are one axis"):
         MinibatchedDistribution(prior, likelihood, grid, batch_size=2)

--- a/tests/modeling/test_pymc_model.py
+++ b/tests/modeling/test_pymc_model.py
@@ -15,7 +15,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from probpipe import ApproximateDistribution
-from probpipe.core.event_template import ArraySpec
+from probpipe.core.event_template import NumericArraySpec
 from probpipe.modeling import PyMCModel
 
 
@@ -297,8 +297,8 @@ class TestEventTemplate:
 
         tpl = PyMCModel(model_fn).event_template
         assert tpl.fields == ("intercept", "slope")
-        assert tpl["intercept"] == ArraySpec(())
-        assert tpl["slope"] == ArraySpec((3,))
+        assert tpl["intercept"] == NumericArraySpec(())
+        assert tpl["slope"] == NumericArraySpec((3,))
 
     def test_observed_rvs_excluded(self):
         """Observed variables are not part of the parameter template."""
@@ -330,8 +330,8 @@ class TestEventTemplate:
         # Declared (no-data) property: sentinel (1,) for alpha.
         tpl = model.event_template
         assert tpl.fields == ("intercept", "alpha")
-        assert tpl["intercept"] == ArraySpec(())
-        assert tpl["alpha"] == ArraySpec((1,))
+        assert tpl["intercept"] == NumericArraySpec(())
+        assert tpl["alpha"] == NumericArraySpec((1,))
         assert model.event_shape == (1 + 1,)
 
         # Template built from a data-conditioned build picks up the real
@@ -346,10 +346,10 @@ class TestEventTemplate:
         names = model._conditioned_param_names(conditioned)
         tpl_c = model._event_template_for(conditioned, names)
         assert tpl_c.fields == ("intercept", "alpha")
-        assert tpl_c["alpha"] == ArraySpec((N,))
+        assert tpl_c["alpha"] == NumericArraySpec((N,))
         assert not hasattr(model, "_last_conditioned_model")
         # Property still reports the declared shape (no hidden mutation).
-        assert model.event_template["alpha"] == ArraySpec((1,))
+        assert model.event_template["alpha"] == NumericArraySpec((1,))
 
     def test_data_dependent_shape_inference_recovers_correct_layout(self):
         """End-to-end: NUTS with a per-observation effect produces a

--- a/tests/modeling/test_stan_model.py
+++ b/tests/modeling/test_stan_model.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 
 from probpipe import SupportsLogProb, log_prob
-from probpipe.core.event_template import ArraySpec
+from probpipe.core.event_template import NumericArraySpec
 from probpipe.modeling._stan import StanModel, _param_blocks, _UnconstrainedStanView
 
 # ---------------------------------------------------------------------------
@@ -437,8 +437,8 @@ class TestUnconstrainedStanView:
         view = structured_model.as_unconstrained_distribution()
         assert view.fields == ("mu", "theta", "L", "p")
         # The simplex is unconstrained in (n-1) free coordinates.
-        assert structured_model.event_template["p"] == ArraySpec((3,))
-        assert view.event_template["p"] == ArraySpec((2,))
+        assert structured_model.event_template["p"] == NumericArraySpec((3,))
+        assert view.event_template["p"] == NumericArraySpec((2,))
 
     def test_log_prob_finite_and_unnormalized_agrees(self, structured_model):
         view = structured_model.as_unconstrained_distribution()


### PR DESCRIPTION
## Summary

Stage 1 of issue 398: the tracked class of the numeric-array kind and its batch
form, so `NumericArraySpec` has the pair every other value spec has.

**Nothing returns them yet.** The operations switch over in a later change; the
suite is unmoved apart from the new tests. Stacked on #418, which is the design
amendment these implement.

## `NumericArray`

Holds one array and carries **no batch axes**, so `shape` is the event shape;
multiplicity lives in `NumericArrayBatch`.

It carries the full array surface — arithmetic, comparison, conversion hooks —
and **arithmetic yields a bare array**:

```python
value = NumericArray(jnp.arange(3.0), name="draw")
value + 1        # Array([1., 2., 3.]) — not a NumericArray
```

Identity is attached by operations, and arithmetic is not one, so a
`NumericArray` is what an operation hands back and what a caller computes
*from*. That is what lets `Record` stay a container and carry none of it.

The ~40 operators are installed from a table rather than written out: they all
forward the same way, and a hand-written list is where one gets forgotten.
`__hash__` is dropped, since an elementwise `__eq__` would make it a false
promise.

**It is a registered pytree.** Writing the tests turned up that it could not be
passed to a traced function at all — JAX no longer converts through
`__jax_array__` during abstractification, so a value must be registered to cross
a `jit` or `vmap` boundary. Its aux carries the identity and the declared
`support`; the **spec is re-derived from the array that arrives**, because a
`NumericArray`'s spec *is* its shape and dtype, so that reading is exact rather
than the guess the batch types must refuse.

## `NumericArrayBatch`

Stores one array with the batch axes leading and splits them from the event axes
by the element spec's shape — the `RecordBatch` split with one column instead of
many. This is where a `draw` level lives for an array-valued law.

Selection yields the element kind, as it does for every batch: `batch[i]` is a
`NumericArray`, materialized under the derived name and inheriting the batch's
lineage.

**Not registered as a pytree yet**, deliberately. Doing so raises the same
question `RecordBatch` answers with its two-transformation contract, and nothing
maps over one until the operations return them.

## The rename

`ArraySpec` → `NumericArraySpec`, so the spec agrees with the class it names as
`RecordSpec`/`Record` does. Mechanical: 415 occurrences across 36 files, plus the
public export. Its own commit, so the diff reads separately from the new code.

**This is breaking** — `ArraySpec` was public API.

## Linked issue(s)

Refs #398 — stage 1 of four. Stacked on #418 (stage 0, the design amendment).

## Test plan

`tests/core/test_numeric_array.py`, 43 tests:

- what each class holds — the event/batch axis split, spec derivation, level
  tiling including one level spanning several axes;
- the identity — user vs auto names, write-once provenance, immutability, and
  that it is unhashable;
- the array surface — arithmetic parametrized over eight expressions, all
  asserted to return a bare `jax.Array`; elementwise comparison; both conversion
  hooks; scalar conversion; indexing and iteration;
- the pytree round trip, spec re-derivation under a shape-changing `tree_map`,
  and that provenance does not survive the boundary;
- selection — element kind, derived name, inherited lineage, sub-batch views;
- the refusals — no batch axis, wrong trailing shape, symbolic event dimension,
  wrong spec kind, axis groups that do not tile.

Full suite: 4739 passed, 54 skipped. `ruff check .` and `ruff format --check .`
clean from the repo root.

## Breaking changes

`ArraySpec` is renamed `NumericArraySpec`. No behaviour changes: the new classes
are not yet returned by anything.

## Documentation

CHANGELOG entries under `Unreleased → Added` and `→ Changed`. The design these
implement is #418.
