### PR TITLE
fix(core): make the new kinds work end to end in the workflow layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    # dev/** covers stacked PRs (a PR based on another PR's dev/ branch),
-    # which would otherwise get no CI until the base merges and the PR
+    # dev/** and consolidated/** cover stacked PRs (a PR based on another PR's
+    # branch), which would otherwise get no CI until the base merges and the PR
     # retargets to main.
-    branches: [main, "dev/**"]
+    branches: [main, "dev/**", "consolidated/**"]
 
 # Cancel superseded runs on PR pushes (saves CI minutes during iteration).
 # Pushes to main keep running — never cancel work that gates the merged history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Every density op keeps a batch operand's levels (#398).** `log_prob` restated
+  the levels its operand carried; `prob`, `unnormalized_log_prob`, and
+  `unnormalized_prob` handed back a bare array, so the same draws scored as a
+  batch over `("chain", "draw")` under one op and as one value of shape `(2, 3)`
+  under another. All four now restate them, so which op is called no longer
+  decides whether the draws were a multiplicity.
+
 - **A declared function can be swept over any kind of batch (#398).** Lifting a
   declaration against a batched operand read `event_template`, the view only a
   batch of records has, so a `NumericArrayBatch`, `OpaqueBatch`, or `FunctionBatch`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   requires at least one field. An empty template is **not** promoted to `NumericEventTemplate`:
 
   result. An empty template is **not** promoted to `NumericEventTemplate`:
+
+
   vacuously every leaf is numeric, which is not a reason to claim it. A batch
   still requires a batch *axis* — a single object with no axis is refused as
   before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The kind table is the single answer to which batch form a field has (#398).**
+  `RecordBatch` construction listed the admissible field kinds inline while the
+  reading end asked the registry, so registering a kind widened one and not the
+  other. Construction now asks the registry too. Aggregating a batch of rows also
+  converts each row through its own `as_jax`, whose set-once cache it was
+  bypassing by converting the raw store directly.
+
 - **A swept row of unstackable elements keeps its level (#398).** A row returning
   a sequence of opaque objects or callables had its own batch stored whole as one
   element of the aggregate, so the row's multiplicity vanished and a row of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A swept row of unstackable elements keeps its level (#398).** A row returning
+  a sequence of opaque objects or callables had its own batch stored whole as one
+  element of the aggregate, so the row's multiplicity vanished and a row of
+  callables came back as an `OpaqueBatch`. The row-stacking path now knows all
+  three batch families, so such a row aggregates to `(rows, row_size)` over both
+  levels and a row of callables gives a `FunctionBatch`. An empty sequence row is
+  a batch of nothing on its own level, as it already was for a single return,
+  which also settles a dispatch disagreement: the mapped path raised where the
+  row-wise path returned.
+
 - **Every density op keeps a batch operand's levels (#398).** `log_prob` restated
   the levels its operand carried; `prob`, `unnormalized_log_prob`, and
   `unnormalized_prob` handed back a bare array, so the same draws scored as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A swept row's kind no longer depends on which executor ran it (#398).** The
+  row-wise path gave each row the tracked class of its own kind; the mapped
+  (`jax.vmap`) path handed its rows to the aggregation raw, so a body returning a
+  mapping raised `cannot aggregate output of type dict` and one returning a
+  sequence raised a spurious row-count mismatch — under `dispatch="auto"`, on
+  bodies that worked under `dispatch="sequential"`. Both paths now read a row
+  through the same rule, and a record row crosses the map as inert columns over no
+  level of its own, the way a batch row already crossed it. A declared
+  `output_template` still names the row's kind, as before.
+
 - **Reading a distribution no longer modifies it.** `BroadcastDistribution`
   assigned its marginal on the first `marginalize()`, and a backend-delegated
   `DistributionArray` assigned its components on the first read, so a query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A declared function can be swept over any kind of batch (#398).** Lifting a
+  declaration against a batched operand read `event_template`, the view only a
+  batch of records has, so a `NumericArrayBatch`, `OpaqueBatch`, or `FunctionBatch`
+  operand raised `does not expose an authoritative event_template for lifting`
+  however its declaration was written. It now reads `element_spec`, which the
+  `Batch` contract states at every kind. Two consequences: every batch kind is
+  read the same way, and a batch of one-field records no longer satisfies a
+  declaration that named a bare array — the record-only view unwrapped a
+  single-field element to its field, so `EventTemplate(v=())` accepted an operand
+  whose elements are records. A distribution operand is unchanged: it is lifted by
+  being sampled, and its event template remains what the draw is checked against.
+
 - **A swept row's kind no longer depends on which executor ran it (#398).** The
   row-wise path gave each row the tracked class of its own kind; the mapped
   (`jax.vmap`) path handed its rows to the aggregation raw, so a body returning a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it was the one aggregation that left the result auto-named. Opaque rows now give
   an `OpaqueBatch` and callable rows a `FunctionBatch`, both named for the
   function as every other aggregation already was.
-
 - **An empty return keeps its host's kind (#398).** A `Function` returning `{}`
   raised, and `[]` / `()` became an `Opaque`, because `Record`, `EventTemplate`,
   and the object batches each required at least one entry. The kind now follows
@@ -116,6 +115,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   result. A *batch* of empty records is not: a batch reads its multiplicity off
   a column, and a zero-field element supplies none, so `RecordBatch` still
   requires at least one field. An empty template is **not** promoted to `NumericEventTemplate`:
+
+  result. An empty template is **not** promoted to `NumericEventTemplate`:
   vacuously every leaf is numeric, which is not a reason to claim it. A batch
   still requires a batch *axis* — a single object with no axis is refused as
   before.

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -94,9 +94,11 @@ if it were user-guide reference text.
 |---|---|
 | `NamedTree` (shared name-keyed tree substrate) | docstrings in `probpipe/core/named_tree.py`; #235 Chapter 1 |
 | `EventTemplate` / `NumericEventTemplate` / `ValueSpec` (raw-value: `NumericArraySpec`·`OpaqueSpec`; `TermSpec`: `RecordSpec`·`DistributionSpec`·`FunctionSpec`) | docstrings in `probpipe/core/event_template.py`; #235 Chapter 1 |
+| the kind table (which tracked class and which batch form each value spec has) | docstrings in `probpipe/core/_kinds.py` |
+| `NumericArray` / `Opaque` (the tracked classes of the two raw-value kinds) | docstrings in `probpipe/core/_numeric_array.py`, `_opaque.py` |
 | `Record` / `NumericRecord` (each stores its type as a `RecordSpec`, with `event_template` a view on it) | docstrings in `probpipe/core/record.py`, `_numeric_record.py`; #235 Chapter 2 |
 | `Batch` / `BatchSpec` (the multiplicity axis: levels, level names, view identity) | docstrings in `probpipe/core/_batch.py`; #235 Chapter 2 |
-| Batch types (`RecordBatch`/`NumericRecordBatch`, `DistributionArray`) | docstrings in `_record_batch.py`, `_numeric_record_batch.py`, `_distribution_array.py`; #235 Chapter 2 |
+| `NumericArrayBatch` (the batch form of the numeric-array kind; one native store, not columns) | docstrings in `probpipe/core/_numeric_array_batch.py`; #235 Chapter 2 |
 | `RecordBatch` / `NumericRecordBatch` (columnar, leaf-path-keyed storage; a collection, not a named tree) | docstrings in `probpipe/core/_record_batch.py`, `_numeric_record_batch.py`; #235 Chapter 2 |
 | `FunctionBatch` / `OpaqueBatch` (the batch forms that *store* their elements, over shared object-array storage) | docstrings in `probpipe/core/_function_batch.py`, `_opaque_batch.py` (storage in `_object_batch.py`); #235 Chapter 2 |
 | `Function` & ops (`sample`, `log_prob`, …) | docstrings in `core/node.py`, `core/ops.py`, `_workflow_result.py`; #235 Chapter 3 |

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -611,20 +611,16 @@ def _make_marginal(
 # _make_stack — stacked sibling of _make_marginal for batched broadcasts
 # ---------------------------------------------------------------------------
 #
-# When a Function broadcasts over a batch of records (parameter
-# sweep), the n inner outputs are independent scenarios indexed by
-# input row — *not* MC draws. The wrapper must preserve row identity:
+# A sweep's rows are independent scenarios indexed by input row, not MC draws,
+# so the aggregate keeps row identity. Each row is first given the kind of the
+# host it is, then the rows aggregate at that kind:
 #
-#   numeric → NumericArrayBatch, one sweep level of (n,)
-#   Record → RecordBatch.stack (NumericRecordBatch when all leaves numeric)
-#   Distribution → DistributionArray
-#   a batch per row (each (m,)) → one batch, levels (sweep, …) over (n, m)
+#   numeric   → NumericArrayBatch          Record       → RecordBatch
+#   opaque    → OpaqueBatch                Distribution → DistributionArray
+#   callable  → FunctionBatch
 #
-# Opaque Python values (e.g. strings) that can't be stacked fall
-# through to a plain-list wrapping with a clear error if even that
-# fails.
-#
-# Caller attaches ``.with_provenance(...)`` externally via ``_coerce_output``.
+# A row that is itself a batch stacks into one batch, the sweep's levels in
+# front of the rows' own. Provenance is attached by ``_coerce_output``.
 # ---------------------------------------------------------------------------
 
 

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from .._weights import Weights
 from ..custom_types import Array
-from ._array_backend import _to_jax_array
+from ._array_backend import _event_shape_of, _is_numeric_leaf, _to_jax_array
 from ._distribution_base import Distribution
 from ._empirical import (
     EmpiricalDistribution,
@@ -699,6 +699,29 @@ def _agreeing_batch_rows(outs: list, *, field_name: str) -> Any:
     return first
 
 
+def _row_at_its_kind(row: Any, field_name: str) -> Any:
+    """One swept row as the tracked term of its own kind.
+
+    Only the two *structural* hosts are converted here. A numeric, opaque, or
+    callable row already reaches a branch below that batches it at its kind, and
+    converting it early would cost the vectorized path for no gain.
+
+    - a ``Mapping`` is a tree, so it becomes a ``Record`` and the rows stack into
+      a batch of records;
+    - a non-empty sequence is a multiplicity, so it becomes a batch of its own and
+      the rows stack with that level inside the sweep's.
+    """
+    from collections.abc import Mapping
+
+    from .record import Record
+
+    if isinstance(row, Mapping):
+        return Record(field_name, dict(row), name_is_auto=True)
+    if isinstance(row, (list, tuple)) and row:
+        return _make_stack(list(row), n=len(row), level_names=(field_name,), field_name=field_name)
+    return row
+
+
 def _make_stack(
     inner_outputs: Any,
     *,
@@ -840,6 +863,13 @@ def _make_stack(
                 )
                 for output in outs
             ]
+        else:
+            # Each row takes the kind of the host it is, before the branches
+            # below read what the rows are. A row is one call's return, and the
+            # boundary that names a *single* return's kind (V.0) is the same rule
+            # — reading a mapping row as an unstackable object, or a sequence row
+            # as event shape, states something the row never said.
+            outs = [_row_at_its_kind(output, field_name) for output in outs]
 
         # A batch per row stacks into one batch with the sweep in front of the
         # rows' own levels. Checked before the Record branch below, which would
@@ -969,6 +999,18 @@ def _make_stack(
                 axis_groups=sweep_groups,
                 name=name or field_name,
                 name_is_auto=name is None,
+            )
+
+        # Numeric rows that do not stack disagree on their shape, and an object
+        # column would record that disagreement as though it were the answer. The
+        # rows say what they are; the aggregate says so too.
+        if outs and all(_is_numeric_leaf(o) for o in outs):
+            shapes = sorted({tuple(_event_shape_of(o)) for o in outs})
+            raise ValueError(
+                f"{field_name}: the rows returned numeric values of differing shapes "
+                f"{shapes}, so they do not stack into one batch. Every row of a sweep "
+                f"contributes one element of one shape; pad the rows, or return a batch "
+                f"from each and let the levels record the difference"
             )
 
         # Rows that do not stack take the batch form of their own kind, which is

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -906,10 +906,11 @@ def _make_stack(
                     name_is_auto=True,
                 )
             if isinstance(first, NumericArrayBatch):
-                # One store rather than columns, so the rows stack directly —
-                # through the array backend, as the columns below do, since a
-                # row's store is in native form.
-                store = jnp.stack([_to_jax_array(o.values) for o in outs], axis=0)
+                # One store rather than columns, so the rows stack directly. Each
+                # row converts through ``as_jax``, not through the backend on its
+                # raw store: the conversion is the batch's own and is cached
+                # set-once there, so a row aggregated again is not converted again.
+                store = jnp.stack([o.as_jax() for o in outs], axis=0)
                 return NumericArrayBatch(
                     store.reshape(batch_shape + store.shape[1:]),
                     (*level_names, *first.level_names),

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -432,6 +432,7 @@ def _stack_declared_columns(
         element_spec=template,
         axis_groups=axis_groups,
         name=name,
+        name_is_auto=True,
     )
 
 
@@ -459,7 +460,14 @@ def _empty_declared_stack(
         else:
             columns[path] = np.empty(batch_shape, dtype=object)
     cls = _batch_class_for(template)
-    return cls(columns, level_names, element_spec=template, axis_groups=axis_groups, name=name)
+    return cls(
+        columns,
+        level_names,
+        element_spec=template,
+        axis_groups=axis_groups,
+        name=name,
+        name_is_auto=True,
+    )
 
 
 def _make_marginal(
@@ -815,7 +823,7 @@ def _make_stack(
             element_spec=inner_outputs.element_spec,
             axis_groups=(*sweep_groups, *inner_outputs.axis_groups),
             name=name or field_name,
-            name_is_auto=name is None,
+            name_is_auto=True,
         )
     if isinstance(inner_outputs, _MappedBatchColumns):
         return _batch_over_swept_columns(
@@ -891,7 +899,7 @@ def _make_stack(
                     element_spec=first.element_spec,
                     axis_groups=(*sweep_groups, *first.axis_groups),
                     name=name or field_name,
-                    name_is_auto=name is None,
+                    name_is_auto=True,
                 )
             # Columns are leaf-keyed, so a nested element needs no special
             # case — and they are read raw: a field that is not an array
@@ -935,8 +943,10 @@ def _make_stack(
             except (TypeError, ValueError):
                 flat = None
             if flat is not None:
-                if batch_shape == (n_total,):
-                    return flat
+                # No early return for the one-level case: the reshape below is
+                # an identity there, and ``stack`` named the batch after its own
+                # class, where every aggregation names it for the function that
+                # produced the rows.
                 n_cur = len(flat.batch_shape)
                 return NumericRecordBatch(
                     {
@@ -946,6 +956,8 @@ def _make_stack(
                     level_names,
                     element_spec=flat.element_spec,
                     axis_groups=sweep_groups,
+                    name=name or field_name,
+                    name_is_auto=True,
                 )
             # No declared template, so the element structure is inferred from the
             # rows. ``RecordBatch.stack`` is what infers it: columns are keyed by
@@ -967,6 +979,8 @@ def _make_stack(
                 level_names,
                 element_spec=flat.element_spec,
                 axis_groups=sweep_groups,
+                name=name or field_name,
+                name_is_auto=True,
             )
 
         # All Distributions → stacked DistributionArray, shaped to
@@ -998,7 +1012,7 @@ def _make_stack(
                 element_spec=NumericArraySpec(event_shape, dtype=stacked.dtype),
                 axis_groups=sweep_groups,
                 name=name or field_name,
-                name_is_auto=name is None,
+                name_is_auto=True,
             )
 
         # Numeric rows that do not stack disagree on their shape, and an object
@@ -1022,7 +1036,7 @@ def _make_stack(
             shared = {
                 "axis_groups": sweep_groups,
                 "name": name or field_name,
-                "name_is_auto": name is None,
+                "name_is_auto": True,
             }
             # ``outs`` first: every row of none is vacuously callable, and no row
             # is a reason to claim the function kind over the fallback.
@@ -1075,7 +1089,7 @@ def _make_stack(
             element_spec=NumericArraySpec(event_shape, dtype=inner_outputs.dtype),
             axis_groups=sweep_groups,
             name=name or field_name,
-            name_is_auto=name is None,
+            name_is_auto=True,
         )
 
     # vmap of a Record-returning function produces a Record with batched leaves

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -28,7 +28,7 @@ from ._empirical import (
 )
 from ._function_batch import FunctionBatch
 from ._immutable import constructing, transient_memo
-from ._numeric_array_batch import NumericArrayBatch
+from ._numeric_array_batch import NumericArrayBatch, _MappedBatchStore
 from ._numeric_record_batch import NumericRecordBatch
 from ._object_batch import _from_iterable, _is_object_array
 from ._opaque_batch import OpaqueBatch
@@ -782,6 +782,18 @@ def _make_stack(
     # Before the generic pytree handling below, which would read the inner batch
     # axis as an event axis and drop the level names with it — the same reason
     # the batch-of-batches case precedes the Record case on the list path.
+    if isinstance(inner_outputs, _MappedBatchStore):
+        # One store rather than columns: the sweep's axes replace the leading one
+        # the transform produced, and the levels are the sweep's then the rows'.
+        store = inner_outputs.store
+        return NumericArrayBatch(
+            store.reshape(batch_shape + store.shape[1:]),
+            (*level_names, *inner_outputs.level_names),
+            element_spec=inner_outputs.element_spec,
+            axis_groups=(*sweep_groups, *inner_outputs.axis_groups),
+            name=name or field_name,
+            name_is_auto=name is None,
+        )
     if isinstance(inner_outputs, _MappedBatchColumns):
         return _batch_over_swept_columns(
             inner_outputs.columns,

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -30,7 +30,7 @@ from ._function_batch import FunctionBatch
 from ._immutable import constructing, transient_memo
 from ._numeric_array_batch import NumericArrayBatch, _MappedBatchStore
 from ._numeric_record_batch import NumericRecordBatch
-from ._object_batch import _from_iterable, _is_object_array
+from ._object_batch import _from_iterable, _is_object_array, _ObjectBatch
 from ._opaque_batch import OpaqueBatch
 from ._record_batch import RecordBatch, _batch_class_for, _MappedBatchColumns
 from .event_template import (
@@ -675,13 +675,18 @@ def _agreeing_batch_rows(outs: list, *, field_name: str) -> Any:
     field the others have and misnaming their axes.
     """
     first = outs[0]
-    # The family, not the exact class: a RecordBatch and a NumericRecordBatch
-    # row hold the same thing, and only one of them says so in its name.
-    family = NumericArrayBatch if isinstance(first, NumericArrayBatch) else RecordBatch
+    # The family, not the exact class: a RecordBatch and a NumericRecordBatch row
+    # hold the same thing, and only one of them says so in its name. An
+    # OpaqueBatch and a FunctionBatch share their storage but not their element
+    # spec, so the spec comparison below is what separates them.
+    for candidate in (NumericArrayBatch, _ObjectBatch, RecordBatch):
+        if isinstance(first, candidate):
+            family = candidate
+            break
     if not all(isinstance(o, family) for o in outs):
         kinds = sorted({type(o).__name__ for o in outs})
         raise TypeError(
-            f"{field_name}: some rows returned a batch of records and some did not "
+            f"{field_name}: some rows returned a batch and some did not "
             f"({', '.join(kinds)}). A swept body returns one kind for every row, since "
             f"the aggregate has one schema; return a batch from every row or from none"
         )
@@ -721,7 +726,12 @@ def _row_at_its_kind(row: Any, field_name: str) -> Any:
 
     if isinstance(row, Mapping):
         return Record(field_name, dict(row), name_is_auto=True)
-    if isinstance(row, (list, tuple)) and row:
+    if isinstance(row, (list, tuple)):
+        if not row:
+            # A batch of nothing, exactly as ``_wrap_as_term`` reads an empty
+            # sequence returned on its own: no element to read a kind off, and the
+            # level still counts zero of them.
+            return OpaqueBatch([], field_name, name=field_name, name_is_auto=True)
         return _make_stack(list(row), n=len(row), level_names=(field_name,), field_name=field_name)
     return row
 
@@ -881,9 +891,20 @@ def _make_stack(
         # inner batch axis.
         # Both batch kinds a swept body can return; each keeps its own kind
         # through the sweep, as a scalar row does.
-        stackable = (RecordBatch, NumericArrayBatch)
+        stackable = (RecordBatch, NumericArrayBatch, _ObjectBatch)
         if outs and any(isinstance(o, stackable) for o in outs):
             first = _agreeing_batch_rows(outs, field_name=field_name)
+            if isinstance(first, _ObjectBatch):
+                # The elements are stored, not stacked, so the aggregate is one
+                # object array over the sweep's axes then the rows' own.
+                store = np.stack([o._store for o in outs], axis=0)
+                return type(first)(
+                    store.reshape(batch_shape + store.shape[1:]),
+                    (*level_names, *first.level_names),
+                    axis_groups=(*sweep_groups, *first.axis_groups),
+                    name=name or field_name,
+                    name_is_auto=True,
+                )
             if isinstance(first, NumericArrayBatch):
                 # One store rather than columns, so the rows stack directly —
                 # through the array backend, as the columns below do, since a

--- a/probpipe/core/_function_batch.py
+++ b/probpipe/core/_function_batch.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Iterable
 
 import numpy as np
 
+from ._kinds import register_kind
 from ._object_batch import _ObjectBatch
 from .event_template import FunctionSpec
 from .provenance import Provenance
@@ -109,3 +110,6 @@ class FunctionBatch(_ObjectBatch[Callable]):
         spec = self._spec.element_spec
         assert isinstance(spec, FunctionSpec)  # narrowed at construction
         return spec
+
+
+register_kind(FunctionSpec, batch_class=FunctionBatch)

--- a/probpipe/core/_function_contract.py
+++ b/probpipe/core/_function_contract.py
@@ -218,6 +218,36 @@ def _bind_function_inputs(
     )
 
 
+def _lifted_element_spec(value: Any, *, function_name: str, name: str) -> ValueSpec | EventTemplate:
+    """What one element of a lifted operand satisfies.
+
+    A :class:`~probpipe.core._batch.Batch` states this uniformly in
+    ``element_spec``, at every kind: a batch of records answers with a
+    ``RecordSpec``, one of arrays with a ``NumericArraySpec``, one of callables
+    with a ``FunctionSpec``. Reading the record-only ``event_template`` view
+    instead let only a batch of records be swept by a declared function, and made
+    a batch of records satisfy a declaration that named a bare array.
+
+    A distribution operand is not a batch, and is lifted by being sampled, so what
+    the body receives is one draw. Its schema is the operand's own event template,
+    passed as the template it is: a scalar law reports a single field named after
+    itself, which the unification pass reads against a declared leaf. Restating
+    that as a record declaration belongs with the ``Distribution``-side rework.
+    """
+    from ._batch import Batch
+
+    if isinstance(value, Batch):
+        return value.element_spec
+    template = getattr(value, "event_template", None)
+    if isinstance(template, EventTemplate):
+        return template
+    raise ValueError(
+        f"Function {function_name!r} input {name!r} states no element specification for "
+        f"lifting: a {type(value).__name__} reports neither an element_spec nor an "
+        f"event_template"
+    )
+
+
 def _bind_planned_function_inputs(
     *,
     function_name: str,
@@ -230,20 +260,9 @@ def _bind_planned_function_inputs(
         return None, {}
     schema_values = dict(values)
     for name in lifted_names:
-        value = values[name]
-        try:
-            lifted_template = value.event_template
-        except (AttributeError, TypeError) as error:
-            raise ValueError(
-                f"Function {function_name!r} input {name!r} does not expose an "
-                "authoritative event_template for lifting"
-            ) from error
-        if not isinstance(lifted_template, EventTemplate):
-            raise ValueError(
-                f"Function {function_name!r} input {name!r} does not expose an "
-                "authoritative event_template for lifting"
-            )
-        schema_values[name] = lifted_template
+        schema_values[name] = _lifted_element_spec(
+            values[name], function_name=function_name, name=name
+        )
     return _unify_event_template_with_value(
         input_template,
         schema_values,

--- a/probpipe/core/_kinds.py
+++ b/probpipe/core/_kinds.py
@@ -1,0 +1,85 @@
+"""The kind table: which tracked class and which batch form each value spec has.
+
+Every value spec has exactly one tracked class and one batch form (design II.2,
+III.1). That correspondence was open-coded at six sites, each knowing a
+different subset, so widening one of them left the others behind — a
+``NumericArrayBatch`` that the record layer could present but the workflow
+planner would not sweep.
+
+The table is declared once here and each kind registers itself at the bottom of
+its own module, next to the classes it names. Registration is import-order
+sensitive by construction, which is why ``probpipe/__init__.py`` imports the
+batch modules eagerly: a lookup before a kind's module has been imported would
+see a table that does not yet mention it.
+
+A spec with no registered batch form is not an oversight — a ``RecordSpec``
+belongs to :class:`~probpipe.RecordBatch`, whose choice between the plain and
+numeric class depends on the *template's* leaves rather than on the spec type
+alone, so the record layer keeps its own resolver.
+
+See design II.2, III.1.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "batch_class_for_spec",
+    "register_kind",
+    "term_class_for_spec",
+]
+
+#: spec type -> (tracked class, batch class). Either may be ``None`` where the
+#: kind has no class of that side.
+_KINDS: dict[type, tuple[type | None, type | None]] = {}
+
+
+def register_kind(
+    spec_type: type, *, term_class: type | None = None, batch_class: type | None = None
+) -> None:
+    """Declare the tracked class and batch form belonging to *spec_type*.
+
+    Called at the bottom of the module defining the classes, so the table is
+    populated by importing the kind rather than by a central list that a new
+    kind has to be added to.
+
+    Raises
+    ------
+    ValueError
+        If *spec_type* is already registered with a different pair. A kind has
+        one tracked class and one batch form; two registrations disagreeing is a
+        contradiction rather than an override.
+    """
+    existing = _KINDS.get(spec_type)
+    pair = (term_class, batch_class)
+    if existing is not None and existing != pair:
+        raise ValueError(
+            f"{spec_type.__name__} is already registered as {existing}, so registering "
+            f"{pair} would give one spec two kinds; a spec has one tracked class and one "
+            f"batch form"
+        )
+    _KINDS[spec_type] = pair
+
+
+def term_class_for_spec(spec: Any) -> type | None:
+    """The tracked class a value satisfying *spec* is returned as, if any."""
+    return _lookup(spec, 0)
+
+
+def batch_class_for_spec(spec: Any) -> type | None:
+    """The batch form a collection of values satisfying *spec* takes, if any."""
+    return _lookup(spec, 1)
+
+
+def _lookup(spec: Any, side: int) -> type | None:
+    """Resolve *spec*'s registered class, honouring subclass registrations.
+
+    The exact type first, then the MRO, so a spec subclass inherits its base's
+    kind unless it registers its own.
+    """
+    for candidate in type(spec).__mro__:
+        entry = _KINDS.get(candidate)
+        if entry is not None and entry[side] is not None:
+            return entry[side]
+    return None

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -20,6 +20,7 @@ from ._array_backend import (
     _to_numpy_array,
 )
 from ._batch import Batch, BatchSpec, _axis_groups_for
+from ._kinds import register_kind
 from ._numeric_array import NumericArray
 from .event_template import NumericArraySpec
 from .provenance import Provenance
@@ -290,3 +291,6 @@ def _numeric_array_batch_unflatten(aux, children):
 jax.tree_util.register_pytree_node(
     NumericArrayBatch, _numeric_array_batch_flatten, _numeric_array_batch_unflatten
 )
+
+# The numeric-array kind: its spec, its tracked class, and this batch form.
+register_kind(NumericArraySpec, term_class=NumericArray, batch_class=NumericArrayBatch)

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -86,7 +86,10 @@ class NumericArrayBatch(Batch[NumericArray]):
 
     _values: Any
 
-    __slots__ = ("_values",)
+    __slots__ = ("_jax_cache", "_values")
+
+    #: Derived from the store rather than transported, as for ``NumericArray``.
+    _transient_state = ("_jax_cache",)
 
     def __init__(
         self,
@@ -194,8 +197,23 @@ class NumericArrayBatch(Batch[NumericArray]):
         arr = np.asarray(arr, dtype=dtype) if dtype is not None else arr
         return arr.copy() if copy else arr
 
+    def as_jax(self) -> Any:
+        """The store as a ``jax.Array`` — the single conversion point.
+
+        A store already held as one passes through, tracers included; a native
+        container converts through its registered backend once and is memoised
+        for this instance, as a :class:`NumericArray`'s value is.
+        """
+        if isinstance(self._values, jax.Array):
+            return self._values
+        cached = getattr(self, "_jax_cache", None)
+        if cached is None:
+            cached = _to_jax_array(self._values)
+            object.__setattr__(self, "_jax_cache", cached)
+        return cached
+
     def __jax_array__(self) -> Any:
-        return _to_jax_array(self._values)
+        return self.as_jax()
 
     def __repr__(self) -> str:
         return (
@@ -245,8 +263,14 @@ class NumericArrayBatch(Batch[NumericArray]):
 
 
 def _numeric_array_batch_flatten(batch: NumericArrayBatch):
-    """Flatten for JAX traversal: the store, keyed by the aux spec."""
-    return [batch._values], (batch._spec, batch._name, batch._name_is_auto)
+    """Flatten for JAX traversal: the store, keyed by the aux spec.
+
+    The boundary presents a bare array, as a ``NumericArray``'s flatten does.
+    Handing the native container to JAX instead fails abstractification before
+    ``__jax_array__`` is ever consulted, so a pandas- or xarray-backed batch
+    could not enter a trace at all.
+    """
+    return [batch.as_jax()], (batch._spec, batch._name, batch._name_is_auto)
 
 
 def _numeric_array_batch_unflatten(aux, children):
@@ -272,6 +296,18 @@ def _numeric_array_batch_unflatten(aux, children):
         object.__setattr__(view, "_values", values)
         view._init_batch(spec, name=name, name_is_auto=name_is_auto)
         return view
+    # The element's own axes are not the transform's to change. A rank check
+    # alone would admit a store whose trailing axes no longer match what the
+    # element declares, and the batch would build with a spec that is a false
+    # statement about its own store — surfacing only at the first selection.
+    event_shape = tuple(element_spec.shape)
+    if event_rank and tuple(shape)[len(shape) - event_rank :] != event_shape:
+        raise ValueError(
+            f"a transform left this NumericArrayBatch over a store of {tuple(shape)}, whose "
+            f"trailing axes are not the event shape {event_shape} its elements declare. A "
+            f"transform maps the elements; changing what one *is* rebuilds the batch where "
+            f"the new element spec is known"
+        )
     surviving = tuple(shape)[: len(shape) - event_rank] if event_rank else tuple(shape)
     if surviving == tuple(spec.batch_shape):
         view = object.__new__(NumericArrayBatch)

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -294,3 +294,79 @@ jax.tree_util.register_pytree_node(
 
 # The numeric-array kind: its spec, its tracked class, and this batch form.
 register_kind(NumericArraySpec, term_class=NumericArray, batch_class=NumericArrayBatch)
+
+
+class _MappedBatchStore:
+    """A single-store batch taken apart, to cross a mapping transform.
+
+    The counterpart of :class:`~probpipe.core._record_batch._MappedBatchColumns`
+    for a batch that holds one store rather than a column per field. The reason
+    is the same: unflattening refuses an added axis because it has no name to
+    give the level, which is right for a raw transform and wrong for an executor
+    that knows both. So the executor hands the transform this inert carrier —
+    its unflatten rebuilds it verbatim, checking nothing — and rebuilds the batch
+    on the far side, where the level name is in hand.
+
+    Private and short-lived: wrapped and unwrapped within one call.
+    """
+
+    __slots__ = ("axis_groups", "element_spec", "level_names", "name", "name_is_auto", "store")
+
+    def __init__(
+        self,
+        store: Any,
+        *,
+        element_spec: NumericArraySpec,
+        level_names: tuple[str, ...],
+        axis_groups: tuple[tuple[int, ...], ...],
+        name: str,
+        name_is_auto: bool,
+    ):
+        self.store = store
+        self.element_spec = element_spec
+        self.level_names = level_names
+        self.axis_groups = axis_groups
+        self.name = name
+        self.name_is_auto = name_is_auto
+
+    @classmethod
+    def of(cls, batch: NumericArrayBatch) -> _MappedBatchStore:
+        """Take *batch* apart, keeping what unflattening could not have inferred."""
+        return cls(
+            batch.values,
+            element_spec=batch.element_spec,
+            level_names=tuple(batch.level_names),
+            axis_groups=tuple(batch.axis_groups),
+            name=batch._name,
+            name_is_auto=batch._name_is_auto,
+        )
+
+
+def _mapped_batch_store_flatten(carried: _MappedBatchStore):
+    return [carried.store], (
+        carried.element_spec,
+        carried.level_names,
+        carried.axis_groups,
+        carried.name,
+        carried.name_is_auto,
+    )
+
+
+def _mapped_batch_store_unflatten(aux, children) -> _MappedBatchStore:
+    element_spec, level_names, axis_groups, name, name_is_auto = aux
+    (store,) = children
+    # No rank check, deliberately: the added axis is the point, and the caller
+    # that added it is the one that can name it.
+    return _MappedBatchStore(
+        store,
+        element_spec=element_spec,
+        level_names=level_names,
+        axis_groups=axis_groups,
+        name=name,
+        name_is_auto=name_is_auto,
+    )
+
+
+jax.tree_util.register_pytree_node(
+    _MappedBatchStore, _mapped_batch_store_flatten, _mapped_batch_store_unflatten
+)

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -10,8 +10,9 @@ from typing import Any
 
 import numpy as np
 
+from ._kinds import register_kind
 from ._object_batch import _ObjectBatch
-from ._opaque import OpaqueSpec
+from ._opaque import Opaque, OpaqueSpec
 from .provenance import Provenance
 
 __all__ = ["OpaqueBatch"]
@@ -111,3 +112,6 @@ class OpaqueBatch(_ObjectBatch[Any]):
         spec = self._spec.element_spec
         assert isinstance(spec, OpaqueSpec)  # narrowed at construction
         return spec
+
+
+register_kind(OpaqueSpec, term_class=Opaque, batch_class=OpaqueBatch)

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -43,7 +43,6 @@ from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._function_batch import FunctionBatch
 from ._kinds import batch_class_for_spec
 from ._object_batch import _from_iterable, _frozen_object_column, _is_object_array
-from ._opaque import OpaqueSpec
 from ._opaque_batch import OpaqueBatch
 from .event_template import (
     EventTemplate,
@@ -241,15 +240,17 @@ class RecordBatch(Batch[Record]):
             if isinstance(spec, NumericArraySpec):
                 _check_array_column(column, spec, path=path, kind=kind)
                 continue
-            if not isinstance(spec, FunctionSpec | OpaqueSpec):
+            if batch_class_for_spec(spec) is None:
                 # A field kind with no batch form cannot be *read* back: reading
                 # one presents the column as the batch of its element kind, and
                 # there is none for this. Admitting it at construction would make
-                # a batch nobody can take a field from.
+                # a batch nobody can take a field from. The registry answers that,
+                # as it does at the reading end, so a newly registered kind is
+                # admitted here without this guard being widened to match.
                 raise TypeError(
                     f"{kind}: the field {path!r} is declared {type(spec).__name__}, which has no "
-                    f"batch form, so a batch cannot present its column; an array field, a "
-                    f"callable field, and an opaque field are the forms a column takes"
+                    f"batch form, so a batch cannot present its column; a kind registers its "
+                    f"batch form beside its classes (see core/_kinds.py)"
                 )
             if not _is_object_array(column):
                 raise TypeError(

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -1411,6 +1411,23 @@ class _MappedBatchColumns:
             name_is_auto=batch._name_is_auto,
         )
 
+    @classmethod
+    def of_record(cls, record: Record) -> _MappedBatchColumns:
+        """One record as columns over no levels of its own.
+
+        A record row has a multiplicity of one, so the axis the map is about to
+        add is the only level the aggregate will have. Naming none here is what
+        says so.
+        """
+        return cls(
+            {path: record[path] for path in record.event_template},
+            element_spec=record.spec,
+            level_names=(),
+            axis_groups=(),
+            name=record._name,
+            name_is_auto=record._name_is_auto,
+        )
+
 
 def _mapped_batch_columns_flatten(carried: _MappedBatchColumns):
     return list(carried.columns.values()), (

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -41,6 +41,7 @@ import numpy as np
 from ._array_backend import _is_numeric_dtype, _to_jax_array
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._function_batch import FunctionBatch
+from ._kinds import batch_class_for_spec
 from ._object_batch import _from_iterable, _frozen_object_column, _is_object_array
 from ._opaque import OpaqueSpec
 from ._opaque_batch import OpaqueBatch
@@ -381,19 +382,21 @@ class RecordBatch(Batch[Record]):
         spec = self.event_template[key]
         if isinstance(spec, NumericArraySpec):
             return column
-        name = f"{self.name}[{key!r}]"
-        column_spec = BatchSpec(spec, self.axis_groups, self.level_names)
-        if isinstance(spec, FunctionSpec):
-            return self._inherit_provenance(
-                FunctionBatch._over_store(column, spec=column_spec, name=name)
+        # Every other kind presents through its registered batch form, so a new
+        # kind is reachable here by registering itself rather than by being added
+        # to a switch this module would otherwise have to know about.
+        column_cls = batch_class_for_spec(spec)
+        if column_cls is None:
+            raise TypeError(
+                f"the field {key!r} is declared {type(spec).__name__}, which has no batch form; "
+                f"a kind registers its batch form beside its classes (see core/_kinds.py)"
             )
-        if isinstance(spec, OpaqueSpec):
-            return self._inherit_provenance(
-                OpaqueBatch._over_store(column, spec=column_spec, name=name)
+        return self._inherit_provenance(
+            column_cls._over_store(
+                column,
+                spec=BatchSpec(spec, self.axis_groups, self.level_names),
+                name=f"{self.name}[{key!r}]",
             )
-        raise TypeError(
-            f"the field {key!r} is declared {type(spec).__name__}, which has no batch form yet; "
-            f"an array field, a callable field, and an opaque field are the forms a column takes"
         )
 
     def _field_view(self, path: str, template: EventTemplate) -> Self:

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -17,7 +17,6 @@ from typing import Any, Literal, Union, get_args, get_origin
 from . import _workflow_call, _workflow_descendants, _workflow_distribution_normalization
 from ._batch import Batch
 from ._distribution_array import DistributionArray
-from ._record_batch import RecordBatch
 from .distribution import Distribution, EmpiricalDistribution
 
 BroadcastRegime = Literal["none", "distribution", "sweep", "nested"]
@@ -194,9 +193,13 @@ def build_broadcast_plan(
         value = _workflow_call.input_ref_value(values, ref)
         expected = _workflow_call.input_ref_hint(signature_info, ref)
 
-        is_batched_record = isinstance(value, RecordBatch)
+        # Any Batch is an operand: what makes a value sweepable is that it holds
+        # a multiplicity on named levels, which is the Batch contract rather than
+        # anything specific to records. A DistributionArray is a Distribution, not
+        # a Batch, so it stays a separate test.
+        is_batch = isinstance(value, Batch)
         is_dist_array = isinstance(value, DistributionArray)
-        if (is_batched_record or is_dist_array) and len(value.batch_shape) > 0:
+        if (is_batch or is_dist_array) and len(value.batch_shape) > 0:
             if _value_matches_hint(value, expected) or expected is Any:
                 continue
             array_args.append(ref)

--- a/probpipe/core/_workflow_result.py
+++ b/probpipe/core/_workflow_result.py
@@ -11,6 +11,7 @@ See design V.0.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any, Literal
 
@@ -73,8 +74,12 @@ def _wrap_as_term(
     # -- a raw host, wrapped into its own kind -----------------------------
     # The kind follows the host's *type*, empty or not: a mapping is a tree and a
     # sequence a multiplicity, and having no entries does not change which.
-    if isinstance(value, dict):
-        return Record(field_name, value, name_is_auto=True)
+    if isinstance(value, Mapping):
+        # Any mapping, not only ``dict``: the value layer reads a mapping as a
+        # tree, and an ``OrderedDict`` or a ``Mapping`` subclass is one. Falling
+        # through would reach ``Opaque``, which refuses mappings, so the return
+        # would raise rather than be wrapped.
+        return Record(field_name, dict(value), name_is_auto=True)
     if isinstance(value, (list, tuple)):
         if not value:
             # No element to read a kind off, and every element spec holds
@@ -83,14 +88,14 @@ def _wrap_as_term(
             from ._opaque_batch import OpaqueBatch
 
             return OpaqueBatch([], field_name, name=field_name, name_is_auto=True)
-        try:
-            # A returned sequence ranges over nothing the call named, so the
-            # level takes the function's own name.
-            return _make_stack(
-                list(value), n=len(value), level_names=(field_name,), field_name=field_name
-            )
-        except (TypeError, ValueError):
-            pass
+        # A returned sequence ranges over nothing the call named, so the level
+        # takes the function's own name. Errors are not caught here: the stack
+        # has a batch form for every element kind, so what reaches this and
+        # raises is the rows disagreeing — which is the caller's to see, not
+        # something to record as one opaque value.
+        return _make_stack(
+            list(value), n=len(value), level_names=(field_name,), field_name=field_name
+        )
     # ``_is_numeric_leaf`` excludes duck-typed objects (``MagicMock`` and the
     # like) whose attribute probing recurses inside ``jnp.asarray``.
     if _is_numeric_leaf(value):

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -33,6 +33,7 @@ from . import (
 from ._batch import Batch
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
+from ._numeric_array_batch import NumericArrayBatch, _MappedBatchStore
 from ._record_batch import RecordBatch, _MappedBatchColumns
 from .config import WorkflowKind, prefect_config
 from .distribution import BroadcastDistribution, Distribution
@@ -332,6 +333,8 @@ def mapped_row_body(
         out = func(**_workflow_call.replace_input_refs(values, replacements))
         if isinstance(out, RecordBatch):
             return _MappedBatchColumns.of(out)
+        if isinstance(out, NumericArrayBatch):
+            return _MappedBatchStore.of(out)
         return out
 
     return one_row

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -31,7 +31,7 @@ from . import (
     _workflow_result,
 )
 from ._batch import Batch
-from ._broadcast_distributions import _make_stack
+from ._broadcast_distributions import _make_stack, _row_at_its_kind
 from ._distribution_array import DistributionArray, _make_distribution_array
 from ._numeric_array_batch import NumericArrayBatch, _MappedBatchStore
 from ._record_batch import RecordBatch, _MappedBatchColumns
@@ -98,6 +98,7 @@ def execute_sweep(
             require_jax_traceable=require_jax_traceable,
             workflow_kind=workflow_kind,
             workflow_name=workflow_name,
+            output_is_declared=output_template is not None,
         )
         aggregate = _make_stack(
             per_row,
@@ -225,6 +226,7 @@ def execute_sweep_rows(
     require_jax_traceable: Callable[[dict[str, Any], list[_workflow_call.WorkflowInputRef]], None],
     workflow_kind: WorkflowKind = WorkflowKind.OFF,
     workflow_name: str = "workflow",
+    output_is_declared: bool = False,
 ) -> Any:
     """Execute pure sweep rows through JAX vmap or row-wise execution."""
     # Zero rows run nothing, so there is no body for a dispatch to trace and no
@@ -274,6 +276,7 @@ def execute_sweep_rows(
             n_total=plan.n_sweep,
             workflow_kind=workflow_kind,
             workflow_name=workflow_name,
+            output_is_declared=output_is_declared,
         )
 
     per_row_values = [
@@ -311,6 +314,8 @@ def mapped_row_body(
     func: Callable[..., Any],
     values: dict[str, Any],
     array_args: Sequence[_workflow_call.WorkflowInputRef],
+    field_name: str,
+    output_is_declared: bool = False,
 ) -> Callable[[Any], Any]:
     """The body ``jax.vmap`` runs for one sweep row, and the probe traces.
 
@@ -319,10 +324,15 @@ def mapped_row_body(
     functions cannot promise.
 
     A row's batched-record argument is rebuilt from raw leaf columns inside the
-    traced call, so nothing infers a batch axis on the way in. On the way out, a
-    returned :class:`Batch` is taken apart into :class:`_MappedBatchColumns`,
-    because the map is about to add an axis that the batch's own unflatten hook
-    could not name — the executor names it afterwards, from the sweep's levels.
+    traced call, so nothing infers a batch axis on the way in. On the way out the
+    row takes the kind of its own return, as a row-wise row does, and a record or
+    a batch is then taken apart into :class:`_MappedBatchColumns` or
+    :class:`_MappedBatchStore`: the map is about to add an axis that neither
+    class's unflatten hook could name, and the executor names it afterwards from
+    the sweep's levels.
+
+    *output_is_declared* says *func* already gave the row a declared template, in
+    which case that template is the row's kind and nothing here re-derives one.
     """
 
     def one_row(array_slice_leaves):
@@ -331,6 +341,12 @@ def mapped_row_body(
             for ref, leaves in zip(array_args, array_slice_leaves)
         }
         out = func(**_workflow_call.replace_input_refs(values, replacements))
+        if not output_is_declared:
+            out = _row_at_its_kind(out, field_name)
+            if isinstance(out, Record):
+                # As a batch row is carried, but with no level of its own: the
+                # axis the map adds is the only one the aggregate will have.
+                return _MappedBatchColumns.of_record(out)
         if isinstance(out, RecordBatch):
             return _MappedBatchColumns.of(out)
         if isinstance(out, NumericArrayBatch):
@@ -348,9 +364,16 @@ def execute_sweep_rows_jax(
     n_total: int,
     workflow_kind: WorkflowKind = WorkflowKind.OFF,
     workflow_name: str = "workflow",
+    output_is_declared: bool = False,
 ) -> Any:
     """Execute the limited single-batch sweep through ``jax.vmap``."""
-    single_call = mapped_row_body(func=func, values=values, array_args=array_args)
+    single_call = mapped_row_body(
+        func=func,
+        values=values,
+        array_args=array_args,
+        field_name=workflow_name,
+        output_is_declared=output_is_declared,
+    )
 
     vmap_input = []
     for ref in array_args:

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -1499,6 +1499,11 @@ def _unify_template_node(
     path: str,
 ) -> EventTemplate:
     """Recursively unify one declared template node with actual structure."""
+    if isinstance(actual, RecordSpec):
+        # An authoritative record declaration states the same fields the template
+        # node does; reading them off it is what lets a declared record operand be
+        # unified from its spec rather than only from a live value.
+        actual = actual.event_template
     children = getattr(actual, "children", None)
 
     if isinstance(children, Mapping):

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -1048,7 +1048,11 @@ class Function(Node, TrackedTerm, Annotated):
                     # The executor's own body, not a copy maintained in the
                     # probe. ``dummy_kw`` already carries non-batched inputs.
                     _row_call = _workflow_sweep.mapped_row_body(
-                        func=func, values=dummy_kw, array_args=refs
+                        func=func,
+                        values=dummy_kw,
+                        array_args=refs,
+                        field_name=self._name,
+                        output_is_declared=self._output_template is not None,
                     )
 
                     probe_leaves = []

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -40,6 +40,7 @@ from . import (
     _workflow_result,
     _workflow_sweep,
 )
+from ._batch import Batch
 from ._function_contract import (
     _bind_function_inputs,
     _bind_planned_function_inputs,
@@ -198,6 +199,18 @@ class Node(ABC):  # noqa: B024
     @property
     def inputs(self) -> Mapping[str, Any]:
         return self._inputs
+
+
+class _UnvectorizableBatchSignal(Exception):
+    """The probe met a batch whose rows the mapped body cannot be built from.
+
+    Raised so the reason survives to the caller: the generic tracing message
+    would say the function is not JAX-traceable, which is not what went wrong.
+    """
+
+    def __init__(self, kinds: list[str]) -> None:
+        super().__init__(", ".join(kinds))
+        self.kinds = kinds
 
 
 class Function(Node, TrackedTerm, Annotated):
@@ -991,6 +1004,7 @@ class Function(Node, TrackedTerm, Annotated):
             dummy_kw = dict(values)
             broadcast_refs = set(broadcast_args)
             batched_sources: dict[_workflow_call.WorkflowInputRef, Any] = {}
+            unvectorized_batches: dict[Any, Any] = {}
             drawn_refs: list[_workflow_call.WorkflowInputRef] = []
             for ref in _workflow_call.iter_input_refs(self._signature_info, values):
                 v = _workflow_call.input_ref_value(values, ref)
@@ -1001,6 +1015,15 @@ class Function(Node, TrackedTerm, Annotated):
                     if isinstance(v, RecordBatch):
                         batched_sources[ref] = v
                         dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, v[0])
+                    elif isinstance(v, Batch):
+                        # A batch that is not a batch of records is still a swept
+                        # source, not a draw. The probe's synthesis below builds a
+                        # leaf per field, which a single-store batch does not have,
+                        # so this route declines rather than mis-reading it as a
+                        # law: ``auto`` runs it sequentially and gets the right
+                        # answer, which an explicit ``jax`` should not silently
+                        # differ from.
+                        unvectorized_batches[ref] = v
                     else:
                         # Nothing to synthesize: the draw itself supplies the
                         # structure and dtype below, which is what lets a
@@ -1016,6 +1039,10 @@ class Function(Node, TrackedTerm, Annotated):
                         replacement = v
                     dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, replacement)
             with _workflow_context._workflow_probe():
+                if unvectorized_batches:
+                    raise _UnvectorizableBatchSignal(
+                        sorted({type(b).__name__ for b in unvectorized_batches.values()})
+                    )
                 if batched_sources:
                     refs = list(batched_sources)
                     # The executor's own body, not a copy maintained in the
@@ -1143,6 +1170,12 @@ class Function(Node, TrackedTerm, Annotated):
         )
         if trace_error is None:
             return
+        if isinstance(trace_error, _UnvectorizableBatchSignal):
+            raise TypeError(
+                f"dispatch='jax' cannot vectorize over {', '.join(trace_error.kinds)}: the "
+                f"mapped row body is built from one leaf per field, which a single-store batch "
+                f"does not have. Use dispatch='auto' or 'sequential', which sweep it correctly."
+            ) from trace_error
         if isinstance(trace_error, _workflow_context._StochasticProbeSignal):
             raise TypeError(
                 "dispatch='jax' cannot execute a wrapped function that requests "

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -219,6 +219,44 @@ def _drawn_at_its_batch_form(
     )
 
 
+def _at_the_operands_levels(computed: Any, operand: Any) -> Any:
+    """Give *computed* the levels *operand* carried, when it is a batch.
+
+    An operation whose value parameter is ``Any``-hinted receives a batch whole
+    and evaluates it in one vectorized call rather than row by row. That is the
+    fused implementation design V.9 allows to register above the elementwise map
+    — but V.9 also says the batch axes are *preserved*, and a bare array does not
+    preserve them. So the levels the operand stated are restated on the result.
+
+    Only the axes the operand accounted for are levels; anything the operation
+    added beyond them belongs to the element, which is why the split is by the
+    operand's rank rather than by the result's.
+    """
+    from ._array_backend import _event_shape_of, _is_numeric_leaf, _numpy_dtype_of
+    from ._batch import Batch
+    from ._numeric_array_batch import NumericArrayBatch
+    from .event_template import NumericArraySpec
+
+    if not isinstance(operand, Batch) or not _is_numeric_leaf(computed):
+        return computed
+    batch_shape = tuple(operand.batch_shape)
+    shape = tuple(_event_shape_of(computed))
+    if shape[: len(batch_shape)] != batch_shape:
+        # The operation did not lay its result out over the operand's axes, so
+        # there is no correspondence to restate.
+        return computed
+    return NumericArrayBatch(
+        computed,
+        tuple(operand.level_names),
+        element_spec=NumericArraySpec(
+            shape=shape[len(batch_shape) :], dtype=_numpy_dtype_of(computed)
+        ),
+        axis_groups=tuple(operand.axis_groups),
+        name=operand.name,
+        name_is_auto=operand.name_is_auto,
+    )
+
+
 # -- keyword value form shared by the density ops ---------------------------
 #
 # Each density op accepts either a positional ``value`` or named field kwargs
@@ -275,7 +313,8 @@ def log_prob(dist: SupportsLogProb, value: Any = None, **field_kwargs: Any) -> A
     """
     if not isinstance(dist, SupportsLogProb):
         raise TypeError(f"{type(dist).__name__} does not support log_prob")
-    return dist._log_prob(_resolve_value("log_prob", dist, value, field_kwargs))
+    resolved = _resolve_value("log_prob", dist, value, field_kwargs)
+    return _at_the_operands_levels(dist._log_prob(resolved), resolved)
 
 
 @function

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -325,8 +325,8 @@ def prob(dist: SupportsLogProb, value: Any = None, **field_kwargs: Any) -> Array
     """
     if not isinstance(dist, SupportsLogProb):
         raise TypeError(f"{type(dist).__name__} does not support prob (missing _log_prob method)")
-    value = _resolve_value("prob", dist, value, field_kwargs)
-    return jnp.exp(dist._log_prob(value))
+    resolved = _resolve_value("prob", dist, value, field_kwargs)
+    return _at_the_operands_levels(jnp.exp(dist._log_prob(resolved)), resolved)
 
 
 @function
@@ -344,8 +344,8 @@ def unnormalized_log_prob(
             f"{type(dist).__name__} does not support unnormalized_log_prob "
             f"(missing _unnormalized_log_prob method)"
         )
-    value = _resolve_value("unnormalized_log_prob", dist, value, field_kwargs)
-    return dist._unnormalized_log_prob(value)
+    resolved = _resolve_value("unnormalized_log_prob", dist, value, field_kwargs)
+    return _at_the_operands_levels(dist._unnormalized_log_prob(resolved), resolved)
 
 
 @function
@@ -363,8 +363,8 @@ def unnormalized_prob(
             f"{type(dist).__name__} does not support unnormalized_prob "
             f"(missing _unnormalized_log_prob method)"
         )
-    value = _resolve_value("unnormalized_prob", dist, value, field_kwargs)
-    return jnp.exp(dist._unnormalized_log_prob(value))
+    resolved = _resolve_value("unnormalized_prob", dist, value, field_kwargs)
+    return _at_the_operands_levels(jnp.exp(dist._unnormalized_log_prob(resolved)), resolved)
 
 
 @function

--- a/tests/core/test_first_class_function.py
+++ b/tests/core/test_first_class_function.py
@@ -456,6 +456,71 @@ class TestApplyContract:
 
         assert result.num_atoms == 5
 
+    def test_every_batch_kind_lifts_against_its_element_spec(self):
+        """A batch states what one element satisfies in ``element_spec``, at every
+        kind, so a declared function reads every batch the same way."""
+        from probpipe import FunctionBatch, NumericArrayBatch, OpaqueBatch
+
+        cases = [
+            (
+                NumericArrayBatch(
+                    jnp.arange(3.0), "row", element_spec=NumericArraySpec(()), name="rows"
+                ),
+                EventTemplate(v=()),
+            ),
+            (OpaqueBatch([object(), object()], "row", name="rows"), EventTemplate(v=None)),
+            (
+                FunctionBatch([lambda z: z, lambda z: z], "row", name="rows"),
+                EventTemplate(v=FunctionSpec()),
+            ),
+            (
+                NumericRecordBatch(
+                    {"x": jnp.arange(3.0)}, "row", element_spec=EventTemplate(x=()), name="rows"
+                ),
+                EventTemplate(v=EventTemplate(x=())),
+            ),
+        ]
+        for operand, input_template in cases:
+            wrapped = Function(
+                func=lambda v: 1.0,
+                name="f",
+                input_template=input_template,
+                dispatch="sequential",
+            )
+
+            result = wrapped(v=operand)
+
+            assert isinstance(result, NumericArrayBatch), type(operand).__name__
+            assert result.level_names == ("row",), type(operand).__name__
+
+    def test_a_batch_of_records_does_not_satisfy_a_bare_array_declaration(self):
+        """Reading the record-only view made a one-field element pass as its field."""
+        rows = NumericRecordBatch(
+            {"x": jnp.arange(3.0)}, "row", element_spec=EventTemplate(x=()), name="rows"
+        )
+        wrapped = Function(
+            func=lambda v: 1.0,
+            name="f",
+            input_template=EventTemplate(v=()),
+            dispatch="sequential",
+        )
+
+        with pytest.raises(ValueError, match=r"RecordSpec.*does not conform"):
+            wrapped(v=rows)
+
+    def test_a_mismatched_element_kind_names_both_specs(self):
+        from probpipe import OpaqueBatch
+
+        wrapped = Function(
+            func=lambda v: 1.0,
+            name="f",
+            input_template=EventTemplate(v=()),
+            dispatch="sequential",
+        )
+
+        with pytest.raises(ValueError, match=r"OpaqueSpec.*does not conform.*NumericArraySpec"):
+            wrapped(v=OpaqueBatch([object()], "row", name="rows"))
+
     def test_authoritative_nested_mapping_must_match_exactly(self):
         template = EventTemplate(
             stats=EventTemplate(copy=("obs",), total=()),
@@ -681,8 +746,9 @@ class TestSymbolicCalls:
         with pytest.raises(
             ValueError,
             match=(
-                r"Function 'identity' input 'x' does not expose an authoritative "
-                r"event_template for lifting"
+                r"Function 'identity' input 'x' states no element specification for "
+                r"lifting: a DistributionArray reports neither an element_spec nor an "
+                r"event_template"
             ),
         ):
             wrapped(values)

--- a/tests/core/test_kinds.py
+++ b/tests/core/test_kinds.py
@@ -1,0 +1,70 @@
+"""The kind table: one tracked class and one batch form per value spec.
+
+The correspondence was open-coded at six sites, each knowing a different
+subset, so widening one left the others behind. These tests pin the table
+itself and the property that made the duplication a bug: every registered kind
+answers both questions the same way wherever it is asked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from probpipe import (
+    FunctionBatch,
+    FunctionSpec,
+    NumericArray,
+    NumericArrayBatch,
+    NumericArraySpec,
+    Opaque,
+    OpaqueBatch,
+    OpaqueSpec,
+)
+from probpipe.core._kinds import batch_class_for_spec, register_kind, term_class_for_spec
+
+
+class TestEveryKindDeclaresItsClasses:
+    @pytest.mark.parametrize(
+        ("spec", "term", "batch"),
+        [
+            pytest.param(NumericArraySpec(shape=()), NumericArray, NumericArrayBatch, id="numeric"),
+            pytest.param(OpaqueSpec(), Opaque, OpaqueBatch, id="opaque"),
+            pytest.param(FunctionSpec(), None, FunctionBatch, id="function"),
+        ],
+    )
+    def test_a_spec_resolves_to_its_pair(self, spec, term, batch):
+        assert term_class_for_spec(spec) is term
+        assert batch_class_for_spec(spec) is batch
+
+    def test_a_kind_with_no_tracked_class_says_so(self):
+        """`FunctionSpec` has a batch form and no separate tracked class — a
+        callable is already a `Function`."""
+        assert term_class_for_spec(FunctionSpec()) is None
+
+
+class TestTheTableIsSingleValued:
+    def test_a_contradicting_registration_is_refused(self):
+        """One spec, one kind. A second registration is a contradiction, not an
+        override, so it raises rather than silently winning."""
+        with pytest.raises(ValueError, match="already registered"):
+            register_kind(OpaqueSpec, term_class=int, batch_class=int)
+
+    def test_re_registering_the_same_pair_is_harmless(self):
+        """Importing a module twice must not raise."""
+        register_kind(OpaqueSpec, term_class=Opaque, batch_class=OpaqueBatch)
+
+        assert batch_class_for_spec(OpaqueSpec()) is OpaqueBatch
+
+    def test_a_spec_subclass_inherits_its_bases_kind(self):
+        """Resolution walks the MRO, so a refinement need not re-register."""
+
+        class _NarrowerOpaque(OpaqueSpec):
+            pass
+
+        assert batch_class_for_spec(_NarrowerOpaque()) is OpaqueBatch
+
+    def test_an_unregistered_spec_resolves_to_nothing(self):
+        class _Unregistered:
+            pass
+
+        assert batch_class_for_spec(_Unregistered()) is None

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -332,6 +332,7 @@ class TestLevelsAreNamedForWhatMintsThem:
 
         assert (drawn.name, drawn.name_is_auto) == ("atoms", False)
 
+
 class TestABatchOperandKeepsItsLevelsThroughAnOperation:
     """Design V.9: a density op maps elementwise "with the batch axes preserved".
 

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -358,3 +358,71 @@ class TestABatchOperandKeepsItsLevelsThroughAnOperation:
         scored = log_prob(self.LAW, jnp.zeros(3))
 
         assert not isinstance(scored, NumericArrayBatch)
+
+
+class TestEveryAggregateIsNamedForItsFunction:
+    """The naming table, widened across the axes that had diverged.
+
+    A sweep's aggregate is built by the boundary, not by a caller, so its name is
+    the producing function's and is marked auto. Three paths disagreed: the
+    undeclared record aggregate took `stack`'s class-name default, and the scalar,
+    opaque, and declared paths marked a derived name as user-given — which would
+    stop a later operation renaming it.
+    """
+
+    @staticmethod
+    def _rows(n: int = 3):
+        from probpipe.core.event_template import NumericEventTemplate
+
+        return NumericRecordBatch(
+            {"x": jnp.arange(float(n))},
+            "row",
+            element_spec=NumericEventTemplate(x=()),
+            name="rows",
+        )
+
+    def _swept(self, body, **controls):
+        return Function(func=body, name="double", dispatch="sequential", **controls)(v=self._rows())
+
+    @pytest.mark.parametrize(
+        ("label", "body"),
+        [
+            ("numeric", lambda v: jnp.asarray(v["x"]) * 2),
+            ("mapping", lambda v: {"y": jnp.asarray(v["x"])}),
+            ("opaque", lambda v: "tag"),
+            ("callable", lambda v: lambda: 1),
+            ("sequence", lambda v: [jnp.asarray(v["x"]), jnp.asarray(v["x"])]),
+        ],
+    )
+    def test_an_undeclared_aggregate_is_named_for_the_function(self, label, body):
+        result = self._swept(body)
+
+        assert (result.name, result.name_is_auto) == ("double", True)
+
+    def test_a_declared_aggregate_is_named_the_same_way(self):
+        from probpipe import EventTemplate
+
+        result = self._swept(
+            lambda v: {"y": jnp.asarray(v["x"])}, output_template=EventTemplate(y=())
+        )
+
+        assert (result.name, result.name_is_auto) == ("double", True)
+
+    def test_a_multi_axis_sweep_is_named_the_same_way(self):
+        """The re-cut to the sweep's own geometry is a separate construction, and
+        it had its own naming."""
+        from probpipe.core.event_template import NumericEventTemplate
+
+        grid = NumericRecordBatch(
+            {"x": jnp.arange(6.0).reshape(2, 3)},
+            ("a", "b"),
+            element_spec=NumericEventTemplate(x=()),
+            name="grid",
+        )
+
+        result = Function(
+            func=lambda v: {"y": jnp.asarray(v["x"])}, name="double", dispatch="sequential"
+        )(v=grid)
+
+        assert (result.name, result.name_is_auto) == ("double", True)
+        assert result.level_names == ("a", "b")

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -323,3 +323,38 @@ class TestLevelsAreNamedForWhatMintsThem:
         )
 
         assert (drawn.name, drawn.name_is_auto) == ("atoms", False)
+
+class TestABatchOperandKeepsItsLevelsThroughAnOperation:
+    """Design V.9: `log_prob` maps elementwise "with the batch axes preserved".
+
+    An operation whose value parameter is `Any`-hinted takes the batch whole and
+    evaluates it in one vectorized call — the fused implementation V.9 allows.
+    That is not licence to hand back a bare array: the axes the operand accounted
+    for are levels, and a result that drops them says the draws were one value.
+    """
+
+    LAW = Normal(0.0, 1.0, name="height")
+
+    def test_log_prob_of_a_batch_of_draws_keeps_the_sample_level(self):
+        drawn = sample(self.LAW, sample_shape=(3,), key=KEY)
+
+        scored = log_prob(self.LAW, drawn)
+
+        assert (scored.batch_shape, scored.level_names) == ((3,), ("sample",))
+
+    def test_the_result_is_named_for_the_operand_it_scored(self):
+        drawn = sample(self.LAW, sample_shape=(3,), key=KEY)
+
+        assert log_prob(self.LAW, drawn).name == drawn.name
+
+    def test_a_single_draw_is_still_a_single_value(self):
+        """No operand levels to restate, so nothing is invented."""
+        scored = log_prob(self.LAW, sample(self.LAW, key=KEY))
+
+        assert not isinstance(scored, NumericArrayBatch)
+
+    def test_a_raw_array_operand_is_left_alone(self):
+        """A bare array states no levels, so the result carries none."""
+        scored = log_prob(self.LAW, jnp.zeros(3))
+
+        assert not isinstance(scored, NumericArrayBatch)

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -33,7 +33,15 @@ from probpipe import (
     RecordBatch,
 )
 from probpipe.core.event_template import NumericEventTemplate
-from probpipe.core.ops import log_prob, mean, sample, variance
+from probpipe.core.ops import (
+    log_prob,
+    mean,
+    prob,
+    sample,
+    unnormalized_log_prob,
+    unnormalized_prob,
+    variance,
+)
 
 KEY = jax.random.PRNGKey(0)
 ELEMENT = NumericEventTemplate(a=())
@@ -325,37 +333,62 @@ class TestLevelsAreNamedForWhatMintsThem:
         assert (drawn.name, drawn.name_is_auto) == ("atoms", False)
 
 class TestABatchOperandKeepsItsLevelsThroughAnOperation:
-    """Design V.9: `log_prob` maps elementwise "with the batch axes preserved".
+    """Design V.9: a density op maps elementwise "with the batch axes preserved".
 
     An operation whose value parameter is `Any`-hinted takes the batch whole and
     evaluates it in one vectorized call — the fused implementation V.9 allows.
     That is not licence to hand back a bare array: the axes the operand accounted
     for are levels, and a result that drops them says the draws were one value.
+
+    Every op that scores a value is covered, since which of them restates the
+    levels is not something a caller should have to know. `prob` and the two
+    unnormalized ops used to drop them, so the same draws scored as a batch under
+    one op and as one wide value under another.
     """
 
     LAW = Normal(0.0, 1.0, name="height")
 
-    def test_log_prob_of_a_batch_of_draws_keeps_the_sample_level(self):
+    @pytest.fixture(
+        params=[log_prob, prob, unnormalized_log_prob, unnormalized_prob], ids=lambda op: op.name
+    )
+    def density_op(self, request):
+        return request.param
+
+    def test_scoring_a_batch_of_draws_keeps_the_sample_level(self, density_op):
         drawn = sample(self.LAW, sample_shape=(3,), key=KEY)
 
-        scored = log_prob(self.LAW, drawn)
+        scored = density_op(self.LAW, drawn)
 
         assert (scored.batch_shape, scored.level_names) == ((3,), ("sample",))
 
-    def test_the_result_is_named_for_the_operand_it_scored(self):
+    def test_the_result_is_named_for_the_operand_it_scored(self, density_op):
         drawn = sample(self.LAW, sample_shape=(3,), key=KEY)
 
-        assert log_prob(self.LAW, drawn).name == drawn.name
+        assert density_op(self.LAW, drawn).name == drawn.name
 
-    def test_a_single_draw_is_still_a_single_value(self):
+    def test_several_levels_are_all_restated(self, density_op):
+        """The operand's own tiling, not one flat axis."""
+        drawn = NumericArrayBatch(
+            jnp.zeros((2, 3)),
+            ("chain", "draw"),
+            element_spec=NumericArraySpec(()),
+            axis_groups=((2,), (3,)),
+            name="draws",
+        )
+
+        scored = density_op(self.LAW, drawn)
+
+        assert (scored.batch_shape, scored.level_names) == ((2, 3), ("chain", "draw"))
+
+    def test_a_single_draw_is_still_a_single_value(self, density_op):
         """No operand levels to restate, so nothing is invented."""
-        scored = log_prob(self.LAW, sample(self.LAW, key=KEY))
+        scored = density_op(self.LAW, sample(self.LAW, key=KEY))
 
         assert not isinstance(scored, NumericArrayBatch)
 
-    def test_a_raw_array_operand_is_left_alone(self):
+    def test_a_raw_array_operand_is_left_alone(self, density_op):
         """A bare array states no levels, so the result carries none."""
-        scored = log_prob(self.LAW, jnp.zeros(3))
+        scored = density_op(self.LAW, jnp.zeros(3))
 
         assert not isinstance(scored, NumericArrayBatch)
 

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -700,3 +700,74 @@ class TestNumericArrayBatchArrayShim:
 
     def test_dtype_reports_the_store(self):
         assert _batch().dtype == jnp.float32
+
+
+class TestANativeBackedBatchCrossesJax:
+    """The compute boundary converts, as it does for a single value.
+
+    Flatten handed JAX the native container, which fails abstractification before
+    `__jax_array__` is ever consulted — so a pandas- or xarray-backed batch could
+    not enter a trace at all.
+    """
+
+    @staticmethod
+    def _pandas_backed():
+        pd = pytest.importorskip("pandas")
+        return NumericArrayBatch(
+            pd.Series([1.0, 2.0, 3.0]),
+            "row",
+            element_spec=NumericArraySpec(shape=()),
+            name="b",
+        )
+
+    def test_a_native_store_reaches_a_trace(self):
+        batch = self._pandas_backed()
+
+        out = jax.jit(lambda x: x)(batch)
+
+        assert isinstance(out, NumericArrayBatch)
+        assert out.level_names == ("row",)
+
+    def test_the_original_keeps_its_native_store(self):
+        """Converting at the boundary does not materialise the batch itself."""
+        pd = pytest.importorskip("pandas")
+        batch = self._pandas_backed()
+
+        jax.jit(lambda x: x)(batch)
+
+        assert isinstance(batch.values, pd.Series)
+
+    def test_conversion_happens_once_and_is_memoised(self):
+        batch = self._pandas_backed()
+
+        assert batch.as_jax() is batch.as_jax()
+
+
+class TestUnflattenChecksTheElementItRebuilds:
+    """A rank check alone admits a store the element spec is false about."""
+
+    @staticmethod
+    def _batch():
+        return NumericArrayBatch(
+            jnp.zeros((4, 3)), "row", element_spec=NumericArraySpec(shape=(3,)), name="b"
+        )
+
+    def test_a_changed_event_shape_is_refused(self):
+        """The element's own axes are not the transform's to change; the batch
+        would otherwise build and fail at the first selection instead."""
+        _, treedef = jax.tree_util.tree_flatten(self._batch())
+
+        with pytest.raises(ValueError, match="not the event shape"):
+            jax.tree_util.tree_unflatten(treedef, [jnp.zeros((4, 5))])
+
+    def test_an_unchanged_store_round_trips(self):
+        leaves, treedef = jax.tree_util.tree_flatten(self._batch())
+
+        rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+
+        assert (rebuilt.batch_shape, rebuilt.level_names) == ((4,), ("row",))
+
+    def test_removing_every_batch_axis_still_yields_the_element(self):
+        _, treedef = jax.tree_util.tree_flatten(self._batch())
+
+        assert isinstance(jax.tree_util.tree_unflatten(treedef, [jnp.zeros((3,))]), NumericArray)

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -1103,3 +1103,37 @@ class TestEveryBatchIsAnOperand:
 
         assert (out.batch_shape, out.level_names) == ((2,), ("row",))
         np.testing.assert_allclose(out.values, [1.0, 2.0])
+
+
+class TestSweepingASingleStoreBatchAgreesAcrossDispatch:
+    """A row that returns a single-store batch keeps its levels, as a record row does."""
+
+    @staticmethod
+    def _rows(n: int = 3):
+        return NumericArrayBatch(
+            jnp.arange(float(n)), "row", element_spec=NumericArraySpec(shape=()), name="rows"
+        )
+
+    @staticmethod
+    def _inner(v):
+        return NumericArrayBatch(
+            jnp.stack([jnp.asarray(v), jnp.asarray(v)]),
+            "inner",
+            element_spec=NumericArraySpec(shape=()),
+            name="i",
+        )
+
+    @pytest.mark.parametrize("dispatch", ["auto", "sequential"])
+    def test_the_rows_own_level_survives(self, dispatch):
+        out = Function(func=self._inner, name="f", dispatch=dispatch)(v=self._rows())
+
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "inner"))
+
+    def test_explicit_jax_says_what_it_cannot_do(self):
+        """The probe builds one leaf per field, which a single-store batch lacks.
+
+        Declining beats mis-reading it as a law: `auto` sweeps it correctly, and
+        an explicit `jax` should not silently differ from that.
+        """
+        with pytest.raises(TypeError, match="cannot vectorize over NumericArrayBatch"):
+            Function(func=self._inner, name="f", dispatch="jax")(v=self._rows())

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -914,7 +914,7 @@ class TestBatchValuedRowAggregation:
         def body(x):
             return self._inner(2) if float(x["x"]) < 1.5 else Record("r", y=0.0)
 
-        with pytest.raises(TypeError, match="some rows returned a batch of records"):
+        with pytest.raises(TypeError, match="some rows returned a batch and some did not"):
             Function(func=body, dispatch="sequential")(x=self._rows())
 
     @pytest.mark.parametrize(

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -22,7 +22,9 @@ import pytest
 from probpipe import (
     EventTemplate,
     Function,
+    FunctionBatch,
     Normal,
+    NumericArray,
     NumericArrayBatch,
     NumericArraySpec,
     NumericRecord,
@@ -1048,3 +1050,56 @@ class TestDeclaredOpaqueOutputAcrossDispatches:
         assert column.shape == (2,)
         assert [int(v) for v in result[0]["y"]] == [1, 2]
         assert [int(v) for v in result[1]["y"]] == [2, 3]
+
+
+class TestEveryBatchIsAnOperand:
+    """A batch is swept because it holds a multiplicity, not because it holds records.
+
+    The planner recognised only `RecordBatch` and `DistributionArray`, so the
+    other batch kinds were handed to a body whole. A body written for one element
+    then saw the whole collection, and the levels collapsed into the value's
+    shape on the way out.
+    """
+
+    @staticmethod
+    def _numeric(n: int = 3):
+        return NumericArrayBatch(
+            jnp.arange(float(n)), "row", element_spec=NumericArraySpec(shape=()), name="rows"
+        )
+
+    def test_a_numeric_array_batch_reaches_the_body_as_an_element(self):
+        seen: list = []
+
+        Function(func=lambda v: (seen.append(v), 0.0)[1], name="f", dispatch="sequential")(
+            v=self._numeric()
+        )
+
+        assert seen
+        assert all(isinstance(row, NumericArray) for row in seen)
+        assert not any(isinstance(row, NumericArrayBatch) for row in seen)
+
+    def test_sweeping_a_numeric_array_batch_keeps_its_level(self):
+        out = Function(func=lambda v: jnp.asarray(v) * 2.0, name="double", dispatch="sequential")(
+            v=self._numeric()
+        )
+
+        assert (out.batch_shape, out.level_names) == ((3,), ("row",))
+
+    def test_an_opaque_batch_hands_the_body_its_stored_element(self):
+        """`OpaqueBatch` stores rather than materializes, so the body sees the
+        caller's own object."""
+        seen: list = []
+
+        Function(func=lambda v: (seen.append(v), 0.0)[1], name="f", dispatch="sequential")(
+            v=OpaqueBatch(["a", "b"], "row", name="rows")
+        )
+
+        assert seen == ["a", "b"]
+
+    def test_a_function_batch_is_swept_too(self):
+        out = Function(func=lambda f: float(f()), name="call", dispatch="sequential")(
+            f=FunctionBatch([lambda: 1.0, lambda: 2.0], "row", name="rows")
+        )
+
+        assert (out.batch_shape, out.level_names) == ((2,), ("row",))
+        np.testing.assert_allclose(out.values, [1.0, 2.0])

--- a/tests/core/test_wrap_at_the_declared_kind.py
+++ b/tests/core/test_wrap_at_the_declared_kind.py
@@ -308,10 +308,15 @@ class TestEachSweptRowTakesItsOwnKind:
     """A row is one call's return, so the rule that names a single return's kind
     is the rule that names a row's.
 
-    Rows reached the aggregation raw, so the branches there read them as whatever
-    they happened to stack as: a mapping row was an unstackable object, and a
-    sequence row's multiplicity became event shape.
+    Every case runs under both dispatches. Which executor a sweep picks is a
+    performance decision, so a row's kind cannot depend on it: the mapped path
+    reads its rows through the same rule the row-wise path does, and the two
+    agree here rather than in prose.
     """
+
+    @pytest.fixture(params=["auto", "sequential"])
+    def dispatch(self, request):
+        return request.param
 
     @staticmethod
     def _rows(n: int = 3):
@@ -325,32 +330,60 @@ class TestEachSweptRowTakesItsOwnKind:
             name="rows",
         )
 
-    def _swept(self, body):
-        return Function(func=body, name="f", dispatch="sequential")(v=self._rows())
+    def _swept(self, body, dispatch):
+        return Function(func=body, name="f", dispatch=dispatch)(v=self._rows())
 
-    def test_a_mapping_row_gives_a_batch_of_records(self):
-        out = self._swept(lambda v: {"y": jnp.asarray(v["x"]) * 2})
+    def test_a_mapping_row_gives_a_batch_of_records(self, dispatch):
+        out = self._swept(lambda v: {"y": jnp.asarray(v["x"]) * 2}, dispatch)
 
         assert list(out.event_template) == ["y"]
         assert (out.batch_shape, out.level_names) == ((3,), ("row",))
+        np.testing.assert_array_equal(np.asarray(out["y"]), np.arange(3.0) * 2)
 
-    def test_any_mapping_counts_not_only_dict(self):
+    def test_a_nested_mapping_row_keeps_its_subtree(self, dispatch):
+        out = self._swept(
+            lambda v: {"lo": jnp.asarray(v["x"]) - 1, "grp": {"hi": jnp.asarray(v["x"]) + 1}},
+            dispatch,
+        )
+
+        assert list(out.event_template) == ["lo", "grp/hi"]
+        np.testing.assert_array_equal(np.asarray(out["grp/hi"]), np.arange(3.0) + 1)
+
+    def test_any_mapping_counts_not_only_dict(self, dispatch):
         from collections import OrderedDict
 
-        out = self._swept(lambda v: OrderedDict(y=jnp.asarray(v["x"])))
+        out = self._swept(lambda v: OrderedDict(y=jnp.asarray(v["x"])), dispatch)
 
         assert list(out.event_template) == ["y"]
 
-    def test_a_sequence_row_keeps_its_own_level(self):
+    def test_a_sequence_row_keeps_its_own_level(self, dispatch):
         """The row's multiplicity is a level, not part of the element's shape."""
-        out = self._swept(lambda v: [jnp.asarray(v["x"]), jnp.asarray(v["x"])])
+        out = self._swept(lambda v: [jnp.asarray(v["x"]), jnp.asarray(v["x"])], dispatch)
 
         assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "f"))
 
-    def test_rows_of_differing_numeric_shape_are_refused(self):
+    def test_a_batch_row_keeps_the_level_it_named(self, dispatch):
+        """A row that names its own level keeps that name inside the sweep's."""
+        from probpipe import NumericRecordBatch
+        from probpipe.core.event_template import NumericEventTemplate
+
+        def body(v):
+            x = jnp.asarray(v["x"])
+            return NumericRecordBatch(
+                {"y": jnp.stack([x, x * 2])},
+                "part",
+                element_spec=NumericEventTemplate(y=()),
+                name="parts",
+            )
+
+        out = self._swept(body, dispatch)
+
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "part"))
+
+    def test_rows_of_differing_numeric_shape_are_refused(self, dispatch):
         """An object column would record the disagreement as if it were the answer."""
         with pytest.raises(ValueError, match="differing shapes"):
-            self._swept(lambda v: jnp.ones(int(jnp.asarray(v["x"])) + 1))
+            self._swept(lambda v: jnp.ones(int(jnp.asarray(v["x"])) + 1), dispatch)
 
     def test_a_disagreement_inside_a_returned_sequence_is_not_swallowed(self):
         """The stack has a batch form for every element kind, so what raises here
@@ -363,7 +396,8 @@ class TestASweptEmptyMappingHitsTheSameWall:
     """Per-row wrapping makes a `{}` row a `Record`, so the sweep reaches the
     field guard and says what the direct routes say."""
 
-    def test_a_swept_body_returning_an_empty_mapping_is_refused(self):
+    @pytest.mark.parametrize("dispatch", ["auto", "sequential"])
+    def test_a_swept_body_returning_an_empty_mapping_is_refused(self, dispatch):
         from probpipe import NumericRecordBatch
         from probpipe.core.event_template import NumericEventTemplate
 
@@ -375,4 +409,4 @@ class TestASweptEmptyMappingHitsTheSameWall:
         )
 
         with pytest.raises(ValueError, match="at least one field"):
-            Function(func=lambda v: {}, name="f", dispatch="sequential")(v=rows)
+            Function(func=lambda v: {}, name="f", dispatch=dispatch)(v=rows)

--- a/tests/core/test_wrap_at_the_declared_kind.py
+++ b/tests/core/test_wrap_at_the_declared_kind.py
@@ -302,3 +302,77 @@ class TestAnEmptyRecordHasNoBatch:
 
         with pytest.raises(ValueError, match="at least one field"):
             RecordBatch({}, "x", element_spec=EventTemplate())
+
+
+class TestEachSweptRowTakesItsOwnKind:
+    """A row is one call's return, so the rule that names a single return's kind
+    is the rule that names a row's.
+
+    Rows reached the aggregation raw, so the branches there read them as whatever
+    they happened to stack as: a mapping row was an unstackable object, and a
+    sequence row's multiplicity became event shape.
+    """
+
+    @staticmethod
+    def _rows(n: int = 3):
+        from probpipe import NumericRecordBatch
+        from probpipe.core.event_template import NumericEventTemplate
+
+        return NumericRecordBatch(
+            {"x": jnp.arange(float(n))},
+            "row",
+            element_spec=NumericEventTemplate(x=()),
+            name="rows",
+        )
+
+    def _swept(self, body):
+        return Function(func=body, name="f", dispatch="sequential")(v=self._rows())
+
+    def test_a_mapping_row_gives_a_batch_of_records(self):
+        out = self._swept(lambda v: {"y": jnp.asarray(v["x"]) * 2})
+
+        assert list(out.event_template) == ["y"]
+        assert (out.batch_shape, out.level_names) == ((3,), ("row",))
+
+    def test_any_mapping_counts_not_only_dict(self):
+        from collections import OrderedDict
+
+        out = self._swept(lambda v: OrderedDict(y=jnp.asarray(v["x"])))
+
+        assert list(out.event_template) == ["y"]
+
+    def test_a_sequence_row_keeps_its_own_level(self):
+        """The row's multiplicity is a level, not part of the element's shape."""
+        out = self._swept(lambda v: [jnp.asarray(v["x"]), jnp.asarray(v["x"])])
+
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "f"))
+
+    def test_rows_of_differing_numeric_shape_are_refused(self):
+        """An object column would record the disagreement as if it were the answer."""
+        with pytest.raises(ValueError, match="differing shapes"):
+            self._swept(lambda v: jnp.ones(int(jnp.asarray(v["x"])) + 1))
+
+    def test_a_disagreement_inside_a_returned_sequence_is_not_swallowed(self):
+        """The stack has a batch form for every element kind, so what raises here
+        is the rows disagreeing — which the caller should see."""
+        with pytest.raises(ValueError, match="differing shapes"):
+            Function(func=lambda: [jnp.ones(1), jnp.ones(2)], name="g")()
+
+
+class TestASweptEmptyMappingHitsTheSameWall:
+    """Per-row wrapping makes a `{}` row a `Record`, so the sweep reaches the
+    field guard and says what the direct routes say."""
+
+    def test_a_swept_body_returning_an_empty_mapping_is_refused(self):
+        from probpipe import NumericRecordBatch
+        from probpipe.core.event_template import NumericEventTemplate
+
+        rows = NumericRecordBatch(
+            {"x": jnp.arange(3.0)},
+            "row",
+            element_spec=NumericEventTemplate(x=()),
+            name="rows",
+        )
+
+        with pytest.raises(ValueError, match="at least one field"):
+            Function(func=lambda v: {}, name="f", dispatch="sequential")(v=rows)

--- a/tests/core/test_wrap_at_the_declared_kind.py
+++ b/tests/core/test_wrap_at_the_declared_kind.py
@@ -362,6 +362,38 @@ class TestEachSweptRowTakesItsOwnKind:
 
         assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "f"))
 
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            (lambda v: [object(), object()], "OpaqueBatch"),
+            (lambda v: [lambda z: z, lambda z: z], "FunctionBatch"),
+        ],
+        ids=["opaque", "callable"],
+    )
+    def test_a_row_of_unstackable_elements_keeps_its_level_too(self, dispatch, body, expected):
+        """The level does not depend on what the elements are.
+
+        These rows were stored whole: the row's own batch became one opaque
+        element of the aggregate, so its multiplicity vanished and a batch of
+        callables came back as opaque.
+        """
+        out = self._swept(body, dispatch)
+
+        assert type(out).__name__ == expected
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "f"))
+
+    def test_an_empty_sequence_row_counts_zero_on_its_level(self, dispatch):
+        """A batch of nothing is still a batch, as it is for a single return."""
+        out = self._swept(lambda v: [], dispatch)
+
+        assert (out.batch_shape, out.level_names) == ((3, 0), ("row", "f"))
+
+    def test_two_nested_anonymous_levels_are_refused(self, dispatch):
+        """Both would take the function's name, and a clash is not resolved by
+        suffixing it."""
+        with pytest.raises(ValueError, match="level names must be unique"):
+            self._swept(lambda v: [[jnp.asarray(v["x"])], [jnp.asarray(v["x"])]], dispatch)
+
     def test_a_batch_row_keeps_the_level_it_named(self, dispatch):
         """A row that names its own level keeps that name inside the sweep's."""
         from probpipe import NumericRecordBatch


### PR DESCRIPTION
Stacked on #436. Part of #398. Addresses the integration gaps found by an external review of the stack.

The new kinds existed and operations returned them, but the workflow layer had not been
told. Everything here is a **wrong answer** rather than a missing feature.

## Batches were not operands

`build_broadcast_plan` recognised only `RecordBatch` and `DistributionArray`, so a
`NumericArrayBatch`, `OpaqueBatch`, or `FunctionBatch` argument was handed to a body
**whole**. A body written for one element received the whole collection, and the levels
collapsed into the value's shape.

What makes a value sweepable is that it holds a multiplicity on named levels — the `Batch`
contract. The test is now `isinstance(value, Batch)`. **This changed no existing test**,
which is the diagnostic: the gap was in what the planner accepted, not in what anything
asserted.

Widening it then exposed the same assumption in three more places: the mapping transform
had no carrier for a single-store batch; the JAX probe read a non-record batch as a *law*;
and operations dropped their operand's levels, so `log_prob(law, sample(law,
sample_shape=(3,)))` returned a bare `(3,)` array. Design V.9 says the batch axes are
preserved, so they now are — split by the **operand's** rank, so anything the operation
added belongs to the element.

## Each swept row takes its own kind

Rows reached the aggregation raw:

| a swept body returning | was | now |
| --- | --- | --- |
| `{"y": ...}` | `TypeError: cannot aggregate outputs of types ['dict']` | `RecordBatch` |
| `OrderedDict(...)` | same, via `Opaque` refusing mappings | `RecordBatch` |
| `[a, b]` | multiplicity became **event shape** | `(3, 2)` on `("row", "f")` |
| ragged numeric rows | silently an `OpaqueBatch` | refused, naming the shapes |

The `except (TypeError, ValueError): pass` around the returned-sequence stack is removed:
it covered nothing — coverage showed the line never executed — while turning a genuine
schema disagreement into one opaque value.

## Aggregates are named for their function

Three paths disagreed. The undeclared record aggregate kept `stack`'s class-name default
(`numericrecordbatch`); the scalar, opaque, callable, and declared paths marked a derived
name as user-given, which would stop a later operation renaming it. The one-level early
return that skipped naming entirely is **removed rather than patched** — the reshape it
avoided is an identity there.

## A native-backed batch crosses a JAX boundary

Flatten handed JAX the native container, which fails abstractification before
`__jax_array__` is consulted, so a pandas- or xarray-backed batch could not be traced at
all. The boundary now converts, memoised, and the batch keeps its native store. Unflatten
also checks the trailing event shape, rather than admitting a store its own `element_spec`
is false about and failing at the first selection.

## The kind registry

The spec → tracked class → batch form correspondence was open-coded at **six sites**, each
knowing a different subset — which is why widening one left the others behind.
`core/_kinds.py` holds it once; each kind registers beside its own classes; a contradicting
registration raises rather than last-writer-wins; resolution walks the MRO.

## Deliberately not finished

Full JAX **vectorization** of a single-store batch. The mapped row body is built from one
leaf per field, which such a batch lacks, so it needs the row body and the probe's synthesis
changed together. Rather than mis-read the batch, an explicit `dispatch='jax'` declines with
that reason; `auto` and `sequential` sweep it correctly and agree on levels and values.

## Found in a second review of the stack

Five more gaps of the same shape — an answer that depended on something it should not have.

**One answer per computation, whichever executor runs it.** The row-wise sweep gave each
row the kind of its own return; the mapped path did not, so a body returning a mapping
raised `_make_stack cannot aggregate output of type dict` under `dispatch="auto"` and
returned a `NumericRecordBatch` under `"sequential"`. A sequence row raised a bogus count
error. The mapped path applies the same per-row rule now, and carries a record row across
the map the way it already carried a batch one. A declared `output_template` still wins, as
it does row-wise. The tests are a parametrised dispatch matrix rather than a second test,
since agreement is the property being asserted.

**Every batch is read the way the `Batch` contract states it.** Lifting a declaration
against a batched operand read `event_template` — the view only a batch of records has — so
a `NumericArrayBatch`, `OpaqueBatch`, or `FunctionBatch` operand could not be swept by a
declared function at all, however its declaration was written. It reads `element_spec` now,
which the ABC states at every kind; the unification pass already had the spec-against-spec
path this needs. That view was also unsound: it unwrapped a single-field element to that
field, so `EventTemplate(v=())` — naming a bare array — accepted an operand whose elements
are records. Reading the element spec refuses it and names both specs.

A distribution operand is deliberately left alone. It is lifted by being sampled, and a
scalar law reports its event as one field named after itself; restating that belongs with
the `Distribution`-side work.

**Every density op keeps its operand's levels.** `log_prob` restated them; `prob`,
`unnormalized_log_prob`, and `unnormalized_prob` returned a bare array, so the axes survived
only as event shape — the same draws scored as a batch over `("chain", "draw")` under one op
and as one value of shape `(2, 3)` under another. All four share the helper this PR
introduced for exactly that.

**A row of unstackable elements keeps its level.** The row-stacking path knew two of the
four batch forms, so a row returning a sequence of opaque objects or callables had its own
batch stored whole as one element: the row's multiplicity vanished and a row of callables
came back as an `OpaqueBatch`. Object batches now get the stacking path their storage calls
for. An empty-sequence row is a batch of nothing on its own level, matching how a single
return already reads one — which settles the last dispatch disagreement. Two nested
anonymous levels stay refused: both would take the function's name, and a clash is not
resolved by suffixing it.

**The kind table answers where it already can.** `RecordBatch` construction listed the
admissible field kinds inline while the reading end asked the registry — the split the
registry was introduced to close. Row aggregation also converted each row's raw store
directly, bypassing the set-once cache on the batch's own `as_jax`.

Suite: 5710 passed, 52 skipped.


