### PR TITLE
feat(core): add Opaque, the tracked class of the opaque kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Selection yields a `NumericArray` under the derived name, as `RecordBatch`
   yields a `Record`.
 
+- **`Opaque` — the tracked class of the opaque kind (#398).** What an operation
+  returns when its declared kind is an `OpaqueSpec`, completing the pair with the
+  `OpaqueBatch` that already existed. It adds identity and nothing else: no
+  attribute forwarding, no `__call__`, no operators — the wrapped value is
+  reached through `.value`, explicitly. `OpaqueBatch`'s element contract is
+  unchanged; it still hands back the object the caller put in rather than
+  wrapping it.
+
 - **`ArrayBackend.take` — positional selection for a native container.** `[]` is
   positional on a numpy-protocol container and reads *labels* on a `pandas` one,
   so a batch stored as a `DataFrame` could not address its own elements. Backends

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged; it still hands back the object the caller put in rather than
   wrapping it.
 
+  The name is the required first argument, as a `Record`'s is: an opaque value
+  exposes nothing else that says what it is, so a default would name every one
+  of them alike. `OpaqueSpec` moves to the same module as the class it types;
+  the public import path is unchanged.
+
 - **`ArrayBackend.take` — positional selection for a native container.** `[]` is
   positional on a numpy-protocol container and reads *labels* on a `pandas` one,
   so a batch stored as a `DataFrame` could not address its own elements. Backends

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -44,6 +44,7 @@ from probpipe.core._numeric_array import NumericArray
 from probpipe.core._numeric_array_batch import NumericArrayBatch
 from probpipe.core._numeric_record import NumericRecord
 from probpipe.core._numeric_record_batch import NumericRecordBatch
+from probpipe.core._opaque import Opaque
 from probpipe.core._opaque_batch import OpaqueBatch
 from probpipe.core._record_batch import RecordBatch
 from probpipe.core._workflow_context import workflow_run
@@ -288,6 +289,7 @@ __all__ = [
     "NumericRecordBatch",
     "NumericRecordDistribution",
     "NumericRecordDistributionView",
+    "Opaque",
     "OpaqueBatch",
     "OpaqueSpec",
     "ParentInfo",

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -44,7 +44,7 @@ from probpipe.core._numeric_array import NumericArray
 from probpipe.core._numeric_array_batch import NumericArrayBatch
 from probpipe.core._numeric_record import NumericRecord
 from probpipe.core._numeric_record_batch import NumericRecordBatch
-from probpipe.core._opaque import Opaque
+from probpipe.core._opaque import Opaque, OpaqueSpec
 from probpipe.core._opaque_batch import OpaqueBatch
 from probpipe.core._record_batch import RecordBatch
 from probpipe.core._workflow_context import workflow_run
@@ -100,7 +100,6 @@ from probpipe.core.event_template import (
     FunctionSpec,
     NumericArraySpec,
     NumericEventTemplate,
-    OpaqueSpec,
     RecordSpec,
     TermSpec,
     ValueSpec,

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -361,11 +361,11 @@ def _update_value_spec(
 ) -> None:
     """Hash a built-in ValueSpec by the declaration fields that define it."""
     from ._batch import BatchSpec
+    from ._opaque import OpaqueSpec
     from .event_template import (
         DistributionSpec,
         FunctionSpec,
         NumericArraySpec,
-        OpaqueSpec,
         RecordSpec,
     )
 

--- a/probpipe/core/_opaque.py
+++ b/probpipe/core/_opaque.py
@@ -1,0 +1,109 @@
+"""Opaque — the tracked class of the opaque kind.
+
+See design III.1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ._immutable import Immutable
+from .event_template import OpaqueSpec
+from .provenance import Provenance
+from .tracked import Annotated, TrackedTerm, auto_name
+
+__all__ = ["Opaque"]
+
+
+class Opaque(Immutable, TrackedTerm, Annotated):
+    """One value of no exposed structure, with identity.
+
+    The tracked class of the opaque kind, as :class:`~probpipe.Record` is of the
+    record kind: what an operation returns when its declared kind is an
+    :class:`~probpipe.OpaqueSpec`. Its batch form is
+    :class:`~probpipe.OpaqueBatch`, which already existed — a batch is a tracked
+    term whatever its elements are, which is why the collection had a class
+    before the element did.
+
+    **It adds identity and nothing else.** No attribute forwarding, no
+    ``__call__``, no operators: the wrapped value is reached through
+    :attr:`value`, explicitly. A box that forwards to be convenient is
+    indistinguishable from the value it wraps, and then the wrapping is a
+    surprise rather than a statement — so this one does not. What an opaque
+    value affords is whatever its own type affords, once it is out.
+
+    Parameters
+    ----------
+    value : Any
+        The value this names. Held as given, never converted or copied — there
+        is nothing to convert it to. Anything but a mapping, which the value
+        layer reads as a subtree rather than a leaf.
+    name : str, optional
+        The value's name. Defaults to ``"opaque"``, marked auto-derived.
+    name_is_auto : bool, default False
+        Whether *name* is auto-derived rather than user-given. A value left
+        unnamed is auto-named regardless.
+    spec : OpaqueSpec, optional
+        What this value satisfies, carrying any opaque ``meta``. Defaults to a
+        bare :class:`~probpipe.OpaqueSpec`.
+    provenance : Provenance, optional
+        How this value was produced.
+
+    Raises
+    ------
+    TypeError
+        If *spec* is not an :class:`~probpipe.OpaqueSpec`, or if *value* is a
+        mapping.
+
+    Examples
+    --------
+    >>> fitted = Opaque(object(), name="sklearn_model")
+    >>> fitted.name
+    'sklearn_model'
+    """
+
+    __slots__ = (
+        "_annotations",
+        "_name",
+        "_name_is_auto",
+        "_provenance",
+        "_spec",
+        "_value",
+    )
+
+    def __init__(
+        self,
+        value: Any,
+        *,
+        name: str | None = None,
+        name_is_auto: bool = False,
+        spec: OpaqueSpec | None = None,
+        provenance: Provenance | None = None,
+    ) -> None:
+        if spec is not None and not isinstance(spec, OpaqueSpec):
+            raise TypeError(f"Opaque spec must be an OpaqueSpec, got {type(spec).__name__}")
+        if isinstance(value, Mapping):
+            raise TypeError(
+                "Opaque holds one unstructured value, and the value layer reads a mapping as a "
+                "subtree rather than a leaf; wrap it as a Record, or as a non-mapping value"
+            )
+        spec = OpaqueSpec() if spec is None else spec
+        if name is None:
+            name, name_is_auto = auto_name(name, "opaque")
+        object.__setattr__(self, "_value", value)
+        object.__setattr__(self, "_spec", spec)
+        self._init_tracked(name, name_is_auto=name_is_auto, provenance=provenance)
+
+    @property
+    def value(self) -> Any:
+        """The wrapped value, untracked. The one way to reach it."""
+        return self._value
+
+    @property
+    def spec(self) -> OpaqueSpec:
+        """This value's own declaration."""
+        return self._spec
+
+    def __repr__(self) -> str:
+        return f"Opaque({self._value!r}, name={self.name!r})"

--- a/probpipe/core/_opaque.py
+++ b/probpipe/core/_opaque.py
@@ -5,45 +5,71 @@ See design III.1.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Hashable, Mapping
+from dataclasses import dataclass
 from typing import Any
 
-from ._immutable import Immutable
-from .event_template import OpaqueSpec
+from .event_template import ValueSpec, _require_hashable
 from .provenance import Provenance
-from .tracked import Annotated, TrackedTerm, auto_name
+from .tracked import Annotated, TrackedTerm
 
-__all__ = ["Opaque"]
+__all__ = ["Opaque", "OpaqueSpec"]
 
 
-class Opaque(Immutable, TrackedTerm, Annotated):
+@dataclass(frozen=True)
+class OpaqueSpec(ValueSpec):
+    """The fallback value spec, for a value no other spec describes.
+
+    An opaque value carries no exposed structure (a string, a DataFrame, an
+    arbitrary Python object, ...). ``meta`` is optional opaque metadata and
+    must be hashable (or ``None``).
+    """
+
+    meta: Hashable = None
+
+    def __post_init__(self) -> None:
+        _require_hashable(self.meta, context="OpaqueSpec.meta")
+
+    def is_valid(self, value: Any) -> bool:
+        """Whether *value* is a valid opaque value — anything but a mapping.
+
+        As the fallback spec, ``OpaqueSpec`` accepts any value **except** a
+        ``Mapping``: a mapping denotes tree structure (a subtree), never a
+        leaf. Every other value is valid, including a numeric array or scalar
+        — such a value is *typically* described by an :class:`NumericArraySpec`, but
+        an explicitly-opaque field still accepts it. ``meta`` is metadata
+        about the spec and is not checked against the value.
+
+        Notes
+        -----
+        The record layer honours the same rule: mappings are never leaves, so
+        :class:`~probpipe.Record` construction materialises a mapping field
+        value into a nested subtree.
+        """
+        return not isinstance(value, Mapping)
+
+
+class Opaque(TrackedTerm, Annotated):
     """One value of no exposed structure, with identity.
 
     The tracked class of the opaque kind, as :class:`~probpipe.Record` is of the
     record kind: what an operation returns when its declared kind is an
     :class:`~probpipe.OpaqueSpec`. Its batch form is
-    :class:`~probpipe.OpaqueBatch`, which already existed — a batch is a tracked
-    term whatever its elements are, which is why the collection had a class
-    before the element did.
+    :class:`~probpipe.OpaqueBatch`.
 
-    **It adds identity and nothing else.** No attribute forwarding, no
-    ``__call__``, no operators: the wrapped value is reached through
-    :attr:`value`, explicitly. A box that forwards to be convenient is
-    indistinguishable from the value it wraps, and then the wrapping is a
-    surprise rather than a statement — so this one does not. What an opaque
-    value affords is whatever its own type affords, once it is out.
+    Its interface is :attr:`value` plus the identity every tracked term carries.
+    What the value affords is its own type's, once it is out.
 
     Parameters
     ----------
+    name : str
+        The value's name, required and first as a :class:`~probpipe.Record`
+        takes it: the name is what says which opaque value this is.
     value : Any
-        The value this names. Held as given, never converted or copied — there
-        is nothing to convert it to. Anything but a mapping, which the value
-        layer reads as a subtree rather than a leaf.
-    name : str, optional
-        The value's name. Defaults to ``"opaque"``, marked auto-derived.
+        The value this names, held as given. Any non-mapping value; the value
+        layer reads a mapping as a subtree.
     name_is_auto : bool, default False
-        Whether *name* is auto-derived rather than user-given. A value left
-        unnamed is auto-named regardless.
+        Whether *name* is auto-derived rather than user-given.
     spec : OpaqueSpec, optional
         What this value satisfies, carrying any opaque ``meta``. Defaults to a
         bare :class:`~probpipe.OpaqueSpec`.
@@ -58,7 +84,7 @@ class Opaque(Immutable, TrackedTerm, Annotated):
 
     Examples
     --------
-    >>> fitted = Opaque(object(), name="sklearn_model")
+    >>> fitted = Opaque("sklearn_model", object())
     >>> fitted.name
     'sklearn_model'
     """
@@ -74,9 +100,10 @@ class Opaque(Immutable, TrackedTerm, Annotated):
 
     def __init__(
         self,
+        name: str,
         value: Any,
+        /,
         *,
-        name: str | None = None,
         name_is_auto: bool = False,
         spec: OpaqueSpec | None = None,
         provenance: Provenance | None = None,
@@ -89,15 +116,13 @@ class Opaque(Immutable, TrackedTerm, Annotated):
                 "subtree rather than a leaf; wrap it as a Record, or as a non-mapping value"
             )
         spec = OpaqueSpec() if spec is None else spec
-        if name is None:
-            name, name_is_auto = auto_name(name, "opaque")
         object.__setattr__(self, "_value", value)
         object.__setattr__(self, "_spec", spec)
         self._init_tracked(name, name_is_auto=name_is_auto, provenance=provenance)
 
     @property
     def value(self) -> Any:
-        """The wrapped value, untracked. The one way to reach it."""
+        """The wrapped value, untracked."""
         return self._value
 
     @property

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -11,7 +11,7 @@ from typing import Any
 import numpy as np
 
 from ._object_batch import _ObjectBatch
-from .event_template import OpaqueSpec
+from ._opaque import OpaqueSpec
 from .provenance import Provenance
 
 __all__ = ["OpaqueBatch"]

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -42,13 +42,13 @@ from ._array_backend import _is_numeric_dtype, _to_jax_array
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._function_batch import FunctionBatch
 from ._object_batch import _from_iterable, _frozen_object_column, _is_object_array
+from ._opaque import OpaqueSpec
 from ._opaque_batch import OpaqueBatch
 from .event_template import (
     EventTemplate,
     FunctionSpec,
     NumericArraySpec,
     NumericEventTemplate,
-    OpaqueSpec,
     RecordSpec,
     ValueSpec,
     _record_declaration_template,

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -65,7 +65,7 @@ from __future__ import annotations
 
 import operator
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Hashable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from math import prod
 from typing import Any
@@ -89,7 +89,6 @@ __all__ = [
     "FunctionSpec",
     "NumericArraySpec",
     "NumericEventTemplate",
-    "OpaqueSpec",
     "RecordSpec",
     "TermSpec",
     "ValueSpec",
@@ -384,39 +383,6 @@ class NumericArraySpec(ValueSpec):
             if not np.can_cast(np.dtype(actual), self.dtype, casting="same_kind"):
                 return False
         return True
-
-
-@dataclass(frozen=True)
-class OpaqueSpec(ValueSpec):
-    """The fallback value spec, for a value no other spec describes.
-
-    An opaque value carries no exposed structure (a string, a DataFrame, an
-    arbitrary Python object, ...). ``meta`` is optional opaque metadata and
-    must be hashable (or ``None``).
-    """
-
-    meta: Hashable = None
-
-    def __post_init__(self) -> None:
-        _require_hashable(self.meta, context="OpaqueSpec.meta")
-
-    def is_valid(self, value: Any) -> bool:
-        """Whether *value* is a valid opaque value — anything but a mapping.
-
-        As the fallback spec, ``OpaqueSpec`` accepts any value **except** a
-        ``Mapping``: a mapping denotes tree structure (a subtree), never a
-        leaf. Every other value is valid, including a numeric array or scalar
-        — such a value is *typically* described by an :class:`NumericArraySpec`, but
-        an explicitly-opaque field still accepts it. ``meta`` is metadata
-        about the spec and is not checked against the value.
-
-        Notes
-        -----
-        The record layer honours the same rule: mappings are never leaves, so
-        :class:`~probpipe.Record` construction materialises a mapping field
-        value into a nested subtree.
-        """
-        return not isinstance(value, Mapping)
 
 
 @dataclass(frozen=True)
@@ -853,6 +819,8 @@ def _to_spec(spec: _FieldSpecInput) -> _FieldSpec:
     if isinstance(spec, (ValueSpec, EventTemplate)):
         return spec
     if spec is None:
+        from ._opaque import OpaqueSpec
+
         return OpaqueSpec()
     if isinstance(spec, tuple):
         return NumericArraySpec(shape=spec)
@@ -1336,6 +1304,8 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
     # -- Repr ---------------------------------------------------------------
 
     def __repr__(self) -> str:
+        from ._opaque import OpaqueSpec
+
         parts = []
         for name, spec in self._tree.items():
             if isinstance(spec, EventTemplate):

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -12,8 +12,9 @@ import jax.numpy as jnp
 
 from .._weights import Weights
 from ..core._immutable import transient_memo
+from ..core._opaque import OpaqueSpec
 from ..core.distribution import Distribution, RecordEmpiricalDistribution
-from ..core.event_template import EventTemplate, NumericArraySpec, NumericEventTemplate, OpaqueSpec
+from ..core.event_template import EventTemplate, NumericArraySpec, NumericEventTemplate
 from ..core.provenance import Provenance
 from ..core.record import Record
 from ..custom_types import Array, ArrayLike

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -881,7 +881,8 @@ class TestMakeStack:
         being mislabeled opaque (#343)."""
         from probpipe import Record, RecordBatch
         from probpipe.core._broadcast_distributions import _make_stack
-        from probpipe.core.event_template import NumericArraySpec, OpaqueSpec
+        from probpipe.core._opaque import OpaqueSpec
+        from probpipe.core.event_template import NumericArraySpec
 
         records = [Record("r", x=jnp.ones(2, dtype=jnp.bfloat16), label=f"r{i}") for i in range(3)]
         out = _make_stack(records, n=3, field_name="demo", level_names=("sweep",))

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -11,6 +11,7 @@ import pytest
 from probpipe import Function, NumericRecord, Record
 from probpipe.core._batch import BatchSpec
 from probpipe.core._numeric_record_batch import NumericRecordBatch
+from probpipe.core._opaque import OpaqueSpec
 from probpipe.core._opaque_batch import OpaqueBatch
 from probpipe.core.event_template import (
     DistributionSpec,
@@ -18,7 +19,6 @@ from probpipe.core.event_template import (
     FunctionSpec,
     NumericArraySpec,
     NumericEventTemplate,
-    OpaqueSpec,
     RecordSpec,
     TermSpec,
     ValueSpec,

--- a/tests/core/test_named_collection.py
+++ b/tests/core/test_named_collection.py
@@ -12,7 +12,8 @@ import numpy as np
 import pytest
 
 from probpipe import EventTemplate, NumericRecord, NumericRecordBatch, Record
-from probpipe.core.event_template import NumericArraySpec, NumericEventTemplate, OpaqueSpec
+from probpipe.core._opaque import OpaqueSpec
+from probpipe.core.event_template import NumericArraySpec, NumericEventTemplate
 
 # ---------------------------------------------------------------------------
 # Construction: path-keyed unflattening and its error cases

--- a/tests/core/test_named_tree.py
+++ b/tests/core/test_named_tree.py
@@ -11,10 +11,10 @@ import jax.numpy as jnp
 import pytest
 
 from probpipe import EventTemplate, NumericRecord, Record
+from probpipe.core._opaque import OpaqueSpec
 from probpipe.core.event_template import (
     NumericArraySpec,
     NumericEventTemplate,
-    OpaqueSpec,
     ValueSpec,
 )
 from probpipe.core.named_tree import NamedTree

--- a/tests/core/test_opaque.py
+++ b/tests/core/test_opaque.py
@@ -1,0 +1,143 @@
+"""Tests for Opaque — the tracked class of the opaque kind."""
+
+from __future__ import annotations
+
+import copy
+import pickle
+
+import pytest
+
+from probpipe import Opaque, OpaqueBatch, OpaqueSpec
+from probpipe.core.provenance import Provenance
+
+
+class _Payload:
+    """A stand-in for the sort of thing an opaque value holds."""
+
+    def __init__(self, tag: str = "x") -> None:
+        self.tag = tag
+
+    def shout(self) -> str:
+        return self.tag.upper()
+
+    def __call__(self) -> str:
+        return "called"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _Payload) and other.tag == self.tag
+
+
+class TestOpaqueHoldsOneValue:
+    def test_the_value_is_reachable_and_unchanged(self):
+        payload = _Payload()
+
+        assert Opaque(payload).value is payload
+
+    def test_the_spec_defaults_to_a_bare_one(self):
+        assert Opaque(_Payload()).spec == OpaqueSpec()
+
+    def test_a_declared_spec_carries_its_meta(self):
+        spec = OpaqueSpec(meta="fitted-model")
+
+        assert Opaque(_Payload(), spec=spec).spec.meta == "fitted-model"
+
+    def test_a_spec_of_another_kind_is_refused(self):
+        with pytest.raises(TypeError, match="must be an OpaqueSpec"):
+            Opaque(_Payload(), spec="not a spec")
+
+    def test_a_mapping_is_refused(self):
+        """The value layer reads a mapping as a subtree, not a leaf."""
+        with pytest.raises(TypeError, match="reads a mapping as a subtree"):
+            Opaque({"a": 1})
+
+    @pytest.mark.parametrize("value", [1, "text", None, [1, 2], (1, 2), _Payload()])
+    def test_anything_else_is_admitted(self, value):
+        assert Opaque(value).value == value
+
+
+class TestOpaqueAddsIdentityAndNothingElse:
+    """A box that forwards is indistinguishable from what it wraps."""
+
+    def test_it_does_not_forward_attributes(self):
+        wrapped = Opaque(_Payload())
+
+        assert not hasattr(wrapped, "shout")
+        with pytest.raises(AttributeError):
+            wrapped.shout()
+
+    def test_it_is_not_callable_even_when_its_value_is(self):
+        wrapped = Opaque(_Payload())
+
+        assert not callable(wrapped)
+        with pytest.raises(TypeError):
+            wrapped()
+
+    def test_the_value_affords_what_it_always_did_once_out(self):
+        assert Opaque(_Payload("hi")).value.shout() == "HI"
+
+    def test_it_carries_no_array_surface(self):
+        wrapped = Opaque(_Payload())
+
+        for absent in ("shape", "dtype", "ndim", "__array__", "as_jax"):
+            assert not hasattr(wrapped, absent)
+
+
+class TestOpaqueCarriesIdentity:
+    def test_a_name_is_kept_and_marked_user_given(self):
+        wrapped = Opaque(_Payload(), name="model")
+
+        assert (wrapped.name, wrapped.name_is_auto) == ("model", False)
+
+    def test_an_omitted_name_is_auto_derived(self):
+        wrapped = Opaque(_Payload())
+
+        assert (wrapped.name, wrapped.name_is_auto) == ("opaque", True)
+
+    def test_provenance_is_write_once(self):
+        wrapped = Opaque(_Payload()).with_provenance(Provenance.create("fit", parents=[]))
+
+        assert wrapped.provenance.operation == "fit"
+        with pytest.raises(RuntimeError, match="already set"):
+            wrapped.with_provenance(Provenance.create("again", parents=[]))
+
+    def test_it_is_immutable(self):
+        with pytest.raises(AttributeError, match="immutable"):
+            Opaque(_Payload())._value = _Payload("other")
+
+    @pytest.mark.parametrize(
+        "roundtrip",
+        [copy.copy, copy.deepcopy, lambda o: pickle.loads(pickle.dumps(o))],
+    )
+    def test_it_survives_copy_and_pickle(self, roundtrip):
+        wrapped = Opaque(_Payload("kept"), name="model")
+
+        rebuilt = roundtrip(wrapped)
+
+        assert isinstance(rebuilt, Opaque)
+        assert rebuilt.name == "model"
+        assert rebuilt.value == _Payload("kept")
+
+
+class TestOpaqueAndItsBatch:
+    """The batch existed first: a collection is tracked whatever it holds."""
+
+    def test_a_batch_of_opaque_values_still_hands_back_what_was_put_in(self):
+        """`OpaqueBatch`'s element contract is unchanged by the new class.
+
+        Its elements are the caller's own objects, stored rather than
+        materialized, so it does not start wrapping them in `Opaque`.
+        """
+        payloads = [_Payload("a"), _Payload("b")]
+
+        batch = OpaqueBatch(payloads, "draw")
+
+        assert batch[0] is payloads[0]
+
+    def test_a_batch_may_hold_opaque_terms_as_its_elements(self):
+        """Nothing stops one, since an `Opaque` is itself a non-mapping value."""
+        terms = [Opaque(_Payload("a"), name="first"), Opaque(_Payload("b"), name="second")]
+
+        batch = OpaqueBatch(terms, "draw")
+
+        assert batch[1] is terms[1]
+        assert batch[1].name == "second"

--- a/tests/core/test_opaque.py
+++ b/tests/core/test_opaque.py
@@ -31,52 +31,52 @@ class TestOpaqueHoldsOneValue:
     def test_the_value_is_reachable_and_unchanged(self):
         payload = _Payload()
 
-        assert Opaque(payload).value is payload
+        assert Opaque("p", payload).value is payload
 
     def test_the_spec_defaults_to_a_bare_one(self):
-        assert Opaque(_Payload()).spec == OpaqueSpec()
+        assert Opaque("p", _Payload()).spec == OpaqueSpec()
 
     def test_a_declared_spec_carries_its_meta(self):
         spec = OpaqueSpec(meta="fitted-model")
 
-        assert Opaque(_Payload(), spec=spec).spec.meta == "fitted-model"
+        assert Opaque("p", _Payload(), spec=spec).spec.meta == "fitted-model"
 
     def test_a_spec_of_another_kind_is_refused(self):
         with pytest.raises(TypeError, match="must be an OpaqueSpec"):
-            Opaque(_Payload(), spec="not a spec")
+            Opaque("p", _Payload(), spec="not a spec")
 
     def test_a_mapping_is_refused(self):
-        """The value layer reads a mapping as a subtree, not a leaf."""
+        """The value layer reads a mapping as a subtree."""
         with pytest.raises(TypeError, match="reads a mapping as a subtree"):
-            Opaque({"a": 1})
+            Opaque("p", {"a": 1})
 
     @pytest.mark.parametrize("value", [1, "text", None, [1, 2], (1, 2), _Payload()])
     def test_anything_else_is_admitted(self, value):
-        assert Opaque(value).value == value
+        assert Opaque("p", value).value == value
 
 
 class TestOpaqueAddsIdentityAndNothingElse:
-    """A box that forwards is indistinguishable from what it wraps."""
+    """Its interface is `value` and the identity a tracked term carries."""
 
     def test_it_does_not_forward_attributes(self):
-        wrapped = Opaque(_Payload())
+        wrapped = Opaque("p", _Payload())
 
         assert not hasattr(wrapped, "shout")
         with pytest.raises(AttributeError):
             wrapped.shout()
 
     def test_it_is_not_callable_even_when_its_value_is(self):
-        wrapped = Opaque(_Payload())
+        wrapped = Opaque("p", _Payload())
 
         assert not callable(wrapped)
         with pytest.raises(TypeError):
             wrapped()
 
     def test_the_value_affords_what_it_always_did_once_out(self):
-        assert Opaque(_Payload("hi")).value.shout() == "HI"
+        assert Opaque("p", _Payload("hi")).value.shout() == "HI"
 
     def test_it_carries_no_array_surface(self):
-        wrapped = Opaque(_Payload())
+        wrapped = Opaque("p", _Payload())
 
         for absent in ("shape", "dtype", "ndim", "__array__", "as_jax"):
             assert not hasattr(wrapped, absent)
@@ -84,17 +84,22 @@ class TestOpaqueAddsIdentityAndNothingElse:
 
 class TestOpaqueCarriesIdentity:
     def test_a_name_is_kept_and_marked_user_given(self):
-        wrapped = Opaque(_Payload(), name="model")
+        wrapped = Opaque("model", _Payload())
 
         assert (wrapped.name, wrapped.name_is_auto) == ("model", False)
 
-    def test_an_omitted_name_is_auto_derived(self):
-        wrapped = Opaque(_Payload())
+    def test_a_name_is_required(self):
+        """The name is what says which opaque value this is."""
+        with pytest.raises(TypeError):
+            Opaque(_Payload())
 
-        assert (wrapped.name, wrapped.name_is_auto) == ("opaque", True)
+    def test_a_derived_name_is_marked_auto(self):
+        wrapped = Opaque("batch[draw=0]", _Payload(), name_is_auto=True)
+
+        assert wrapped.name_is_auto is True
 
     def test_provenance_is_write_once(self):
-        wrapped = Opaque(_Payload()).with_provenance(Provenance.create("fit", parents=[]))
+        wrapped = Opaque("p", _Payload()).with_provenance(Provenance.create("fit", parents=[]))
 
         assert wrapped.provenance.operation == "fit"
         with pytest.raises(RuntimeError, match="already set"):
@@ -102,14 +107,14 @@ class TestOpaqueCarriesIdentity:
 
     def test_it_is_immutable(self):
         with pytest.raises(AttributeError, match="immutable"):
-            Opaque(_Payload())._value = _Payload("other")
+            Opaque("p", _Payload())._value = _Payload("other")
 
     @pytest.mark.parametrize(
         "roundtrip",
         [copy.copy, copy.deepcopy, lambda o: pickle.loads(pickle.dumps(o))],
     )
     def test_it_survives_copy_and_pickle(self, roundtrip):
-        wrapped = Opaque(_Payload("kept"), name="model")
+        wrapped = Opaque("model", _Payload("kept"))
 
         rebuilt = roundtrip(wrapped)
 
@@ -119,14 +124,10 @@ class TestOpaqueCarriesIdentity:
 
 
 class TestOpaqueAndItsBatch:
-    """The batch existed first: a collection is tracked whatever it holds."""
+    """A collection is tracked whatever it holds."""
 
     def test_a_batch_of_opaque_values_still_hands_back_what_was_put_in(self):
-        """`OpaqueBatch`'s element contract is unchanged by the new class.
-
-        Its elements are the caller's own objects, stored rather than
-        materialized, so it does not start wrapping them in `Opaque`.
-        """
+        """Its elements are stored, so a batch hands back the caller's object."""
         payloads = [_Payload("a"), _Payload("b")]
 
         batch = OpaqueBatch(payloads, "draw")
@@ -134,8 +135,8 @@ class TestOpaqueAndItsBatch:
         assert batch[0] is payloads[0]
 
     def test_a_batch_may_hold_opaque_terms_as_its_elements(self):
-        """Nothing stops one, since an `Opaque` is itself a non-mapping value."""
-        terms = [Opaque(_Payload("a"), name="first"), Opaque(_Payload("b"), name="second")]
+        """An `Opaque` is itself a non-mapping value."""
+        terms = [Opaque("first", _Payload("a")), Opaque("second", _Payload("b"))]
 
         batch = OpaqueBatch(terms, "draw")
 

--- a/tests/core/test_record_batch.py
+++ b/tests/core/test_record_batch.py
@@ -33,8 +33,8 @@ from probpipe import (
 )
 from probpipe.core import _array_backend
 from probpipe.core._numeric_record_batch import NumericRecordBatch
+from probpipe.core._opaque import OpaqueSpec
 from probpipe.core._record_batch import RecordBatch
-from probpipe.core.event_template import OpaqueSpec
 
 
 @pytest.fixture
@@ -1511,7 +1511,7 @@ class TestPyTreeRebuildContract:
 
     def test_retyping_an_opaque_column_is_refused(self):
         """The same for a field whose spec narrows what an entry may be."""
-        from probpipe.core.event_template import OpaqueSpec
+        from probpipe.core._opaque import OpaqueSpec
 
         column = _object_column(["north", "south"])
         batch = RecordBatch(

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -26,11 +26,11 @@ from probpipe import (
     RecordBatch,
 )
 from probpipe.core._empirical import BootstrapReplicateDistribution, EmpiricalDistribution
+from probpipe.core._opaque import OpaqueSpec
 from probpipe.core.event_template import (
     EventTemplate,
     NumericArraySpec,
     NumericEventTemplate,
-    OpaqueSpec,
 )
 from probpipe.core.record import Record
 


### PR DESCRIPTION
## Summary

Stage 2 of issue 398: `Opaque`, the tracked class of the opaque kind — the last
value spec without one.

`OpaqueSpec` had a batch form already, since a collection is a tracked term
whatever its elements are; the *element* was the half that was missing. With
this, every value spec has exactly one tracked class and one batch form:

| spec | element | batch |
| --- | --- | --- |
| `NumericArraySpec` | `NumericArray` | `NumericArrayBatch` |
| `OpaqueSpec` | **`Opaque`** (new) | `OpaqueBatch` |
| `RecordSpec` | `Record` / `NumericRecord` | `RecordBatch` / `NumericRecordBatch` |
| `FunctionSpec` | `Function` | `FunctionBatch` |
| `DistributionSpec` | `Distribution` | *(later wave)* |

**Nothing returns one yet.** The operations switch over in a later change.
Stacked on #419.

## It adds identity and nothing else

No attribute forwarding, no `__call__`, no operators. The wrapped value is
reached through `.value`, explicitly:

```python
fitted = Opaque(some_model, name="posterior_sampler")
fitted.value.predict(x)     # what it affords is its own type's, once it is out
fitted.predict(x)           # AttributeError
fitted()                    # TypeError, even though the value is callable
```

A box that forwards to be convenient is indistinguishable from the value it
wraps, and then the wrapping is a surprise rather than a statement. This is the
deliberate contrast with `NumericArray`, which *does* carry a full surface —
because an array has one meaning for `+` and an arbitrary object has none.

A mapping is refused, which is the rule `OpaqueSpec.is_valid` already states:
the value layer reads a mapping as a subtree rather than a leaf.

## `OpaqueBatch` is untouched

Its elements are **stored** rather than materialized, so it keeps handing back
the caller's own object rather than wrapping each one in an `Opaque`. Two tests
pin that: `batch[0] is payloads[0]`, and a batch whose elements are themselves
`Opaque` terms hands those back under their own names.

## Linked issue(s)

Refs #398 — stage 2 of four. Stacked on #419 (stage 1).

## Test plan

`tests/core/test_opaque.py`, 24 tests: what it holds (value reachable and
unchanged, spec default and `meta`, the mapping refusal, a parametrized sweep
over admitted value types); **that it adds nothing** (no attribute forwarding,
not callable when its value is, no array surface, and the value still affords
everything once out); identity (names, write-once provenance, immutability,
copy/deepcopy/pickle round trips); and the two `OpaqueBatch` contract tests.

Full suite: 4788 passed, 54 skipped. 100% coverage on the new module.
`ruff check .` and `ruff format --check .` clean from the repo root.

## Breaking changes

None. The class is new and nothing returns it yet.

## Documentation

CHANGELOG entry under `Unreleased → Added`. The design is #418.
