### PR TITLE
Aggregate a sweep of numeric rows at their own kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call, retain the resulting joint distribution, or materialize and reuse
   samples explicitly when a shared realization is required.
 
+- **A sweep over numeric rows aggregates as a `NumericArrayBatch` (#398).** A
+  `Function` swept over a batch collected numeric rows into a single-field
+  `NumericRecordBatch` keyed by the function's own name, so `out["my_func"]`
+  reached the column. The aggregate is now the batch form of the rows' own kind,
+  read through `.values`.
+
+  A row that is itself a batch keeps its levels either way. Only `RecordBatch`
+  rows did before, so once a scalar law's `sample` began returning a
+  `NumericArrayBatch`, a swept `sample(dist_array, sample_shape=(7,))` read the
+  rows' `draw` axis as event shape and dropped the level. It now gives
+  `batch_shape == (n, 7)` on levels `("dist", "sample")`, as the record-valued
+  case already did.
+
 - **A non-empty `sample_shape` puts the draws on a `sample` level (#398).**
   `sample(law, sample_shape=(5,))` for an array-valued law gives a
   `NumericArrayBatch` whose `batch_shape` is the sample shape, on one level named

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -27,6 +27,7 @@ from ._empirical import (
     RecordEmpiricalDistribution,
 )
 from ._immutable import constructing, transient_memo
+from ._numeric_array_batch import NumericArrayBatch
 from ._numeric_record_batch import NumericRecordBatch
 from ._object_batch import _from_iterable, _is_object_array
 from ._record_batch import RecordBatch, _batch_class_for, _MappedBatchColumns
@@ -604,7 +605,7 @@ def _make_marginal(
 # sweep), the n inner outputs are independent scenarios indexed by
 # input row — *not* MC draws. The wrapper must preserve row identity:
 #
-#   numeric → NumericRecordBatch(result=..., one sweep level of (n,))
+#   numeric → NumericArrayBatch, one sweep level of (n,)
 #   Record → RecordBatch.stack (NumericRecordBatch when all leaves numeric)
 #   Distribution → DistributionArray
 #   a batch per row (each (m,)) → one batch, levels (sweep, …) over (n, m)
@@ -656,6 +657,44 @@ def _batch_over_swept_columns(
         name=name,
         name_is_auto=True,
     )
+
+
+def _agreeing_batch_rows(outs: list, *, field_name: str) -> Any:
+    """The first row, once every row is a batch that agrees with it.
+
+    A batch row is all-or-nothing. Falling through on a mixture, or on rows that
+    disagree, reaches the generic handlers — which would read a row's own batch
+    axis as an event axis and discard its level names with it. Matching the
+    shape alone would take the first row's schema for all of them, dropping a
+    field the others have and misnaming their axes.
+    """
+    first = outs[0]
+    # The family, not the exact class: a RecordBatch and a NumericRecordBatch
+    # row hold the same thing, and only one of them says so in its name.
+    family = NumericArrayBatch if isinstance(first, NumericArrayBatch) else RecordBatch
+    if not all(isinstance(o, family) for o in outs):
+        kinds = sorted({type(o).__name__ for o in outs})
+        raise TypeError(
+            f"{field_name}: some rows returned a batch of records and some did not "
+            f"({', '.join(kinds)}). A swept body returns one kind for every row, since "
+            f"the aggregate has one schema; return a batch from every row or from none"
+        )
+    for other in outs[1:]:
+        if (
+            other.element_spec == first.element_spec
+            and other.batch_shape == first.batch_shape
+            and other.level_names == first.level_names
+            and other.axis_groups == first.axis_groups
+        ):
+            continue
+        raise ValueError(
+            f"{field_name}: the rows returned batches that disagree — "
+            f"{first.level_names} over {first.batch_shape} against "
+            f"{other.level_names} over {other.batch_shape}. Rows stack into one batch, "
+            f"which states one element spec and one multiplicity for all of them, so "
+            f"every row must return the same schema on the same levels"
+        )
+    return first
 
 
 def _make_stack(
@@ -792,40 +831,23 @@ def _make_stack(
         # rows' own levels. Checked before the Record branch below, which would
         # otherwise claim a batch of records and collapse its
         # inner batch axis.
-        if outs and any(isinstance(o, RecordBatch) for o in outs):
-            # A batch row is all-or-nothing. Falling through on a mixture, or on
-            # rows that disagree, reaches the generic handlers — which would take a
-            # single-field numeric batch for an array, read its inner batch axis as
-            # an event axis, and discard the level names with it. There is no
-            # aggregate to build from rows that do not agree on what they hold, so
-            # this says so where the disagreement is visible.
-            if not all(isinstance(o, RecordBatch) for o in outs):
-                kinds = sorted({type(o).__name__ for o in outs})
-                raise TypeError(
-                    f"{field_name}: some rows returned a batch of records and some did not "
-                    f"({', '.join(kinds)}). A swept body returns one kind for every row, since "
-                    f"the aggregate has one schema; return a batch from every row or from none"
-                )
-            first = outs[0]
-            # Every row must agree on what it holds and on which axes hold it.
-            # Matching the shape alone would take the first row's schema and level
-            # names for all of them, dropping a field the others have and
-            # misnaming their axes — a batch whose spec is a false statement about
-            # its own columns.
-            for other in outs[1:]:
-                if (
-                    other.element_spec == first.element_spec
-                    and other.batch_shape == first.batch_shape
-                    and other.level_names == first.level_names
-                    and other.axis_groups == first.axis_groups
-                ):
-                    continue
-                raise ValueError(
-                    f"{field_name}: the rows returned batches that disagree — "
-                    f"{first.level_names} over {first.batch_shape} against "
-                    f"{other.level_names} over {other.batch_shape}. Rows stack into one batch, "
-                    f"which states one element spec and one multiplicity for all of them, so "
-                    f"every row must return the same schema on the same levels"
+        # Both batch kinds a swept body can return; each keeps its own kind
+        # through the sweep, as a scalar row does.
+        stackable = (RecordBatch, NumericArrayBatch)
+        if outs and any(isinstance(o, stackable) for o in outs):
+            first = _agreeing_batch_rows(outs, field_name=field_name)
+            if isinstance(first, NumericArrayBatch):
+                # One store rather than columns, so the rows stack directly —
+                # through the array backend, as the columns below do, since a
+                # row's store is in native form.
+                store = jnp.stack([_to_jax_array(o.values) for o in outs], axis=0)
+                return NumericArrayBatch(
+                    store.reshape(batch_shape + store.shape[1:]),
+                    (*level_names, *first.level_names),
+                    element_spec=first.element_spec,
+                    axis_groups=(*sweep_groups, *first.axis_groups),
+                    name=name or field_name,
+                    name_is_auto=name is None,
                 )
             # Columns are leaf-keyed, so a nested element needs no special
             # case — and they are read raw: a field that is not an array
@@ -914,9 +936,8 @@ def _make_stack(
                 event_template=event_template,
             )
 
-        # Numeric scalars / arrays → wrap in a NumericRecordBatch with
-        # the single "result" field carrying the stacked values,
-        # reshape leading axis to batch_shape.
+        # Numeric scalars / arrays → the batch form of their own kind, with the
+        # leading axis re-cut to batch_shape.
         try:
             stacked = jnp.stack(
                 [jnp.asarray(o) for o in outs],
@@ -927,12 +948,13 @@ def _make_stack(
 
         if stacked is not None:
             event_shape = tuple(stacked.shape[1:])
-            reshaped = stacked.reshape(batch_shape + event_shape)
-            return NumericRecordBatch(
-                {field_name: reshaped},
+            return NumericArrayBatch(
+                stacked.reshape(batch_shape + event_shape),
                 level_names,
-                element_spec=EventTemplate(**{field_name: event_shape}),
+                element_spec=NumericArraySpec(event_shape, dtype=stacked.dtype),
                 axis_groups=sweep_groups,
+                name=name or field_name,
+                name_is_auto=name is None,
             )
 
         # Last-ditch: wrap as a RecordBatch whose single field holds a
@@ -985,11 +1007,13 @@ def _make_stack(
                 template=event_template,
                 name=name or field_name,
             )
-        return NumericRecordBatch(
-            {field_name: inner_outputs.reshape(batch_shape + event_shape)},
+        return NumericArrayBatch(
+            inner_outputs.reshape(batch_shape + event_shape),
             level_names,
-            element_spec=EventTemplate(**{field_name: event_shape}),
+            element_spec=NumericArraySpec(event_shape, dtype=inner_outputs.dtype),
             axis_groups=sweep_groups,
+            name=name or field_name,
+            name_is_auto=name is None,
         )
 
     # vmap of a Record-returning function produces a Record with batched leaves

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -829,25 +829,28 @@ class TestMakeStack:
     shape-(n,) aggregate. Every case is a parameter-sweep-like scenario
     where row identity must survive; there is no marginalisation."""
 
-    def test_list_of_scalars_wraps_as_numeric_record_batch(self):
-        from probpipe import NumericRecordBatch
+    def test_list_of_scalars_wraps_as_numeric_array_batch(self):
+        """Numeric rows aggregate at their own kind, with no field to address."""
+        from probpipe import NumericArrayBatch
         from probpipe.core._broadcast_distributions import _make_stack
 
         out = _make_stack([1.0, 2.0, 3.0, 4.0], n=4, field_name="demo", level_names=("sweep",))
-        assert isinstance(out, NumericRecordBatch)
-        assert out.batch_shape == (4,)
-        assert out.event_template.fields == ("demo",)
-        np.testing.assert_allclose(out["demo"], [1.0, 2.0, 3.0, 4.0])
+        assert isinstance(out, NumericArrayBatch)
+        assert (out.batch_shape, out.level_names) == ((4,), ("sweep",))
+        assert tuple(out.element_spec.shape) == ()
+        np.testing.assert_allclose(out.values, [1.0, 2.0, 3.0, 4.0])
 
     def test_list_of_arrays_preserves_event_shape(self):
-        from probpipe import NumericRecordBatch
+        """The rows' own shape is the element's; only the sweep axis is a level."""
+        from probpipe import NumericArrayBatch
         from probpipe.core._broadcast_distributions import _make_stack
 
         values = [jnp.arange(3.0) + 10.0 * i for i in range(4)]
         out = _make_stack(values, n=4, field_name="demo", level_names=("sweep",))
-        assert isinstance(out, NumericRecordBatch)
+        assert isinstance(out, NumericArrayBatch)
         assert out.batch_shape == (4,)
-        assert out["demo"].shape == (4, 3)
+        assert tuple(out.element_spec.shape) == (3,)
+        assert out.values.shape == (4, 3)
 
     def test_list_of_numeric_records_promotes_to_numeric_array(self):
         from probpipe import NumericRecord, NumericRecordBatch
@@ -919,17 +922,22 @@ class TestMakeStack:
         np.testing.assert_allclose(out["x"][0], [0, 1, 2, 3])
         np.testing.assert_allclose(out["x"][2], [20, 21, 22, 23])
 
-    def test_vmap_ndarray_wraps_as_numeric_record_batch(self):
+    def test_vmap_ndarray_wraps_as_numeric_array_batch(self):
         """A bare ``jnp.ndarray`` with leading axis n (typical ``jax.vmap``
-        output for scalar-returning fns) wraps without unstacking."""
-        from probpipe import NumericRecordBatch
+        output for scalar-returning fns) wraps without unstacking.
+
+        The mapped path agrees with the row-wise one above: same kind, same
+        split of the sweep axis from the element's.
+        """
+        from probpipe import NumericArrayBatch
         from probpipe.core._broadcast_distributions import _make_stack
 
         arr = jnp.arange(12.0).reshape(4, 3)
         out = _make_stack(arr, n=4, field_name="demo", level_names=("sweep",))
-        assert isinstance(out, NumericRecordBatch)
+        assert isinstance(out, NumericArrayBatch)
         assert out.batch_shape == (4,)
-        assert out["demo"].shape == (4, 3)
+        assert tuple(out.element_spec.shape) == (3,)
+        assert out.values.shape == (4, 3)
 
     def test_declared_vmap_array_requires_single_leaf_template(self):
         from probpipe import EventTemplate

--- a/tests/core/test_distribution_array.py
+++ b/tests/core/test_distribution_array.py
@@ -21,6 +21,7 @@ import pytest
 from probpipe import (
     EventTemplate,
     Normal,
+    NumericArrayBatch,
     NumericRecordBatch,
     ProductDistribution,
     Provenance,
@@ -422,28 +423,31 @@ class TestZeroDDispatch:
 class TestSampleViaSweep:
     """``sample(da)`` vectorizes over the DistArray's batch_shape.
 
-    Each cell is a scalar Distribution; ``sample(component, sample_shape)``
-    returns a leaf-shaped array; ``_make_stack`` assembles them into a
-    ``NumericRecordBatch`` with ``batch_shape = da.batch_shape`` and
-    per-field leaf shape equal to ``sample_shape + event_shape``.
+    Each cell is a scalar Distribution, so each row's draw is a
+    ``NumericArrayBatch``; the sweep stacks them into one, its own level in
+    front of the rows' ``draw``.
     """
 
     def test_scalar_components_no_sample_shape(self):
         comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(4)]
         da = _make_distribution_array(comps)
         s = sample(da)
-        assert isinstance(s, NumericRecordBatch)
-        assert s.batch_shape == (4,)
-        assert s["sample"].shape == (4,)
+        assert isinstance(s, NumericArrayBatch)
+        assert (s.batch_shape, s.level_names) == ((4,), ("dist",))
+        assert s.values.shape == (4,)
 
     def test_scalar_components_with_sample_shape(self):
+        """The rows' draw level survives the sweep rather than becoming shape.
+
+        A drawn axis read as event shape would state that each cell holds one
+        7-vector, where it holds seven draws.
+        """
         comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(4)]
         da = _make_distribution_array(comps)
         s = sample(da, sample_shape=(7,))
-        assert isinstance(s, NumericRecordBatch)
-        # batch_shape is the DistArray's own shape; sample_shape is leaf.
-        assert s.batch_shape == (4,)
-        assert s["sample"].shape == (4, 7)
+        assert isinstance(s, NumericArrayBatch)
+        assert (s.batch_shape, s.level_names) == ((4, 7), ("dist", "sample"))
+        assert tuple(s.element_spec.shape) == ()
 
     def test_components_drive_samples(self):
         """Per-cell mean of the 1000-sample draw concentrates at each
@@ -451,16 +455,17 @@ class TestSampleViaSweep:
         comps = [Normal(loc=float(i) * 100, scale=1e-3, name=f"d{i}") for i in range(3)]
         da = _make_distribution_array(comps)
         s = sample(da, sample_shape=(1000,))
-        # batch_shape (3,), leaf (1000,) → field shape (3, 1000).
-        means = s["sample"].mean(axis=-1)
+        # Levels (dist, draw) over (3, 1000): the draw axis is the trailing one.
+        means = s.values.mean(axis=-1)
         np.testing.assert_allclose(means, jnp.array([0.0, 100.0, 200.0]), atol=0.2)
 
     def test_multi_d_batch_shape(self):
+        """A multi-axis sweep keeps its own axes in front of the draw level."""
         comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(6)]
         da = _make_distribution_array(comps, batch_shape=(2, 3))
         s = sample(da, sample_shape=(5,))
-        assert s.batch_shape == (2, 3)
-        assert s["sample"].shape == (2, 3, 5)
+        assert (s.batch_shape, s.level_names) == ((2, 3, 5), ("dist", "sample"))
+        assert s.values.shape == (2, 3, 5)
 
     def test_record_valued_components_scalar_sample(self):
         comps = [
@@ -512,17 +517,16 @@ class TestMeanVianSweep:
         comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(4)]
         da = _make_distribution_array(comps)
         m = mean(da)
-        assert isinstance(m, NumericRecordBatch)
+        assert isinstance(m, NumericArrayBatch)
         assert m.batch_shape == (4,)
-        assert m["mean"].shape == (4,)
-        np.testing.assert_allclose(m["mean"], [0.0, 1.0, 2.0, 3.0])
+        np.testing.assert_allclose(m.values, [0.0, 1.0, 2.0, 3.0])
 
     def test_multi_d_mean_shape(self):
         comps = [Normal(loc=float(i), scale=1.0, name=f"d{i}") for i in range(6)]
         da = _make_distribution_array(comps, batch_shape=(3, 2))
         m = mean(da)
         assert m.batch_shape == (3, 2)
-        assert m["mean"].shape == (3, 2)
+        assert m.values.shape == (3, 2)
 
     def test_record_components_mean_is_record_batch(self):
         comps = [
@@ -547,10 +551,9 @@ class TestVarianceViaSweep:
         comps = [Normal(loc=0.0, scale=float(i + 1), name=f"d{i}") for i in range(3)]
         da = _make_distribution_array(comps)
         v = variance(da)
-        assert isinstance(v, NumericRecordBatch)
+        assert isinstance(v, NumericArrayBatch)
         assert v.batch_shape == (3,)
-        assert v["variance"].shape == (3,)
-        np.testing.assert_allclose(v["variance"], [1.0, 4.0, 9.0])
+        np.testing.assert_allclose(v.values, [1.0, 4.0, 9.0])
 
 
 class TestLogProbViaSweep:
@@ -568,14 +571,14 @@ class TestLogProbViaSweep:
         # Single scalar value broadcasts to every cell.
         value = jnp.asarray(0.0)
         lp = log_prob(da, value=value)
-        assert isinstance(lp, NumericRecordBatch)
+        assert isinstance(lp, NumericArrayBatch)
         assert lp.batch_shape == (3,)
         # Cell i evaluates Normal(i, 1) at 0 → gaussian log-density at
         # distance ``i`` from the mean.
         expected = jnp.array(
             [Normal(loc=float(i), scale=1.0, name=f"d{i}")._log_prob(0.0) for i in range(3)]
         )
-        np.testing.assert_allclose(lp["log_prob"], expected, rtol=1e-5)
+        np.testing.assert_allclose(lp.values, expected, rtol=1e-5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_first_class_function.py
+++ b/tests/core/test_first_class_function.py
@@ -1292,7 +1292,7 @@ class TestVariadicPlanning:
         result = wrapped(rows, 2.0)
 
         assert result.batch_shape == (3,)
-        np.testing.assert_allclose(result["<lambda>"], np.arange(3.0) + 2)
+        np.testing.assert_allclose(result.values, np.arange(3.0) + 2)
 
     def test_record_batch_in_any_varargs_is_swept(self):
         rows = NumericRecordBatch.stack(
@@ -1305,7 +1305,7 @@ class TestVariadicPlanning:
         result = Function(func=double)(rows)
 
         assert result.batch_shape == (3,)
-        np.testing.assert_allclose(result["double"], np.arange(3.0) * 2)
+        np.testing.assert_allclose(result.values, np.arange(3.0) * 2)
 
     def test_record_batch_in_any_varkwargs_is_swept(self):
         rows = NumericRecordBatch.stack(
@@ -1318,7 +1318,7 @@ class TestVariadicPlanning:
         result = Function(func=double)(rows=rows)
 
         assert result.batch_shape == (3,)
-        np.testing.assert_allclose(result["double"], np.arange(3.0) * 2)
+        np.testing.assert_allclose(result.values, np.arange(3.0) * 2)
 
     def test_tracked_varargs_are_provenance_parents(self, full_provenance_mode):
         first = NumericRecord("first", value=1.0)

--- a/tests/core/test_log_prob_kwargs.py
+++ b/tests/core/test_log_prob_kwargs.py
@@ -25,6 +25,7 @@ from probpipe import (
     MinibatchedDistribution,
     MultivariateNormal,
     Normal,
+    NumericArrayBatch,
     NumericRecord,
     NumericRecordBatch,
     ProductDistribution,
@@ -66,10 +67,10 @@ class TestKwargFormScalar:
 
         result = log_prob(d, x=rows.select("x")["x"])
 
-        assert isinstance(result, NumericRecordBatch)
+        assert isinstance(result, NumericArrayBatch)
         assert result.batch_shape == (3,)
         expected = jnp.stack([log_prob.apply(d, float(value)) for value in range(3)])
-        np.testing.assert_allclose(result["log_prob"], expected)
+        np.testing.assert_allclose(result.values, expected)
 
 
 class TestKwargFormRecord:

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -23,6 +23,7 @@ from probpipe import (
     EventTemplate,
     Function,
     Normal,
+    NumericArrayBatch,
     NumericArraySpec,
     NumericRecord,
     OpaqueBatch,
@@ -323,7 +324,7 @@ class TestSiblingViewsZipThroughACall:
         out = add(x=views["x"], y=views["y"])
 
         assert out.batch_shape == (3,)
-        np.testing.assert_allclose(np.asarray(out["add"]), [0.0, 11.0, 22.0])
+        np.testing.assert_allclose(out.values, [0.0, 11.0, 22.0])
 
 
 class TestOpaqueColumnsAreRearrangedRaw:
@@ -519,7 +520,7 @@ class TestMultiLevelSweeps:
         out = scale(p=grid)
 
         assert out.batch_shape == (2, 3)
-        np.testing.assert_allclose(np.asarray(out["scale"]), np.arange(6.0).reshape(2, 3) * 10.0)
+        np.testing.assert_allclose(out.values, np.arange(6.0).reshape(2, 3) * 10.0)
 
     def test_two_groups_and_a_returned_batch_keep_their_partition(self):
         """The aggregate mints one level per swept group, then the rows' own
@@ -586,7 +587,7 @@ class TestAutoDispatchFallsBackForABatchReturningBody:
         out = double(v=source)
 
         assert out.batch_shape == (3,)
-        np.testing.assert_allclose(np.asarray(out["double"]), [0.0, 2.0, 4.0])
+        np.testing.assert_allclose(out.values, [0.0, 2.0, 4.0])
 
 
 class TestSameRankTransformsCannotLieEither:
@@ -759,7 +760,7 @@ class TestZeroWidthEventsUnderExplicitJax:
         assert out.batch_shape == (3,)
         # Row identities survive, so the zero-width column really was carried
         # per row rather than the output being indistinguishable zeros.
-        np.testing.assert_allclose(np.asarray(out["<lambda>"]), [0.0, 1.0, 2.0])
+        np.testing.assert_allclose(out.values, [0.0, 1.0, 2.0])
 
 
 class TestShapeCannotRecoverAxisProvenance:
@@ -945,6 +946,65 @@ class TestBatchValuedRowAggregation:
         out = Function(func=lambda x: self._inner(2), dispatch="sequential")(x=self._rows())
         assert out.batch_shape == (3, 2)
         assert out.level_names == ("row", "inner")
+
+    @staticmethod
+    def _inner_array(n: int, level: str = "inner"):
+        return NumericArrayBatch(
+            jnp.zeros(n), level, element_spec=NumericArraySpec(shape=()), name="inner"
+        )
+
+    def test_array_batch_rows_stack_with_the_sweep_in_front(self):
+        """A row's own levels survive whichever batch kind it returns.
+
+        Read as event shape instead, the rows' axis would say each cell holds
+        one 2-vector where it holds two elements on a level.
+        """
+        out = Function(func=lambda x: self._inner_array(2), dispatch="sequential")(x=self._rows())
+
+        assert isinstance(out, NumericArrayBatch)
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "inner"))
+        assert tuple(out.element_spec.shape) == ()
+
+    def test_array_batch_rows_stack_from_their_native_store(self):
+        """A row's store is in native form, so stacking goes through its backend.
+
+        ``jnp.stack`` sees only what the duck path recognises, and would refuse a
+        registered container that converts perfectly well through ``to_jax``.
+        """
+        import pandas as pd
+
+        from probpipe.core._broadcast_distributions import _make_stack
+
+        rows = [
+            NumericArrayBatch(
+                pd.Series([1.0 * i, 2.0 * i]),
+                "inner",
+                element_spec=NumericArraySpec(shape=()),
+                name="inner",
+            )
+            for i in range(1, 4)
+        ]
+
+        out = _make_stack(rows, n=3, field_name="f", level_names=("sweep",))
+
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("sweep", "inner"))
+        np.testing.assert_allclose(np.asarray(out.values)[2], [3.0, 6.0])
+
+    def test_array_batch_rows_disagreeing_on_their_multiplicity_are_refused(self):
+        def body(x):
+            return self._inner_array(2) if float(x["x"]) < 0.5 else self._inner_array(3)
+
+        with pytest.raises(ValueError, match="returned batches that disagree"):
+            Function(func=body, dispatch="sequential")(x=self._rows())
+
+    def test_mixing_array_batch_and_record_batch_rows_is_refused(self):
+        """The two kinds hold different things, so there is no one aggregate."""
+
+        def body(x):
+            return self._inner_array(2) if float(x["x"]) < 0.5 else self._inner(2)
+
+        with pytest.raises(TypeError, match="one kind for every row"):
+            Function(func=body, dispatch="sequential")(x=self._rows())
 
     def test_a_returned_design_aggregates_as_a_plain_batch(self):
         """The aggregate is not itself a design: a subclass with its own

--- a/tests/core/test_workflow_distribution_normalization.py
+++ b/tests/core/test_workflow_distribution_normalization.py
@@ -16,7 +16,7 @@ from probpipe import (
     EmpiricalDistribution,
     KDEDistribution,
     Normal,
-    NumericRecordBatch,
+    NumericArrayBatch,
     NumericRecordDistribution,
     log_prob,
     mean,
@@ -208,9 +208,9 @@ class TestDistributionArrayHandling:
 
         result = wf(dist=da)
 
-        assert isinstance(result, NumericRecordBatch)
+        assert isinstance(result, NumericArrayBatch)
         assert result.batch_shape == (1,)
-        np.testing.assert_allclose(result[result.event_template.fields[0]], jnp.asarray([3.0]))
+        np.testing.assert_allclose(result.values, jnp.asarray([3.0]))
 
 
 class TestUnhintedExternalDistribution:

--- a/tests/core/test_workflow_sweep.py
+++ b/tests/core/test_workflow_sweep.py
@@ -184,7 +184,7 @@ class TestExecuteSweep:
             1.0,
             2.0,
         ]
-        np.testing.assert_allclose(result["double"], jnp.asarray([0.0, 2.0, 4.0]))
+        np.testing.assert_allclose(result.values, jnp.asarray([0.0, 2.0, 4.0]))
 
     def test_include_inputs_is_rejected_for_sweep(self):
         values = {"p": _numeric_record_batch("x", range(1))}

--- a/tests/record/test_design.py
+++ b/tests/record/test_design.py
@@ -13,6 +13,7 @@ import pytest
 from probpipe import (
     FullFactorialDesign,
     NumericArray,
+    NumericArrayBatch,
     NumericRecord,
     NumericRecordBatch,
     Record,
@@ -145,11 +146,11 @@ class TestDesignAsSweep:
 
         ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
         out = fit(p=ff)
-        assert isinstance(out, NumericRecordBatch)
+        assert isinstance(out, NumericArrayBatch)
         assert out.batch_shape == (6,)
         # Insertion order: r outer, K inner.
         np.testing.assert_allclose(
-            np.asarray(out["fit"]),
+            out.values,
             [1.5 * 60, 1.5 * 80, 1.8 * 60, 1.8 * 80, 2.0 * 60, 2.0 * 80],
         )
 
@@ -157,8 +158,8 @@ class TestDesignAsSweep:
         """Splatting ``**design.select_all()`` yields sibling views of
         the same Design. The WF sweep layer groups them by parent
         identity and iterates in lockstep — one inner call per row —
-        producing a ``NumericRecordBatch`` identical to the single
-        Record-arg pattern (``fit(p=design)``)."""
+        producing an aggregate identical to the single Record-arg pattern
+        (``fit(p=design)``)."""
 
         @function
         def product(r, K):
@@ -166,11 +167,11 @@ class TestDesignAsSweep:
 
         ff = FullFactorialDesign(r=[1.5, 1.8, 2.0], K=[60.0, 80.0])
         out = product(**ff.select_all())
-        assert isinstance(out, NumericRecordBatch)
+        assert isinstance(out, NumericArrayBatch)
         assert out.batch_shape == (6,)
         # Insertion order: r outer, K inner.
         np.testing.assert_allclose(
-            np.asarray(out["product"]),
+            out.values,
             [1.5 * 60, 1.5 * 80, 1.8 * 60, 1.8 * 80, 2.0 * 60, 2.0 * 80],
         )
 
@@ -190,10 +191,7 @@ class TestDesignAsSweep:
         out_a = fit_a(p=ff)
         out_b = fit_b(**ff.select_all())
         assert out_a.batch_shape == out_b.batch_shape == (6,)
-        np.testing.assert_allclose(
-            np.asarray(out_a["fit_a"]),
-            np.asarray(out_b["fit_b"]),
-        )
+        np.testing.assert_allclose(out_a.values, out_b.values)
 
     def test_raw_fields_still_cartesian_product(self):
         """Passing raw columns (``design["r"]``, ``design["K"]``) gives


### PR DESCRIPTION
> **Note.** This replaces #423, which GitHub auto-closed when the branch was
> briefly force-pushed with no commits ahead of its base, and which the API
> refuses to reopen. Same branch, same content.

Stacked on #422 (`dev/sample-draw-level`). Part of #398.

## What changes

A `Function` swept over a batch collected numeric rows into a single-field `NumericRecordBatch` keyed by the function's own name. Both array-row branches of `_make_stack` — the row-wise list path and the mapped `jnp.ndarray` path — now build a `NumericArrayBatch`.

```python
out = my_func(p=design)          # a sweep over 6 rows
out["my_func"]                   # before
out.values                       # now
```

## The batch-row branch covered only one kind

`_make_stack` has a branch for rows that are themselves batches, so a row's own levels end up behind the sweep's rather than being read as event shape. It tested for `RecordBatch` only.

That was harmless until #422, where a scalar law's `sample` began returning a `NumericArrayBatch`. Those rows then fell past the branch into the generic array handling, which read the rows' `draw` axis as event shape and dropped the level — exactly the failure the branch's own comment describes:

> which would take a single-field numeric batch for an array, read its inner batch axis as an event axis, and discard the level names with it

Concretely, `sample(dist_array, sample_shape=(7,))`:

| | before | now |
| --- | --- | --- |
| `batch_shape` | `(4,)` | `(4, 7)` |
| `level_names` | `("dist",)` | `("dist", "draw")` |
| element shape | `(7,)` | `()` |

The record-valued path was already `("dist", "draw")` over `(3, 5)`, so the two agree again. This is what design V.9 states: the outer level ranges over the laws and the inner over each law's draws, "a `RecordBatch` for a record-drawing law, and the batch form of the declared kind otherwise".

## Shared agreement checks

The all-or-nothing and row-agreement checks move into `_agreeing_batch_rows`, used by both kinds. It matches on the batch *family* rather than the exact class, so a `RecordBatch` row and a `NumericRecordBatch` row still stack together — they hold the same thing and only one says so in its name.

## Tests

24 failures, matching the measurement recorded when this stage was scoped. All were the old contract: 12 indexing the aggregate by the function's name, 12 asserting `isinstance(..., NumericRecordBatch)`. No functional gaps.

Fixing the batch-row branch resolved 3 of them before any test was touched.

New coverage in `TestBatchValuedRowAggregation`, mirroring what existed for `RecordBatch` rows:

- array-batch rows stack with the sweep level in front
- array-batch rows disagreeing on their multiplicity are refused
- mixing an array-batch row with a record-batch row is refused

Suite: 4823 passed, 54 skipped. `ruff check` / `ruff format --check` clean.

## Not in scope

`_wrap_declared_function_output` — the path taken when a `Function` carries an `output_template` — still needs the same kind dispatch. That is the next piece.
