### PR TITLE
feat(core): give the numeric-array and opaque kinds their tracked classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Selection yields a `NumericArray` under the derived name, as `RecordBatch`
   yields a `Record`.
 
+- **`Opaque` — the tracked class of the opaque kind (#398).** What an operation
+  returns when its declared kind is an `OpaqueSpec`, completing the pair with the
+  `OpaqueBatch` that already existed. It adds identity and nothing else: no
+  attribute forwarding, no `__call__`, no operators — the wrapped value is
+  reached through `.value`, explicitly. `OpaqueBatch`'s element contract is
+  unchanged; it still hands back the object the caller put in rather than
+  wrapping it.
+
 - **`ArrayBackend.take` — positional selection for a native container.** `[]` is
   positional on a numpy-protocol container and reads *labels* on a `pandas` one,
   so a batch stored as a `DataFrame` could not address its own elements. Backends

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,11 +95,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   later change.
 
   `NumericArray` holds one array and carries no batch axes, so its `shape` is the
-  event shape. It carries the full array surface, and **arithmetic on it yields a
-  bare array** — identity is attached by operations, and arithmetic is not one.
-  It is a registered pytree, which is what lets it cross a `jit` or `vmap`
-  boundary; its spec is re-derived from the array that arrives, since a shape and
-  a dtype state it exactly.
+  event shape. Construction **validates without converting** — the value is stored
+  in its native form and materialises at most once, at the compute boundary — the
+  rule `NumericRecord` already follows for its leaves. It carries the full array
+  surface, and **arithmetic yields a bare value of the stored type**: identity is
+  attached by operations, and arithmetic is not one. It is a registered pytree,
+  which is what lets it cross a `jit` or `vmap` boundary; the boundary presents a
+  bare array, and its spec is re-derived from what arrives, since a shape and a
+  dtype state it exactly.
 
   `NumericArrayBatch` stores one array with the batch axes leading and splits
   them from the event axes by its element spec. Selection yields a `NumericArray`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,12 +132,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`ArraySpec` is renamed `NumericArraySpec` (#398).** The spec now agrees with
-  the class it names, as `RecordSpec`/`Record` does. `Array` remains the type
-  alias for a bare backend array.
-
-### Changed
-
 ### Removed (breaking)
 
 - **`RecordArray` and `NumericRecordArray` are gone; the batch of records is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   `NumericArrayBatch` stores one array with the batch axes leading and splits
   them from the event axes by its element spec, which it validates the stored
-  dtype against at construction — the batch asserts that spec of every element.
+  dtype against at construction — the batch asserts that spec of every element,
+  so a store that reports no single dtype cannot carry a pinned one either.
   Selection yields a `NumericArray` under the derived name, as `RecordBatch`
   yields a `Record`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call, retain the resulting joint distribution, or materialize and reuse
   samples explicitly when a shared realization is required.
 
+### Added
+
+- **`NumericArray` and `NumericArrayBatch` (#398).** The tracked class of the
+  numeric-array kind and its batch form, so `NumericArraySpec` has the pair every
+  other value spec has. Nothing returns them yet; the operations switch over in a
+  later change.
+
+  `NumericArray` holds one array and carries no batch axes, so its `shape` is the
+  event shape. It carries the full array surface, and **arithmetic on it yields a
+  bare array** — identity is attached by operations, and arithmetic is not one.
+  It is a registered pytree, which is what lets it cross a `jit` or `vmap`
+  boundary; its spec is re-derived from the array that arrives, since a shape and
+  a dtype state it exactly.
+
+  `NumericArrayBatch` stores one array with the batch axes leading and splits
+  them from the event axes by its element spec. Selection yields a `NumericArray`
+  under the derived name, as `RecordBatch` yields a `Record`.
+
+### Changed
+
+- **`ArraySpec` is renamed `NumericArraySpec` (#398).** The spec now agrees with
+  the class it names, as `RecordSpec`/`Record` does. `Array` remains the type
+  alias for a bare backend array.
+
 ### Changed
 
 ### Removed (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,8 +105,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dtype state it exactly.
 
   `NumericArrayBatch` stores one array with the batch axes leading and splits
-  them from the event axes by its element spec. Selection yields a `NumericArray`
-  under the derived name, as `RecordBatch` yields a `Record`.
+  them from the event axes by its element spec, which it validates the stored
+  dtype against at construction — the batch asserts that spec of every element.
+  Selection yields a `NumericArray` under the derived name, as `RecordBatch`
+  yields a `Record`.
+
+- **`ArrayBackend.take` — positional selection for a native container.** `[]` is
+  positional on a numpy-protocol container and reads *labels* on a `pandas` one,
+  so a batch stored as a `DataFrame` could not address its own elements. Backends
+  now declare how to select by position, defaulting to `obj[index]`; the built-in
+  `pandas` backends select through `.iloc`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged; it still hands back the object the caller put in rather than
   wrapping it.
 
+  The name is the required first argument, as a `Record`'s is: an opaque value
+  exposes nothing else that says what it is, so a default would name every one
+  of them alike. `OpaqueSpec` moves to the same module as the class it types;
+  the public import path is unchanged.
+
 - **`ArrayBackend.take` — positional selection for a native container.** `[]` is
   positional on a numpy-protocol container and reads *labels* on a `pandas` one,
   so a batch stored as a `DataFrame` could not address its own elements. Backends

--- a/docs/api/records.md
+++ b/docs/api/records.md
@@ -43,10 +43,13 @@ or by position with `[]`, and indexing returns a view named by what it selected
 
 ### Batch forms that store objects
 
-A numeric array batches natively, with the batch axes leading, so it needs no
-class. A callable and an opaque object have no such form — there is nothing to
-stack them into — so each gets a thin `Batch` that stores its elements and
-carries the one specification they all satisfy, adding no other interface.
+Every value spec has one tracked class and one batch form. A numeric array
+batches natively, with the batch axes leading, but native storage is not
+identity: `NumericArrayBatch` is what carries a level name, a specification, and
+provenance, so the array kind takes a class like every other. A callable and an
+opaque object have no native stacking at all — there is nothing to stack them
+into — so each gets a thin `Batch` that stores its elements and carries the one
+specification they all satisfy, adding no other interface.
 
 Both take their elements the same way. Pass a flat sequence, or an object array
 of any shape to give the batch more than one axis; a nested sequence is *not*
@@ -62,6 +65,12 @@ batch holds the elements it validated even if the caller keeps writing to the
 array they passed. And construction needs at least one element, while *selecting*
 none is fine: an empty batch is reached with `batch[0:0]` rather than built from
 an empty sequence, whose shape could not be inferred anyway.
+
+::: probpipe.NumericArray
+
+::: probpipe.NumericArrayBatch
+
+::: probpipe.Opaque
 
 ::: probpipe.FunctionBatch
 

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -44,6 +44,7 @@ from probpipe.core._numeric_array import NumericArray
 from probpipe.core._numeric_array_batch import NumericArrayBatch
 from probpipe.core._numeric_record import NumericRecord
 from probpipe.core._numeric_record_batch import NumericRecordBatch
+from probpipe.core._opaque import Opaque
 from probpipe.core._opaque_batch import OpaqueBatch
 from probpipe.core._record_batch import RecordBatch
 from probpipe.core._workflow_context import workflow_run
@@ -288,6 +289,7 @@ __all__ = [
     "NumericRecordBatch",
     "NumericRecordDistribution",
     "NumericRecordDistributionView",
+    "Opaque",
     "OpaqueBatch",
     "OpaqueSpec",
     "ParentInfo",

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -44,7 +44,7 @@ from probpipe.core._numeric_array import NumericArray
 from probpipe.core._numeric_array_batch import NumericArrayBatch
 from probpipe.core._numeric_record import NumericRecord
 from probpipe.core._numeric_record_batch import NumericRecordBatch
-from probpipe.core._opaque import Opaque
+from probpipe.core._opaque import Opaque, OpaqueSpec
 from probpipe.core._opaque_batch import OpaqueBatch
 from probpipe.core._record_batch import RecordBatch
 from probpipe.core._workflow_context import workflow_run
@@ -100,7 +100,6 @@ from probpipe.core.event_template import (
     FunctionSpec,
     NumericArraySpec,
     NumericEventTemplate,
-    OpaqueSpec,
     RecordSpec,
     TermSpec,
     ValueSpec,

--- a/probpipe/__init__.py
+++ b/probpipe/__init__.py
@@ -40,6 +40,8 @@ from probpipe.core._array_backend import (
 from probpipe.core._batch import Batch, BatchSpec
 from probpipe.core._distribution_array import DistributionArray
 from probpipe.core._function_batch import FunctionBatch
+from probpipe.core._numeric_array import NumericArray
+from probpipe.core._numeric_array_batch import NumericArrayBatch
 from probpipe.core._numeric_record import NumericRecord
 from probpipe.core._numeric_record_batch import NumericRecordBatch
 from probpipe.core._opaque_batch import OpaqueBatch
@@ -276,6 +278,8 @@ __all__ = [
     "NegativeBinomial",
     # Continuous
     "Normal",
+    "NumericArray",
+    "NumericArrayBatch",
     "NumericArraySpec",
     "NumericEventTemplate",
     "NumericJointEmpirical",

--- a/probpipe/core/_array_backend.py
+++ b/probpipe/core/_array_backend.py
@@ -147,6 +147,14 @@ class ArrayBackend:
     to_numpy : callable, optional
         ``to_numpy(obj) -> np.ndarray`` — the fingerprint materialisation.
         Defaults to ``np.asarray(obj)``.
+    take : callable, optional
+        ``take(obj, index) -> Any`` — **positional** selection along the
+        leading axes, where *index* is a tuple of ints and slices, one per
+        leading axis. Defaults to ``obj[index]``, which is positional for a
+        numpy-protocol container. A container whose ``[]`` means something else
+        must override it: ``pandas`` reads labels there, so its backend selects
+        through ``.iloc``. This is what lets a batch address its elements by
+        position without materialising the whole store.
     metadata : callable, optional
         ``metadata(obj) -> Any`` — the container's **identity-bearing
         metadata beyond its values** (an ``xarray`` array's dims / coords /
@@ -167,6 +175,7 @@ class ArrayBackend:
     is_numeric: Callable[[Any], bool] = field(kw_only=True, default=lambda obj: True)
     to_jax: Callable[[Any], jax.Array] = field(kw_only=True, default=_default_to_jax)
     to_numpy: Callable[[Any], np.ndarray] = field(kw_only=True, default=_default_to_numpy)
+    take: Callable[[Any, tuple], Any] = field(kw_only=True, default=lambda obj, index: obj[index])
     metadata: Callable[[Any], Any] = field(kw_only=True, default=lambda obj: None)
 
 
@@ -315,6 +324,20 @@ def _numpy_dtype_of(value: Any) -> np.dtype | None:
     if nd is None:
         nd = np.asarray(value).dtype
     return nd
+
+
+def _take_at(value: Any, index: tuple) -> Any:
+    """Select positionally along *value*'s leading axes.
+
+    The one place positional selection happens, so a container whose ``[]``
+    means something other than position — a ``pandas`` object, where it reads
+    labels — is addressed through its backend rather than by a caller that
+    happens to know.
+    """
+    backend = array_backend_for(value)
+    if backend is not None:
+        return backend.take(value, index)
+    return value[index]
 
 
 def _to_numpy_array(value: Any) -> np.ndarray:
@@ -483,6 +506,7 @@ def _register_pandas() -> None:
             is_numeric=lambda s: _column_numeric(s.dtype),
             to_jax=lambda s: jnp.asarray(_dense(s, (s.dtype,))),
             to_numpy=lambda s: _dense(s, (s.dtype,)),
+            take=lambda obj, index: obj.iloc[index],
             metadata=_series_metadata,
         ),
     )
@@ -511,6 +535,7 @@ def _register_pandas() -> None:
             is_numeric=_frame_is_numeric,
             to_jax=lambda df: jnp.asarray(_dense(df, df.dtypes)),
             to_numpy=lambda df: _dense(df, df.dtypes),
+            take=lambda obj, index: obj.iloc[index],
             metadata=_frame_metadata,
         ),
     )

--- a/probpipe/core/_fingerprint.py
+++ b/probpipe/core/_fingerprint.py
@@ -361,11 +361,11 @@ def _update_value_spec(
 ) -> None:
     """Hash a built-in ValueSpec by the declaration fields that define it."""
     from ._batch import BatchSpec
+    from ._opaque import OpaqueSpec
     from .event_template import (
         DistributionSpec,
         FunctionSpec,
         NumericArraySpec,
-        OpaqueSpec,
         RecordSpec,
     )
 

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -18,7 +18,6 @@ from ._array_backend import (
     _to_jax_array,
     _to_numpy_array,
 )
-from ._immutable import Immutable
 from .event_template import NumericArraySpec
 from .provenance import Provenance
 from .tracked import Annotated, TrackedTerm, auto_name
@@ -26,7 +25,7 @@ from .tracked import Annotated, TrackedTerm, auto_name
 __all__ = ["NumericArray"]
 
 
-class NumericArray(Immutable, TrackedTerm, Annotated):
+class NumericArray(TrackedTerm, Annotated):
     """One numeric array value, with identity.
 
     The tracked class of the numeric-array kind, as :class:`~probpipe.Record` is
@@ -38,11 +37,10 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
     Parameters
     ----------
     value : array-like
-        The array this names. **Stored verbatim in its native form** — a bare
-        array, an ``xarray`` / ``pandas`` container, or any registered backend —
-        so a lazy or disk-backed value is not materialised to be named. A bare
-        Python scalar carries no metadata and is normalised to a 0-d
-        ``jax.Array``.
+        The array this names, stored verbatim in its native form: a bare array,
+        an ``xarray`` / ``pandas`` container, or any registered backend, so a
+        lazy or disk-backed value stays lazy. A bare Python scalar carries no
+        metadata to read and is normalised to a 0-d ``jax.Array``.
     name : str, optional
         The value's name. Defaults to ``"numericarray"``, marked auto-derived.
     name_is_auto : bool, default False
@@ -64,21 +62,16 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
 
     Notes
     -----
-    Construction **validates without converting**, reading container metadata
-    only. Conversion to ``jax.Array`` happens at the compute boundary — the
-    pytree flatten that ``jit`` / ``vmap`` / ``grad`` traverse, and the explicit
-    conversion hooks — through a set-once cache, so the value materialises at
-    most once per instance. This is the storage rule
+    Construction validates against metadata alone, so the value materialises at
+    most once per instance and only at a compute boundary — the storage rule
     :class:`~probpipe.NumericRecord` follows for its leaves.
 
-    **Arithmetic yields a bare array**, not a ``NumericArray``. Identity is
-    attached by operations, and arithmetic is not one: a ``NumericArray`` is
-    what an operation hands back and what a caller computes *from*. The full
-    array surface is here — arithmetic, comparison, and the conversion hooks —
-    because with no fields and no field count ``arr + 1`` has exactly one
-    meaning, which is what lets :class:`~probpipe.Record` stay a container and
-    carry none of it. The operators forward to the stored value, so they return
-    **its** type: arithmetic on a numpy-backed one yields ``numpy``.
+    It carries the full array surface: arithmetic, comparison, and the
+    conversion hooks. With one value and no fields, ``arr + 1`` has a single
+    meaning, which is what lets :class:`~probpipe.Record` stay a container.
+    The operators forward to the stored value and return what it returns, so
+    arithmetic on a numpy-backed one yields ``numpy``, and identity stays with
+    the operations that attach it.
 
     Examples
     --------
@@ -147,9 +140,9 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
     def as_jax(self) -> Any:
         """The value as a ``jax.Array`` — the single conversion point.
 
-        A value already stored as one (a tracer inside a transform included)
-        passes through; a native container converts through its registered
-        backend exactly once, memoised for this instance.
+        A value already stored as one passes through, tracers included; a
+        native container converts through its registered backend once and is
+        memoised for this instance.
         """
         if isinstance(self._value, jax.Array):
             return self._value
@@ -173,13 +166,10 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
     def dtype(self) -> Any:
         """The stored value's dtype, or ``None`` when it has no single one.
 
-        The **value's**, not the declaration's, as for a single-field
-        ``NumericRecord``. These two can differ: ``is_valid`` admits a same-kind
-        cast, so a float32 value satisfies a float64 declaration. This shim
-        exists so a ``NumericArray`` can stand in for an array, and on an array
-        ``.dtype`` describes the data — a caller sizing a buffer or branching on
-        it must not be told the declaration instead. The declaration is
-        :attr:`spec`, and comparing the two is what makes the tolerance visible.
+        The value's rather than the declaration's, as for a single-field
+        ``NumericRecord``: a caller sizing a buffer or branching on the dtype is
+        asking about the data. The two can differ, since ``is_valid`` admits a
+        same-kind cast; :attr:`spec` carries the declaration.
         """
         return _numpy_dtype_of(self._value)
 
@@ -194,21 +184,14 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
         return f"NumericArray({self._value!r}, name={self.name!r})"
 
     # -- the array surface --------------------------------------------------
-    #
-    # Every operator returns what the underlying array returns, which is a bare
-    # array. ``_unwrap`` lets a NumericArray appear on either side.
-
-    @staticmethod
-    def _unwrap(other: Any) -> Any:
-        return other._value if isinstance(other, NumericArray) else other
 
     def __array__(self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
         arr = _to_numpy_array(self._value)
         arr = np.asarray(arr, dtype=dtype) if dtype is not None else arr
         return arr.copy() if copy else arr
 
-    # JAX reads ``__jax_array__`` for ``jnp.asarray``; without it the numpy
-    # hook above would win and tracing support would be lost.
+    # JAX reads this for ``jnp.asarray``; the numpy hook above would win
+    # otherwise and drop tracing.
     def __jax_array__(self) -> Any:
         return self.as_jax()
 
@@ -231,14 +214,16 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
         return iter(self._value)
 
 
+def _unwrap(other: Any) -> Any:
+    """The array inside a ``NumericArray``, or *other* unchanged."""
+    return other._value if isinstance(other, NumericArray) else other
+
+
 def _install_array_operators() -> None:
     """Forward the array operators to the held array, returning what it returns.
 
-    Written once rather than spelled out per operator: there are some forty of
-    them, they all do the same thing, and a hand-written list is where one gets
-    forgotten. The reflected and in-place forms come from the same table — an
-    in-place operator on an immutable term is the out-of-place one, and returns
-    a bare array like the rest.
+    Installed from a table so the forty of them stay one rule. An in-place
+    operator on an immutable term is the out-of-place one.
     """
     binary = [
         "add", "sub", "mul", "matmul", "truediv", "floordiv", "mod", "divmod",
@@ -249,14 +234,14 @@ def _install_array_operators() -> None:
 
     def _binary(name: str):
         def method(self: NumericArray, other: Any) -> Any:
-            return getattr(self._value, f"__{name}__")(NumericArray._unwrap(other))
+            return getattr(self._value, f"__{name}__")(_unwrap(other))
 
         method.__name__ = f"__{name}__"
         return method
 
     def _reflected(name: str):
         def method(self: NumericArray, other: Any) -> Any:
-            return getattr(self._value, f"__r{name}__")(NumericArray._unwrap(other))
+            return getattr(self._value, f"__r{name}__")(_unwrap(other))
 
         method.__name__ = f"__r{name}__"
         return method
@@ -271,8 +256,6 @@ def _install_array_operators() -> None:
     for op in binary:
         setattr(NumericArray, f"__{op}__", _binary(op))
         setattr(NumericArray, f"__r{op}__", _reflected(op))
-        # An in-place operator rebinds the caller's name to the bare result; the
-        # term itself is immutable and unchanged.
         setattr(NumericArray, f"__i{op}__", _binary(op))
     for op in comparison:
         setattr(NumericArray, f"__{op}__", _binary(op))
@@ -282,8 +265,7 @@ def _install_array_operators() -> None:
 
 _install_array_operators()
 
-# ``__eq__`` is elementwise, so the inherited ``__hash__`` would be a false
-# promise: two values comparing "equal" produce an array, not a bool.
+# ``__eq__`` is elementwise, so a hash would promise more than it can keep.
 NumericArray.__hash__ = None  # type: ignore[assignment]
 
 
@@ -292,40 +274,35 @@ NumericArray.__hash__ = None  # type: ignore[assignment]
 # ---------------------------------------------------------------------------
 
 
-def _numeric_array_flatten(value: NumericArray) -> tuple[list, tuple[str, bool, Any]]:
-    """Flatten for JAX traversal: the array, keyed by the identity and support.
+def _numeric_array_flatten(
+    value: NumericArray,
+) -> tuple[list, tuple[NumericArraySpec, str, bool]]:
+    """Flatten for JAX traversal: the array, keyed by the declaration and identity.
 
-    The **shape and dtype are not aux**, unlike a ``Record``'s template. A
-    ``NumericArray``'s spec is exactly its array's shape and dtype, so a
-    transform that changes either leaves the spec re-derivable from what
-    arrives — an exact reading, not the guess the record types must refuse.
-    What cannot be re-derived is the declared ``support``, which rides along.
+    The aux triple every tracked class flattens to. The declaration rides along
+    rather than being re-read off the child, because it is not recoverable from
+    one: ``is_valid`` admits a same-kind cast, so a float32 value under a
+    float64 declaration would come back declaring float32.
     """
     # The boundary presents a bare array, as a ``NumericRecord``'s does: this
     # is one of the compute boundaries native form converts at.
-    return [value.as_jax()], (value._name, value._name_is_auto, value._spec.support)
+    return [value.as_jax()], (value._spec, value._name, value._name_is_auto)
 
 
-def _numeric_array_unflatten(aux: tuple[str, bool, Any], children: list) -> NumericArray:
+def _numeric_array_unflatten(
+    aux: tuple[NumericArraySpec, str, bool], children: list
+) -> NumericArray:
     """Rebuild without converting or validating the child.
 
-    JAX unflattens with whatever it is carrying, which is not always an array:
-    ``tree_map(lambda x: None, value)`` builds a skeleton, and internal
-    traversals pass sentinel objects. Running the constructor here would convert
-    and validate, so those raise instead of rebuilding — the reason ``Record``
-    and ``RecordBatch`` take ``_validate_leaves=False`` on this same path. The
-    spec is derived only when the child can state one, and is left to the
-    constructor's own rule otherwise.
+    JAX unflattens with whatever it carries, and a skeleton from
+    ``tree_map(lambda x: None, value)`` or an internal sentinel is not an array
+    — the reason ``Record`` and ``RecordBatch`` take ``_validate_leaves=False``
+    on this path. A transform may also have resized the value, which is why the
+    spec a rebuilt value carries is the one it was declared with rather than one
+    read off the child: on this path a shape is transform-relative.
     """
-    name, name_is_auto, support = aux
+    spec, name, name_is_auto = aux
     (array,) = children
-    shape = getattr(array, "shape", None)
-    dtype = getattr(array, "dtype", None)
-    if shape is None or dtype is None:
-        # Not an array: a skeleton or a sentinel, which carries no spec to state.
-        spec = None
-    else:
-        spec = NumericArraySpec(shape=tuple(shape), dtype=dtype, support=support)
     value = object.__new__(NumericArray)
     object.__setattr__(value, "_value", array)
     object.__setattr__(value, "_spec", spec)

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -166,16 +166,26 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """The event shape, read from metadata. No batch axes are carried."""
-        return tuple(self._spec.shape)
+        """The event shape, read from the value's metadata. No batch axes."""
+        return _event_shape_of(self._value)
 
     @property
     def dtype(self) -> Any:
-        return self._spec.dtype
+        """The stored value's dtype, or ``None`` when it has no single one.
+
+        The **value's**, not the declaration's, as for a single-field
+        ``NumericRecord``. These two can differ: ``is_valid`` admits a same-kind
+        cast, so a float32 value satisfies a float64 declaration. This shim
+        exists so a ``NumericArray`` can stand in for an array, and on an array
+        ``.dtype`` describes the data — a caller sizing a buffer or branching on
+        it must not be told the declaration instead. The declaration is
+        :attr:`spec`, and comparing the two is what makes the tolerance visible.
+        """
+        return _numpy_dtype_of(self._value)
 
     @property
     def ndim(self) -> int:
-        return len(self._spec.shape)
+        return len(self.shape)
 
     def __len__(self) -> int:
         return len(self._value)

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import operator
 from typing import Any
 
+import jax
 import numpy as np
 
 from ._array_backend import _to_jax_array
@@ -236,3 +237,32 @@ _install_array_operators()
 # ``__eq__`` is elementwise, so the inherited ``__hash__`` would be a false
 # promise: two values comparing "equal" produce an array, not a bool.
 NumericArray.__hash__ = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# JAX PyTree registration
+# ---------------------------------------------------------------------------
+
+
+def _numeric_array_flatten(value: NumericArray) -> tuple[list, tuple[str, bool, Any]]:
+    """Flatten for JAX traversal: the array, keyed by the identity and support.
+
+    The **shape and dtype are not aux**, unlike a ``Record``'s template. A
+    ``NumericArray``'s spec is exactly its array's shape and dtype, so a
+    transform that changes either leaves the spec re-derivable from what
+    arrives — an exact reading, not the guess the record types must refuse.
+    What cannot be re-derived is the declared ``support``, which rides along.
+    """
+    return [value._value], (value._name, value._name_is_auto, value._spec.support)
+
+
+def _numeric_array_unflatten(aux: tuple[str, bool, Any], children: list) -> NumericArray:
+    name, name_is_auto, support = aux
+    (array,) = children
+    spec = None
+    if support is not None and hasattr(array, "shape") and hasattr(array, "dtype"):
+        spec = NumericArraySpec(shape=tuple(array.shape), dtype=array.dtype, support=support)
+    return NumericArray(array, name=name, name_is_auto=name_is_auto, spec=spec)
+
+
+jax.tree_util.register_pytree_node(NumericArray, _numeric_array_flatten, _numeric_array_unflatten)

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -1,0 +1,238 @@
+"""NumericArray — the tracked class of the numeric-array kind.
+
+See design III.1.
+"""
+
+from __future__ import annotations
+
+import operator
+from typing import Any
+
+import numpy as np
+
+from ._array_backend import _to_jax_array
+from ._immutable import Immutable
+from .event_template import NumericArraySpec
+from .provenance import Provenance
+from .tracked import Annotated, TrackedTerm, auto_name
+
+__all__ = ["NumericArray"]
+
+
+class NumericArray(Immutable, TrackedTerm, Annotated):
+    """One numeric array value, with identity.
+
+    The tracked class of the numeric-array kind, as :class:`~probpipe.Record` is
+    of the record kind: what an operation returns when its declared kind is a
+    :class:`~probpipe.NumericArraySpec`. It holds a single array and carries no
+    batch axes, so :attr:`shape` is the **event** shape; multiplicity lives in
+    :class:`~probpipe.NumericArrayBatch`.
+
+    Parameters
+    ----------
+    value : array-like
+        The array this names. Converted through the registered backend, so a
+        native leaf becomes a ``jax.Array`` at the same boundary every other
+        numeric conversion uses.
+    name : str, optional
+        The value's name. Defaults to ``"numericarray"``, marked auto-derived.
+    name_is_auto : bool, default False
+        Whether *name* is auto-derived rather than user-given. A value left
+        unnamed is auto-named regardless.
+    spec : NumericArraySpec, optional
+        What this value satisfies. Derived from the array's shape and dtype when
+        omitted, with an unconstrained support.
+    provenance : Provenance, optional
+        How this value was produced.
+
+    Raises
+    ------
+    TypeError
+        If *spec* is not a :class:`NumericArraySpec`, or if *value* does not
+        convert to an array.
+    ValueError
+        If *value*'s shape or dtype does not satisfy *spec*.
+
+    Notes
+    -----
+    **Arithmetic yields a bare array**, not a ``NumericArray``. Identity is
+    attached by operations, and arithmetic is not one: a ``NumericArray`` is
+    what an operation hands back and what a caller computes *from*. The full
+    array surface is here — arithmetic, comparison, and the conversion hooks —
+    because with no fields and no field count ``arr + 1`` has exactly one
+    meaning, which is what lets :class:`~probpipe.Record` stay a container and
+    carry none of it.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> value = NumericArray(jnp.arange(3.0), name="draw")
+    >>> value.shape
+    (3,)
+    >>> value + 1          # a bare array, not a NumericArray
+    Array([1., 2., 3.], dtype=float32)
+    """
+
+    __slots__ = (
+        "_annotations",
+        "_name",
+        "_name_is_auto",
+        "_provenance",
+        "_spec",
+        "_value",
+    )
+
+    def __init__(
+        self,
+        value: Any,
+        *,
+        name: str | None = None,
+        name_is_auto: bool = False,
+        spec: NumericArraySpec | None = None,
+        provenance: Provenance | None = None,
+    ) -> None:
+        if spec is not None and not isinstance(spec, NumericArraySpec):
+            raise TypeError(
+                f"NumericArray spec must be a NumericArraySpec, got {type(spec).__name__}"
+            )
+        try:
+            array = _to_jax_array(value)
+        except Exception as exc:
+            raise TypeError(
+                f"NumericArray holds one numeric array; {type(value).__name__} does not convert"
+            ) from exc
+        if spec is None:
+            spec = NumericArraySpec(shape=tuple(array.shape), dtype=array.dtype)
+        elif not spec.is_valid(array):
+            raise ValueError(
+                f"the array does not satisfy its declaration: shape {tuple(array.shape)} and "
+                f"dtype {array.dtype} against {spec}"
+            )
+        if name is None:
+            name, name_is_auto = auto_name(name, "numericarray")
+        object.__setattr__(self, "_value", array)
+        object.__setattr__(self, "_spec", spec)
+        self._init_tracked(name, name_is_auto=name_is_auto, provenance=provenance)
+
+    # -- what it holds ------------------------------------------------------
+
+    @property
+    def value(self) -> Any:
+        """The array itself, untracked."""
+        return self._value
+
+    @property
+    def spec(self) -> NumericArraySpec:
+        """This value's own declaration."""
+        return self._spec
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """The event shape. A ``NumericArray`` carries no batch axes."""
+        return tuple(self._value.shape)
+
+    @property
+    def dtype(self) -> Any:
+        return self._value.dtype
+
+    @property
+    def ndim(self) -> int:
+        return int(self._value.ndim)
+
+    def __len__(self) -> int:
+        return len(self._value)
+
+    def __repr__(self) -> str:
+        return f"NumericArray({self._value!r}, name={self.name!r})"
+
+    # -- the array surface --------------------------------------------------
+    #
+    # Every operator returns what the underlying array returns, which is a bare
+    # array. ``_unwrap`` lets a NumericArray appear on either side.
+
+    @staticmethod
+    def _unwrap(other: Any) -> Any:
+        return other._value if isinstance(other, NumericArray) else other
+
+    def __array__(self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
+        arr = np.asarray(self._value, dtype=dtype) if dtype is not None else np.asarray(self._value)
+        return arr.copy() if copy else arr
+
+    # JAX reads ``__jax_array__`` for ``jnp.asarray``; without it the numpy
+    # hook above would win and tracing support would be lost.
+    def __jax_array__(self) -> Any:
+        return self._value
+
+    def __float__(self) -> float:
+        return float(self._value)
+
+    def __int__(self) -> int:
+        return int(self._value)
+
+    def __bool__(self) -> bool:
+        return bool(self._value)
+
+    def __index__(self) -> int:
+        return operator.index(self._value)
+
+    def __getitem__(self, key: Any) -> Any:
+        return self._value[key]
+
+    def __iter__(self):
+        return iter(self._value)
+
+
+def _install_array_operators() -> None:
+    """Forward the array operators to the held array, returning what it returns.
+
+    Written once rather than spelled out per operator: there are some forty of
+    them, they all do the same thing, and a hand-written list is where one gets
+    forgotten. The reflected and in-place forms come from the same table — an
+    in-place operator on an immutable term is the out-of-place one, and returns
+    a bare array like the rest.
+    """
+    binary = [
+        "add", "sub", "mul", "matmul", "truediv", "floordiv", "mod", "divmod",
+        "pow", "lshift", "rshift", "and", "xor", "or",
+    ]  # fmt: skip
+    comparison = ["lt", "le", "eq", "ne", "gt", "ge"]
+    unary = ["neg", "pos", "abs", "invert"]
+
+    def _binary(name: str):
+        def method(self: NumericArray, other: Any) -> Any:
+            return getattr(self._value, f"__{name}__")(NumericArray._unwrap(other))
+
+        method.__name__ = f"__{name}__"
+        return method
+
+    def _reflected(name: str):
+        def method(self: NumericArray, other: Any) -> Any:
+            return getattr(self._value, f"__r{name}__")(NumericArray._unwrap(other))
+
+        method.__name__ = f"__r{name}__"
+        return method
+
+    def _unary(name: str):
+        def method(self: NumericArray) -> Any:
+            return getattr(self._value, f"__{name}__")()
+
+        method.__name__ = f"__{name}__"
+        return method
+
+    for op in binary:
+        setattr(NumericArray, f"__{op}__", _binary(op))
+        setattr(NumericArray, f"__r{op}__", _reflected(op))
+        # An in-place operator rebinds the caller's name to the bare result; the
+        # term itself is immutable and unchanged.
+        setattr(NumericArray, f"__i{op}__", _binary(op))
+    for op in comparison:
+        setattr(NumericArray, f"__{op}__", _binary(op))
+    for op in unary:
+        setattr(NumericArray, f"__{op}__", _unary(op))
+
+
+_install_array_operators()
+
+# ``__eq__`` is elementwise, so the inherited ``__hash__`` would be a false
+# promise: two values comparing "equal" produce an array, not a bool.
+NumericArray.__hash__ = None  # type: ignore[assignment]

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -20,7 +20,7 @@ from ._array_backend import (
 )
 from .event_template import NumericArraySpec
 from .provenance import Provenance
-from .tracked import Annotated, TrackedTerm, auto_name
+from .tracked import Annotated, TrackedTerm
 
 __all__ = ["NumericArray"]
 
@@ -41,11 +41,16 @@ class NumericArray(TrackedTerm, Annotated):
         an ``xarray`` / ``pandas`` container, or any registered backend, so a
         lazy or disk-backed value stays lazy. A bare Python scalar carries no
         metadata to read and is normalised to a 0-d ``jax.Array``.
-    name : str, optional
-        The value's name. Defaults to ``"numericarray"``, marked auto-derived.
+    name : str
+        The value's name, **required**, as a :class:`~probpipe.Record`'s and an
+        :class:`~probpipe.Opaque`'s are. A value carries no fields to describe it,
+        so the name is what says which one it is; a class-name default would name
+        every array in a pipeline alike. A caller that derives one says so with
+        *name_is_auto*.
     name_is_auto : bool, default False
-        Whether *name* is auto-derived rather than user-given. A value left
-        unnamed is auto-named regardless.
+        Whether *name* is auto-derived rather than user-given — set by an
+        operation that derives one, as the output boundary does when it names a
+        result after the function that produced it.
     spec : NumericArraySpec, optional
         What this value satisfies. Derived from the array's shape and dtype when
         omitted, with an unconstrained support.
@@ -100,7 +105,7 @@ class NumericArray(TrackedTerm, Annotated):
         self,
         value: Any,
         *,
-        name: str | None = None,
+        name: str,
         name_is_auto: bool = False,
         spec: NumericArraySpec | None = None,
         provenance: Provenance | None = None,
@@ -124,8 +129,6 @@ class NumericArray(TrackedTerm, Annotated):
                 f"the array does not satisfy its declaration: shape {shape} and "
                 f"dtype {dtype} against {spec}"
             )
-        if name is None:
-            name, name_is_auto = auto_name(name, "numericarray")
         object.__setattr__(self, "_value", stored)
         object.__setattr__(self, "_spec", spec)
         self._init_tracked(name, name_is_auto=name_is_auto, provenance=provenance)

--- a/probpipe/core/_numeric_array.py
+++ b/probpipe/core/_numeric_array.py
@@ -11,7 +11,13 @@ from typing import Any
 import jax
 import numpy as np
 
-from ._array_backend import _to_jax_array
+from ._array_backend import (
+    _event_shape_of,
+    _is_numeric_leaf,
+    _numpy_dtype_of,
+    _to_jax_array,
+    _to_numpy_array,
+)
 from ._immutable import Immutable
 from .event_template import NumericArraySpec
 from .provenance import Provenance
@@ -32,9 +38,11 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
     Parameters
     ----------
     value : array-like
-        The array this names. Converted through the registered backend, so a
-        native leaf becomes a ``jax.Array`` at the same boundary every other
-        numeric conversion uses.
+        The array this names. **Stored verbatim in its native form** — a bare
+        array, an ``xarray`` / ``pandas`` container, or any registered backend —
+        so a lazy or disk-backed value is not materialised to be named. A bare
+        Python scalar carries no metadata and is normalised to a 0-d
+        ``jax.Array``.
     name : str, optional
         The value's name. Defaults to ``"numericarray"``, marked auto-derived.
     name_is_auto : bool, default False
@@ -49,20 +57,28 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
     Raises
     ------
     TypeError
-        If *spec* is not a :class:`NumericArraySpec`, or if *value* does not
-        convert to an array.
+        If *spec* is not a :class:`NumericArraySpec`, or if *value* is not a
+        numeric leaf.
     ValueError
         If *value*'s shape or dtype does not satisfy *spec*.
 
     Notes
     -----
+    Construction **validates without converting**, reading container metadata
+    only. Conversion to ``jax.Array`` happens at the compute boundary — the
+    pytree flatten that ``jit`` / ``vmap`` / ``grad`` traverse, and the explicit
+    conversion hooks — through a set-once cache, so the value materialises at
+    most once per instance. This is the storage rule
+    :class:`~probpipe.NumericRecord` follows for its leaves.
+
     **Arithmetic yields a bare array**, not a ``NumericArray``. Identity is
     attached by operations, and arithmetic is not one: a ``NumericArray`` is
     what an operation hands back and what a caller computes *from*. The full
     array surface is here — arithmetic, comparison, and the conversion hooks —
     because with no fields and no field count ``arr + 1`` has exactly one
     meaning, which is what lets :class:`~probpipe.Record` stay a container and
-    carry none of it.
+    carry none of it. The operators forward to the stored value, so they return
+    **its** type: arithmetic on a numpy-backed one yields ``numpy``.
 
     Examples
     --------
@@ -76,12 +92,16 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
 
     __slots__ = (
         "_annotations",
+        "_jax_cache",
         "_name",
         "_name_is_auto",
         "_provenance",
         "_spec",
         "_value",
     )
+
+    #: Derived from the value rather than transported, as for ``NumericRecord``.
+    _transient_state = ("_jax_cache",)
 
     def __init__(
         self,
@@ -96,22 +116,24 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
             raise TypeError(
                 f"NumericArray spec must be a NumericArraySpec, got {type(spec).__name__}"
             )
-        try:
-            array = _to_jax_array(value)
-        except Exception as exc:
+        if not _is_numeric_leaf(value):
             raise TypeError(
-                f"NumericArray holds one numeric array; {type(value).__name__} does not convert"
-            ) from exc
+                f"NumericArray holds one numeric array; {type(value).__name__} is not a numeric leaf"
+            )
+        # A bare Python scalar carries no metadata to read, so it is the one
+        # thing normalised at construction — as ``NumericRecord`` normalises it.
+        stored = _to_jax_array(value) if isinstance(value, (int, float, complex, bool)) else value
+        shape, dtype = _event_shape_of(stored), _numpy_dtype_of(stored)
         if spec is None:
-            spec = NumericArraySpec(shape=tuple(array.shape), dtype=array.dtype)
-        elif not spec.is_valid(array):
+            spec = NumericArraySpec(shape=shape, dtype=dtype)
+        elif not spec.is_valid(stored):
             raise ValueError(
-                f"the array does not satisfy its declaration: shape {tuple(array.shape)} and "
-                f"dtype {array.dtype} against {spec}"
+                f"the array does not satisfy its declaration: shape {shape} and "
+                f"dtype {dtype} against {spec}"
             )
         if name is None:
             name, name_is_auto = auto_name(name, "numericarray")
-        object.__setattr__(self, "_value", array)
+        object.__setattr__(self, "_value", stored)
         object.__setattr__(self, "_spec", spec)
         self._init_tracked(name, name_is_auto=name_is_auto, provenance=provenance)
 
@@ -119,8 +141,23 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
 
     @property
     def value(self) -> Any:
-        """The array itself, untracked."""
+        """The stored value, in the form it was given. Untracked."""
         return self._value
+
+    def as_jax(self) -> Any:
+        """The value as a ``jax.Array`` — the single conversion point.
+
+        A value already stored as one (a tracer inside a transform included)
+        passes through; a native container converts through its registered
+        backend exactly once, memoised for this instance.
+        """
+        if isinstance(self._value, jax.Array):
+            return self._value
+        cached = getattr(self, "_jax_cache", None)
+        if cached is None:
+            cached = _to_jax_array(self._value)
+            object.__setattr__(self, "_jax_cache", cached)
+        return cached
 
     @property
     def spec(self) -> NumericArraySpec:
@@ -129,16 +166,16 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """The event shape. A ``NumericArray`` carries no batch axes."""
-        return tuple(self._value.shape)
+        """The event shape, read from metadata. No batch axes are carried."""
+        return tuple(self._spec.shape)
 
     @property
     def dtype(self) -> Any:
-        return self._value.dtype
+        return self._spec.dtype
 
     @property
     def ndim(self) -> int:
-        return int(self._value.ndim)
+        return len(self._spec.shape)
 
     def __len__(self) -> int:
         return len(self._value)
@@ -156,25 +193,26 @@ class NumericArray(Immutable, TrackedTerm, Annotated):
         return other._value if isinstance(other, NumericArray) else other
 
     def __array__(self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
-        arr = np.asarray(self._value, dtype=dtype) if dtype is not None else np.asarray(self._value)
+        arr = _to_numpy_array(self._value)
+        arr = np.asarray(arr, dtype=dtype) if dtype is not None else arr
         return arr.copy() if copy else arr
 
     # JAX reads ``__jax_array__`` for ``jnp.asarray``; without it the numpy
     # hook above would win and tracing support would be lost.
     def __jax_array__(self) -> Any:
-        return self._value
+        return self.as_jax()
 
     def __float__(self) -> float:
-        return float(self._value)
+        return float(self.as_jax())
 
     def __int__(self) -> int:
-        return int(self._value)
+        return int(self.as_jax())
 
     def __bool__(self) -> bool:
-        return bool(self._value)
+        return bool(self.as_jax())
 
     def __index__(self) -> int:
-        return operator.index(self._value)
+        return operator.index(self.as_jax())
 
     def __getitem__(self, key: Any) -> Any:
         return self._value[key]
@@ -253,16 +291,36 @@ def _numeric_array_flatten(value: NumericArray) -> tuple[list, tuple[str, bool, 
     arrives — an exact reading, not the guess the record types must refuse.
     What cannot be re-derived is the declared ``support``, which rides along.
     """
-    return [value._value], (value._name, value._name_is_auto, value._spec.support)
+    # The boundary presents a bare array, as a ``NumericRecord``'s does: this
+    # is one of the compute boundaries native form converts at.
+    return [value.as_jax()], (value._name, value._name_is_auto, value._spec.support)
 
 
 def _numeric_array_unflatten(aux: tuple[str, bool, Any], children: list) -> NumericArray:
+    """Rebuild without converting or validating the child.
+
+    JAX unflattens with whatever it is carrying, which is not always an array:
+    ``tree_map(lambda x: None, value)`` builds a skeleton, and internal
+    traversals pass sentinel objects. Running the constructor here would convert
+    and validate, so those raise instead of rebuilding — the reason ``Record``
+    and ``RecordBatch`` take ``_validate_leaves=False`` on this same path. The
+    spec is derived only when the child can state one, and is left to the
+    constructor's own rule otherwise.
+    """
     name, name_is_auto, support = aux
     (array,) = children
-    spec = None
-    if support is not None and hasattr(array, "shape") and hasattr(array, "dtype"):
-        spec = NumericArraySpec(shape=tuple(array.shape), dtype=array.dtype, support=support)
-    return NumericArray(array, name=name, name_is_auto=name_is_auto, spec=spec)
+    shape = getattr(array, "shape", None)
+    dtype = getattr(array, "dtype", None)
+    if shape is None or dtype is None:
+        # Not an array: a skeleton or a sentinel, which carries no spec to state.
+        spec = None
+    else:
+        spec = NumericArraySpec(shape=tuple(shape), dtype=dtype, support=support)
+    value = object.__new__(NumericArray)
+    object.__setattr__(value, "_value", array)
+    object.__setattr__(value, "_spec", spec)
+    value._init_tracked(name, name_is_auto=name_is_auto)
+    return value
 
 
 jax.tree_util.register_pytree_node(NumericArray, _numeric_array_flatten, _numeric_array_unflatten)

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -8,9 +8,17 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Self
 
+import jax
 import numpy as np
 
-from ._array_backend import _event_shape_of, _is_numeric_leaf, _numpy_dtype_of, _take_at
+from ._array_backend import (
+    _event_shape_of,
+    _is_numeric_leaf,
+    _numpy_dtype_of,
+    _take_at,
+    _to_jax_array,
+    _to_numpy_array,
+)
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._numeric_array import NumericArray
 from .event_template import NumericArraySpec
@@ -40,10 +48,15 @@ class NumericArrayBatch(Batch[NumericArray]):
     axis_groups : iterable of iterable of int, optional
         The axis sizes each level holds, in order, tiling ``batch_shape``.
         Defaults to one axis per level.
-    name : str, optional
-        The batch's name; defaults to ``"numericarraybatch"``, marked auto.
+    name : str
+        The batch's name, **required**, as a :class:`~probpipe.Record`'s and an
+        :class:`~probpipe.Opaque`'s are. A batch is what an operation hands back,
+        and the name is what says which one it is; a class-name default would name
+        every batch in a pipeline alike. A caller that derives one says so with
+        *name_is_auto*.
     name_is_auto : bool, default False
-        Whether *name* is auto-derived rather than user-given.
+        Whether *name* is auto-derived rather than user-given — set by an
+        operation that derives one, as a view does for a selected sub-batch.
     provenance : Provenance, optional
         How this batch was produced.
 
@@ -54,7 +67,9 @@ class NumericArrayBatch(Batch[NumericArray]):
         not convert to an array.
     TypeError
         Also if the stored array's dtype is one the declared element does not
-        admit — a cross-kind conversion.
+        admit — a cross-kind conversion — or if the store reports no single
+        dtype while the element declares one, which leaves the claim
+        unsubstantiated.
     ValueError
         If *values* has fewer axes than the event shape it must end with, which
         would leave no batch axis; if its trailing axes are not that event
@@ -79,7 +94,7 @@ class NumericArrayBatch(Batch[NumericArray]):
         *,
         element_spec: NumericArraySpec,
         axis_groups: Iterable[Iterable[int]] | None = None,
-        name: str | None = None,
+        name: str,
         name_is_auto: bool = False,
         provenance: Provenance | None = None,
     ) -> None:
@@ -105,12 +120,18 @@ class NumericArrayBatch(Batch[NumericArray]):
                 f"the stored array ends with {stored[len(stored) - n_event :]} where its "
                 f"elements declare the event shape {event_shape}"
             )
-        # The batch asserts *element_spec* of every element, so a column whose
-        # dtype the declaration does not admit makes that assertion false. Caught
-        # here rather than at the first selection, which is where NumericArray
-        # would otherwise raise — one layer too late to name the batch.
+        # The batch asserts *element_spec* of every element, so the store's own
+        # dtype has to satisfy it.
         dtype = _numpy_dtype_of(values)
-        if element_spec.dtype is not None and dtype is not None:
+        if element_spec.dtype is not None:
+            if dtype is None:
+                # A heterogeneous store has no single dtype to check a pinned
+                # one against, so the claim is unsupportable either way.
+                raise TypeError(
+                    f"the stored array reports no single dtype, so the declared element "
+                    f"{np.dtype(element_spec.dtype)} cannot be shown to hold of it; declare "
+                    f"no dtype, or store a container that has one"
+                )
             if not np.can_cast(dtype, element_spec.dtype, casting="same_kind"):
                 raise TypeError(
                     f"the stored array has dtype {dtype}, which the declared element "
@@ -127,8 +148,6 @@ class NumericArrayBatch(Batch[NumericArray]):
 
         names = (level_names,) if isinstance(level_names, str) else tuple(level_names)
         groups = _axis_groups_for(batch_shape, names, axis_groups, kind="NumericArrayBatch")
-        if name is None:
-            name, name_is_auto = "numericarraybatch", True
         object.__setattr__(self, "_values", values)
         self._init_batch(
             BatchSpec(element_spec, groups, names),
@@ -151,9 +170,31 @@ class NumericArrayBatch(Batch[NumericArray]):
         """The stored array, batch axes leading, in native form. Untracked."""
         return self._values
 
+    # -- the array shim, as ``NumericRecordBatch`` carries from its sole field.
+    # ``batch_shape`` / ``batch_size`` stay the names for the batch axes alone.
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """The store's full shape, ``(*batch_shape, *event_shape)``."""
+        return tuple(_event_shape_of(self._values))
+
     @property
     def dtype(self) -> Any:
-        return self.element_spec.dtype
+        """The store's dtype — the value's, as a :class:`NumericArray`'s is."""
+        return _numpy_dtype_of(self._values)
+
+    @property
+    def ndim(self) -> int:
+        """The rank of the store, batch axes included."""
+        return len(self.shape)
+
+    def __array__(self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
+        arr = _to_numpy_array(self._values)
+        arr = np.asarray(arr, dtype=dtype) if dtype is not None else arr
+        return arr.copy() if copy else arr
+
+    def __jax_array__(self) -> Any:
+        return _to_jax_array(self._values)
 
     def __repr__(self) -> str:
         return (
@@ -166,14 +207,11 @@ class NumericArrayBatch(Batch[NumericArray]):
     def _element_at(self, index: tuple[int, ...], *, name: str) -> NumericArray:
         """The array at a fully-integer positional *index*, as a `NumericArray`.
 
-        Selection is positional and goes through the value's backend, since
-        ``[]`` reads labels rather than positions on a ``pandas`` container.
-
-        Indexing a stored array does not produce the element on its own — the
-        element is the *tracked* value around it — so this is the materializing
-        side of both rules :meth:`~probpipe.core._batch.Batch._element_at`
-        states: it takes the derived *name*, marked auto, and inherits this
-        batch's provenance.
+        The materializing side of both rules
+        :meth:`~probpipe.core._batch.Batch._element_at` states: the element
+        takes the derived *name*, marked auto, and inherits this batch's
+        provenance. Selection goes through the backend, since ``[]`` is
+        positional only on a numpy-protocol container.
         """
         return self._inherit_provenance(
             NumericArray(
@@ -198,3 +236,57 @@ class NumericArrayBatch(Batch[NumericArray]):
         object.__setattr__(view, "_values", _take_at(self._values, index))
         view._init_batch(spec, name=name, name_is_auto=True)
         return view
+
+
+# ---------------------------------------------------------------------------
+# JAX PyTree registration
+# ---------------------------------------------------------------------------
+
+
+def _numeric_array_batch_flatten(batch: NumericArrayBatch):
+    """Flatten for JAX traversal: the store, keyed by the aux spec."""
+    return [batch._values], (batch._spec, batch._name, batch._name_is_auto)
+
+
+def _numeric_array_batch_unflatten(aux, children):
+    """Rebuild over the transformations a batch can state honestly.
+
+    The contract ``RecordBatch`` states, over one column instead of many. A
+    treedef carries neither ``in_axes`` nor ``out_axes``, so which level a
+    transform consumed is unrecoverable — *a shape is not a provenance* — and
+    two transformations are supported:
+
+    - **Every batch axis preserved**, the ordinary round trip, reusing the spec.
+    - **Every batch axis removed**: the value is one element, so a
+      :class:`NumericArray` is returned.
+    """
+    spec, name, name_is_auto = aux
+    (values,) = children
+    element_spec = spec.element_spec
+    event_rank = len(element_spec.shape)
+    shape = getattr(values, "shape", None)
+    if shape is None:
+        # A skeleton or sentinel has no shape to measure; rebuilt verbatim.
+        view = object.__new__(NumericArrayBatch)
+        object.__setattr__(view, "_values", values)
+        view._init_batch(spec, name=name, name_is_auto=name_is_auto)
+        return view
+    surviving = tuple(shape)[: len(shape) - event_rank] if event_rank else tuple(shape)
+    if surviving == tuple(spec.batch_shape):
+        view = object.__new__(NumericArrayBatch)
+        object.__setattr__(view, "_values", values)
+        view._init_batch(spec, name=name, name_is_auto=name_is_auto)
+        return view
+    if not surviving:
+        return NumericArray(values, name=name, name_is_auto=name_is_auto, spec=element_spec)
+    raise ValueError(
+        f"a transform left this NumericArrayBatch over {surviving} where its levels account "
+        f"for {tuple(spec.batch_shape)}. A batch keeps every batch axis or removes all of "
+        f"them, since an added or resized axis belongs to no level and unflattening has no "
+        f"name to give one; build the batch where the axis is added, or map over its store"
+    )
+
+
+jax.tree_util.register_pytree_node(
+    NumericArrayBatch, _numeric_array_batch_flatten, _numeric_array_batch_unflatten
+)

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Self
 
-from ._array_backend import _event_shape_of, _is_numeric_leaf
+import numpy as np
+
+from ._array_backend import _event_shape_of, _is_numeric_leaf, _numpy_dtype_of, _take_at
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._numeric_array import NumericArray
 from .event_template import NumericArraySpec
@@ -50,6 +52,9 @@ class NumericArrayBatch(Batch[NumericArray]):
     TypeError
         If *element_spec* is not a :class:`NumericArraySpec`, or *values* does
         not convert to an array.
+    TypeError
+        Also if the stored array's dtype is one the declared element does not
+        admit — a cross-kind conversion.
     ValueError
         If *values* has fewer axes than the event shape it must end with, which
         would leave no batch axis; if its trailing axes are not that event
@@ -100,6 +105,18 @@ class NumericArrayBatch(Batch[NumericArray]):
                 f"the stored array ends with {stored[len(stored) - n_event :]} where its "
                 f"elements declare the event shape {event_shape}"
             )
+        # The batch asserts *element_spec* of every element, so a column whose
+        # dtype the declaration does not admit makes that assertion false. Caught
+        # here rather than at the first selection, which is where NumericArray
+        # would otherwise raise — one layer too late to name the batch.
+        dtype = _numpy_dtype_of(values)
+        if element_spec.dtype is not None and dtype is not None:
+            if not np.can_cast(dtype, element_spec.dtype, casting="same_kind"):
+                raise TypeError(
+                    f"the stored array has dtype {dtype}, which the declared element "
+                    f"{np.dtype(element_spec.dtype)} does not admit; a widening or a "
+                    f"within-kind narrowing passes, a cross-kind conversion does not"
+                )
         batch_shape = stored[: len(stored) - n_event] if n_event else stored
         if not batch_shape:
             raise ValueError(
@@ -149,6 +166,9 @@ class NumericArrayBatch(Batch[NumericArray]):
     def _element_at(self, index: tuple[int, ...], *, name: str) -> NumericArray:
         """The array at a fully-integer positional *index*, as a `NumericArray`.
 
+        Selection is positional and goes through the value's backend, since
+        ``[]`` reads labels rather than positions on a ``pandas`` container.
+
         Indexing a stored array does not produce the element on its own — the
         element is the *tracked* value around it — so this is the materializing
         side of both rules :meth:`~probpipe.core._batch.Batch._element_at`
@@ -157,7 +177,7 @@ class NumericArrayBatch(Batch[NumericArray]):
         """
         return self._inherit_provenance(
             NumericArray(
-                self._values[index],
+                _take_at(self._values, index),
                 name=name,
                 name_is_auto=True,
                 spec=self.element_spec,
@@ -168,12 +188,13 @@ class NumericArrayBatch(Batch[NumericArray]):
         """A view over the same array, indexed on the batch axes as given.
 
         *index* addresses the leading axes only, so the event axes are untouched
-        and array indexing yields a view rather than a copy. Built without
+        and selection yields a view rather than a copy. It goes through the
+        value's backend, since ``[]`` is not positional on every container. Built without
         ``__init__`` for the reason ``RecordBatch`` gives: the spec and the name
         are already decided, and re-deriving them from the view's own shape
         would lose the levels a dropped axis came from.
         """
         view = object.__new__(self._view_type)
-        object.__setattr__(view, "_values", self._values[index])
+        object.__setattr__(view, "_values", _take_at(self._values, index))
         view._init_batch(spec, name=name, name_is_auto=True)
         return view

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Self
 
-from ._array_backend import _to_jax_array
+from ._array_backend import _event_shape_of, _is_numeric_leaf
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._numeric_array import NumericArray
 from .event_template import NumericArraySpec
@@ -28,6 +28,8 @@ class NumericArrayBatch(Batch[NumericArray]):
     ----------
     values : array-like
         One array holding every element, shaped ``(*batch_shape, *event_shape)``.
+        Stored verbatim in its native form, as a :class:`NumericArray`'s value
+        is, so a lazy or disk-backed column is not materialised to be batched.
     level_names : str or iterable of str
         One name per level, outermost first; a single string names one level.
     element_spec : NumericArraySpec
@@ -87,14 +89,11 @@ class NumericArrayBatch(Batch[NumericArray]):
                 f"a symbolic dimension gives the event shape no size to split the stored "
                 f"axes by; bind {element_spec.shape} with with_dims before batching"
             )
-        try:
-            array = _to_jax_array(values)
-        except Exception as exc:
+        if not _is_numeric_leaf(values):
             raise TypeError(
-                f"NumericArrayBatch stores one array; {type(values).__name__} does not convert"
-            ) from exc
-
-        stored = tuple(array.shape)
+                f"NumericArrayBatch stores one array; {type(values).__name__} is not a numeric leaf"
+            )
+        stored = _event_shape_of(values)
         n_event = len(event_shape)
         if n_event and stored[len(stored) - n_event :] != event_shape:
             raise ValueError(
@@ -113,7 +112,7 @@ class NumericArrayBatch(Batch[NumericArray]):
         groups = _axis_groups_for(batch_shape, names, axis_groups, kind="NumericArrayBatch")
         if name is None:
             name, name_is_auto = "numericarraybatch", True
-        object.__setattr__(self, "_values", array)
+        object.__setattr__(self, "_values", values)
         self._init_batch(
             BatchSpec(element_spec, groups, names),
             name=name,
@@ -132,12 +131,12 @@ class NumericArrayBatch(Batch[NumericArray]):
 
     @property
     def values(self) -> Any:
-        """The stored array, batch axes leading. Untracked."""
+        """The stored array, batch axes leading, in native form. Untracked."""
         return self._values
 
     @property
     def dtype(self) -> Any:
-        return self._values.dtype
+        return self.element_spec.dtype
 
     def __repr__(self) -> str:
         return (
@@ -174,7 +173,7 @@ class NumericArrayBatch(Batch[NumericArray]):
         are already decided, and re-deriving them from the view's own shape
         would lose the levels a dropped axis came from.
         """
-        view = object.__new__(type(self))
+        view = object.__new__(self._view_type)
         object.__setattr__(view, "_values", self._values[index])
         view._init_batch(spec, name=name, name_is_auto=True)
         return view

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -1,0 +1,180 @@
+"""NumericArrayBatch — the batch form of the numeric-array kind.
+
+See design III.1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Self
+
+from ._array_backend import _to_jax_array
+from ._batch import Batch, BatchSpec, _axis_groups_for
+from ._numeric_array import NumericArray
+from .event_template import NumericArraySpec
+from .provenance import Provenance
+
+__all__ = ["NumericArrayBatch"]
+
+
+class NumericArrayBatch(Batch[NumericArray]):
+    """A batch of numeric arrays sharing one :class:`NumericArraySpec`.
+
+    Storage is a single array with the batch axes leading — the split
+    :class:`~probpipe.RecordBatch` uses, with one column instead of many. This
+    is where a `draw` level lives for an array-valued law.
+
+    Parameters
+    ----------
+    values : array-like
+        One array holding every element, shaped ``(*batch_shape, *event_shape)``.
+    level_names : str or iterable of str
+        One name per level, outermost first; a single string names one level.
+    element_spec : NumericArraySpec
+        What every element satisfies. Its ``shape`` is the event shape, so it is
+        what splits the stored array's axes into batch and event.
+    axis_groups : iterable of iterable of int, optional
+        The axis sizes each level holds, in order, tiling ``batch_shape``.
+        Defaults to one axis per level.
+    name : str, optional
+        The batch's name; defaults to ``"numericarraybatch"``, marked auto.
+    name_is_auto : bool, default False
+        Whether *name* is auto-derived rather than user-given.
+    provenance : Provenance, optional
+        How this batch was produced.
+
+    Raises
+    ------
+    TypeError
+        If *element_spec* is not a :class:`NumericArraySpec`, or *values* does
+        not convert to an array.
+    ValueError
+        If *values* has fewer axes than the event shape it must end with, which
+        would leave no batch axis; if its trailing axes are not that event
+        shape; if a declared dimension is symbolic, which gives the event shape
+        no size to split by; or if *axis_groups* does not tile ``batch_shape``.
+
+    Notes
+    -----
+    Selection yields the element kind, as it does for every batch:
+    ``batch[i]`` is a :class:`NumericArray`. It materializes, so each element
+    takes the derived name and inherits this batch's lineage.
+    """
+
+    _values: Any
+
+    __slots__ = ("_values",)
+
+    def __init__(
+        self,
+        values: Any,
+        level_names: str | Iterable[str],
+        *,
+        element_spec: NumericArraySpec,
+        axis_groups: Iterable[Iterable[int]] | None = None,
+        name: str | None = None,
+        name_is_auto: bool = False,
+        provenance: Provenance | None = None,
+    ) -> None:
+        if not isinstance(element_spec, NumericArraySpec):
+            raise TypeError(
+                f"NumericArrayBatch element_spec must be a NumericArraySpec, "
+                f"got {type(element_spec).__name__}"
+            )
+        event_shape = tuple(element_spec.shape)
+        if any(not isinstance(axis, int) for axis in event_shape):
+            raise ValueError(
+                f"a symbolic dimension gives the event shape no size to split the stored "
+                f"axes by; bind {element_spec.shape} with with_dims before batching"
+            )
+        try:
+            array = _to_jax_array(values)
+        except Exception as exc:
+            raise TypeError(
+                f"NumericArrayBatch stores one array; {type(values).__name__} does not convert"
+            ) from exc
+
+        stored = tuple(array.shape)
+        n_event = len(event_shape)
+        if n_event and stored[len(stored) - n_event :] != event_shape:
+            raise ValueError(
+                f"the stored array ends with {stored[len(stored) - n_event :]} where its "
+                f"elements declare the event shape {event_shape}"
+            )
+        batch_shape = stored[: len(stored) - n_event] if n_event else stored
+        if not batch_shape:
+            raise ValueError(
+                f"a batch has at least one batch axis, and an array of shape {stored} over "
+                f"elements of event shape {event_shape} leaves none; a single value is a "
+                f"NumericArray"
+            )
+
+        names = (level_names,) if isinstance(level_names, str) else tuple(level_names)
+        groups = _axis_groups_for(batch_shape, names, axis_groups, kind="NumericArrayBatch")
+        if name is None:
+            name, name_is_auto = "numericarraybatch", True
+        object.__setattr__(self, "_values", array)
+        self._init_batch(
+            BatchSpec(element_spec, groups, names),
+            name=name,
+            name_is_auto=name_is_auto,
+            provenance=provenance,
+        )
+
+    # -- what it holds ------------------------------------------------------
+
+    @property
+    def element_spec(self) -> NumericArraySpec:
+        """What every element satisfies — a view on :attr:`spec`."""
+        spec = self.spec.element_spec
+        assert isinstance(spec, NumericArraySpec)
+        return spec
+
+    @property
+    def values(self) -> Any:
+        """The stored array, batch axes leading. Untracked."""
+        return self._values
+
+    @property
+    def dtype(self) -> Any:
+        return self._values.dtype
+
+    def __repr__(self) -> str:
+        return (
+            f"NumericArrayBatch(batch_shape={self.batch_shape}, "
+            f"levels={self.level_names}, event_shape={tuple(self.element_spec.shape)})"
+        )
+
+    # -- the concrete-storage seam ------------------------------------------
+
+    def _element_at(self, index: tuple[int, ...], *, name: str) -> NumericArray:
+        """The array at a fully-integer positional *index*, as a `NumericArray`.
+
+        Indexing a stored array does not produce the element on its own — the
+        element is the *tracked* value around it — so this is the materializing
+        side of both rules :meth:`~probpipe.core._batch.Batch._element_at`
+        states: it takes the derived *name*, marked auto, and inherits this
+        batch's provenance.
+        """
+        return self._inherit_provenance(
+            NumericArray(
+                self._values[index],
+                name=name,
+                name_is_auto=True,
+                spec=self.element_spec,
+            )
+        )
+
+    def _sub_batch_at(self, index: tuple[int | slice, ...], *, spec: BatchSpec, name: str) -> Self:
+        """A view over the same array, indexed on the batch axes as given.
+
+        *index* addresses the leading axes only, so the event axes are untouched
+        and array indexing yields a view rather than a copy. Built without
+        ``__init__`` for the reason ``RecordBatch`` gives: the spec and the name
+        are already decided, and re-deriving them from the view's own shape
+        would lose the levels a dropped axis came from.
+        """
+        view = object.__new__(type(self))
+        object.__setattr__(view, "_values", self._values[index])
+        view._init_batch(spec, name=name, name_is_auto=True)
+        return view

--- a/probpipe/core/_opaque.py
+++ b/probpipe/core/_opaque.py
@@ -1,0 +1,109 @@
+"""Opaque — the tracked class of the opaque kind.
+
+See design III.1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ._immutable import Immutable
+from .event_template import OpaqueSpec
+from .provenance import Provenance
+from .tracked import Annotated, TrackedTerm, auto_name
+
+__all__ = ["Opaque"]
+
+
+class Opaque(Immutable, TrackedTerm, Annotated):
+    """One value of no exposed structure, with identity.
+
+    The tracked class of the opaque kind, as :class:`~probpipe.Record` is of the
+    record kind: what an operation returns when its declared kind is an
+    :class:`~probpipe.OpaqueSpec`. Its batch form is
+    :class:`~probpipe.OpaqueBatch`, which already existed — a batch is a tracked
+    term whatever its elements are, which is why the collection had a class
+    before the element did.
+
+    **It adds identity and nothing else.** No attribute forwarding, no
+    ``__call__``, no operators: the wrapped value is reached through
+    :attr:`value`, explicitly. A box that forwards to be convenient is
+    indistinguishable from the value it wraps, and then the wrapping is a
+    surprise rather than a statement — so this one does not. What an opaque
+    value affords is whatever its own type affords, once it is out.
+
+    Parameters
+    ----------
+    value : Any
+        The value this names. Held as given, never converted or copied — there
+        is nothing to convert it to. Anything but a mapping, which the value
+        layer reads as a subtree rather than a leaf.
+    name : str, optional
+        The value's name. Defaults to ``"opaque"``, marked auto-derived.
+    name_is_auto : bool, default False
+        Whether *name* is auto-derived rather than user-given. A value left
+        unnamed is auto-named regardless.
+    spec : OpaqueSpec, optional
+        What this value satisfies, carrying any opaque ``meta``. Defaults to a
+        bare :class:`~probpipe.OpaqueSpec`.
+    provenance : Provenance, optional
+        How this value was produced.
+
+    Raises
+    ------
+    TypeError
+        If *spec* is not an :class:`~probpipe.OpaqueSpec`, or if *value* is a
+        mapping.
+
+    Examples
+    --------
+    >>> fitted = Opaque(object(), name="sklearn_model")
+    >>> fitted.name
+    'sklearn_model'
+    """
+
+    __slots__ = (
+        "_annotations",
+        "_name",
+        "_name_is_auto",
+        "_provenance",
+        "_spec",
+        "_value",
+    )
+
+    def __init__(
+        self,
+        value: Any,
+        *,
+        name: str | None = None,
+        name_is_auto: bool = False,
+        spec: OpaqueSpec | None = None,
+        provenance: Provenance | None = None,
+    ) -> None:
+        if spec is not None and not isinstance(spec, OpaqueSpec):
+            raise TypeError(f"Opaque spec must be an OpaqueSpec, got {type(spec).__name__}")
+        if isinstance(value, Mapping):
+            raise TypeError(
+                "Opaque holds one unstructured value, and the value layer reads a mapping as a "
+                "subtree rather than a leaf; wrap it as a Record, or as a non-mapping value"
+            )
+        spec = OpaqueSpec() if spec is None else spec
+        if name is None:
+            name, name_is_auto = auto_name(name, "opaque")
+        object.__setattr__(self, "_value", value)
+        object.__setattr__(self, "_spec", spec)
+        self._init_tracked(name, name_is_auto=name_is_auto, provenance=provenance)
+
+    @property
+    def value(self) -> Any:
+        """The wrapped value, untracked. The one way to reach it."""
+        return self._value
+
+    @property
+    def spec(self) -> OpaqueSpec:
+        """This value's own declaration."""
+        return self._spec
+
+    def __repr__(self) -> str:
+        return f"Opaque({self._value!r}, name={self.name!r})"

--- a/probpipe/core/_opaque.py
+++ b/probpipe/core/_opaque.py
@@ -5,45 +5,71 @@ See design III.1.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Hashable, Mapping
+from dataclasses import dataclass
 from typing import Any
 
-from ._immutable import Immutable
-from .event_template import OpaqueSpec
+from .event_template import ValueSpec, _require_hashable
 from .provenance import Provenance
-from .tracked import Annotated, TrackedTerm, auto_name
+from .tracked import Annotated, TrackedTerm
 
-__all__ = ["Opaque"]
+__all__ = ["Opaque", "OpaqueSpec"]
 
 
-class Opaque(Immutable, TrackedTerm, Annotated):
+@dataclass(frozen=True)
+class OpaqueSpec(ValueSpec):
+    """The fallback value spec, for a value no other spec describes.
+
+    An opaque value carries no exposed structure (a string, a DataFrame, an
+    arbitrary Python object, ...). ``meta`` is optional opaque metadata and
+    must be hashable (or ``None``).
+    """
+
+    meta: Hashable = None
+
+    def __post_init__(self) -> None:
+        _require_hashable(self.meta, context="OpaqueSpec.meta")
+
+    def is_valid(self, value: Any) -> bool:
+        """Whether *value* is a valid opaque value — anything but a mapping.
+
+        As the fallback spec, ``OpaqueSpec`` accepts any value **except** a
+        ``Mapping``: a mapping denotes tree structure (a subtree), never a
+        leaf. Every other value is valid, including a numeric array or scalar
+        — such a value is *typically* described by an :class:`NumericArraySpec`, but
+        an explicitly-opaque field still accepts it. ``meta`` is metadata
+        about the spec and is not checked against the value.
+
+        Notes
+        -----
+        The record layer honours the same rule: mappings are never leaves, so
+        :class:`~probpipe.Record` construction materialises a mapping field
+        value into a nested subtree.
+        """
+        return not isinstance(value, Mapping)
+
+
+class Opaque(TrackedTerm, Annotated):
     """One value of no exposed structure, with identity.
 
     The tracked class of the opaque kind, as :class:`~probpipe.Record` is of the
     record kind: what an operation returns when its declared kind is an
     :class:`~probpipe.OpaqueSpec`. Its batch form is
-    :class:`~probpipe.OpaqueBatch`, which already existed — a batch is a tracked
-    term whatever its elements are, which is why the collection had a class
-    before the element did.
+    :class:`~probpipe.OpaqueBatch`.
 
-    **It adds identity and nothing else.** No attribute forwarding, no
-    ``__call__``, no operators: the wrapped value is reached through
-    :attr:`value`, explicitly. A box that forwards to be convenient is
-    indistinguishable from the value it wraps, and then the wrapping is a
-    surprise rather than a statement — so this one does not. What an opaque
-    value affords is whatever its own type affords, once it is out.
+    Its interface is :attr:`value` plus the identity every tracked term carries.
+    What the value affords is its own type's, once it is out.
 
     Parameters
     ----------
+    name : str
+        The value's name, required and first as a :class:`~probpipe.Record`
+        takes it: the name is what says which opaque value this is.
     value : Any
-        The value this names. Held as given, never converted or copied — there
-        is nothing to convert it to. Anything but a mapping, which the value
-        layer reads as a subtree rather than a leaf.
-    name : str, optional
-        The value's name. Defaults to ``"opaque"``, marked auto-derived.
+        The value this names, held as given. Any non-mapping value; the value
+        layer reads a mapping as a subtree.
     name_is_auto : bool, default False
-        Whether *name* is auto-derived rather than user-given. A value left
-        unnamed is auto-named regardless.
+        Whether *name* is auto-derived rather than user-given.
     spec : OpaqueSpec, optional
         What this value satisfies, carrying any opaque ``meta``. Defaults to a
         bare :class:`~probpipe.OpaqueSpec`.
@@ -58,7 +84,7 @@ class Opaque(Immutable, TrackedTerm, Annotated):
 
     Examples
     --------
-    >>> fitted = Opaque(object(), name="sklearn_model")
+    >>> fitted = Opaque("sklearn_model", object())
     >>> fitted.name
     'sklearn_model'
     """
@@ -74,9 +100,10 @@ class Opaque(Immutable, TrackedTerm, Annotated):
 
     def __init__(
         self,
+        name: str,
         value: Any,
+        /,
         *,
-        name: str | None = None,
         name_is_auto: bool = False,
         spec: OpaqueSpec | None = None,
         provenance: Provenance | None = None,
@@ -89,15 +116,13 @@ class Opaque(Immutable, TrackedTerm, Annotated):
                 "subtree rather than a leaf; wrap it as a Record, or as a non-mapping value"
             )
         spec = OpaqueSpec() if spec is None else spec
-        if name is None:
-            name, name_is_auto = auto_name(name, "opaque")
         object.__setattr__(self, "_value", value)
         object.__setattr__(self, "_spec", spec)
         self._init_tracked(name, name_is_auto=name_is_auto, provenance=provenance)
 
     @property
     def value(self) -> Any:
-        """The wrapped value, untracked. The one way to reach it."""
+        """The wrapped value, untracked."""
         return self._value
 
     @property

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -11,7 +11,7 @@ from typing import Any
 import numpy as np
 
 from ._object_batch import _ObjectBatch
-from .event_template import OpaqueSpec
+from ._opaque import OpaqueSpec
 from .provenance import Provenance
 
 __all__ = ["OpaqueBatch"]

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -42,13 +42,13 @@ from ._array_backend import _is_numeric_dtype, _to_jax_array
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._function_batch import FunctionBatch
 from ._object_batch import _from_iterable, _frozen_object_column, _is_object_array
+from ._opaque import OpaqueSpec
 from ._opaque_batch import OpaqueBatch
 from .event_template import (
     EventTemplate,
     FunctionSpec,
     NumericArraySpec,
     NumericEventTemplate,
-    OpaqueSpec,
     RecordSpec,
     ValueSpec,
     _record_declaration_template,

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -65,7 +65,7 @@ from __future__ import annotations
 
 import operator
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Hashable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from math import prod
 from typing import Any
@@ -89,7 +89,6 @@ __all__ = [
     "FunctionSpec",
     "NumericArraySpec",
     "NumericEventTemplate",
-    "OpaqueSpec",
     "RecordSpec",
     "TermSpec",
     "ValueSpec",
@@ -384,39 +383,6 @@ class NumericArraySpec(ValueSpec):
             if not np.can_cast(np.dtype(actual), self.dtype, casting="same_kind"):
                 return False
         return True
-
-
-@dataclass(frozen=True)
-class OpaqueSpec(ValueSpec):
-    """The fallback value spec, for a value no other spec describes.
-
-    An opaque value carries no exposed structure (a string, a DataFrame, an
-    arbitrary Python object, ...). ``meta`` is optional opaque metadata and
-    must be hashable (or ``None``).
-    """
-
-    meta: Hashable = None
-
-    def __post_init__(self) -> None:
-        _require_hashable(self.meta, context="OpaqueSpec.meta")
-
-    def is_valid(self, value: Any) -> bool:
-        """Whether *value* is a valid opaque value — anything but a mapping.
-
-        As the fallback spec, ``OpaqueSpec`` accepts any value **except** a
-        ``Mapping``: a mapping denotes tree structure (a subtree), never a
-        leaf. Every other value is valid, including a numeric array or scalar
-        — such a value is *typically* described by an :class:`NumericArraySpec`, but
-        an explicitly-opaque field still accepts it. ``meta`` is metadata
-        about the spec and is not checked against the value.
-
-        Notes
-        -----
-        The record layer honours the same rule: mappings are never leaves, so
-        :class:`~probpipe.Record` construction materialises a mapping field
-        value into a nested subtree.
-        """
-        return not isinstance(value, Mapping)
 
 
 @dataclass(frozen=True)
@@ -853,6 +819,8 @@ def _to_spec(spec: _FieldSpecInput) -> _FieldSpec:
     if isinstance(spec, (ValueSpec, EventTemplate)):
         return spec
     if spec is None:
+        from ._opaque import OpaqueSpec
+
         return OpaqueSpec()
     if isinstance(spec, tuple):
         return NumericArraySpec(shape=spec)
@@ -1336,6 +1304,8 @@ class EventTemplate(NamedTree[ValueSpec], Immutable):
     # -- Repr ---------------------------------------------------------------
 
     def __repr__(self) -> str:
+        from ._opaque import OpaqueSpec
+
         parts = []
         for name, spec in self._tree.items():
             if isinstance(spec, EventTemplate):

--- a/probpipe/inference/_approximate_distribution.py
+++ b/probpipe/inference/_approximate_distribution.py
@@ -12,8 +12,9 @@ import jax.numpy as jnp
 
 from .._weights import Weights
 from ..core._immutable import transient_memo
+from ..core._opaque import OpaqueSpec
 from ..core.distribution import Distribution, RecordEmpiricalDistribution
-from ..core.event_template import EventTemplate, NumericArraySpec, NumericEventTemplate, OpaqueSpec
+from ..core.event_template import EventTemplate, NumericArraySpec, NumericEventTemplate
 from ..core.provenance import Provenance
 from ..core.record import Record
 from ..custom_types import Array, ArrayLike

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -881,7 +881,8 @@ class TestMakeStack:
         being mislabeled opaque (#343)."""
         from probpipe import Record, RecordBatch
         from probpipe.core._broadcast_distributions import _make_stack
-        from probpipe.core.event_template import NumericArraySpec, OpaqueSpec
+        from probpipe.core._opaque import OpaqueSpec
+        from probpipe.core.event_template import NumericArraySpec
 
         records = [Record("r", x=jnp.ones(2, dtype=jnp.bfloat16), label=f"r{i}") for i in range(3)]
         out = _make_stack(records, n=3, field_name="demo", level_names=("sweep",))

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -11,6 +11,7 @@ import pytest
 from probpipe import Function, NumericRecord, Record
 from probpipe.core._batch import BatchSpec
 from probpipe.core._numeric_record_batch import NumericRecordBatch
+from probpipe.core._opaque import OpaqueSpec
 from probpipe.core._opaque_batch import OpaqueBatch
 from probpipe.core.event_template import (
     DistributionSpec,
@@ -18,7 +19,6 @@ from probpipe.core.event_template import (
     FunctionSpec,
     NumericArraySpec,
     NumericEventTemplate,
-    OpaqueSpec,
     RecordSpec,
     TermSpec,
     ValueSpec,

--- a/tests/core/test_named_collection.py
+++ b/tests/core/test_named_collection.py
@@ -12,7 +12,8 @@ import numpy as np
 import pytest
 
 from probpipe import EventTemplate, NumericRecord, NumericRecordBatch, Record
-from probpipe.core.event_template import NumericArraySpec, NumericEventTemplate, OpaqueSpec
+from probpipe.core._opaque import OpaqueSpec
+from probpipe.core.event_template import NumericArraySpec, NumericEventTemplate
 
 # ---------------------------------------------------------------------------
 # Construction: path-keyed unflattening and its error cases

--- a/tests/core/test_named_tree.py
+++ b/tests/core/test_named_tree.py
@@ -11,10 +11,10 @@ import jax.numpy as jnp
 import pytest
 
 from probpipe import EventTemplate, NumericRecord, Record
+from probpipe.core._opaque import OpaqueSpec
 from probpipe.core.event_template import (
     NumericArraySpec,
     NumericEventTemplate,
-    OpaqueSpec,
     ValueSpec,
 )
 from probpipe.core.named_tree import NamedTree

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -45,6 +45,51 @@ class TestNumericArrayHoldsOneValue:
             NumericArray(jnp.arange(3.0), spec="not a spec")
 
 
+class TestNumericArrayStoresNativeForm:
+    """Construction validates without converting, as `NumericRecord` does.
+
+    A lazy or disk-backed value is not materialised merely to be named, and a
+    container's own metadata is not discarded.
+    """
+
+    def test_an_array_is_stored_verbatim(self):
+        raw = np.arange(3.0)
+
+        assert NumericArray(raw).value is raw
+
+    def test_a_container_keeps_its_own_metadata(self):
+        xr = pytest.importorskip("xarray")
+        data = xr.DataArray(np.arange(3.0), dims=["t"], coords={"t": [10, 20, 30]})
+
+        stored = NumericArray(data).value
+
+        assert isinstance(stored, xr.DataArray)
+        assert list(stored.coords) == ["t"]
+
+    def test_the_spec_is_read_from_metadata(self):
+        assert NumericArray(np.arange(3.0)).shape == (3,)
+
+    def test_a_bare_scalar_is_normalised(self):
+        """It carries no metadata to read, so it is the one thing converted."""
+        assert isinstance(NumericArray(2.5).value, jax.Array)
+
+    def test_conversion_happens_once_and_is_memoised(self):
+        value = NumericArray(np.arange(3.0))
+
+        assert isinstance(value.as_jax(), jax.Array)
+        assert value.as_jax() is value.as_jax()
+
+    def test_the_pytree_boundary_presents_a_bare_array(self):
+        """One of the compute boundaries native form converts at."""
+        (leaf,) = jax.tree_util.tree_leaves(NumericArray(np.arange(3.0)))
+
+        assert isinstance(leaf, jax.Array)
+
+    def test_a_non_numeric_value_is_refused(self):
+        with pytest.raises(TypeError, match="is not a numeric leaf"):
+            NumericArray("not numeric")
+
+
 class TestNumericArrayCarriesIdentity:
     def test_a_name_is_kept_and_marked_user_given(self):
         value = NumericArray(jnp.arange(3.0), name="draw")
@@ -98,6 +143,13 @@ class TestNumericArrayComputesAsAnArray:
 
         assert not isinstance(result, NumericArray)
         assert isinstance(result, jax.Array)
+
+    def test_arithmetic_returns_the_stored_types_own_result(self):
+        """The operators forward to the value, so a numpy-backed one stays numpy."""
+        result = NumericArray(np.arange(3.0)) + 1
+
+        assert isinstance(result, np.ndarray)
+        assert not isinstance(result, jax.Array)
 
     def test_it_computes_the_same_values_as_the_array_it_holds(self):
         raw = jnp.arange(3.0)
@@ -220,6 +272,28 @@ class TestNumericArrayBatchSelection:
     def test_an_element_carries_the_batch_element_spec(self):
         assert _batch()[1].spec == _batch().element_spec
 
+    def test_a_sub_batch_takes_the_declared_view_type(self):
+        """`Batch._view_type` is the hook a subclass overrides to shed its state.
+
+        Reaching for ``type(self)`` instead would hand such a subclass a view
+        claiming to answer for state the view never received.
+        """
+
+        class _Derived(NumericArrayBatch):
+            __slots__ = ()
+
+            @property
+            def _view_type(self) -> type:
+                return NumericArrayBatch
+
+        derived = _Derived(
+            jnp.arange(12.0).reshape(4, 3),
+            "draw",
+            element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+        )
+
+        assert type(derived[1:3]) is NumericArrayBatch
+
     def test_a_slice_is_a_sub_batch(self):
         sub = _batch(name="posterior")[1:3]
 
@@ -311,6 +385,27 @@ class TestNumericArrayIsAPyTree:
         rebuilt = jax.tree_util.tree_map(lambda x: x, value)
 
         assert rebuilt.spec.support == positive
+
+    def test_a_skeleton_rebuilds_rather_than_raising(self):
+        """JAX unflattens with whatever it carries, which is not always an array.
+
+        Mapping a tree to ``None`` builds a skeleton, and internal traversals
+        pass sentinels. Constructing here would convert and validate, so both
+        would raise instead of rebuilding.
+        """
+        value = NumericArray(jnp.arange(3.0), name="draw")
+
+        skeleton = jax.tree_util.tree_map(lambda x: None, value)
+
+        assert isinstance(skeleton, NumericArray)
+        assert skeleton.name == "draw"
+
+    def test_a_sentinel_child_rebuilds(self):
+        _, treedef = jax.tree_util.tree_flatten(NumericArray(jnp.arange(3.0)))
+
+        rebuilt = jax.tree_util.tree_unflatten(treedef, [object()])
+
+        assert isinstance(rebuilt, NumericArray)
 
     def test_provenance_does_not_survive_the_boundary(self):
         """As for `Record`: lineage rides on the function layer, not the treedef."""

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -22,28 +22,30 @@ def _batch(values=None, level_names="draw", **kwargs) -> NumericArrayBatch:
 class TestNumericArrayHoldsOneValue:
     def test_shape_is_the_event_shape(self):
         """A NumericArray carries no batch axes, so its shape is the event's."""
-        value = NumericArray(jnp.zeros((2, 5)))
+        value = NumericArray(jnp.zeros((2, 5)), name="v")
 
         assert value.shape == (2, 5)
         assert value.ndim == 2
         assert len(value) == 2
 
     def test_the_spec_is_derived_when_omitted(self):
-        value = NumericArray(jnp.arange(3.0))
+        value = NumericArray(jnp.arange(3.0), name="v")
 
         assert value.spec == NumericArraySpec(shape=(3,), dtype=jnp.float32)
 
     def test_a_supplied_spec_is_checked(self):
         with pytest.raises(ValueError, match="does not satisfy its declaration"):
-            NumericArray(jnp.arange(3.0), spec=NumericArraySpec(shape=(2,), dtype=jnp.float32))
+            NumericArray(
+                jnp.arange(3.0), spec=NumericArraySpec(shape=(2,), dtype=jnp.float32), name="v"
+            )
 
     def test_a_value_that_is_not_an_array_is_refused(self):
         with pytest.raises(TypeError, match="holds one numeric array"):
-            NumericArray(object())
+            NumericArray(object(), name="v")
 
     def test_a_spec_of_another_kind_is_refused(self):
         with pytest.raises(TypeError, match="must be a NumericArraySpec"):
-            NumericArray(jnp.arange(3.0), spec="not a spec")
+            NumericArray(jnp.arange(3.0), spec="not a spec", name="v")
 
 
 class TestNumericArrayStoresNativeForm:
@@ -56,33 +58,33 @@ class TestNumericArrayStoresNativeForm:
     def test_an_array_is_stored_verbatim(self):
         raw = np.arange(3.0)
 
-        assert NumericArray(raw).value is raw
+        assert NumericArray(raw, name="v").value is raw
 
     def test_a_container_keeps_its_own_metadata(self):
         xr = pytest.importorskip("xarray")
         data = xr.DataArray(np.arange(3.0), dims=["t"], coords={"t": [10, 20, 30]})
 
-        stored = NumericArray(data).value
+        stored = NumericArray(data, name="v").value
 
         assert isinstance(stored, xr.DataArray)
         assert list(stored.coords) == ["t"]
 
     def test_the_spec_is_read_from_metadata(self):
-        assert NumericArray(np.arange(3.0)).shape == (3,)
+        assert NumericArray(np.arange(3.0), name="v").shape == (3,)
 
     def test_a_bare_scalar_is_normalised(self):
         """It carries no metadata to read, so it is normalised."""
-        assert isinstance(NumericArray(2.5).value, jax.Array)
+        assert isinstance(NumericArray(2.5, name="v").value, jax.Array)
 
     def test_conversion_happens_once_and_is_memoised(self):
-        value = NumericArray(np.arange(3.0))
+        value = NumericArray(np.arange(3.0), name="v")
 
         assert isinstance(value.as_jax(), jax.Array)
         assert value.as_jax() is value.as_jax()
 
     def test_the_pytree_boundary_presents_a_bare_array(self):
         """A compute boundary, where native form converts."""
-        (leaf,) = jax.tree_util.tree_leaves(NumericArray(np.arange(3.0)))
+        (leaf,) = jax.tree_util.tree_leaves(NumericArray(np.arange(3.0), name="v"))
 
         assert isinstance(leaf, jax.Array)
 
@@ -94,6 +96,7 @@ class TestNumericArrayStoresNativeForm:
         value = NumericArray(
             jnp.zeros(3, dtype=jnp.float32),
             spec=NumericArraySpec(shape=(3,), dtype=jnp.float64),
+            name="v",
         )
 
         assert value.dtype == jnp.float32
@@ -101,7 +104,7 @@ class TestNumericArrayStoresNativeForm:
 
     def test_a_non_numeric_value_is_refused(self):
         with pytest.raises(TypeError, match="is not a numeric leaf"):
-            NumericArray("not numeric")
+            NumericArray("not numeric", name="v")
 
 
 class TestNumericArrayCarriesIdentity:
@@ -110,11 +113,22 @@ class TestNumericArrayCarriesIdentity:
 
         assert (value.name, value.name_is_auto) == ("draw", False)
 
-    def test_an_omitted_name_is_auto_derived(self):
-        assert NumericArray(jnp.arange(3.0)).name_is_auto is True
+    def test_a_name_is_required(self):
+        """A value carries no fields to describe it, so the name is what says
+        which one it is; a class-name default would name every array alike."""
+        with pytest.raises(TypeError, match="name"):
+            NumericArray(jnp.arange(3.0))
+
+    def test_a_derived_name_is_marked_auto(self):
+        """Set by an operation that derives one, as the output boundary does."""
+        value = NumericArray(jnp.arange(3.0), name="outer", name_is_auto=True)
+
+        assert (value.name, value.name_is_auto) == ("outer", True)
 
     def test_provenance_is_write_once(self):
-        value = NumericArray(jnp.arange(3.0)).with_provenance(Provenance.create("test", parents=[]))
+        value = NumericArray(jnp.arange(3.0), name="v").with_provenance(
+            Provenance.create("test", parents=[])
+        )
 
         assert value.provenance.operation == "test"
         with pytest.raises(RuntimeError, match="already set"):
@@ -122,17 +136,17 @@ class TestNumericArrayCarriesIdentity:
 
     def test_it_is_immutable(self):
         with pytest.raises(AttributeError, match="immutable"):
-            NumericArray(jnp.arange(3.0))._value = jnp.zeros(3)
+            NumericArray(jnp.arange(3.0), name="v")._value = jnp.zeros(3)
 
     def test_the_array_is_reachable_untracked(self):
         raw = jnp.arange(3.0)
 
-        assert NumericArray(raw).value is raw
+        assert NumericArray(raw, name="v").value is raw
 
     def test_it_is_unhashable(self):
         """`__eq__` is elementwise, so a hash would promise more than it keeps."""
         with pytest.raises(TypeError):
-            hash(NumericArray(jnp.arange(3.0)))
+            hash(NumericArray(jnp.arange(3.0), name="v"))
 
 
 class TestNumericArrayComputesAsAnArray:
@@ -153,14 +167,14 @@ class TestNumericArrayComputesAsAnArray:
     )
     def test_arithmetic_yields_a_bare_array(self, compute):
         """Identity is attached by operations; arithmetic is not one."""
-        result = compute(NumericArray(jnp.arange(3.0)))
+        result = compute(NumericArray(jnp.arange(3.0), name="v"))
 
         assert not isinstance(result, NumericArray)
         assert isinstance(result, jax.Array)
 
     def test_arithmetic_returns_the_stored_types_own_result(self):
         """The operators forward to the value, so numpy stays numpy."""
-        result = NumericArray(np.arange(3.0)) + 1
+        result = NumericArray(np.arange(3.0), name="v") + 1
 
         assert isinstance(result, np.ndarray)
         assert not isinstance(result, jax.Array)
@@ -169,22 +183,23 @@ class TestNumericArrayComputesAsAnArray:
         raw = jnp.arange(3.0)
 
         np.testing.assert_array_equal(
-            np.asarray(NumericArray(raw) * 2 + 1), np.asarray(raw * 2 + 1)
+            np.asarray(NumericArray(raw, name="v") * 2 + 1), np.asarray(raw * 2 + 1)
         )
 
     def test_two_numeric_arrays_combine(self):
-        pair = NumericArray(jnp.arange(3.0)) + NumericArray(jnp.ones(3))
+        pair = NumericArray(jnp.arange(3.0), name="v") + NumericArray(jnp.ones(3), name="v")
 
         assert not isinstance(pair, NumericArray)
         np.testing.assert_array_equal(np.asarray(pair), np.asarray(jnp.arange(1.0, 4.0)))
 
     def test_comparison_is_elementwise(self):
         np.testing.assert_array_equal(
-            np.asarray(NumericArray(jnp.arange(3.0)) == 1.0), np.array([False, True, False])
+            np.asarray(NumericArray(jnp.arange(3.0), name="v") == 1.0),
+            np.array([False, True, False]),
         )
 
     def test_it_converts_through_both_hooks(self):
-        value = NumericArray(jnp.arange(3.0))
+        value = NumericArray(jnp.arange(3.0), name="v")
 
         np.testing.assert_array_equal(np.asarray(value), np.arange(3.0))
         assert isinstance(jnp.asarray(value), jax.Array)
@@ -197,23 +212,23 @@ class TestNumericArrayComputesAsAnArray:
             return x * 2
 
         np.testing.assert_allclose(
-            np.asarray(double(NumericArray(jnp.arange(3.0)))), np.arange(3.0) * 2
+            np.asarray(double(NumericArray(jnp.arange(3.0), name="v"))), np.arange(3.0) * 2
         )
 
     def test_a_scalar_converts_to_a_number(self):
-        assert float(NumericArray(jnp.asarray(2.5))) == 2.5
-        assert int(NumericArray(jnp.asarray(2))) == 2
+        assert float(NumericArray(jnp.asarray(2.5), name="v")) == 2.5
+        assert int(NumericArray(jnp.asarray(2), name="v")) == 2
 
     def test_a_scalar_is_truthy_by_its_value(self):
-        assert bool(NumericArray(jnp.asarray(1.0))) is True
-        assert bool(NumericArray(jnp.asarray(0.0))) is False
+        assert bool(NumericArray(jnp.asarray(1.0), name="v")) is True
+        assert bool(NumericArray(jnp.asarray(0.0), name="v")) is False
 
     def test_an_integer_scalar_indexes(self):
         """``__index__`` is what lets one stand in for a position."""
-        assert [10, 20, 30][NumericArray(jnp.asarray(1))] == 20
+        assert [10, 20, 30][NumericArray(jnp.asarray(1), name="v")] == 20
 
     def test_indexing_and_iteration_reach_the_array(self):
-        value = NumericArray(jnp.arange(3.0))
+        value = NumericArray(jnp.arange(3.0), name="v")
 
         assert float(value[1]) == 1.0
         assert [float(x) for x in value] == [0.0, 1.0, 2.0]
@@ -491,7 +506,9 @@ class TestNumericArrayIsAPyTree:
         The value reports what it now holds; the spec keeps saying what was
         declared, which is the only thing the round trip can be faithful to.
         """
-        stacked = jax.tree_util.tree_map(lambda x: jnp.stack([x, x]), NumericArray(jnp.arange(3.0)))
+        stacked = jax.tree_util.tree_map(
+            lambda x: jnp.stack([x, x]), NumericArray(jnp.arange(3.0), name="v")
+        )
 
         assert stacked.shape == (2, 3)
         assert stacked.spec == NumericArraySpec(shape=(3,), dtype=jnp.float32)
@@ -505,6 +522,7 @@ class TestNumericArrayIsAPyTree:
         value = NumericArray(
             jnp.arange(3.0, dtype=jnp.float32),
             spec=NumericArraySpec(shape=(3,), dtype=np.float64),
+            name="v",
         )
 
         leaves, treedef = jax.tree_util.tree_flatten(value)
@@ -513,7 +531,7 @@ class TestNumericArrayIsAPyTree:
 
     def test_a_skeleton_still_carries_its_declaration(self):
         """`spec` is typed as one, so a rebuilt value has to have one."""
-        skeleton = jax.tree_util.tree_map(lambda x: None, NumericArray(jnp.arange(3.0)))
+        skeleton = jax.tree_util.tree_map(lambda x: None, NumericArray(jnp.arange(3.0), name="v"))
 
         assert skeleton.spec == NumericArraySpec(shape=(3,), dtype=jnp.float32)
 
@@ -524,6 +542,7 @@ class TestNumericArrayIsAPyTree:
         value = NumericArray(
             jnp.arange(1.0, 4.0),
             spec=NumericArraySpec(shape=(3,), dtype=jnp.float32, support=positive),
+            name="v",
         )
 
         rebuilt = jax.tree_util.tree_map(lambda x: x, value)
@@ -540,7 +559,7 @@ class TestNumericArrayIsAPyTree:
         assert skeleton.name == "draw"
 
     def test_a_sentinel_child_rebuilds(self):
-        _, treedef = jax.tree_util.tree_flatten(NumericArray(jnp.arange(3.0)))
+        _, treedef = jax.tree_util.tree_flatten(NumericArray(jnp.arange(3.0), name="v"))
 
         rebuilt = jax.tree_util.tree_unflatten(treedef, [object()])
 
@@ -548,7 +567,7 @@ class TestNumericArrayIsAPyTree:
 
     def test_provenance_does_not_survive_the_boundary(self):
         """As for `Record`: lineage rides on the function layer, not the treedef."""
-        value = NumericArray(jnp.arange(3.0)).with_provenance(
+        value = NumericArray(jnp.arange(3.0), name="v").with_provenance(
             Provenance.create("sample", parents=[])
         )
 

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -15,6 +15,7 @@ def _batch(values=None, level_names="draw", **kwargs) -> NumericArrayBatch:
     if values is None:
         values = jnp.arange(12.0).reshape(4, 3)
     kwargs.setdefault("element_spec", NumericArraySpec(shape=(3,), dtype=jnp.float32))
+    kwargs.setdefault("name", "draws")
     return NumericArrayBatch(values, level_names, **kwargs)
 
 
@@ -70,7 +71,7 @@ class TestNumericArrayStoresNativeForm:
         assert NumericArray(np.arange(3.0)).shape == (3,)
 
     def test_a_bare_scalar_is_normalised(self):
-        """It carries no metadata to read, so it is the one thing converted."""
+        """It carries no metadata to read, so it is normalised."""
         assert isinstance(NumericArray(2.5).value, jax.Array)
 
     def test_conversion_happens_once_and_is_memoised(self):
@@ -80,16 +81,15 @@ class TestNumericArrayStoresNativeForm:
         assert value.as_jax() is value.as_jax()
 
     def test_the_pytree_boundary_presents_a_bare_array(self):
-        """One of the compute boundaries native form converts at."""
+        """A compute boundary, where native form converts."""
         (leaf,) = jax.tree_util.tree_leaves(NumericArray(np.arange(3.0)))
 
         assert isinstance(leaf, jax.Array)
 
     def test_dtype_reports_the_value_not_the_declaration(self):
-        """The shim stands in for an array, and an array's dtype is its data's.
+        """An array's dtype describes its data; ``.spec`` carries the declaration.
 
-        ``is_valid`` admits a same-kind cast, so the two can differ; the
-        declaration stays reachable as ``.spec``.
+        ``is_valid`` admits a same-kind cast, so the two can differ.
         """
         value = NumericArray(
             jnp.zeros(3, dtype=jnp.float32),
@@ -130,7 +130,7 @@ class TestNumericArrayCarriesIdentity:
         assert NumericArray(raw).value is raw
 
     def test_it_is_unhashable(self):
-        """`__eq__` is elementwise, so a hash would be a false promise."""
+        """`__eq__` is elementwise, so a hash would promise more than it keeps."""
         with pytest.raises(TypeError):
             hash(NumericArray(jnp.arange(3.0)))
 
@@ -152,14 +152,14 @@ class TestNumericArrayComputesAsAnArray:
         ],
     )
     def test_arithmetic_yields_a_bare_array(self, compute):
-        """Identity is attached by operations, and arithmetic is not one."""
+        """Identity is attached by operations; arithmetic is not one."""
         result = compute(NumericArray(jnp.arange(3.0)))
 
         assert not isinstance(result, NumericArray)
         assert isinstance(result, jax.Array)
 
     def test_arithmetic_returns_the_stored_types_own_result(self):
-        """The operators forward to the value, so a numpy-backed one stays numpy."""
+        """The operators forward to the value, so numpy stays numpy."""
         result = NumericArray(np.arange(3.0)) + 1
 
         assert isinstance(result, np.ndarray)
@@ -190,7 +190,7 @@ class TestNumericArrayComputesAsAnArray:
         assert isinstance(jnp.asarray(value), jax.Array)
 
     def test_it_traces_under_jit(self):
-        """``__jax_array__`` is why the numpy hook does not win and drop tracing."""
+        """Registration is what carries it into a trace."""
 
         @jax.jit
         def double(x):
@@ -229,7 +229,10 @@ class TestNumericArrayBatchHoldsTheMultiplicity:
 
     def test_scalar_elements_leave_every_axis_to_the_batch(self):
         batch = NumericArrayBatch(
-            jnp.arange(4.0), "draw", element_spec=NumericArraySpec(shape=(), dtype=jnp.float32)
+            jnp.arange(4.0),
+            "draw",
+            element_spec=NumericArraySpec(shape=(), dtype=jnp.float32),
+            name="draws",
         )
 
         assert batch.batch_shape == (4,)
@@ -263,7 +266,7 @@ class TestNumericArrayBatchHoldsTheMultiplicity:
 
 
 class TestNumericArrayBatchSelection:
-    """Selection yields the element kind, as it does for every batch."""
+    """Selection yields the element kind, as for every batch."""
 
     def test_an_element_is_a_numeric_array(self):
         element = _batch()[1]
@@ -278,7 +281,7 @@ class TestNumericArrayBatchSelection:
         assert element.name_is_auto is True
 
     def test_an_element_inherits_the_batch_lineage(self):
-        """Selecting computes nothing, so the element carries the batch's own."""
+        """Selecting computes nothing, so the element carries the batch's lineage."""
         batch = _batch().with_provenance(Provenance.create("sample", parents=[]))
 
         assert batch[1].provenance is batch.provenance
@@ -287,11 +290,7 @@ class TestNumericArrayBatchSelection:
         assert _batch()[1].spec == _batch().element_spec
 
     def test_a_sub_batch_takes_the_declared_view_type(self):
-        """`Batch._view_type` is the hook a subclass overrides to shed its state.
-
-        Reaching for ``type(self)`` instead would hand such a subclass a view
-        claiming to answer for state the view never received.
-        """
+        """`Batch._view_type` is the hook a subclass overrides to shed its state."""
 
         class _Derived(NumericArrayBatch):
             __slots__ = ()
@@ -304,6 +303,7 @@ class TestNumericArrayBatchSelection:
             jnp.arange(12.0).reshape(4, 3),
             "draw",
             element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+            name="derived",
         )
 
         assert type(derived[1:3]) is NumericArrayBatch
@@ -328,9 +328,12 @@ class TestNumericArrayBatchOverNativeContainers:
         return pd.DataFrame(np.arange(12.0).reshape(4, 3))
 
     def test_an_element_selects_by_position_not_by_label(self):
-        """``df[0]`` is a column; the element is the row at position 0."""
+        """``df[0]`` is a column, while the element is the row at position 0."""
         batch = NumericArrayBatch(
-            self._frame(), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+            self._frame(),
+            "draw",
+            element_spec=NumericArraySpec(shape=(3,), dtype=np.float64),
+            name="draws",
         )
 
         element = batch[1]
@@ -341,7 +344,10 @@ class TestNumericArrayBatchOverNativeContainers:
 
     def test_a_sub_batch_selects_by_position(self):
         batch = NumericArrayBatch(
-            self._frame(), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+            self._frame(),
+            "draw",
+            element_spec=NumericArraySpec(shape=(3,), dtype=np.float64),
+            name="draws",
         )
 
         sub = batch[1:3]
@@ -354,7 +360,7 @@ class TestNumericArrayBatchOverNativeContainers:
         frame = self._frame()
 
         batch = NumericArrayBatch(
-            frame, "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+            frame, "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64), name="draws"
         )
 
         assert isinstance(batch.values, pd.DataFrame)
@@ -362,10 +368,13 @@ class TestNumericArrayBatchOverNativeContainers:
 
 class TestNumericArrayBatchRefusals:
     def test_a_stored_array_with_no_batch_axis_is_refused(self):
-        """One value is a NumericArray; a batch has at least one batch axis."""
+        """A batch has at least one batch axis; one value is a NumericArray."""
         with pytest.raises(ValueError, match="at least one batch axis"):
             NumericArrayBatch(
-                jnp.zeros(3), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32)
+                jnp.zeros(3),
+                "draw",
+                element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+                name="draws",
             )
 
     def test_trailing_axes_that_are_not_the_event_shape_are_refused(self):
@@ -374,49 +383,85 @@ class TestNumericArrayBatchRefusals:
                 jnp.zeros((4, 5)),
                 "draw",
                 element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+                name="draws",
             )
 
     def test_a_symbolic_event_dimension_is_refused(self):
-        """A symbolic size gives the stored axes nothing to split by."""
+        """A symbolic size leaves the stored axes no split point."""
         with pytest.raises(ValueError, match="symbolic dimension"):
             NumericArrayBatch(
                 jnp.zeros((4, 3)),
                 "draw",
                 element_spec=NumericArraySpec(shape=("n",), dtype=jnp.float32),
+                name="draws",
             )
 
     def test_values_that_are_not_an_array_are_refused(self):
         with pytest.raises(TypeError, match="stores one array"):
             NumericArrayBatch(
-                object(), "draw", element_spec=NumericArraySpec(shape=(), dtype=jnp.float32)
+                object(),
+                "draw",
+                element_spec=NumericArraySpec(shape=(), dtype=jnp.float32),
+                name="draws",
             )
 
     def test_a_dtype_the_declaration_does_not_admit_is_refused(self):
-        """The batch asserts the spec of every element, so it checks at build.
-
-        Left to the first selection, ``NumericArray`` raises one layer too late
-        to name the batch that made the false claim.
-        """
+        """The batch asserts the spec of every element, so it checks at build."""
         with pytest.raises(TypeError, match="does not admit"):
             NumericArrayBatch(
                 jnp.zeros((2, 3), dtype=jnp.float32),
                 "draw",
                 element_spec=NumericArraySpec(shape=(3,), dtype=jnp.int32),
+                name="draws",
             )
 
+    def test_a_store_with_no_single_dtype_cannot_carry_a_pinned_one(self):
+        """A backend may report no single dtype, which supports no pinned one."""
+        from probpipe import ArrayBackend, register_array_backend
+
+        class _NoSingleDtype:
+            def __init__(self, array):
+                self.array = array
+
+        register_array_backend(
+            _NoSingleDtype,
+            ArrayBackend(
+                event_shape=lambda o: o.array.shape,
+                numpy_dtype=lambda o: None,
+                to_jax=lambda o: jnp.asarray(o.array),
+                to_numpy=lambda o: np.asarray(o.array),
+                take=lambda o, index: _NoSingleDtype(o.array[index]),
+            ),
+        )
+        store = _NoSingleDtype(np.zeros((4, 3)))
+
+        with pytest.raises(TypeError, match="reports no single dtype"):
+            NumericArrayBatch(
+                store,
+                "draw",
+                element_spec=NumericArraySpec(shape=(3,), dtype=np.int32),
+                name="draws",
+            )
+
+        # Declaring no dtype leaves nothing to substantiate, so it still builds.
+        assert NumericArrayBatch(
+            store, "draw", element_spec=NumericArraySpec(shape=(3,)), name="draws"
+        ).batch_shape == (4,)
+
     def test_a_same_kind_dtype_is_admitted(self):
-        """A widening or within-kind narrowing passes, as it does for a record."""
+        """A widening or within-kind narrowing passes, as for a record."""
         batch = NumericArrayBatch(
             jnp.zeros((2, 3), dtype=jnp.float32),
             "draw",
             element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float64),
+            name="draws",
         )
 
         assert batch.batch_shape == (2,)
 
     def test_an_element_spec_of_another_kind_is_refused(self):
         with pytest.raises(TypeError, match="must be a NumericArraySpec"):
-            NumericArrayBatch(jnp.zeros((4, 3)), "draw", element_spec="not a spec")
+            NumericArrayBatch(jnp.zeros((4, 3)), "draw", element_spec="not a spec", name="draws")
 
     def test_axis_groups_must_tile_the_batch_shape(self):
         with pytest.raises(ValueError):
@@ -426,9 +471,8 @@ class TestNumericArrayBatchRefusals:
 class TestNumericArrayIsAPyTree:
     """Registration is what lets it cross a transform boundary at all.
 
-    JAX no longer converts through ``__jax_array__`` during abstractification,
-    so a value that is not a registered pytree cannot be passed to a traced
-    function.
+    A traced function reaches its arguments through the pytree registry, so
+    registration is what carries a value into one.
     """
 
     def test_it_round_trips_through_flatten_and_unflatten(self):
@@ -441,18 +485,40 @@ class TestNumericArrayIsAPyTree:
         assert (rebuilt.name, rebuilt.name_is_auto) == ("draw", False)
         np.testing.assert_array_equal(np.asarray(rebuilt), np.arange(3.0))
 
-    def test_a_transform_that_changes_the_shape_re_derives_the_spec(self):
-        """Its spec *is* its shape and dtype, so what arrives states it exactly.
+    def test_a_transform_that_changes_the_shape_keeps_the_declaration(self):
+        """On this path a shape is transform-relative, so it states nothing.
 
-        This is why no rank has to be inferred here the way a batch's must be.
+        The value reports what it now holds; the spec keeps saying what was
+        declared, which is the only thing the round trip can be faithful to.
         """
         stacked = jax.tree_util.tree_map(lambda x: jnp.stack([x, x]), NumericArray(jnp.arange(3.0)))
 
         assert stacked.shape == (2, 3)
-        assert stacked.spec == NumericArraySpec(shape=(2, 3), dtype=jnp.float32)
+        assert stacked.spec == NumericArraySpec(shape=(3,), dtype=jnp.float32)
+
+    def test_a_declared_dtype_is_not_re_read_off_the_value(self):
+        """`is_valid` admits a same-kind cast, so the two can differ.
+
+        Deriving the spec from what arrives would quietly restate a float64
+        declaration as float32 — the declaration is what the aux carries.
+        """
+        value = NumericArray(
+            jnp.arange(3.0, dtype=jnp.float32),
+            spec=NumericArraySpec(shape=(3,), dtype=np.float64),
+        )
+
+        leaves, treedef = jax.tree_util.tree_flatten(value)
+
+        assert jax.tree_util.tree_unflatten(treedef, leaves).spec.dtype == np.float64
+
+    def test_a_skeleton_still_carries_its_declaration(self):
+        """`spec` is typed as one, so a rebuilt value has to have one."""
+        skeleton = jax.tree_util.tree_map(lambda x: None, NumericArray(jnp.arange(3.0)))
+
+        assert skeleton.spec == NumericArraySpec(shape=(3,), dtype=jnp.float32)
 
     def test_a_declared_support_rides_along(self):
-        """Shape and dtype re-derive; a support could not, so it is aux."""
+        """The declaration is the aux, support included."""
         from probpipe import positive
 
         value = NumericArray(
@@ -465,12 +531,7 @@ class TestNumericArrayIsAPyTree:
         assert rebuilt.spec.support == positive
 
     def test_a_skeleton_rebuilds_rather_than_raising(self):
-        """JAX unflattens with whatever it carries, which is not always an array.
-
-        Mapping a tree to ``None`` builds a skeleton, and internal traversals
-        pass sentinels. Constructing here would convert and validate, so both
-        would raise instead of rebuilding.
-        """
+        """JAX unflattens with whatever it carries, and a skeleton is not an array."""
         value = NumericArray(jnp.arange(3.0), name="draw")
 
         skeleton = jax.tree_util.tree_map(lambda x: None, value)
@@ -494,3 +555,101 @@ class TestNumericArrayIsAPyTree:
         rebuilt = jax.tree_util.tree_map(lambda x: x, value)
 
         assert rebuilt.provenance is None
+
+
+class TestABatchIsNamed:
+    """A batch's name is required, as a `Record`'s and an `Opaque`'s are."""
+
+    def test_a_name_is_required(self):
+        with pytest.raises(TypeError, match="name"):
+            NumericArrayBatch(
+                jnp.arange(12.0).reshape(4, 3),
+                "draw",
+                element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+            )
+
+    def test_a_given_name_is_marked_user_given(self):
+        batch = _batch(name="posterior")
+
+        assert (batch.name, batch.name_is_auto) == ("posterior", False)
+
+    def test_a_derived_name_says_so(self):
+        """A view derives its name, and marks it, rather than defaulting."""
+        sub = _batch(name="posterior")[1:3]
+
+        assert (sub.name, sub.name_is_auto) == ("posterior[draw=1:3]", True)
+
+
+class TestNumericArrayBatchIsAPyTree:
+    """The two-transformation contract `RecordBatch` states, over one column.
+
+    Registration is what lets a batch reach a traced function.
+    """
+
+    def test_it_round_trips_unchanged(self):
+        batch = _batch(name="posterior")
+
+        rebuilt = jax.tree_util.tree_map(lambda x: x, batch)
+
+        assert isinstance(rebuilt, NumericArrayBatch)
+        assert rebuilt.batch_shape == (4,)
+        assert rebuilt.level_names == ("draw",)
+
+    def test_removing_every_batch_axis_yields_the_element(self):
+        """The value is one element, so it comes back as one.
+
+        Observed through ``tree_map``: a ``vmap`` restacks, so the removal is
+        visible only on the way in, inside the trace.
+        """
+        out = jax.tree_util.tree_map(lambda x: x[0], _batch())
+
+        assert isinstance(out, NumericArray)
+        assert out.shape == (3,)
+
+    def test_a_vmap_hands_the_body_an_element_and_stacks_what_it_returns(self):
+        """Which is why the batch's own levels are read rather than inferred.
+
+        Unflattening a slice removes every batch axis, so the body receives a
+        `NumericArray`, and returning it stacks into one with the mapped axis
+        prepended. That value carries no levels, so its spec re-derives exactly
+        from the arriving shape.
+        """
+        out = jax.vmap(lambda element: element)(_batch())
+
+        assert isinstance(out, NumericArray)
+        assert out.shape == (4, 3)
+
+    def test_a_partial_or_resized_rank_is_refused(self):
+        """A shape is not a provenance: no reading says which level survived."""
+        with pytest.raises(ValueError, match="belongs to no level"):
+            jax.tree_util.tree_map(lambda x: jnp.stack([x, x]), _batch())
+
+    def test_a_skeleton_rebuilds_rather_than_raising(self):
+        skeleton = jax.tree_util.tree_map(lambda x: None, _batch())
+
+        assert isinstance(skeleton, NumericArrayBatch)
+
+    def test_it_reaches_a_traced_function(self):
+        total = jax.jit(lambda b: jnp.sum(b))(_batch())
+
+        assert float(total) == float(jnp.sum(jnp.arange(12.0)))
+
+
+class TestNumericArrayBatchArrayShim:
+    """Single-column, so it forwards from its store."""
+
+    def test_shape_is_the_whole_store(self):
+        batch = _batch()
+
+        assert batch.shape == (4, 3)
+        assert batch.ndim == 2
+        assert batch.batch_shape == (4,)
+
+    def test_it_converts_through_both_hooks(self):
+        batch = _batch()
+
+        assert np.asarray(batch).shape == (4, 3)
+        assert isinstance(jnp.asarray(batch), jax.Array)
+
+    def test_dtype_reports_the_store(self):
+        assert _batch().dtype == jnp.float32

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -1,0 +1,323 @@
+"""Tests for NumericArray and NumericArrayBatch — the numeric-array kind."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from probpipe import NumericArray, NumericArrayBatch, NumericArraySpec
+from probpipe.core.provenance import Provenance
+
+
+def _batch(values=None, level_names="draw", **kwargs) -> NumericArrayBatch:
+    if values is None:
+        values = jnp.arange(12.0).reshape(4, 3)
+    kwargs.setdefault("element_spec", NumericArraySpec(shape=(3,), dtype=jnp.float32))
+    return NumericArrayBatch(values, level_names, **kwargs)
+
+
+class TestNumericArrayHoldsOneValue:
+    def test_shape_is_the_event_shape(self):
+        """A NumericArray carries no batch axes, so its shape is the event's."""
+        value = NumericArray(jnp.zeros((2, 5)))
+
+        assert value.shape == (2, 5)
+        assert value.ndim == 2
+        assert len(value) == 2
+
+    def test_the_spec_is_derived_when_omitted(self):
+        value = NumericArray(jnp.arange(3.0))
+
+        assert value.spec == NumericArraySpec(shape=(3,), dtype=jnp.float32)
+
+    def test_a_supplied_spec_is_checked(self):
+        with pytest.raises(ValueError, match="does not satisfy its declaration"):
+            NumericArray(jnp.arange(3.0), spec=NumericArraySpec(shape=(2,), dtype=jnp.float32))
+
+    def test_a_value_that_is_not_an_array_is_refused(self):
+        with pytest.raises(TypeError, match="holds one numeric array"):
+            NumericArray(object())
+
+    def test_a_spec_of_another_kind_is_refused(self):
+        with pytest.raises(TypeError, match="must be a NumericArraySpec"):
+            NumericArray(jnp.arange(3.0), spec="not a spec")
+
+
+class TestNumericArrayCarriesIdentity:
+    def test_a_name_is_kept_and_marked_user_given(self):
+        value = NumericArray(jnp.arange(3.0), name="draw")
+
+        assert (value.name, value.name_is_auto) == ("draw", False)
+
+    def test_an_omitted_name_is_auto_derived(self):
+        assert NumericArray(jnp.arange(3.0)).name_is_auto is True
+
+    def test_provenance_is_write_once(self):
+        value = NumericArray(jnp.arange(3.0)).with_provenance(Provenance.create("test", parents=[]))
+
+        assert value.provenance.operation == "test"
+        with pytest.raises(RuntimeError, match="already set"):
+            value.with_provenance(Provenance.create("again", parents=[]))
+
+    def test_it_is_immutable(self):
+        with pytest.raises(AttributeError, match="immutable"):
+            NumericArray(jnp.arange(3.0))._value = jnp.zeros(3)
+
+    def test_the_array_is_reachable_untracked(self):
+        raw = jnp.arange(3.0)
+
+        assert NumericArray(raw).value is raw
+
+    def test_it_is_unhashable(self):
+        """`__eq__` is elementwise, so a hash would be a false promise."""
+        with pytest.raises(TypeError):
+            hash(NumericArray(jnp.arange(3.0)))
+
+
+class TestNumericArrayComputesAsAnArray:
+    """The full array surface, because with no fields `arr + 1` has one meaning."""
+
+    @pytest.mark.parametrize(
+        "compute",
+        [
+            lambda v: v + 1,
+            lambda v: 1 + v,
+            lambda v: v * v,
+            lambda v: v - 1.0,
+            lambda v: 2.0 / (v + 1),
+            lambda v: -v,
+            lambda v: abs(v),
+            lambda v: v**2,
+        ],
+    )
+    def test_arithmetic_yields_a_bare_array(self, compute):
+        """Identity is attached by operations, and arithmetic is not one."""
+        result = compute(NumericArray(jnp.arange(3.0)))
+
+        assert not isinstance(result, NumericArray)
+        assert isinstance(result, jax.Array)
+
+    def test_it_computes_the_same_values_as_the_array_it_holds(self):
+        raw = jnp.arange(3.0)
+
+        np.testing.assert_array_equal(
+            np.asarray(NumericArray(raw) * 2 + 1), np.asarray(raw * 2 + 1)
+        )
+
+    def test_two_numeric_arrays_combine(self):
+        pair = NumericArray(jnp.arange(3.0)) + NumericArray(jnp.ones(3))
+
+        assert not isinstance(pair, NumericArray)
+        np.testing.assert_array_equal(np.asarray(pair), np.asarray(jnp.arange(1.0, 4.0)))
+
+    def test_comparison_is_elementwise(self):
+        np.testing.assert_array_equal(
+            np.asarray(NumericArray(jnp.arange(3.0)) == 1.0), np.array([False, True, False])
+        )
+
+    def test_it_converts_through_both_hooks(self):
+        value = NumericArray(jnp.arange(3.0))
+
+        np.testing.assert_array_equal(np.asarray(value), np.arange(3.0))
+        assert isinstance(jnp.asarray(value), jax.Array)
+
+    def test_it_traces_under_jit(self):
+        """``__jax_array__`` is why the numpy hook does not win and drop tracing."""
+
+        @jax.jit
+        def double(x):
+            return x * 2
+
+        np.testing.assert_allclose(
+            np.asarray(double(NumericArray(jnp.arange(3.0)))), np.arange(3.0) * 2
+        )
+
+    def test_a_scalar_converts_to_a_number(self):
+        assert float(NumericArray(jnp.asarray(2.5))) == 2.5
+        assert int(NumericArray(jnp.asarray(2))) == 2
+
+    def test_a_scalar_is_truthy_by_its_value(self):
+        assert bool(NumericArray(jnp.asarray(1.0))) is True
+        assert bool(NumericArray(jnp.asarray(0.0))) is False
+
+    def test_an_integer_scalar_indexes(self):
+        """``__index__`` is what lets one stand in for a position."""
+        assert [10, 20, 30][NumericArray(jnp.asarray(1))] == 20
+
+    def test_indexing_and_iteration_reach_the_array(self):
+        value = NumericArray(jnp.arange(3.0))
+
+        assert float(value[1]) == 1.0
+        assert [float(x) for x in value] == [0.0, 1.0, 2.0]
+
+
+class TestNumericArrayBatchHoldsTheMultiplicity:
+    def test_the_element_spec_splits_batch_axes_from_event_axes(self):
+        batch = _batch()
+
+        assert batch.batch_shape == (4,)
+        assert batch.batch_size == 4
+        assert tuple(batch.element_spec.shape) == (3,)
+
+    def test_scalar_elements_leave_every_axis_to_the_batch(self):
+        batch = NumericArrayBatch(
+            jnp.arange(4.0), "draw", element_spec=NumericArraySpec(shape=(), dtype=jnp.float32)
+        )
+
+        assert batch.batch_shape == (4,)
+
+    def test_levels_tile_the_batch_shape(self):
+        batch = _batch(
+            jnp.arange(24.0).reshape(2, 4, 3),
+            ("chain", "draw"),
+        )
+
+        assert batch.level_names == ("chain", "draw")
+        assert batch.axis_groups == ((2,), (4,))
+        assert batch.batch_shape == (2, 4)
+
+    def test_the_stored_array_and_its_dtype_are_reachable(self):
+        batch = _batch()
+
+        assert batch.values.shape == (4, 3)
+        assert batch.dtype == jnp.float32
+
+    def test_the_repr_states_the_split(self):
+        assert repr(_batch()) == (
+            "NumericArrayBatch(batch_shape=(4,), levels=('draw',), event_shape=(3,))"
+        )
+
+    def test_one_level_may_span_several_axes(self):
+        batch = _batch(jnp.arange(24.0).reshape(2, 4, 3), "cell", axis_groups=((2, 4),))
+
+        assert batch.level_names == ("cell",)
+        assert batch.axis_groups == ((2, 4),)
+
+
+class TestNumericArrayBatchSelection:
+    """Selection yields the element kind, as it does for every batch."""
+
+    def test_an_element_is_a_numeric_array(self):
+        element = _batch()[1]
+
+        assert isinstance(element, NumericArray)
+        np.testing.assert_array_equal(np.asarray(element), np.array([3.0, 4.0, 5.0]))
+
+    def test_an_element_takes_the_derived_name(self):
+        element = _batch(name="posterior")[1]
+
+        assert element.name == "posterior[draw=1]"
+        assert element.name_is_auto is True
+
+    def test_an_element_inherits_the_batch_lineage(self):
+        """Selecting computes nothing, so the element carries the batch's own."""
+        batch = _batch().with_provenance(Provenance.create("sample", parents=[]))
+
+        assert batch[1].provenance is batch.provenance
+
+    def test_an_element_carries_the_batch_element_spec(self):
+        assert _batch()[1].spec == _batch().element_spec
+
+    def test_a_slice_is_a_sub_batch(self):
+        sub = _batch(name="posterior")[1:3]
+
+        assert isinstance(sub, NumericArrayBatch)
+        assert sub.batch_shape == (2,)
+        assert sub.name == "posterior[draw=1:3]"
+
+    def test_iteration_yields_elements(self):
+        assert [type(e) for e in _batch()] == [NumericArray] * 4
+
+
+class TestNumericArrayBatchRefusals:
+    def test_a_stored_array_with_no_batch_axis_is_refused(self):
+        """One value is a NumericArray; a batch has at least one batch axis."""
+        with pytest.raises(ValueError, match="at least one batch axis"):
+            NumericArrayBatch(
+                jnp.zeros(3), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32)
+            )
+
+    def test_trailing_axes_that_are_not_the_event_shape_are_refused(self):
+        with pytest.raises(ValueError, match="where its elements declare the event shape"):
+            NumericArrayBatch(
+                jnp.zeros((4, 5)),
+                "draw",
+                element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float32),
+            )
+
+    def test_a_symbolic_event_dimension_is_refused(self):
+        """A symbolic size gives the stored axes nothing to split by."""
+        with pytest.raises(ValueError, match="symbolic dimension"):
+            NumericArrayBatch(
+                jnp.zeros((4, 3)),
+                "draw",
+                element_spec=NumericArraySpec(shape=("n",), dtype=jnp.float32),
+            )
+
+    def test_values_that_are_not_an_array_are_refused(self):
+        with pytest.raises(TypeError, match="stores one array"):
+            NumericArrayBatch(
+                object(), "draw", element_spec=NumericArraySpec(shape=(), dtype=jnp.float32)
+            )
+
+    def test_an_element_spec_of_another_kind_is_refused(self):
+        with pytest.raises(TypeError, match="must be a NumericArraySpec"):
+            NumericArrayBatch(jnp.zeros((4, 3)), "draw", element_spec="not a spec")
+
+    def test_axis_groups_must_tile_the_batch_shape(self):
+        with pytest.raises(ValueError):
+            _batch(jnp.arange(24.0).reshape(2, 4, 3), "cell", axis_groups=((2, 3),))
+
+
+class TestNumericArrayIsAPyTree:
+    """Registration is what lets it cross a transform boundary at all.
+
+    JAX no longer converts through ``__jax_array__`` during abstractification,
+    so a value that is not a registered pytree cannot be passed to a traced
+    function.
+    """
+
+    def test_it_round_trips_through_flatten_and_unflatten(self):
+        value = NumericArray(jnp.arange(3.0), name="draw")
+
+        leaves, treedef = jax.tree_util.tree_flatten(value)
+        rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+
+        assert isinstance(rebuilt, NumericArray)
+        assert (rebuilt.name, rebuilt.name_is_auto) == ("draw", False)
+        np.testing.assert_array_equal(np.asarray(rebuilt), np.arange(3.0))
+
+    def test_a_transform_that_changes_the_shape_re_derives_the_spec(self):
+        """Its spec *is* its shape and dtype, so what arrives states it exactly.
+
+        This is why no rank has to be inferred here the way a batch's must be.
+        """
+        stacked = jax.tree_util.tree_map(lambda x: jnp.stack([x, x]), NumericArray(jnp.arange(3.0)))
+
+        assert stacked.shape == (2, 3)
+        assert stacked.spec == NumericArraySpec(shape=(2, 3), dtype=jnp.float32)
+
+    def test_a_declared_support_rides_along(self):
+        """Shape and dtype re-derive; a support could not, so it is aux."""
+        from probpipe import positive
+
+        value = NumericArray(
+            jnp.arange(1.0, 4.0),
+            spec=NumericArraySpec(shape=(3,), dtype=jnp.float32, support=positive),
+        )
+
+        rebuilt = jax.tree_util.tree_map(lambda x: x, value)
+
+        assert rebuilt.spec.support == positive
+
+    def test_provenance_does_not_survive_the_boundary(self):
+        """As for `Record`: lineage rides on the function layer, not the treedef."""
+        value = NumericArray(jnp.arange(3.0)).with_provenance(
+            Provenance.create("sample", parents=[])
+        )
+
+        rebuilt = jax.tree_util.tree_map(lambda x: x, value)
+
+        assert rebuilt.provenance is None

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -85,6 +85,20 @@ class TestNumericArrayStoresNativeForm:
 
         assert isinstance(leaf, jax.Array)
 
+    def test_dtype_reports_the_value_not_the_declaration(self):
+        """The shim stands in for an array, and an array's dtype is its data's.
+
+        ``is_valid`` admits a same-kind cast, so the two can differ; the
+        declaration stays reachable as ``.spec``.
+        """
+        value = NumericArray(
+            jnp.zeros(3, dtype=jnp.float32),
+            spec=NumericArraySpec(shape=(3,), dtype=jnp.float64),
+        )
+
+        assert value.dtype == jnp.float32
+        assert value.spec.dtype == jnp.float64
+
     def test_a_non_numeric_value_is_refused(self):
         with pytest.raises(TypeError, match="is not a numeric leaf"):
             NumericArray("not numeric")
@@ -305,6 +319,47 @@ class TestNumericArrayBatchSelection:
         assert [type(e) for e in _batch()] == [NumericArray] * 4
 
 
+class TestNumericArrayBatchOverNativeContainers:
+    """Selection is positional, which `[]` is not on every container."""
+
+    @staticmethod
+    def _frame():
+        pd = pytest.importorskip("pandas")
+        return pd.DataFrame(np.arange(12.0).reshape(4, 3))
+
+    def test_an_element_selects_by_position_not_by_label(self):
+        """``df[0]`` is a column; the element is the row at position 0."""
+        batch = NumericArrayBatch(
+            self._frame(), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+        )
+
+        element = batch[1]
+
+        assert isinstance(element, NumericArray)
+        assert element.shape == (3,)
+        np.testing.assert_array_equal(np.asarray(element), np.array([3.0, 4.0, 5.0]))
+
+    def test_a_sub_batch_selects_by_position(self):
+        batch = NumericArrayBatch(
+            self._frame(), "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+        )
+
+        sub = batch[1:3]
+
+        assert isinstance(sub, NumericArrayBatch)
+        assert sub.batch_shape == (2,)
+
+    def test_the_container_is_still_stored_verbatim(self):
+        pd = pytest.importorskip("pandas")
+        frame = self._frame()
+
+        batch = NumericArrayBatch(
+            frame, "draw", element_spec=NumericArraySpec(shape=(3,), dtype=np.float64)
+        )
+
+        assert isinstance(batch.values, pd.DataFrame)
+
+
 class TestNumericArrayBatchRefusals:
     def test_a_stored_array_with_no_batch_axis_is_refused(self):
         """One value is a NumericArray; a batch has at least one batch axis."""
@@ -335,6 +390,29 @@ class TestNumericArrayBatchRefusals:
             NumericArrayBatch(
                 object(), "draw", element_spec=NumericArraySpec(shape=(), dtype=jnp.float32)
             )
+
+    def test_a_dtype_the_declaration_does_not_admit_is_refused(self):
+        """The batch asserts the spec of every element, so it checks at build.
+
+        Left to the first selection, ``NumericArray`` raises one layer too late
+        to name the batch that made the false claim.
+        """
+        with pytest.raises(TypeError, match="does not admit"):
+            NumericArrayBatch(
+                jnp.zeros((2, 3), dtype=jnp.float32),
+                "draw",
+                element_spec=NumericArraySpec(shape=(3,), dtype=jnp.int32),
+            )
+
+    def test_a_same_kind_dtype_is_admitted(self):
+        """A widening or within-kind narrowing passes, as it does for a record."""
+        batch = NumericArrayBatch(
+            jnp.zeros((2, 3), dtype=jnp.float32),
+            "draw",
+            element_spec=NumericArraySpec(shape=(3,), dtype=jnp.float64),
+        )
+
+        assert batch.batch_shape == (2,)
 
     def test_an_element_spec_of_another_kind_is_refused(self):
         with pytest.raises(TypeError, match="must be a NumericArraySpec"):

--- a/tests/core/test_opaque.py
+++ b/tests/core/test_opaque.py
@@ -1,0 +1,143 @@
+"""Tests for Opaque — the tracked class of the opaque kind."""
+
+from __future__ import annotations
+
+import copy
+import pickle
+
+import pytest
+
+from probpipe import Opaque, OpaqueBatch, OpaqueSpec
+from probpipe.core.provenance import Provenance
+
+
+class _Payload:
+    """A stand-in for the sort of thing an opaque value holds."""
+
+    def __init__(self, tag: str = "x") -> None:
+        self.tag = tag
+
+    def shout(self) -> str:
+        return self.tag.upper()
+
+    def __call__(self) -> str:
+        return "called"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _Payload) and other.tag == self.tag
+
+
+class TestOpaqueHoldsOneValue:
+    def test_the_value_is_reachable_and_unchanged(self):
+        payload = _Payload()
+
+        assert Opaque(payload).value is payload
+
+    def test_the_spec_defaults_to_a_bare_one(self):
+        assert Opaque(_Payload()).spec == OpaqueSpec()
+
+    def test_a_declared_spec_carries_its_meta(self):
+        spec = OpaqueSpec(meta="fitted-model")
+
+        assert Opaque(_Payload(), spec=spec).spec.meta == "fitted-model"
+
+    def test_a_spec_of_another_kind_is_refused(self):
+        with pytest.raises(TypeError, match="must be an OpaqueSpec"):
+            Opaque(_Payload(), spec="not a spec")
+
+    def test_a_mapping_is_refused(self):
+        """The value layer reads a mapping as a subtree, not a leaf."""
+        with pytest.raises(TypeError, match="reads a mapping as a subtree"):
+            Opaque({"a": 1})
+
+    @pytest.mark.parametrize("value", [1, "text", None, [1, 2], (1, 2), _Payload()])
+    def test_anything_else_is_admitted(self, value):
+        assert Opaque(value).value == value
+
+
+class TestOpaqueAddsIdentityAndNothingElse:
+    """A box that forwards is indistinguishable from what it wraps."""
+
+    def test_it_does_not_forward_attributes(self):
+        wrapped = Opaque(_Payload())
+
+        assert not hasattr(wrapped, "shout")
+        with pytest.raises(AttributeError):
+            wrapped.shout()
+
+    def test_it_is_not_callable_even_when_its_value_is(self):
+        wrapped = Opaque(_Payload())
+
+        assert not callable(wrapped)
+        with pytest.raises(TypeError):
+            wrapped()
+
+    def test_the_value_affords_what_it_always_did_once_out(self):
+        assert Opaque(_Payload("hi")).value.shout() == "HI"
+
+    def test_it_carries_no_array_surface(self):
+        wrapped = Opaque(_Payload())
+
+        for absent in ("shape", "dtype", "ndim", "__array__", "as_jax"):
+            assert not hasattr(wrapped, absent)
+
+
+class TestOpaqueCarriesIdentity:
+    def test_a_name_is_kept_and_marked_user_given(self):
+        wrapped = Opaque(_Payload(), name="model")
+
+        assert (wrapped.name, wrapped.name_is_auto) == ("model", False)
+
+    def test_an_omitted_name_is_auto_derived(self):
+        wrapped = Opaque(_Payload())
+
+        assert (wrapped.name, wrapped.name_is_auto) == ("opaque", True)
+
+    def test_provenance_is_write_once(self):
+        wrapped = Opaque(_Payload()).with_provenance(Provenance.create("fit", parents=[]))
+
+        assert wrapped.provenance.operation == "fit"
+        with pytest.raises(RuntimeError, match="already set"):
+            wrapped.with_provenance(Provenance.create("again", parents=[]))
+
+    def test_it_is_immutable(self):
+        with pytest.raises(AttributeError, match="immutable"):
+            Opaque(_Payload())._value = _Payload("other")
+
+    @pytest.mark.parametrize(
+        "roundtrip",
+        [copy.copy, copy.deepcopy, lambda o: pickle.loads(pickle.dumps(o))],
+    )
+    def test_it_survives_copy_and_pickle(self, roundtrip):
+        wrapped = Opaque(_Payload("kept"), name="model")
+
+        rebuilt = roundtrip(wrapped)
+
+        assert isinstance(rebuilt, Opaque)
+        assert rebuilt.name == "model"
+        assert rebuilt.value == _Payload("kept")
+
+
+class TestOpaqueAndItsBatch:
+    """The batch existed first: a collection is tracked whatever it holds."""
+
+    def test_a_batch_of_opaque_values_still_hands_back_what_was_put_in(self):
+        """`OpaqueBatch`'s element contract is unchanged by the new class.
+
+        Its elements are the caller's own objects, stored rather than
+        materialized, so it does not start wrapping them in `Opaque`.
+        """
+        payloads = [_Payload("a"), _Payload("b")]
+
+        batch = OpaqueBatch(payloads, "draw")
+
+        assert batch[0] is payloads[0]
+
+    def test_a_batch_may_hold_opaque_terms_as_its_elements(self):
+        """Nothing stops one, since an `Opaque` is itself a non-mapping value."""
+        terms = [Opaque(_Payload("a"), name="first"), Opaque(_Payload("b"), name="second")]
+
+        batch = OpaqueBatch(terms, "draw")
+
+        assert batch[1] is terms[1]
+        assert batch[1].name == "second"

--- a/tests/core/test_opaque.py
+++ b/tests/core/test_opaque.py
@@ -31,52 +31,52 @@ class TestOpaqueHoldsOneValue:
     def test_the_value_is_reachable_and_unchanged(self):
         payload = _Payload()
 
-        assert Opaque(payload).value is payload
+        assert Opaque("p", payload).value is payload
 
     def test_the_spec_defaults_to_a_bare_one(self):
-        assert Opaque(_Payload()).spec == OpaqueSpec()
+        assert Opaque("p", _Payload()).spec == OpaqueSpec()
 
     def test_a_declared_spec_carries_its_meta(self):
         spec = OpaqueSpec(meta="fitted-model")
 
-        assert Opaque(_Payload(), spec=spec).spec.meta == "fitted-model"
+        assert Opaque("p", _Payload(), spec=spec).spec.meta == "fitted-model"
 
     def test_a_spec_of_another_kind_is_refused(self):
         with pytest.raises(TypeError, match="must be an OpaqueSpec"):
-            Opaque(_Payload(), spec="not a spec")
+            Opaque("p", _Payload(), spec="not a spec")
 
     def test_a_mapping_is_refused(self):
-        """The value layer reads a mapping as a subtree, not a leaf."""
+        """The value layer reads a mapping as a subtree."""
         with pytest.raises(TypeError, match="reads a mapping as a subtree"):
-            Opaque({"a": 1})
+            Opaque("p", {"a": 1})
 
     @pytest.mark.parametrize("value", [1, "text", None, [1, 2], (1, 2), _Payload()])
     def test_anything_else_is_admitted(self, value):
-        assert Opaque(value).value == value
+        assert Opaque("p", value).value == value
 
 
 class TestOpaqueAddsIdentityAndNothingElse:
-    """A box that forwards is indistinguishable from what it wraps."""
+    """Its interface is `value` and the identity a tracked term carries."""
 
     def test_it_does_not_forward_attributes(self):
-        wrapped = Opaque(_Payload())
+        wrapped = Opaque("p", _Payload())
 
         assert not hasattr(wrapped, "shout")
         with pytest.raises(AttributeError):
             wrapped.shout()
 
     def test_it_is_not_callable_even_when_its_value_is(self):
-        wrapped = Opaque(_Payload())
+        wrapped = Opaque("p", _Payload())
 
         assert not callable(wrapped)
         with pytest.raises(TypeError):
             wrapped()
 
     def test_the_value_affords_what_it_always_did_once_out(self):
-        assert Opaque(_Payload("hi")).value.shout() == "HI"
+        assert Opaque("p", _Payload("hi")).value.shout() == "HI"
 
     def test_it_carries_no_array_surface(self):
-        wrapped = Opaque(_Payload())
+        wrapped = Opaque("p", _Payload())
 
         for absent in ("shape", "dtype", "ndim", "__array__", "as_jax"):
             assert not hasattr(wrapped, absent)
@@ -84,17 +84,22 @@ class TestOpaqueAddsIdentityAndNothingElse:
 
 class TestOpaqueCarriesIdentity:
     def test_a_name_is_kept_and_marked_user_given(self):
-        wrapped = Opaque(_Payload(), name="model")
+        wrapped = Opaque("model", _Payload())
 
         assert (wrapped.name, wrapped.name_is_auto) == ("model", False)
 
-    def test_an_omitted_name_is_auto_derived(self):
-        wrapped = Opaque(_Payload())
+    def test_a_name_is_required(self):
+        """The name is what says which opaque value this is."""
+        with pytest.raises(TypeError):
+            Opaque(_Payload())
 
-        assert (wrapped.name, wrapped.name_is_auto) == ("opaque", True)
+    def test_a_derived_name_is_marked_auto(self):
+        wrapped = Opaque("batch[draw=0]", _Payload(), name_is_auto=True)
+
+        assert wrapped.name_is_auto is True
 
     def test_provenance_is_write_once(self):
-        wrapped = Opaque(_Payload()).with_provenance(Provenance.create("fit", parents=[]))
+        wrapped = Opaque("p", _Payload()).with_provenance(Provenance.create("fit", parents=[]))
 
         assert wrapped.provenance.operation == "fit"
         with pytest.raises(RuntimeError, match="already set"):
@@ -102,14 +107,14 @@ class TestOpaqueCarriesIdentity:
 
     def test_it_is_immutable(self):
         with pytest.raises(AttributeError, match="immutable"):
-            Opaque(_Payload())._value = _Payload("other")
+            Opaque("p", _Payload())._value = _Payload("other")
 
     @pytest.mark.parametrize(
         "roundtrip",
         [copy.copy, copy.deepcopy, lambda o: pickle.loads(pickle.dumps(o))],
     )
     def test_it_survives_copy_and_pickle(self, roundtrip):
-        wrapped = Opaque(_Payload("kept"), name="model")
+        wrapped = Opaque("model", _Payload("kept"))
 
         rebuilt = roundtrip(wrapped)
 
@@ -119,14 +124,10 @@ class TestOpaqueCarriesIdentity:
 
 
 class TestOpaqueAndItsBatch:
-    """The batch existed first: a collection is tracked whatever it holds."""
+    """A collection is tracked whatever it holds."""
 
     def test_a_batch_of_opaque_values_still_hands_back_what_was_put_in(self):
-        """`OpaqueBatch`'s element contract is unchanged by the new class.
-
-        Its elements are the caller's own objects, stored rather than
-        materialized, so it does not start wrapping them in `Opaque`.
-        """
+        """Its elements are stored, so a batch hands back the caller's object."""
         payloads = [_Payload("a"), _Payload("b")]
 
         batch = OpaqueBatch(payloads, "draw")
@@ -134,8 +135,8 @@ class TestOpaqueAndItsBatch:
         assert batch[0] is payloads[0]
 
     def test_a_batch_may_hold_opaque_terms_as_its_elements(self):
-        """Nothing stops one, since an `Opaque` is itself a non-mapping value."""
-        terms = [Opaque(_Payload("a"), name="first"), Opaque(_Payload("b"), name="second")]
+        """An `Opaque` is itself a non-mapping value."""
+        terms = [Opaque("first", _Payload("a")), Opaque("second", _Payload("b"))]
 
         batch = OpaqueBatch(terms, "draw")
 

--- a/tests/core/test_record_batch.py
+++ b/tests/core/test_record_batch.py
@@ -33,8 +33,8 @@ from probpipe import (
 )
 from probpipe.core import _array_backend
 from probpipe.core._numeric_record_batch import NumericRecordBatch
+from probpipe.core._opaque import OpaqueSpec
 from probpipe.core._record_batch import RecordBatch
-from probpipe.core.event_template import OpaqueSpec
 
 
 @pytest.fixture
@@ -1511,7 +1511,7 @@ class TestPyTreeRebuildContract:
 
     def test_retyping_an_opaque_column_is_refused(self):
         """The same for a field whose spec narrows what an entry may be."""
-        from probpipe.core.event_template import OpaqueSpec
+        from probpipe.core._opaque import OpaqueSpec
 
         column = _object_column(["north", "south"])
         batch = RecordBatch(

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -26,11 +26,11 @@ from probpipe import (
     RecordBatch,
 )
 from probpipe.core._empirical import BootstrapReplicateDistribution, EmpiricalDistribution
+from probpipe.core._opaque import OpaqueSpec
 from probpipe.core.event_template import (
     EventTemplate,
     NumericArraySpec,
     NumericEventTemplate,
-    OpaqueSpec,
 )
 from probpipe.core.record import Record
 


### PR DESCRIPTION
Stacked on #434. Part of #398.

**Purely additive**: new classes and their tests. Nothing that already existed changes
behaviour, so this can be read on its own terms.

## What it adds

Every value spec should have one tracked class and one batch form. Two kinds had neither:

| spec | tracked class | batch form |
| --- | --- | --- |
| `NumericArraySpec` | **`NumericArray`** | **`NumericArrayBatch`** |
| `OpaqueSpec` | **`Opaque`** | `OpaqueBatch` (already existed) |

`NumericArray` holds one array with identity. Its `shape` is the **event** shape — it
carries no batch axes; multiplicity lives in `NumericArrayBatch`. It carries the full array
surface (arithmetic, comparison, conversion hooks) because with no fields and no field
count `arr + 1` has exactly one meaning, which is what lets `Record` stay a container.
**Arithmetic yields a bare array**: identity is attached by operations, and arithmetic is
not one.

`Opaque` adds identity and nothing else — no attribute forwarding, no `__call__`, one
explicit accessor. A box that forwards is indistinguishable from what it wraps.

## Points worth review

- **Native-form storage.** Construction validates against container metadata and does not
  convert, so a lazy or disk-backed value is not materialised merely to be named.
  Conversion happens at the compute boundary through a set-once cache.
- **The pytree aux carries the declaration.** It is not re-read off the arriving array:
  `is_valid` admits a same-kind cast, so a float32 value under a float64 declaration would
  otherwise come back declaring float32.
- **`NumericArrayBatch` requires a name.** A batch is what an operation hands back, and the
  name says which one it is; a class-name default would name every batch in a pipeline
  alike. The other batch classes do not yet follow this — that is the fifth PR.
- **`OpaqueSpec` moves** into `_opaque.py`, beside the class it names.

Suite: 5534 passed, 54 skipped.
