### PR TITLE
fix(core): each swept row takes its own kind, and the aggregate is named for its function

### DIFF
--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from .._weights import Weights
 from ..custom_types import Array
-from ._array_backend import _to_jax_array
+from ._array_backend import _event_shape_of, _is_numeric_leaf, _to_jax_array
 from ._distribution_base import Distribution
 from ._empirical import (
     EmpiricalDistribution,
@@ -699,6 +699,29 @@ def _agreeing_batch_rows(outs: list, *, field_name: str) -> Any:
     return first
 
 
+def _row_at_its_kind(row: Any, field_name: str) -> Any:
+    """One swept row as the tracked term of its own kind.
+
+    Only the two *structural* hosts are converted here. A numeric, opaque, or
+    callable row already reaches a branch below that batches it at its kind, and
+    converting it early would cost the vectorized path for no gain.
+
+    - a ``Mapping`` is a tree, so it becomes a ``Record`` and the rows stack into
+      a batch of records;
+    - a non-empty sequence is a multiplicity, so it becomes a batch of its own and
+      the rows stack with that level inside the sweep's.
+    """
+    from collections.abc import Mapping
+
+    from .record import Record
+
+    if isinstance(row, Mapping):
+        return Record(field_name, dict(row), name_is_auto=True)
+    if isinstance(row, (list, tuple)) and row:
+        return _make_stack(list(row), n=len(row), level_names=(field_name,), field_name=field_name)
+    return row
+
+
 def _make_stack(
     inner_outputs: Any,
     *,
@@ -840,6 +863,13 @@ def _make_stack(
                 )
                 for output in outs
             ]
+        else:
+            # Each row takes the kind of the host it is, before the branches
+            # below read what the rows are. A row is one call's return, and the
+            # boundary that names a *single* return's kind (V.0) is the same rule
+            # — reading a mapping row as an unstackable object, or a sequence row
+            # as event shape, states something the row never said.
+            outs = [_row_at_its_kind(output, field_name) for output in outs]
 
         # A batch per row stacks into one batch with the sweep in front of the
         # rows' own levels. Checked before the Record branch below, which would
@@ -969,6 +999,18 @@ def _make_stack(
                 axis_groups=sweep_groups,
                 name=name or field_name,
                 name_is_auto=name is None,
+            )
+
+        # Numeric rows that do not stack disagree on their shape, and an object
+        # column would record that disagreement as though it were the answer. The
+        # rows say what they are; the aggregate says so too.
+        if outs and all(_is_numeric_leaf(o) for o in outs):
+            shapes = sorted({tuple(_event_shape_of(o)) for o in outs})
+            raise ValueError(
+                f"{field_name}: the rows returned numeric values of differing shapes "
+                f"{shapes}, so they do not stack into one batch. Every row of a sweep "
+                f"contributes one element of one shape; pad the rows, or return a batch "
+                f"from each and let the levels record the difference"
             )
 
         # Rows that do not stack take the batch form of their own kind, which is

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -432,6 +432,7 @@ def _stack_declared_columns(
         element_spec=template,
         axis_groups=axis_groups,
         name=name,
+        name_is_auto=True,
     )
 
 
@@ -459,7 +460,14 @@ def _empty_declared_stack(
         else:
             columns[path] = np.empty(batch_shape, dtype=object)
     cls = _batch_class_for(template)
-    return cls(columns, level_names, element_spec=template, axis_groups=axis_groups, name=name)
+    return cls(
+        columns,
+        level_names,
+        element_spec=template,
+        axis_groups=axis_groups,
+        name=name,
+        name_is_auto=True,
+    )
 
 
 def _make_marginal(
@@ -815,7 +823,7 @@ def _make_stack(
             element_spec=inner_outputs.element_spec,
             axis_groups=(*sweep_groups, *inner_outputs.axis_groups),
             name=name or field_name,
-            name_is_auto=name is None,
+            name_is_auto=True,
         )
     if isinstance(inner_outputs, _MappedBatchColumns):
         return _batch_over_swept_columns(
@@ -891,7 +899,7 @@ def _make_stack(
                     element_spec=first.element_spec,
                     axis_groups=(*sweep_groups, *first.axis_groups),
                     name=name or field_name,
-                    name_is_auto=name is None,
+                    name_is_auto=True,
                 )
             # Columns are leaf-keyed, so a nested element needs no special
             # case — and they are read raw: a field that is not an array
@@ -935,8 +943,10 @@ def _make_stack(
             except (TypeError, ValueError):
                 flat = None
             if flat is not None:
-                if batch_shape == (n_total,):
-                    return flat
+                # No early return for the one-level case: the reshape below is
+                # an identity there, and ``stack`` named the batch after its own
+                # class, where every aggregation names it for the function that
+                # produced the rows.
                 n_cur = len(flat.batch_shape)
                 return NumericRecordBatch(
                     {
@@ -946,6 +956,8 @@ def _make_stack(
                     level_names,
                     element_spec=flat.element_spec,
                     axis_groups=sweep_groups,
+                    name=name or field_name,
+                    name_is_auto=True,
                 )
             # No declared template, so the element structure is inferred from the
             # rows. ``RecordBatch.stack`` is what infers it: columns are keyed by
@@ -967,6 +979,8 @@ def _make_stack(
                 level_names,
                 element_spec=flat.element_spec,
                 axis_groups=sweep_groups,
+                name=name or field_name,
+                name_is_auto=True,
             )
 
         # All Distributions → stacked DistributionArray, shaped to
@@ -998,7 +1012,7 @@ def _make_stack(
                 element_spec=NumericArraySpec(event_shape, dtype=stacked.dtype),
                 axis_groups=sweep_groups,
                 name=name or field_name,
-                name_is_auto=name is None,
+                name_is_auto=True,
             )
 
         # Numeric rows that do not stack disagree on their shape, and an object
@@ -1022,7 +1036,7 @@ def _make_stack(
             shared = {
                 "axis_groups": sweep_groups,
                 "name": name or field_name,
-                "name_is_auto": name is None,
+                "name_is_auto": True,
             }
             # ``outs`` first: every row of none is vacuously callable, and no row
             # is a reason to claim the function kind over the fallback.
@@ -1075,7 +1089,7 @@ def _make_stack(
             element_spec=NumericArraySpec(event_shape, dtype=inner_outputs.dtype),
             axis_groups=sweep_groups,
             name=name or field_name,
-            name_is_auto=name is None,
+            name_is_auto=True,
         )
 
     # vmap of a Record-returning function produces a Record with batched leaves

--- a/probpipe/core/_workflow_result.py
+++ b/probpipe/core/_workflow_result.py
@@ -9,6 +9,7 @@ planning reserved for #369.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any, Literal
 
@@ -71,8 +72,12 @@ def _wrap_as_term(
     # -- a raw host, wrapped into its own kind -----------------------------
     # The kind follows the host's *type*, empty or not: a mapping is a tree and a
     # sequence a multiplicity, and having no entries does not change which.
-    if isinstance(value, dict):
-        return Record(field_name, value, name_is_auto=True)
+    if isinstance(value, Mapping):
+        # Any mapping, not only ``dict``: the value layer reads a mapping as a
+        # tree, and an ``OrderedDict`` or a ``Mapping`` subclass is one. Falling
+        # through would reach ``Opaque``, which refuses mappings, so the return
+        # would raise rather than be wrapped.
+        return Record(field_name, dict(value), name_is_auto=True)
     if isinstance(value, (list, tuple)):
         if not value:
             # No element to read a kind off, and every element spec holds
@@ -81,14 +86,14 @@ def _wrap_as_term(
             from ._opaque_batch import OpaqueBatch
 
             return OpaqueBatch([], field_name, name=field_name, name_is_auto=True)
-        try:
-            # A returned sequence ranges over nothing the call named, so the
-            # level takes the function's own name.
-            return _make_stack(
-                list(value), n=len(value), level_names=(field_name,), field_name=field_name
-            )
-        except (TypeError, ValueError):
-            pass
+        # A returned sequence ranges over nothing the call named, so the level
+        # takes the function's own name. Errors are not caught here: the stack
+        # has a batch form for every element kind, so what reaches this and
+        # raises is the rows disagreeing — which is the caller's to see, not
+        # something to record as one opaque value.
+        return _make_stack(
+            list(value), n=len(value), level_names=(field_name,), field_name=field_name
+        )
     # ``_is_numeric_leaf`` excludes duck-typed objects (``MagicMock`` and the
     # like) whose attribute probing recurses inside ``jnp.asarray``.
     if _is_numeric_leaf(value):

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -312,3 +312,71 @@ class TestABatchOperandKeepsItsLevelsThroughAnOperation:
         scored = log_prob(self.LAW, jnp.zeros(3))
 
         assert not isinstance(scored, NumericArrayBatch)
+
+
+class TestEveryAggregateIsNamedForItsFunction:
+    """The naming table, widened across the axes that had diverged.
+
+    A sweep's aggregate is built by the boundary, not by a caller, so its name is
+    the producing function's and is marked auto. Three paths disagreed: the
+    undeclared record aggregate took `stack`'s class-name default, and the scalar,
+    opaque, and declared paths marked a derived name as user-given — which would
+    stop a later operation renaming it.
+    """
+
+    @staticmethod
+    def _rows(n: int = 3):
+        from probpipe.core.event_template import NumericEventTemplate
+
+        return NumericRecordBatch(
+            {"x": jnp.arange(float(n))},
+            "row",
+            element_spec=NumericEventTemplate(x=()),
+            name="rows",
+        )
+
+    def _swept(self, body, **controls):
+        return Function(func=body, name="double", dispatch="sequential", **controls)(v=self._rows())
+
+    @pytest.mark.parametrize(
+        ("label", "body"),
+        [
+            ("numeric", lambda v: jnp.asarray(v["x"]) * 2),
+            ("mapping", lambda v: {"y": jnp.asarray(v["x"])}),
+            ("opaque", lambda v: "tag"),
+            ("callable", lambda v: lambda: 1),
+            ("sequence", lambda v: [jnp.asarray(v["x"]), jnp.asarray(v["x"])]),
+        ],
+    )
+    def test_an_undeclared_aggregate_is_named_for_the_function(self, label, body):
+        result = self._swept(body)
+
+        assert (result.name, result.name_is_auto) == ("double", True)
+
+    def test_a_declared_aggregate_is_named_the_same_way(self):
+        from probpipe import EventTemplate
+
+        result = self._swept(
+            lambda v: {"y": jnp.asarray(v["x"])}, output_template=EventTemplate(y=())
+        )
+
+        assert (result.name, result.name_is_auto) == ("double", True)
+
+    def test_a_multi_axis_sweep_is_named_the_same_way(self):
+        """The re-cut to the sweep's own geometry is a separate construction, and
+        it had its own naming."""
+        from probpipe.core.event_template import NumericEventTemplate
+
+        grid = NumericRecordBatch(
+            {"x": jnp.arange(6.0).reshape(2, 3)},
+            ("a", "b"),
+            element_spec=NumericEventTemplate(x=()),
+            name="grid",
+        )
+
+        result = Function(
+            func=lambda v: {"y": jnp.asarray(v["x"])}, name="double", dispatch="sequential"
+        )(v=grid)
+
+        assert (result.name, result.name_is_auto) == ("double", True)
+        assert result.level_names == ("a", "b")

--- a/tests/core/test_wrap_at_the_declared_kind.py
+++ b/tests/core/test_wrap_at_the_declared_kind.py
@@ -277,3 +277,58 @@ class TestASequenceAggregatesAtItsRowsKind:
         """The last-ditch branch alone used to leave the aggregate auto-named."""
         for value in ([1.0, 2.0], ["a", "b"], [lambda: 1], []):
             assert self._returned(value).name == "f"
+
+
+class TestEachSweptRowTakesItsOwnKind:
+    """A row is one call's return, so the rule that names a single return's kind
+    is the rule that names a row's.
+
+    Rows reached the aggregation raw, so the branches there read them as whatever
+    they happened to stack as: a mapping row was an unstackable object, and a
+    sequence row's multiplicity became event shape.
+    """
+
+    @staticmethod
+    def _rows(n: int = 3):
+        from probpipe import NumericRecordBatch
+        from probpipe.core.event_template import NumericEventTemplate
+
+        return NumericRecordBatch(
+            {"x": jnp.arange(float(n))},
+            "row",
+            element_spec=NumericEventTemplate(x=()),
+            name="rows",
+        )
+
+    def _swept(self, body):
+        return Function(func=body, name="f", dispatch="sequential")(v=self._rows())
+
+    def test_a_mapping_row_gives_a_batch_of_records(self):
+        out = self._swept(lambda v: {"y": jnp.asarray(v["x"]) * 2})
+
+        assert list(out.event_template) == ["y"]
+        assert (out.batch_shape, out.level_names) == ((3,), ("row",))
+
+    def test_any_mapping_counts_not_only_dict(self):
+        from collections import OrderedDict
+
+        out = self._swept(lambda v: OrderedDict(y=jnp.asarray(v["x"])))
+
+        assert list(out.event_template) == ["y"]
+
+    def test_a_sequence_row_keeps_its_own_level(self):
+        """The row's multiplicity is a level, not part of the element's shape."""
+        out = self._swept(lambda v: [jnp.asarray(v["x"]), jnp.asarray(v["x"])])
+
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "f"))
+
+    def test_rows_of_differing_numeric_shape_are_refused(self):
+        """An object column would record the disagreement as if it were the answer."""
+        with pytest.raises(ValueError, match="differing shapes"):
+            self._swept(lambda v: jnp.ones(int(jnp.asarray(v["x"])) + 1))
+
+    def test_a_disagreement_inside_a_returned_sequence_is_not_swallowed(self):
+        """The stack has a batch form for every element kind, so what raises here
+        is the rows disagreeing — which the caller should see."""
+        with pytest.raises(ValueError, match="differing shapes"):
+            Function(func=lambda: [jnp.ones(1), jnp.ones(2)], name="g")()


### PR DESCRIPTION
Stacked on #431. Addresses the "per-point host-kind wrapping" and "aggregate naming" items of the stack review.

## Each swept row takes its own kind

A row is one call's return, so the rule that names a single return's kind (design V.0) is
the rule that names a row's. Rows reached the aggregation raw, and the branches there read
them as whatever they happened to stack as. Four wrong answers, not four missing features:

| a swept body returning | was | now |
| --- | --- | --- |
| `{"y": ...}` | `TypeError: cannot aggregate outputs of types ['dict']` | `RecordBatch` |
| `OrderedDict(y=...)` | same, via `Opaque` refusing mappings | `RecordBatch` |
| `[a, b]` | multiplicity became **event shape** | `(3, 2)` on `("row", "f")` |
| ragged numeric rows | silently an `OpaqueBatch` | refused, naming the shapes |

Only the two *structural* hosts are converted per row. A numeric, opaque, or callable row
already reaches a branch that batches it at its kind, and converting it early would cost
the vectorized path for no gain.

The single-value boundary now tests `Mapping` rather than `dict`, so a mapping subclass is
a tree there too.

## The swallowed exception is gone

`except (TypeError, ValueError): pass` around the returned-sequence stack covered nothing —
the line never executed in the whole suite — while turning a genuine schema disagreement
into one opaque value. The stack now has a batch form for every element kind, so what
reaches it and raises is the rows disagreeing, which is the caller's to see.

## An aggregate is named for its function

An aggregate is built by the boundary, not a caller, so its name is derived and must be
marked auto — otherwise a later operation reads it as a caller's statement and declines to
rename it. Three paths disagreed:

- the undeclared record aggregate kept `stack`'s class-name default, so a swept mapping came
  back named `numericrecordbatch`;
- the scalar, opaque, callable, and declared paths marked the derived name as user-given;
- the one-level early return skipped the construction that names it at all. **Removed rather
  than patched** — the reshape it avoided is an identity in that case, so the general path
  already covered it.

| swept body | name | `name_is_auto` |
| --- | --- | --- |
| numeric / mapping / opaque / callable / sequence | `double` | `True` |
| declared `output_template` | `double` | `True` |
| multi-axis sweep | `double` | `True` |

## Tests

Suite: 5649 passed, 54 skipped. New coverage pins each row kind's aggregate, the two
refusals, `Mapping` at the single-value boundary, and the naming table widened across
declared/undeclared, single/multi-axis, and every result kind — the form that would have
shown the divergence in the first place.
