### PR TITLE
fix(core): every batch is a workflow operand

### DIFF
--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -28,7 +28,7 @@ from ._empirical import (
 )
 from ._function_batch import FunctionBatch
 from ._immutable import constructing, transient_memo
-from ._numeric_array_batch import NumericArrayBatch
+from ._numeric_array_batch import NumericArrayBatch, _MappedBatchStore
 from ._numeric_record_batch import NumericRecordBatch
 from ._object_batch import _from_iterable, _is_object_array
 from ._opaque_batch import OpaqueBatch
@@ -782,6 +782,18 @@ def _make_stack(
     # Before the generic pytree handling below, which would read the inner batch
     # axis as an event axis and drop the level names with it — the same reason
     # the batch-of-batches case precedes the Record case on the list path.
+    if isinstance(inner_outputs, _MappedBatchStore):
+        # One store rather than columns: the sweep's axes replace the leading one
+        # the transform produced, and the levels are the sweep's then the rows'.
+        store = inner_outputs.store
+        return NumericArrayBatch(
+            store.reshape(batch_shape + store.shape[1:]),
+            (*level_names, *inner_outputs.level_names),
+            element_spec=inner_outputs.element_spec,
+            axis_groups=(*sweep_groups, *inner_outputs.axis_groups),
+            name=name or field_name,
+            name_is_auto=name is None,
+        )
     if isinstance(inner_outputs, _MappedBatchColumns):
         return _batch_over_swept_columns(
             inner_outputs.columns,

--- a/probpipe/core/_function_batch.py
+++ b/probpipe/core/_function_batch.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Iterable
 
 import numpy as np
 
+from ._kinds import register_kind
 from ._object_batch import _ObjectBatch
 from .event_template import FunctionSpec
 from .provenance import Provenance
@@ -109,3 +110,6 @@ class FunctionBatch(_ObjectBatch[Callable]):
         spec = self._spec.element_spec
         assert isinstance(spec, FunctionSpec)  # narrowed at construction
         return spec
+
+
+register_kind(FunctionSpec, batch_class=FunctionBatch)

--- a/probpipe/core/_kinds.py
+++ b/probpipe/core/_kinds.py
@@ -1,0 +1,85 @@
+"""The kind table: which tracked class and which batch form each value spec has.
+
+Every value spec has exactly one tracked class and one batch form (design II.2,
+III.1). That correspondence was open-coded at six sites, each knowing a
+different subset, so widening one of them left the others behind — a
+``NumericArrayBatch`` that the record layer could present but the workflow
+planner would not sweep.
+
+The table is declared once here and each kind registers itself at the bottom of
+its own module, next to the classes it names. Registration is import-order
+sensitive by construction, which is why ``probpipe/__init__.py`` imports the
+batch modules eagerly: a lookup before a kind's module has been imported would
+see a table that does not yet mention it.
+
+A spec with no registered batch form is not an oversight — a ``RecordSpec``
+belongs to :class:`~probpipe.RecordBatch`, whose choice between the plain and
+numeric class depends on the *template's* leaves rather than on the spec type
+alone, so the record layer keeps its own resolver.
+
+See design II.2, III.1.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "batch_class_for_spec",
+    "register_kind",
+    "term_class_for_spec",
+]
+
+#: spec type -> (tracked class, batch class). Either may be ``None`` where the
+#: kind has no class of that side.
+_KINDS: dict[type, tuple[type | None, type | None]] = {}
+
+
+def register_kind(
+    spec_type: type, *, term_class: type | None = None, batch_class: type | None = None
+) -> None:
+    """Declare the tracked class and batch form belonging to *spec_type*.
+
+    Called at the bottom of the module defining the classes, so the table is
+    populated by importing the kind rather than by a central list that a new
+    kind has to be added to.
+
+    Raises
+    ------
+    ValueError
+        If *spec_type* is already registered with a different pair. A kind has
+        one tracked class and one batch form; two registrations disagreeing is a
+        contradiction rather than an override.
+    """
+    existing = _KINDS.get(spec_type)
+    pair = (term_class, batch_class)
+    if existing is not None and existing != pair:
+        raise ValueError(
+            f"{spec_type.__name__} is already registered as {existing}, so registering "
+            f"{pair} would give one spec two kinds; a spec has one tracked class and one "
+            f"batch form"
+        )
+    _KINDS[spec_type] = pair
+
+
+def term_class_for_spec(spec: Any) -> type | None:
+    """The tracked class a value satisfying *spec* is returned as, if any."""
+    return _lookup(spec, 0)
+
+
+def batch_class_for_spec(spec: Any) -> type | None:
+    """The batch form a collection of values satisfying *spec* takes, if any."""
+    return _lookup(spec, 1)
+
+
+def _lookup(spec: Any, side: int) -> type | None:
+    """Resolve *spec*'s registered class, honouring subclass registrations.
+
+    The exact type first, then the MRO, so a spec subclass inherits its base's
+    kind unless it registers its own.
+    """
+    for candidate in type(spec).__mro__:
+        entry = _KINDS.get(candidate)
+        if entry is not None and entry[side] is not None:
+            return entry[side]
+    return None

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -20,6 +20,7 @@ from ._array_backend import (
     _to_numpy_array,
 )
 from ._batch import Batch, BatchSpec, _axis_groups_for
+from ._kinds import register_kind
 from ._numeric_array import NumericArray
 from .event_template import NumericArraySpec
 from .provenance import Provenance
@@ -290,3 +291,6 @@ def _numeric_array_batch_unflatten(aux, children):
 jax.tree_util.register_pytree_node(
     NumericArrayBatch, _numeric_array_batch_flatten, _numeric_array_batch_unflatten
 )
+
+# The numeric-array kind: its spec, its tracked class, and this batch form.
+register_kind(NumericArraySpec, term_class=NumericArray, batch_class=NumericArrayBatch)

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -294,3 +294,79 @@ jax.tree_util.register_pytree_node(
 
 # The numeric-array kind: its spec, its tracked class, and this batch form.
 register_kind(NumericArraySpec, term_class=NumericArray, batch_class=NumericArrayBatch)
+
+
+class _MappedBatchStore:
+    """A single-store batch taken apart, to cross a mapping transform.
+
+    The counterpart of :class:`~probpipe.core._record_batch._MappedBatchColumns`
+    for a batch that holds one store rather than a column per field. The reason
+    is the same: unflattening refuses an added axis because it has no name to
+    give the level, which is right for a raw transform and wrong for an executor
+    that knows both. So the executor hands the transform this inert carrier —
+    its unflatten rebuilds it verbatim, checking nothing — and rebuilds the batch
+    on the far side, where the level name is in hand.
+
+    Private and short-lived: wrapped and unwrapped within one call.
+    """
+
+    __slots__ = ("axis_groups", "element_spec", "level_names", "name", "name_is_auto", "store")
+
+    def __init__(
+        self,
+        store: Any,
+        *,
+        element_spec: NumericArraySpec,
+        level_names: tuple[str, ...],
+        axis_groups: tuple[tuple[int, ...], ...],
+        name: str,
+        name_is_auto: bool,
+    ):
+        self.store = store
+        self.element_spec = element_spec
+        self.level_names = level_names
+        self.axis_groups = axis_groups
+        self.name = name
+        self.name_is_auto = name_is_auto
+
+    @classmethod
+    def of(cls, batch: NumericArrayBatch) -> _MappedBatchStore:
+        """Take *batch* apart, keeping what unflattening could not have inferred."""
+        return cls(
+            batch.values,
+            element_spec=batch.element_spec,
+            level_names=tuple(batch.level_names),
+            axis_groups=tuple(batch.axis_groups),
+            name=batch._name,
+            name_is_auto=batch._name_is_auto,
+        )
+
+
+def _mapped_batch_store_flatten(carried: _MappedBatchStore):
+    return [carried.store], (
+        carried.element_spec,
+        carried.level_names,
+        carried.axis_groups,
+        carried.name,
+        carried.name_is_auto,
+    )
+
+
+def _mapped_batch_store_unflatten(aux, children) -> _MappedBatchStore:
+    element_spec, level_names, axis_groups, name, name_is_auto = aux
+    (store,) = children
+    # No rank check, deliberately: the added axis is the point, and the caller
+    # that added it is the one that can name it.
+    return _MappedBatchStore(
+        store,
+        element_spec=element_spec,
+        level_names=level_names,
+        axis_groups=axis_groups,
+        name=name,
+        name_is_auto=name_is_auto,
+    )
+
+
+jax.tree_util.register_pytree_node(
+    _MappedBatchStore, _mapped_batch_store_flatten, _mapped_batch_store_unflatten
+)

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -10,8 +10,9 @@ from typing import Any
 
 import numpy as np
 
+from ._kinds import register_kind
 from ._object_batch import _ObjectBatch
-from ._opaque import OpaqueSpec
+from ._opaque import Opaque, OpaqueSpec
 from .provenance import Provenance
 
 __all__ = ["OpaqueBatch"]
@@ -111,3 +112,6 @@ class OpaqueBatch(_ObjectBatch[Any]):
         spec = self._spec.element_spec
         assert isinstance(spec, OpaqueSpec)  # narrowed at construction
         return spec
+
+
+register_kind(OpaqueSpec, term_class=Opaque, batch_class=OpaqueBatch)

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -41,6 +41,7 @@ import numpy as np
 from ._array_backend import _is_numeric_dtype, _to_jax_array
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._function_batch import FunctionBatch
+from ._kinds import batch_class_for_spec
 from ._object_batch import _from_iterable, _frozen_object_column, _is_object_array
 from ._opaque import OpaqueSpec
 from ._opaque_batch import OpaqueBatch
@@ -381,19 +382,21 @@ class RecordBatch(Batch[Record]):
         spec = self.event_template[key]
         if isinstance(spec, NumericArraySpec):
             return column
-        name = f"{self.name}[{key!r}]"
-        column_spec = BatchSpec(spec, self.axis_groups, self.level_names)
-        if isinstance(spec, FunctionSpec):
-            return self._inherit_provenance(
-                FunctionBatch._over_store(column, spec=column_spec, name=name)
+        # Every other kind presents through its registered batch form, so a new
+        # kind is reachable here by registering itself rather than by being added
+        # to a switch this module would otherwise have to know about.
+        column_cls = batch_class_for_spec(spec)
+        if column_cls is None:
+            raise TypeError(
+                f"the field {key!r} is declared {type(spec).__name__}, which has no batch form; "
+                f"a kind registers its batch form beside its classes (see core/_kinds.py)"
             )
-        if isinstance(spec, OpaqueSpec):
-            return self._inherit_provenance(
-                OpaqueBatch._over_store(column, spec=column_spec, name=name)
+        return self._inherit_provenance(
+            column_cls._over_store(
+                column,
+                spec=BatchSpec(spec, self.axis_groups, self.level_names),
+                name=f"{self.name}[{key!r}]",
             )
-        raise TypeError(
-            f"the field {key!r} is declared {type(spec).__name__}, which has no batch form yet; "
-            f"an array field, a callable field, and an opaque field are the forms a column takes"
         )
 
     def _field_view(self, path: str, template: EventTemplate) -> Self:

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -17,7 +17,6 @@ from typing import Any, Literal, Union, get_args, get_origin
 from . import _workflow_call, _workflow_descendants, _workflow_distribution_normalization
 from ._batch import Batch
 from ._distribution_array import DistributionArray
-from ._record_batch import RecordBatch
 from .distribution import Distribution, EmpiricalDistribution
 
 BroadcastRegime = Literal["none", "distribution", "sweep", "nested"]
@@ -194,9 +193,13 @@ def build_broadcast_plan(
         value = _workflow_call.input_ref_value(values, ref)
         expected = _workflow_call.input_ref_hint(signature_info, ref)
 
-        is_batched_record = isinstance(value, RecordBatch)
+        # Any Batch is an operand: what makes a value sweepable is that it holds
+        # a multiplicity on named levels, which is the Batch contract rather than
+        # anything specific to records. A DistributionArray is a Distribution, not
+        # a Batch, so it stays a separate test.
+        is_batch = isinstance(value, Batch)
         is_dist_array = isinstance(value, DistributionArray)
-        if (is_batched_record or is_dist_array) and len(value.batch_shape) > 0:
+        if (is_batch or is_dist_array) and len(value.batch_shape) > 0:
             if _value_matches_hint(value, expected) or expected is Any:
                 continue
             array_args.append(ref)

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -33,6 +33,7 @@ from . import (
 from ._batch import Batch
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
+from ._numeric_array_batch import NumericArrayBatch, _MappedBatchStore
 from ._record_batch import RecordBatch, _MappedBatchColumns
 from .config import WorkflowKind, prefect_config
 from .distribution import BroadcastDistribution, Distribution
@@ -332,6 +333,8 @@ def mapped_row_body(
         out = func(**_workflow_call.replace_input_refs(values, replacements))
         if isinstance(out, RecordBatch):
             return _MappedBatchColumns.of(out)
+        if isinstance(out, NumericArrayBatch):
+            return _MappedBatchStore.of(out)
         return out
 
     return one_row

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -40,6 +40,7 @@ from . import (
     _workflow_result,
     _workflow_sweep,
 )
+from ._batch import Batch
 from ._function_contract import (
     _bind_function_inputs,
     _bind_planned_function_inputs,
@@ -198,6 +199,18 @@ class Node(ABC):  # noqa: B024
     @property
     def inputs(self) -> Mapping[str, Any]:
         return self._inputs
+
+
+class _UnvectorizableBatchSignal(Exception):
+    """The probe met a batch whose rows the mapped body cannot be built from.
+
+    Raised so the reason survives to the caller: the generic tracing message
+    would say the function is not JAX-traceable, which is not what went wrong.
+    """
+
+    def __init__(self, kinds: list[str]) -> None:
+        super().__init__(", ".join(kinds))
+        self.kinds = kinds
 
 
 class Function(Node, TrackedTerm, Annotated):
@@ -991,6 +1004,7 @@ class Function(Node, TrackedTerm, Annotated):
             dummy_kw = dict(values)
             broadcast_refs = set(broadcast_args)
             batched_sources: dict[_workflow_call.WorkflowInputRef, Any] = {}
+            unvectorized_batches: dict[Any, Any] = {}
             drawn_refs: list[_workflow_call.WorkflowInputRef] = []
             for ref in _workflow_call.iter_input_refs(self._signature_info, values):
                 v = _workflow_call.input_ref_value(values, ref)
@@ -1001,6 +1015,15 @@ class Function(Node, TrackedTerm, Annotated):
                     if isinstance(v, RecordBatch):
                         batched_sources[ref] = v
                         dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, v[0])
+                    elif isinstance(v, Batch):
+                        # A batch that is not a batch of records is still a swept
+                        # source, not a draw. The probe's synthesis below builds a
+                        # leaf per field, which a single-store batch does not have,
+                        # so this route declines rather than mis-reading it as a
+                        # law: ``auto`` runs it sequentially and gets the right
+                        # answer, which an explicit ``jax`` should not silently
+                        # differ from.
+                        unvectorized_batches[ref] = v
                     else:
                         # Nothing to synthesize: the draw itself supplies the
                         # structure and dtype below, which is what lets a
@@ -1016,6 +1039,10 @@ class Function(Node, TrackedTerm, Annotated):
                         replacement = v
                     dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, replacement)
             with _workflow_context._workflow_probe():
+                if unvectorized_batches:
+                    raise _UnvectorizableBatchSignal(
+                        sorted({type(b).__name__ for b in unvectorized_batches.values()})
+                    )
                 if batched_sources:
                     refs = list(batched_sources)
                     # The executor's own body, not a copy maintained in the
@@ -1143,6 +1170,12 @@ class Function(Node, TrackedTerm, Annotated):
         )
         if trace_error is None:
             return
+        if isinstance(trace_error, _UnvectorizableBatchSignal):
+            raise TypeError(
+                f"dispatch='jax' cannot vectorize over {', '.join(trace_error.kinds)}: the "
+                f"mapped row body is built from one leaf per field, which a single-store batch "
+                f"does not have. Use dispatch='auto' or 'sequential', which sweep it correctly."
+            ) from trace_error
         if isinstance(trace_error, _workflow_context._StochasticProbeSignal):
             raise TypeError(
                 "dispatch='jax' cannot execute a wrapped function that requests "

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -166,6 +166,44 @@ def _drawn_at_its_batch_form(
     )
 
 
+def _at_the_operands_levels(computed: Any, operand: Any) -> Any:
+    """Give *computed* the levels *operand* carried, when it is a batch.
+
+    An operation whose value parameter is ``Any``-hinted receives a batch whole
+    and evaluates it in one vectorized call rather than row by row. That is the
+    fused implementation design V.9 allows to register above the elementwise map
+    — but V.9 also says the batch axes are *preserved*, and a bare array does not
+    preserve them. So the levels the operand stated are restated on the result.
+
+    Only the axes the operand accounted for are levels; anything the operation
+    added beyond them belongs to the element, which is why the split is by the
+    operand's rank rather than by the result's.
+    """
+    from ._array_backend import _event_shape_of, _is_numeric_leaf, _numpy_dtype_of
+    from ._batch import Batch
+    from ._numeric_array_batch import NumericArrayBatch
+    from .event_template import NumericArraySpec
+
+    if not isinstance(operand, Batch) or not _is_numeric_leaf(computed):
+        return computed
+    batch_shape = tuple(operand.batch_shape)
+    shape = tuple(_event_shape_of(computed))
+    if shape[: len(batch_shape)] != batch_shape:
+        # The operation did not lay its result out over the operand's axes, so
+        # there is no correspondence to restate.
+        return computed
+    return NumericArrayBatch(
+        computed,
+        tuple(operand.level_names),
+        element_spec=NumericArraySpec(
+            shape=shape[len(batch_shape) :], dtype=_numpy_dtype_of(computed)
+        ),
+        axis_groups=tuple(operand.axis_groups),
+        name=operand.name,
+        name_is_auto=operand.name_is_auto,
+    )
+
+
 # -- keyword value form shared by the density ops ---------------------------
 #
 # Each density op accepts either a positional ``value`` or named field kwargs
@@ -222,7 +260,8 @@ def log_prob(dist: SupportsLogProb, value: Any = None, **field_kwargs: Any) -> A
     """
     if not isinstance(dist, SupportsLogProb):
         raise TypeError(f"{type(dist).__name__} does not support log_prob")
-    return dist._log_prob(_resolve_value("log_prob", dist, value, field_kwargs))
+    resolved = _resolve_value("log_prob", dist, value, field_kwargs)
+    return _at_the_operands_levels(dist._log_prob(resolved), resolved)
 
 
 @function

--- a/tests/core/test_kinds.py
+++ b/tests/core/test_kinds.py
@@ -1,0 +1,70 @@
+"""The kind table: one tracked class and one batch form per value spec.
+
+The correspondence was open-coded at six sites, each knowing a different
+subset, so widening one left the others behind. These tests pin the table
+itself and the property that made the duplication a bug: every registered kind
+answers both questions the same way wherever it is asked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from probpipe import (
+    FunctionBatch,
+    FunctionSpec,
+    NumericArray,
+    NumericArrayBatch,
+    NumericArraySpec,
+    Opaque,
+    OpaqueBatch,
+    OpaqueSpec,
+)
+from probpipe.core._kinds import batch_class_for_spec, register_kind, term_class_for_spec
+
+
+class TestEveryKindDeclaresItsClasses:
+    @pytest.mark.parametrize(
+        ("spec", "term", "batch"),
+        [
+            pytest.param(NumericArraySpec(shape=()), NumericArray, NumericArrayBatch, id="numeric"),
+            pytest.param(OpaqueSpec(), Opaque, OpaqueBatch, id="opaque"),
+            pytest.param(FunctionSpec(), None, FunctionBatch, id="function"),
+        ],
+    )
+    def test_a_spec_resolves_to_its_pair(self, spec, term, batch):
+        assert term_class_for_spec(spec) is term
+        assert batch_class_for_spec(spec) is batch
+
+    def test_a_kind_with_no_tracked_class_says_so(self):
+        """`FunctionSpec` has a batch form and no separate tracked class — a
+        callable is already a `Function`."""
+        assert term_class_for_spec(FunctionSpec()) is None
+
+
+class TestTheTableIsSingleValued:
+    def test_a_contradicting_registration_is_refused(self):
+        """One spec, one kind. A second registration is a contradiction, not an
+        override, so it raises rather than silently winning."""
+        with pytest.raises(ValueError, match="already registered"):
+            register_kind(OpaqueSpec, term_class=int, batch_class=int)
+
+    def test_re_registering_the_same_pair_is_harmless(self):
+        """Importing a module twice must not raise."""
+        register_kind(OpaqueSpec, term_class=Opaque, batch_class=OpaqueBatch)
+
+        assert batch_class_for_spec(OpaqueSpec()) is OpaqueBatch
+
+    def test_a_spec_subclass_inherits_its_bases_kind(self):
+        """Resolution walks the MRO, so a refinement need not re-register."""
+
+        class _NarrowerOpaque(OpaqueSpec):
+            pass
+
+        assert batch_class_for_spec(_NarrowerOpaque()) is OpaqueBatch
+
+    def test_an_unregistered_spec_resolves_to_nothing(self):
+        class _Unregistered:
+            pass
+
+        assert batch_class_for_spec(_Unregistered()) is None

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -276,3 +276,39 @@ class TestLevelsAreNamedForWhatMintsThem:
         result = Function(func=lambda: [1.0, 2.0], name="myfunc")()
 
         assert result.level_names == ("myfunc",)
+
+
+class TestABatchOperandKeepsItsLevelsThroughAnOperation:
+    """Design V.9: `log_prob` maps elementwise "with the batch axes preserved".
+
+    An operation whose value parameter is `Any`-hinted takes the batch whole and
+    evaluates it in one vectorized call — the fused implementation V.9 allows.
+    That is not licence to hand back a bare array: the axes the operand accounted
+    for are levels, and a result that drops them says the draws were one value.
+    """
+
+    LAW = Normal(0.0, 1.0, name="height")
+
+    def test_log_prob_of_a_batch_of_draws_keeps_the_sample_level(self):
+        drawn = sample(self.LAW, sample_shape=(3,), key=KEY)
+
+        scored = log_prob(self.LAW, drawn)
+
+        assert (scored.batch_shape, scored.level_names) == ((3,), ("sample",))
+
+    def test_the_result_is_named_for_the_operand_it_scored(self):
+        drawn = sample(self.LAW, sample_shape=(3,), key=KEY)
+
+        assert log_prob(self.LAW, drawn).name == drawn.name
+
+    def test_a_single_draw_is_still_a_single_value(self):
+        """No operand levels to restate, so nothing is invented."""
+        scored = log_prob(self.LAW, sample(self.LAW, key=KEY))
+
+        assert not isinstance(scored, NumericArrayBatch)
+
+    def test_a_raw_array_operand_is_left_alone(self):
+        """A bare array states no levels, so the result carries none."""
+        scored = log_prob(self.LAW, jnp.zeros(3))
+
+        assert not isinstance(scored, NumericArrayBatch)

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -1103,3 +1103,37 @@ class TestEveryBatchIsAnOperand:
 
         assert (out.batch_shape, out.level_names) == ((2,), ("row",))
         np.testing.assert_allclose(out.values, [1.0, 2.0])
+
+
+class TestSweepingASingleStoreBatchAgreesAcrossDispatch:
+    """A row that returns a single-store batch keeps its levels, as a record row does."""
+
+    @staticmethod
+    def _rows(n: int = 3):
+        return NumericArrayBatch(
+            jnp.arange(float(n)), "row", element_spec=NumericArraySpec(shape=()), name="rows"
+        )
+
+    @staticmethod
+    def _inner(v):
+        return NumericArrayBatch(
+            jnp.stack([jnp.asarray(v), jnp.asarray(v)]),
+            "inner",
+            element_spec=NumericArraySpec(shape=()),
+            name="i",
+        )
+
+    @pytest.mark.parametrize("dispatch", ["auto", "sequential"])
+    def test_the_rows_own_level_survives(self, dispatch):
+        out = Function(func=self._inner, name="f", dispatch=dispatch)(v=self._rows())
+
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "inner"))
+
+    def test_explicit_jax_says_what_it_cannot_do(self):
+        """The probe builds one leaf per field, which a single-store batch lacks.
+
+        Declining beats mis-reading it as a law: `auto` sweeps it correctly, and
+        an explicit `jax` should not silently differ from that.
+        """
+        with pytest.raises(TypeError, match="cannot vectorize over NumericArrayBatch"):
+            Function(func=self._inner, name="f", dispatch="jax")(v=self._rows())

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -22,7 +22,9 @@ import pytest
 from probpipe import (
     EventTemplate,
     Function,
+    FunctionBatch,
     Normal,
+    NumericArray,
     NumericArrayBatch,
     NumericArraySpec,
     NumericRecord,
@@ -1048,3 +1050,56 @@ class TestDeclaredOpaqueOutputAcrossDispatches:
         assert column.shape == (2,)
         assert [int(v) for v in result[0]["y"]] == [1, 2]
         assert [int(v) for v in result[1]["y"]] == [2, 3]
+
+
+class TestEveryBatchIsAnOperand:
+    """A batch is swept because it holds a multiplicity, not because it holds records.
+
+    The planner recognised only `RecordBatch` and `DistributionArray`, so the
+    other batch kinds were handed to a body whole. A body written for one element
+    then saw the whole collection, and the levels collapsed into the value's
+    shape on the way out.
+    """
+
+    @staticmethod
+    def _numeric(n: int = 3):
+        return NumericArrayBatch(
+            jnp.arange(float(n)), "row", element_spec=NumericArraySpec(shape=()), name="rows"
+        )
+
+    def test_a_numeric_array_batch_reaches_the_body_as_an_element(self):
+        seen: list = []
+
+        Function(func=lambda v: (seen.append(v), 0.0)[1], name="f", dispatch="sequential")(
+            v=self._numeric()
+        )
+
+        assert seen
+        assert all(isinstance(row, NumericArray) for row in seen)
+        assert not any(isinstance(row, NumericArrayBatch) for row in seen)
+
+    def test_sweeping_a_numeric_array_batch_keeps_its_level(self):
+        out = Function(func=lambda v: jnp.asarray(v) * 2.0, name="double", dispatch="sequential")(
+            v=self._numeric()
+        )
+
+        assert (out.batch_shape, out.level_names) == ((3,), ("row",))
+
+    def test_an_opaque_batch_hands_the_body_its_stored_element(self):
+        """`OpaqueBatch` stores rather than materializes, so the body sees the
+        caller's own object."""
+        seen: list = []
+
+        Function(func=lambda v: (seen.append(v), 0.0)[1], name="f", dispatch="sequential")(
+            v=OpaqueBatch(["a", "b"], "row", name="rows")
+        )
+
+        assert seen == ["a", "b"]
+
+    def test_a_function_batch_is_swept_too(self):
+        out = Function(func=lambda f: float(f()), name="call", dispatch="sequential")(
+            f=FunctionBatch([lambda: 1.0, lambda: 2.0], "row", name="rows")
+        )
+
+        assert (out.batch_shape, out.level_names) == ((2,), ("row",))
+        np.testing.assert_allclose(out.values, [1.0, 2.0])


### PR DESCRIPTION
Stacked on #428. Addresses the "generic `Batch` planning and JAX parity" item of the stack review.

## The gap

`build_broadcast_plan` recognised only `RecordBatch` and `DistributionArray`, so a
`NumericArrayBatch`, `OpaqueBatch`, or `FunctionBatch` argument was handed to a body
**whole**. A body written for one element received the whole collection, and the levels
collapsed into the value's shape on the way out.

What makes a value sweepable is that it holds a multiplicity on named levels — the `Batch`
contract, not anything specific to records. The test is now `isinstance(value, Batch)`.
`DistributionArray` is a `Distribution` and not a `Batch`, so it stays separate.

| argument | body receives | result |
| --- | --- | --- |
| `NumericArrayBatch` | a `NumericArray` element | batch on the argument's level |
| `OpaqueBatch` | the stored object | batch on the argument's level |
| `FunctionBatch` | the callable | batch on the argument's level |

## The same assumption, three more places

Widening one site is what exposed the rest, which is the argument for the registry below.

**A mapping transform had no carrier for a single-store batch.** A row returning a
`RecordBatch` crosses inside `_MappedBatchColumns`, an inert carrier whose unflatten
rebuilds it verbatim — which is what lets it survive the added axis that `RecordBatch`
unflattening must refuse, since a shape is not a provenance. `_MappedBatchStore` is that
carrier for a batch holding one store, and lives beside the class it carries.

**The probe read a non-record batch as a law.** It classified any non-`RecordBatch`
argument as a *draw*, so a `NumericArrayBatch` argument failed with an internal contract
error about a missing stochastic plan. It is a swept source, and the probe now says so.

**An operation dropped its operand's levels.** `log_prob(law, sample(law, sample_shape=(3,)))`
returned a bare `(3,)` array. The vectorized path is right — it is the fused
implementation design V.9 allows above the elementwise map — but V.9 also says the batch
axes are *preserved*. The levels the operand stated are now restated on the result, split
by the **operand's** rank so anything the operation added belongs to the element.

## The registry

The spec → tracked class → batch form correspondence was open-coded at six sites, each
knowing a different subset. That is precisely why widening one left the others behind.

`core/_kinds.py` holds the table; each kind registers itself at the bottom of the module
defining its classes, so a new kind becomes known by being imported rather than by being
added to a list elsewhere. Registration refuses a contradicting pair rather than letting
the last writer win, and resolution walks the MRO so a spec refinement inherits its base's
kind. `_column_as_batch` is the first consumer routed through it, replacing a three-way
`isinstance` switch.

`RecordSpec` keeps its own resolver: the choice between the plain and numeric record batch
depends on the template's leaves, not on the spec type.

## Deliberately not finished

Full JAX **vectorization** of a single-store batch. The mapped row body is built from one
leaf per field, which such a batch does not have, so widening it means changing the row
body and the probe's synthesis together. Rather than mis-read the batch, an explicit
`dispatch='jax'` now declines with that reason; `auto` and `sequential` sweep it
correctly, verified to agree on both levels and values.

## Tests

Suite: 5640 passed, 54 skipped. The planner widening changed **no existing test** — the
gap was in what the planner accepted, not in what anything asserted, which is why it
survived this long. New coverage: batches as operands across all three kinds, dispatch
agreement for batch-returning rows, the decline message, the kind table including its
contradiction guard and MRO resolution, and level preservation through `log_prob`.
