### PR TITLE
An empty return keeps its host's kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call, retain the resulting joint distribution, or materialize and reuse
   samples explicitly when a shared realization is required.
 
+- **An empty return keeps its host's kind (#398).** A `Function` returning `{}`
+  raised, and `[]` / `()` became an `Opaque`, because `Record`, `EventTemplate`,
+  and the object batches each required at least one entry. The kind now follows
+  the host's *type* whether or not anything is in it: `{}` is an empty `Record`,
+  and `[]` / `()` an `OpaqueBatch` of `batch_shape == (0,)` — no element can say
+  what kind it holds, and every element spec holds vacuously of none.
+
+  `Record()`, `EventTemplate()`, and `OpaqueBatch([], level)` are legal as a
+  result. An empty template is **not** promoted to `NumericEventTemplate`:
+  vacuously every leaf is numeric, which is not a reason to claim it. A batch
+  still requires a batch *axis* — a single object with no axis is refused as
+  before.
+
 - **A sweep over numeric rows aggregates as a `NumericArrayBatch` (#398).** A
   `Function` swept over a batch collected numeric rows into a single-field
   `NumericRecordBatch` keyed by the function's own name, so `out["my_func"]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call, retain the resulting joint distribution, or materialize and reuse
   samples explicitly when a shared realization is required.
 
+- **A sweep of opaque or callable rows aggregates at its own kind (#398).** Rows
+  that do not stack numerically fell to a single-field `RecordBatch` keyed by the
+  function's name — the burial the output boundary otherwise stopped doing — and
+  it was the one aggregation that left the result auto-named. Opaque rows now give
+  an `OpaqueBatch` and callable rows a `FunctionBatch`, both named for the
+  function as every other aggregation already was.
+
 - **An empty return keeps its host's kind (#398).** A `Function` returning `{}`
   raised, and `[]` / `()` became an `Opaque`, because `Record`, `EventTemplate`,
   and the object batches each required at least one entry. The kind now follows

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -26,10 +26,12 @@ from ._empirical import (
     EmpiricalDistribution,
     RecordEmpiricalDistribution,
 )
+from ._function_batch import FunctionBatch
 from ._immutable import constructing, transient_memo
 from ._numeric_array_batch import NumericArrayBatch
 from ._numeric_record_batch import NumericRecordBatch
 from ._object_batch import _from_iterable, _is_object_array
+from ._opaque_batch import OpaqueBatch
 from ._record_batch import RecordBatch, _batch_class_for, _MappedBatchColumns
 from .event_template import (
     EventTemplate,
@@ -957,16 +959,22 @@ def _make_stack(
                 name_is_auto=name is None,
             )
 
-        # Last-ditch: wrap as a RecordBatch whose single field holds a
-        # numpy object-dtype array of the opaque outputs.
+        # Rows that do not stack take the batch form of their own kind, which is
+        # the multiplicity side of the table ``_wrap_as_term`` states for one
+        # value: a callable batches as a FunctionBatch and anything else as an
+        # OpaqueBatch. Both store their elements, so nothing has to stack.
         try:
-            object_array = np.asarray(outs, dtype=object).reshape(batch_shape)
-            return RecordBatch(
-                {field_name: object_array},
-                level_names,
-                element_spec=EventTemplate(**{field_name: None}),
-                axis_groups=sweep_groups,
-            )
+            object_array = _from_iterable(outs, kind="_make_stack").reshape(batch_shape)
+            shared = {
+                "axis_groups": sweep_groups,
+                "name": name or field_name,
+                "name_is_auto": name is None,
+            }
+            # ``outs`` first: every row of none is vacuously callable, and no row
+            # is a reason to claim the function kind over the fallback.
+            if outs and all(callable(o) for o in outs):
+                return FunctionBatch(object_array, level_names, **shared)
+            return OpaqueBatch(object_array, level_names, **shared)
         except (TypeError, ValueError) as exc:
             types_seen = sorted({type(o).__name__ for o in outs})
             raise TypeError(

--- a/probpipe/core/_function_batch.py
+++ b/probpipe/core/_function_batch.py
@@ -45,8 +45,8 @@ class FunctionBatch(_ObjectBatch[Callable]):
         mapping, or an array that is not ``dtype=object`` — each iterates into
         something other than its elements — or is not iterable at all.
     ValueError
-        If ``elements`` is empty, or is a zero-dimensional array (one object with
-        no batch axis); if ``axis_groups`` does not tile the shape the elements are
+        If ``elements`` is a zero-dimensional array (one object, with no batch
+        axis to count along); if ``axis_groups`` does not tile the shape the elements are
         stored in; or if ``axis_groups`` is omitted and the number of level names
         does not match the number of axes.
 

--- a/probpipe/core/_object_batch.py
+++ b/probpipe/core/_object_batch.py
@@ -65,8 +65,8 @@ class _ObjectBatch[E](Batch[E]):
         which iterates into something other than its elements — if it is not
         iterable at all, or if an ndarray of elements is not ``dtype=object``.
     ValueError
-        If ``elements`` is empty, or is a zero-dimensional array (one object with
-        no batch axis), if ``axis_groups`` does not tile the stored shape, or if
+        If ``elements`` is a zero-dimensional array (one object, with no batch
+        axis to count along), if ``axis_groups`` does not tile the stored shape, or if
         ``axis_groups`` is omitted and the number of names does not match the
         number of axes.
 
@@ -78,11 +78,11 @@ class _ObjectBatch[E](Batch[E]):
     :class:`~probpipe.core._batch.Batch` refuses to resolve a clash by
     suffixing. The caller that mints a level knows what it means.
 
-    Construction requires at least one element, while *selecting* none is
-    allowed: ``batch[0:0]`` is a batch of nothing, as the level algebra intends.
-    The asymmetry is deliberate — an empty literal at construction is almost
-    always a mistake, and a shape cannot be inferred from it — so an empty batch
-    is reached by selecting one rather than by building one.
+    Construction admits no elements, as selection always did: ``batch[0:0]`` and
+    ``OpaqueBatch([], "draw")`` are both a batch of nothing. Zero is a count the
+    level can carry, and an object array of no elements still reports the shape
+    ``(0,)`` to read it from. What is refused is a missing *axis*: a
+    zero-dimensional store is one object, with no level to count along.
     """
 
     _store: np.ndarray
@@ -226,8 +226,6 @@ def _as_object_array(elements: np.ndarray | Iterable[Any], *, kind: str) -> np.n
         _refuse_container(elements, kind=kind)
         store = _from_iterable(elements, kind=kind)
 
-    if store.size == 0:
-        raise ValueError(f"{kind} requires at least one element")
     if store.ndim == 0:
         raise ValueError(f"{kind} requires at least one batch axis; got a single object")
     store.setflags(write=False)

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -45,8 +45,8 @@ class OpaqueBatch(_ObjectBatch[Any]):
         mapping, or an array that is not ``dtype=object`` — each iterates into
         something other than its elements — or is not iterable at all.
     ValueError
-        If ``elements`` is empty, or is a zero-dimensional array (one object with
-        no batch axis); if ``axis_groups`` does not tile the shape the elements are
+        If ``elements`` is a zero-dimensional array (one object, with no batch
+        axis to count along); if ``axis_groups`` does not tile the shape the elements are
         stored in; or if ``axis_groups`` is omitted and the number of level names
         does not match the number of axes.
 

--- a/probpipe/core/_workflow_result.py
+++ b/probpipe/core/_workflow_result.py
@@ -69,9 +69,18 @@ def _wrap_as_term(
         return value
 
     # -- a raw host, wrapped into its own kind -----------------------------
-    if isinstance(value, dict) and value:
+    # The kind follows the host's *type*, empty or not: a mapping is a tree and a
+    # sequence a multiplicity, and having no entries does not change which.
+    if isinstance(value, dict):
         return Record(field_name, value, name_is_auto=True)
-    if isinstance(value, (list, tuple)) and value:
+    if isinstance(value, (list, tuple)):
+        if not value:
+            # No element to read a kind off, and every element spec holds
+            # vacuously of none, so the batch makes the least specific claim it
+            # can. Its own kind is still a batch, which is what the host says.
+            from ._opaque_batch import OpaqueBatch
+
+            return OpaqueBatch([], field_name, name=field_name, name_is_auto=True)
         try:
             # A returned sequence ranges over nothing the call named, so the
             # level takes the function's own name.

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -1014,8 +1014,6 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
             for name in field_specs:
                 _check_no_path_sep(name)
             nested = dict(field_specs)
-        if not nested:
-            raise ValueError(f"{type(self).__name__} requires at least one field")
         specs: dict[str, _FieldSpec] = {}
         for name, spec in nested.items():
             if isinstance(spec, Mapping):

--- a/probpipe/core/record.py
+++ b/probpipe/core/record.py
@@ -441,8 +441,6 @@ class Record(NamedTree[Any], TrackedTerm, Annotated):
             for field_name in fields:
                 _check_no_path_sep(field_name)
             field_inputs = dict(fields)
-        if not field_inputs:
-            raise ValueError("Record requires at least one named field")
 
         if event_template is not None and event_template.free_dims and _validate_leaves:
             event_template, _ = _unify_event_template_with_value(

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -829,6 +829,28 @@ class TestMakeStack:
     shape-(n,) aggregate. Every case is a parameter-sweep-like scenario
     where row identity must survive; there is no marginalisation."""
 
+    def test_the_shape_is_given_exactly_once(self):
+        """``batch_shape`` and ``n`` are two spellings of one thing."""
+        from probpipe.core._broadcast_distributions import _make_stack
+
+        with pytest.raises(TypeError, match="requires either batch_shape or n"):
+            _make_stack([1.0], field_name="demo", level_names=("sweep",))
+        with pytest.raises(TypeError, match="batch_shape OR n, not both"):
+            _make_stack([1.0], batch_shape=(1,), n=1, field_name="demo", level_names=("sweep",))
+
+    def test_one_level_name_per_group_of_axes(self):
+        """A level name that names no group would name nothing."""
+        from probpipe.core._broadcast_distributions import _make_stack
+
+        with pytest.raises(ValueError, match="mints one level per group"):
+            _make_stack(
+                [1.0, 2.0, 3.0, 4.0],
+                batch_shape=(2, 2),
+                axis_groups=((2,), (2,)),
+                field_name="demo",
+                level_names=("only_one",),
+            )
+
     def test_list_of_scalars_wraps_as_numeric_array_batch(self):
         """Numeric rows aggregate at their own kind, with no field to address."""
         from probpipe import NumericArrayBatch

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -84,9 +84,20 @@ class TestConstruction:
         with pytest.raises(ValueError, match="Cannot pass both"):
             EventTemplate({"a": ()}, b=(2,))
 
-    def test_empty_raises(self):
-        with pytest.raises(ValueError, match="at least one"):
-            EventTemplate()
+    def test_the_empty_template_is_legal(self):
+        """A template is a finite map of fields, and the empty map is one.
+
+        It is also the identity of template composition, which a floor of one
+        field would leave inexpressible.
+        """
+        empty = EventTemplate()
+
+        assert len(empty) == 0
+        assert list(empty) == []
+
+    def test_the_empty_template_is_not_promoted_to_numeric(self):
+        """Vacuously every leaf is numeric, which is not a reason to claim it."""
+        assert not isinstance(EventTemplate(), NumericEventTemplate)
 
     def test_none_spec(self):
         tpl = EventTemplate(label=None, x=())
@@ -418,9 +429,8 @@ class TestInferFrom:
         assert isinstance(tpl.at_path("params"), EventTemplate)
         assert tpl["params/m"] == NumericArraySpec((2,))
 
-    def test_empty_mapping_raises(self):
-        with pytest.raises(ValueError, match="at least one field"):
-            EventTemplate.infer_from({})
+    def test_an_empty_mapping_infers_the_empty_template(self):
+        assert len(EventTemplate.infer_from({})) == 0
 
     def test_array_fields(self):
         r = Record("r", x=jnp.zeros(5), y=jnp.zeros((2, 3)))

--- a/tests/core/test_function_opaque_batch.py
+++ b/tests/core/test_function_opaque_batch.py
@@ -141,9 +141,17 @@ class TestConstructionRefusals:
         with pytest.raises(TypeError, match=r"element at \(1, 0\)"):
             cls(store, ["chain", "draw"])
 
-    def test_no_elements_is_refused(self):
-        with pytest.raises(ValueError, match="at least one element"):
-            OpaqueBatch([], "site")
+    def test_no_elements_is_a_batch_of_none(self):
+        """A multiplicity of zero is a multiplicity; a *missing axis* is not.
+
+        The element count is what the level measures, so zero is an answer. The
+        refusal below is the real distinction: an object with no axis at all has
+        no level to count along.
+        """
+        batch = OpaqueBatch([], "site")
+
+        assert (batch.batch_shape, batch.level_names) == ((0,), ("site",))
+        assert len(batch) == 0
 
     def test_a_single_object_is_not_a_batch(self):
         with pytest.raises(ValueError, match="at least one batch axis"):

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -178,6 +178,34 @@ class TestNumericArrayComputesAsAnArray:
         assert not isinstance(pair, NumericArray)
         np.testing.assert_array_equal(np.asarray(pair), np.asarray(jnp.arange(1.0, 4.0)))
 
+    def test_the_reflected_operators_agree_with_the_forward_ones(self):
+        """`1.0 - arr` is `arr`'s subtraction seen from the other side.
+
+        Operand order is not a semantic distinction, so an array-like that
+        computes one way and refuses the other would be a trap rather than a
+        simplification.
+        """
+        value = NumericArray(jnp.arange(3.0))
+
+        np.testing.assert_array_equal(np.asarray(1.0 - value), np.asarray(1.0 - jnp.arange(3.0)))
+        np.testing.assert_array_equal(np.asarray(2.0 * value), np.asarray(value * 2.0))
+
+    def test_an_in_place_operator_rebinds_to_a_bare_array(self):
+        """An in-place operator on an immutable term is the out-of-place one.
+
+        The name is rebound to the *result*, which is a bare array like any other
+        arithmetic result — the term is not mutated, and does not survive.
+        """
+        value = NumericArray(jnp.arange(3.0), name="kept")
+        original = value
+
+        value += 1.0
+
+        assert not isinstance(value, NumericArray)
+        assert isinstance(original, NumericArray)
+        assert original.name == "kept"
+        np.testing.assert_array_equal(np.asarray(value), np.arange(1.0, 4.0))
+
     def test_comparison_is_elementwise(self):
         np.testing.assert_array_equal(
             np.asarray(NumericArray(jnp.arange(3.0)) == 1.0), np.array([False, True, False])

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -72,9 +72,11 @@ class TestConstruction:
         with pytest.raises(ValueError, match="Cannot pass both"):
             Record("r", {"a": 1.0}, b=2.0)
 
-    def test_empty_raises(self):
-        with pytest.raises(ValueError, match="at least one"):
-            Record("r")
+    def test_the_empty_record_is_legal(self):
+        """A record is a named tree, and the tree with no branches is one."""
+        empty = Record("r")
+
+        assert (empty.name, list(empty.event_template)) == ("r", [])
 
     def test_all_numeric_promotes_and_coerces(self):
         from probpipe import NumericRecord

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -838,9 +838,9 @@ class TestZeroRowsAgreeAcrossDispatch:
         }
 
         types = {type(r).__name__ for r in results.values()}
-        templates = {repr(r.event_template) for r in results.values()}
+        specs = {repr(r.element_spec) for r in results.values()}
         assert len(types) == 1
-        assert len(templates) == 1
+        assert len(specs) == 1
 
 
 class TestFunctionValuedColumnsStack:

--- a/tests/core/test_wrap_at_the_declared_kind.py
+++ b/tests/core/test_wrap_at_the_declared_kind.py
@@ -201,3 +201,43 @@ class TestASampleShapeGetsADrawLevel:
 
         assert not isinstance(drawn, NumericArray)
         assert drawn.shape == (2, 7)
+
+
+class TestAnEmptyReturnKeepsItsHostsKind:
+    """The kind follows the host's type, and having no entries does not change it.
+
+    A mapping is a tree and a sequence a multiplicity whether or not anything is
+    in it. Reading the kind off the *cardinality* instead would give a function
+    returning a dict a result type that varies with its data.
+    """
+
+    @staticmethod
+    def _returned(value):
+        return Function(func=lambda: value, name="f")()
+
+    def test_an_empty_mapping_is_an_empty_record(self):
+        result = self._returned({})
+
+        assert isinstance(result, Record)
+        assert list(result.event_template) == []
+
+    @pytest.mark.parametrize("sequence", [[], ()], ids=["list", "tuple"])
+    def test_an_empty_sequence_is_a_batch_of_no_elements(self, sequence):
+        """No element to read a kind off, so the batch claims the least it can.
+
+        Every element spec holds vacuously of no elements, which is why the
+        opaque one is not a narrowing here.
+        """
+        from probpipe import OpaqueBatch
+
+        result = self._returned(sequence)
+
+        assert isinstance(result, OpaqueBatch)
+        assert (result.batch_shape, result.level_names) == ((0,), ("f",))
+
+    def test_an_empty_array_is_still_an_array(self):
+        """Distinct from an empty container: the kind was never in doubt."""
+        result = self._returned(jnp.array([]))
+
+        assert isinstance(result, NumericArray)
+        assert result.shape == (0,)

--- a/tests/core/test_wrap_at_the_declared_kind.py
+++ b/tests/core/test_wrap_at_the_declared_kind.py
@@ -241,3 +241,39 @@ class TestAnEmptyReturnKeepsItsHostsKind:
 
         assert isinstance(result, NumericArray)
         assert result.shape == (0,)
+
+
+class TestASequenceAggregatesAtItsRowsKind:
+    """The multiplicity side of the same table: rows batch at their own kind.
+
+    Numeric rows had a batch form and opaque or callable ones did not, so they
+    fell to a single-field `RecordBatch` keyed by the function's name — the
+    burial this boundary otherwise stopped doing.
+    """
+
+    @staticmethod
+    def _returned(value):
+        return Function(func=lambda: value, name="f")()
+
+    def test_numeric_rows_batch_as_arrays(self):
+        from probpipe import NumericArrayBatch
+
+        assert isinstance(self._returned([1.0, 2.0]), NumericArrayBatch)
+
+    def test_opaque_rows_batch_as_opaque(self):
+        from probpipe import OpaqueBatch
+
+        result = self._returned(["a", "b"])
+
+        assert isinstance(result, OpaqueBatch)
+        assert [result[0], result[1]] == ["a", "b"]
+
+    def test_callable_rows_batch_as_functions(self):
+        from probpipe import FunctionBatch
+
+        assert isinstance(self._returned([lambda: 1, lambda: 2]), FunctionBatch)
+
+    def test_every_kind_takes_the_functions_name(self):
+        """The last-ditch branch alone used to leave the aggregate auto-named."""
+        for value in ([1.0, 2.0], ["a", "b"], [lambda: 1], []):
+            assert self._returned(value).name == "f"

--- a/tests/record/test_design.py
+++ b/tests/record/test_design.py
@@ -16,6 +16,7 @@ from probpipe import (
     NumericArrayBatch,
     NumericRecord,
     NumericRecordBatch,
+    OpaqueBatch,
     Record,
     RecordBatch,
     function,
@@ -227,9 +228,11 @@ class TestDesignAsSweep:
             scale=[0.5, 1.0],
         )
         out = label(p=ff)
-        assert isinstance(out, RecordBatch)
+        # A string row is an opaque value, so the rows batch at that kind and
+        # the elements are reached by position rather than by a field name.
+        assert isinstance(out, OpaqueBatch)
         assert out.batch_shape == (4,)
-        assert list(out["label"]) == [
+        assert [out[i] for i in range(4)] == [
             "nutpie-0.5",
             "nutpie-1.0",
             "pymc-0.5",


### PR DESCRIPTION
Stacked on #426. Part of #398.

## The bug

A `Function` returning an empty mapping **raised**:

```
TypeError: Opaque holds one unstructured value, and the value layer reads a
mapping as a subtree rather than a leaf
```

`{}` fell past the record branch (guarded by `and value`) all the way to `Opaque`, which refuses mappings on principle. `[]` and `()` reached `Opaque` too — no crash, but the wrong kind.

## Why the guards were wrong

V.0 wraps a raw host **into its own kind**, and the kinds are ordered by *host type*. The empty cases broke that: `{"a": 1}` is a `Record` but `{}` was an `Opaque`, so the result type depended on **cardinality**. That is the same error `_stack_declared_columns` already rejects — "the declared kind decides the storage, not what the values happen to look like".

The `and value` guards were not a kind decision. They were a workaround for a floor of one entry in three places:

| | floor |
| --- | --- |
| `Record` | `raise ValueError("Record requires at least one named field")` |
| `EventTemplate` | `requires at least one field` |
| object batches | `requires at least one element` |

## What changes

The floors are removed rather than special-cased.

- `{}` → an empty `Record` over `EventTemplate()`
- `[]` / `()` → an `OpaqueBatch` with `batch_shape == (0,)`, on a level named for the function

A record is a finite map of fields, and the empty map is one — it is also the **identity of template composition**, which a floor of one left inexpressible.

For the sequence case no element can say what kind the batch holds, and every element spec holds vacuously of none, so the opaque one is not a narrowing. It is also the only batch whose shape stays derivable: `batch_shape` is *derived from* the store, and an object array of zero elements still reports `(0,)`, where a zero-column `RecordBatch` would have nothing to read `(0,)` from.

Two things deliberately unchanged:

- **An empty template is not promoted to `NumericEventTemplate`.** Vacuously every leaf is numeric; that is not a reason to claim it. The predicate already read `if specs and _all_numeric(...)`, so the tie-break was written.
- **A batch still requires a batch axis.** Zero elements is a multiplicity; a single object with *no axis* has no level to count along, and is refused as before.

An empty **array** was never affected — `jnp.array([])` is a well-formed array value and wraps as a `NumericArray` of shape `(0,)`.

## Blast radius

Exactly **three** tests changed — the ones asserting the floors, plus the `OpaqueBatch` sibling. Nothing else in 4824 tests depended on the invariant, which is the measure of how load-bearing it was.

## Corner cases pinned

Line coverage was already 100% on these modules, which hid the gaps: `NumericArray`'s ~40 operators are installed in a loop, so running the loop covers the lines while each operator stays unasserted. Now pinned:

- the three empty returns, and the empty array they are not
- **reflected operators** (`1.0 - arr`) agree with the forward ones
- **in-place operators** rebind to a bare array — `arr += 1` does not mutate the term and does not preserve it
- `_make_stack`'s argument guards: `batch_shape` XOR `n`, and one level name per group of axes

Suite: 4833 passed, 54 skipped. `ruff check` / `ruff format --check` clean.

## Note on reflected operators

I checked whether to drop them. The asymmetry worth knowing about is **not** theirs — it comes from `__array__`:

| left operand | `left - v` | `v - left` |
| --- | --- | --- |
| Python float / int | jax | jax |
| `np.float64` / `np.ndarray` | **numpy** | jax |
| jax array | jax | jax |

numpy coerces through `__array__` and never consults `__rsub__`, so removing the reflected methods would not fix that row — it would only break the Python-scalar and jax rows, which are correct today. The lever for the numpy row is `__array_ufunc__ = None`, which would also stop `np.sin(v)` working. Left as is; the working cases are now pinned.
