### PR TITLE
fix(core): a native-backed batch crosses a JAX boundary

### DIFF
--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -86,7 +86,10 @@ class NumericArrayBatch(Batch[NumericArray]):
 
     _values: Any
 
-    __slots__ = ("_values",)
+    __slots__ = ("_jax_cache", "_values")
+
+    #: Derived from the store rather than transported, as for ``NumericArray``.
+    _transient_state = ("_jax_cache",)
 
     def __init__(
         self,
@@ -194,8 +197,23 @@ class NumericArrayBatch(Batch[NumericArray]):
         arr = np.asarray(arr, dtype=dtype) if dtype is not None else arr
         return arr.copy() if copy else arr
 
+    def as_jax(self) -> Any:
+        """The store as a ``jax.Array`` — the single conversion point.
+
+        A store already held as one passes through, tracers included; a native
+        container converts through its registered backend once and is memoised
+        for this instance, as a :class:`NumericArray`'s value is.
+        """
+        if isinstance(self._values, jax.Array):
+            return self._values
+        cached = getattr(self, "_jax_cache", None)
+        if cached is None:
+            cached = _to_jax_array(self._values)
+            object.__setattr__(self, "_jax_cache", cached)
+        return cached
+
     def __jax_array__(self) -> Any:
-        return _to_jax_array(self._values)
+        return self.as_jax()
 
     def __repr__(self) -> str:
         return (
@@ -245,8 +263,14 @@ class NumericArrayBatch(Batch[NumericArray]):
 
 
 def _numeric_array_batch_flatten(batch: NumericArrayBatch):
-    """Flatten for JAX traversal: the store, keyed by the aux spec."""
-    return [batch._values], (batch._spec, batch._name, batch._name_is_auto)
+    """Flatten for JAX traversal: the store, keyed by the aux spec.
+
+    The boundary presents a bare array, as a ``NumericArray``'s flatten does.
+    Handing the native container to JAX instead fails abstractification before
+    ``__jax_array__`` is ever consulted, so a pandas- or xarray-backed batch
+    could not enter a trace at all.
+    """
+    return [batch.as_jax()], (batch._spec, batch._name, batch._name_is_auto)
 
 
 def _numeric_array_batch_unflatten(aux, children):
@@ -272,6 +296,18 @@ def _numeric_array_batch_unflatten(aux, children):
         object.__setattr__(view, "_values", values)
         view._init_batch(spec, name=name, name_is_auto=name_is_auto)
         return view
+    # The element's own axes are not the transform's to change. A rank check
+    # alone would admit a store whose trailing axes no longer match what the
+    # element declares, and the batch would build with a spec that is a false
+    # statement about its own store — surfacing only at the first selection.
+    event_shape = tuple(element_spec.shape)
+    if event_rank and tuple(shape)[len(shape) - event_rank :] != event_shape:
+        raise ValueError(
+            f"a transform left this NumericArrayBatch over a store of {tuple(shape)}, whose "
+            f"trailing axes are not the event shape {event_shape} its elements declare. A "
+            f"transform maps the elements; changing what one *is* rebuilds the batch where "
+            f"the new element spec is known"
+        )
     surviving = tuple(shape)[: len(shape) - event_rank] if event_rank else tuple(shape)
     if surviving == tuple(spec.batch_shape):
         view = object.__new__(NumericArrayBatch)

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -681,3 +681,74 @@ class TestNumericArrayBatchArrayShim:
 
     def test_dtype_reports_the_store(self):
         assert _batch().dtype == jnp.float32
+
+
+class TestANativeBackedBatchCrossesJax:
+    """The compute boundary converts, as it does for a single value.
+
+    Flatten handed JAX the native container, which fails abstractification before
+    `__jax_array__` is ever consulted — so a pandas- or xarray-backed batch could
+    not enter a trace at all.
+    """
+
+    @staticmethod
+    def _pandas_backed():
+        pd = pytest.importorskip("pandas")
+        return NumericArrayBatch(
+            pd.Series([1.0, 2.0, 3.0]),
+            "row",
+            element_spec=NumericArraySpec(shape=()),
+            name="b",
+        )
+
+    def test_a_native_store_reaches_a_trace(self):
+        batch = self._pandas_backed()
+
+        out = jax.jit(lambda x: x)(batch)
+
+        assert isinstance(out, NumericArrayBatch)
+        assert out.level_names == ("row",)
+
+    def test_the_original_keeps_its_native_store(self):
+        """Converting at the boundary does not materialise the batch itself."""
+        pd = pytest.importorskip("pandas")
+        batch = self._pandas_backed()
+
+        jax.jit(lambda x: x)(batch)
+
+        assert isinstance(batch.values, pd.Series)
+
+    def test_conversion_happens_once_and_is_memoised(self):
+        batch = self._pandas_backed()
+
+        assert batch.as_jax() is batch.as_jax()
+
+
+class TestUnflattenChecksTheElementItRebuilds:
+    """A rank check alone admits a store the element spec is false about."""
+
+    @staticmethod
+    def _batch():
+        return NumericArrayBatch(
+            jnp.zeros((4, 3)), "row", element_spec=NumericArraySpec(shape=(3,)), name="b"
+        )
+
+    def test_a_changed_event_shape_is_refused(self):
+        """The element's own axes are not the transform's to change; the batch
+        would otherwise build and fail at the first selection instead."""
+        leaves, treedef = jax.tree_util.tree_flatten(self._batch())
+
+        with pytest.raises(ValueError, match="not the event shape"):
+            jax.tree_util.tree_unflatten(treedef, [jnp.zeros((4, 5))])
+
+    def test_an_unchanged_store_round_trips(self):
+        leaves, treedef = jax.tree_util.tree_flatten(self._batch())
+
+        rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+
+        assert (rebuilt.batch_shape, rebuilt.level_names) == ((4,), ("row",))
+
+    def test_removing_every_batch_axis_still_yields_the_element(self):
+        leaves, treedef = jax.tree_util.tree_flatten(self._batch())
+
+        assert isinstance(jax.tree_util.tree_unflatten(treedef, [jnp.zeros((3,))]), NumericArray)


### PR DESCRIPTION
Stacked on #432. Addresses the "native pytree conversion / validation" items of the stack review.

## A native-backed batch could not enter a trace

`NumericArrayBatch`'s flatten handed JAX the native container. Abstractification fails
there, before `__jax_array__` is ever consulted, so a pandas- or xarray-backed batch could
not be traced at all — while the single-value `NumericArray` beside it could, because its
flatten already converted.

```python
b = NumericArrayBatch(pd.Series([1.0, 2.0, 3.0]), "row", element_spec=..., name="b")
jax.jit(lambda x: x)(b)
# TypeError: Argument '0  1.0 ...' of type <class 'pandas.Series'> is not a valid JAX type
```

The boundary now presents a bare array, as `NumericArray`'s flatten does, and the
conversion is **memoised on the instance** rather than repeated per call. The batch keeps
its native store — converting at the boundary is not materialising the batch:

| | after `jit` |
| --- | --- |
| the traced value | `ArrayImpl` |
| `batch.values` | still `pd.Series` |
| `as_jax()` twice | the same object |

## Unflatten did not check the element it rebuilt

It compared the surviving **rank** and let the trailing axes be anything, so a transform
that resized the event shape produced a batch whose `element_spec` was a false statement
about its own store. It built successfully and failed later, at the first selection:

```
rebuilt.values.shape   == (4, 5)
rebuilt.element_spec   == NumericArraySpec(shape=(3,))   # not what it holds
rebuilt[0]             -> ValueError, one layer too late
```

The element's own axes are not the transform's to change. Changing what an element *is*
rebuilds the batch where the new spec is known, so this refuses with that reason. The two
transformations the contract does allow are unaffected — every batch axis preserved, or
every one removed, which still yields a `NumericArray`.

## Tests

Suite: 5656 passed, 54 skipped. New coverage: a native store reaching a trace, the store
surviving it, conversion memoised, the resized-event refusal, and both permitted round
trips.
