### PR TITLE
fix(core)!: one answer per computation, whatever ran it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A declared function can be swept over any kind of batch (#398).** Lifting a
+  declaration against a batched operand read `event_template`, the view only a
+  batch of records has, so a `NumericArrayBatch`, `OpaqueBatch`, or `FunctionBatch`
+  operand raised `does not expose an authoritative event_template for lifting`
+  however its declaration was written. It now reads `element_spec`, which the
+  `Batch` contract states at every kind. Two consequences: every batch kind is
+  read the same way, and a batch of one-field records no longer satisfies a
+  declaration that named a bare array — the record-only view unwrapped a
+  single-field element to its field, so `EventTemplate(v=())` accepted an operand
+  whose elements are records. A distribution operand is unchanged: it is lifted by
+  being sampled, and its event template remains what the draw is checked against.
+
 - **A swept row's kind no longer depends on which executor ran it (#398).** The
   row-wise path gave each row the tracked class of its own kind; the mapped
   (`jax.vmap`) path handed its rows to the aggregation raw, so a body returning a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `[]` / `()` an `OpaqueBatch` of `batch_shape == (0,)` — no element can say
   what kind it holds, and every element spec holds vacuously of none.
 
-  `Record()`, `EventTemplate()`, and `OpaqueBatch([], level)` are legal as a
+  `Record()`, `EventTemplate()`, and `OpaqueBatch([], level, name=...)` are legal as a
   result. A *batch* of empty records is not: a batch reads its multiplicity off
   a column, and a zero-field element supplies none, so `RecordBatch` still
   requires at least one field. An empty template is **not** promoted to `NumericEventTemplate`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The kind table is the single answer to which batch form a field has (#398).**
+  `RecordBatch` construction listed the admissible field kinds inline while the
+  reading end asked the registry, so registering a kind widened one and not the
+  other. Construction now asks the registry too. Aggregating a batch of rows also
+  converts each row through its own `as_jax`, whose set-once cache it was
+  bypassing by converting the raw store directly.
+
 - **`sample(law, sample_shape=...)` mints the `sample` level for every kind of
   draw (#398).** *Breaking.* The boundary assumed a law that assembles its own
   draws also names what they range over. An empirical did not: numeric atoms came

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A swept row's kind no longer depends on which executor ran it (#398).** The
+  row-wise path gave each row the tracked class of its own kind; the mapped
+  (`jax.vmap`) path handed its rows to the aggregation raw, so a body returning a
+  mapping raised `cannot aggregate output of type dict` and one returning a
+  sequence raised a spurious row-count mismatch — under `dispatch="auto"`, on
+  bodies that worked under `dispatch="sequential"`. Both paths now read a row
+  through the same rule, and a record row crosses the map as inert columns over no
+  level of its own, the way a batch row already crossed it. A declared
+  `output_template` still names the row's kind, as before.
+
 - **Reading a distribution no longer modifies it.** `BroadcastDistribution`
   assigned its marginal on the first `marginalize()`, and a backend-delegated
   `DistributionArray` assigned its components on the first read, so a query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   requires at least one field. An empty template is **not** promoted to `NumericEventTemplate`:
 
   result. An empty template is **not** promoted to `NumericEventTemplate`:
+
+
   vacuously every leaf is numeric, which is not a reason to claim it. A batch
   still requires a batch *axis* — a single object with no axis is refused as
   before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A swept row of unstackable elements keeps its level (#398).** A row returning
+  a sequence of opaque objects or callables had its own batch stored whole as one
+  element of the aggregate, so the row's multiplicity vanished and a row of
+  callables came back as an `OpaqueBatch`. The row-stacking path now knows all
+  three batch families, so such a row aggregates to `(rows, row_size)` over both
+  levels and a row of callables gives a `FunctionBatch`. An empty sequence row is
+  a batch of nothing on its own level, as it already was for a single return,
+  which also settles a dispatch disagreement: the mapped path raised where the
+  row-wise path returned.
+
 - **Every density op keeps a batch operand's levels (#398).** `log_prob` restated
   the levels its operand carried; `prob`, `unnormalized_log_prob`, and
   `unnormalized_prob` handed back a bare array, so the same draws scored as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it was the one aggregation that left the result auto-named. Opaque rows now give
   an `OpaqueBatch` and callable rows a `FunctionBatch`, both named for the
   function as every other aggregation already was.
-
 - **An empty return keeps its host's kind (#398).** A `Function` returning `{}`
   raised, and `[]` / `()` became an `Opaque`, because `Record`, `EventTemplate`,
   and the object batches each required at least one entry. The kind now follows
@@ -96,6 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   result. A *batch* of empty records is not: a batch reads its multiplicity off
   a column, and a zero-field element supplies none, so `RecordBatch` still
   requires at least one field. An empty template is **not** promoted to `NumericEventTemplate`:
+
+  result. An empty template is **not** promoted to `NumericEventTemplate`:
   vacuously every leaf is numeric, which is not a reason to claim it. A batch
   still requires a batch *axis* — a single object with no axis is refused as
   before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Every density op keeps a batch operand's levels (#398).** `log_prob` restated
+  the levels its operand carried; `prob`, `unnormalized_log_prob`, and
+  `unnormalized_prob` handed back a bare array, so the same draws scored as a
+  batch over `("chain", "draw")` under one op and as one value of shape `(2, 3)`
+  under another. All four now restate them, so which op is called no longer
+  decides whether the draws were a multiplicity.
+
 - **A declared function can be swept over any kind of batch (#398).** Lifting a
   declaration against a batched operand read `event_template`, the view only a
   batch of records has, so a `NumericArrayBatch`, `OpaqueBatch`, or `FunctionBatch`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (breaking)
 
+- **Every batch requires a name (#398).** `RecordBatch`, `NumericRecordBatch`,
+  `OpaqueBatch`, and `FunctionBatch` defaulted to their own lowercased class name,
+  so a pipeline full of them read `recordbatch` / `opaquebatch` — a name that says
+  what the object *is*, which its type already says, and nothing about which one it
+  is. `NumericArray` and `NumericArrayBatch` require one for the same reason.
+
+  A name is now given, or derived from something that carries meaning. `stack`
+  derives one from the records it stacks, so no call site has to invent it, and a
+  structural transform carries the name forward with the flag saying where it came
+  from rather than dropping it for a default that no longer exists.
+
+  The distribution-side placeholders (`DistributionArray`, `EmpiricalDistribution`,
+  the marginal and bootstrap names) are deliberately untouched — those classes are
+  being reworked, and changing their naming now would collide with that.
+
 - **Workflow-scoped structural RNG, co-sampling, and validated replay (#389).**
   Function-owned RNG controls—`Function(..., seed=...)`, the former reserved
   call-level RNG option, and `Function.with_options(seed=...)`—have been removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`sample(law, sample_shape=...)` mints the `sample` level for every kind of
+  draw (#398).** *Breaking.* The boundary assumed a law that assembles its own
+  draws also names what they range over. An empirical did not: numeric atoms came
+  back as one `NumericRecord` whose fields had grown an axis, record atoms and
+  opaque atoms as a single `Opaque` holding the whole array. All three now give
+  the batch form of the draw's kind — `NumericRecordBatch`, `NumericRecordBatch`,
+  `OpaqueBatch` — over a `sample` level, matching what a plain law already gave.
+  Code that read `drawn["field"]` on such a result now reads a column of a batch
+  rather than a field of a record, and `"field" in drawn` is now
+  `"field" in drawn.event_template`. A single draw is unchanged.
+
 - **A swept row of unstackable elements keeps its level (#398).** A row returning
   a sequence of opaque objects or callables had its own batch stored whole as one
   element of the aggregate, so the row's multiplicity vanished and a row of

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -93,10 +93,12 @@ if it were user-guide reference text.
 | Abstraction | Canonical contract location |
 |---|---|
 | `NamedTree` (shared name-keyed tree substrate) | docstrings in `probpipe/core/named_tree.py`; #235 Chapter 1 |
-| `EventTemplate` / `NumericEventTemplate` / `ValueSpec` (raw-value: `ArraySpec`·`OpaqueSpec`; `TermSpec`: `RecordSpec`·`DistributionSpec`·`FunctionSpec`) | docstrings in `probpipe/core/event_template.py`; #235 Chapter 1 |
+| `EventTemplate` / `NumericEventTemplate` / `ValueSpec` (raw-value: `NumericArraySpec`·`OpaqueSpec`; `TermSpec`: `RecordSpec`·`DistributionSpec`·`FunctionSpec`) | docstrings in `probpipe/core/event_template.py`; #235 Chapter 1 |
+| the kind table (which tracked class and which batch form each value spec has) | docstrings in `probpipe/core/_kinds.py` |
+| `NumericArray` / `Opaque` (the tracked classes of the two raw-value kinds) | docstrings in `probpipe/core/_numeric_array.py`, `_opaque.py` |
 | `Record` / `NumericRecord` (each stores its type as a `RecordSpec`, with `event_template` a view on it) | docstrings in `probpipe/core/record.py`, `_numeric_record.py`; #235 Chapter 2 |
 | `Batch` / `BatchSpec` (the multiplicity axis: levels, level names, view identity) | docstrings in `probpipe/core/_batch.py`; #235 Chapter 2 |
-| Batch types (`RecordBatch`/`NumericRecordBatch`, `DistributionArray`) | docstrings in `_record_batch.py`, `_numeric_record_batch.py`, `_distribution_array.py`; #235 Chapter 2 |
+| Batch forms, one per kind (`RecordBatch`/`NumericRecordBatch`, `NumericArrayBatch`, `OpaqueBatch`, `FunctionBatch`, `DistributionArray`) | docstrings in `_record_batch.py`, `_numeric_record_batch.py`, `_numeric_array_batch.py`, `_opaque_batch.py`, `_function_batch.py`, `_distribution_array.py`; #235 Chapter 2 |
 | `RecordBatch` / `NumericRecordBatch` (columnar, leaf-path-keyed storage; a collection, not a named tree) | docstrings in `probpipe/core/_record_batch.py`, `_numeric_record_batch.py`; #235 Chapter 2 |
 | `FunctionBatch` / `OpaqueBatch` (the batch forms that *store* their elements, over shared object-array storage) | docstrings in `probpipe/core/_function_batch.py`, `_opaque_batch.py` (storage in `_object_batch.py`); #235 Chapter 2 |
 | `Function` & ops (`sample`, `log_prob`, …) | docstrings in `core/node.py`, `core/ops.py`, `_workflow_result.py`; #235 Chapter 3 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -708,7 +708,7 @@ register_array_backend(
 ```
 
 One registration makes the type recognised everywhere at once:
-template inference and `ArraySpec.is_valid`, `NumericRecord`
+template inference and `NumericArraySpec.is_valid`, `NumericRecord`
 promotion, boundary conversion, batch stacking, and `fingerprint()`.
 The built-in registration covers `pandas.DataFrame` (per-column
 `.dtypes`, no single `.dtype`). Lookup walks the MRO of `type(obj)`,

--- a/docs/api/records.md
+++ b/docs/api/records.md
@@ -62,7 +62,7 @@ checked against the shared specification at construction.
 Two consequences worth knowing. The store is frozen and a supplied array is
 copied — the pointer array only, so the elements themselves stay shared — so a
 batch holds the elements it validated even if the caller keeps writing to the
-array they passed. And a batch of no elements is a batch: `OpaqueBatch([], "draw")`
+array they passed. And a batch of no elements is a batch: `OpaqueBatch([], "draw", name="draws")`
 and `batch[0:0]` both give one, since zero is a count the level can carry. What a
 batch does need is an *axis* — a single object with none has no level to count
 along, and is refused.

--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -206,7 +206,7 @@
     "    y = np.asarray(satellites, dtype=np.float32)\n",
     "    template = NumericEventTemplate(X=(), y=())\n",
     "    return NumericRecordBatch(\n",
-    "        {'X': width_z, 'y': y}, 'obs', element_spec=template,\n",
+    "        {'X': width_z, 'y': y}, 'obs', element_spec=template, name='data',\n",
     "    )\n",
     "\n",
     "\n",

--- a/docs/user_guide/02_records.ipynb
+++ b/docs/user_guide/02_records.ipynb
@@ -944,6 +944,7 @@
     "    },\n",
     "    \"obs\",\n",
     "    element_spec=EventTemplate(counts=(5,), label=None, duration=()),\n",
+    "    name=\"observations\",\n",
     ")\n",
     "print(observations)\n",
     "print(\"type:\", type(observations).__name__)\n",

--- a/docs/user_guide/12_diagnostics_workflow.ipynb
+++ b/docs/user_guide/12_diagnostics_workflow.ipynb
@@ -290,6 +290,7 @@
     "        {\"X\": width_z, \"y\": y},\n",
     "        \"obs\",\n",
     "        element_spec=template,\n",
+    "        name=\"data\",\n",
     "    )\n",
     "\n",
     "\n",

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -611,20 +611,16 @@ def _make_marginal(
 # _make_stack — stacked sibling of _make_marginal for batched broadcasts
 # ---------------------------------------------------------------------------
 #
-# When a Function broadcasts over a batch of records (parameter
-# sweep), the n inner outputs are independent scenarios indexed by
-# input row — *not* MC draws. The wrapper must preserve row identity:
+# A sweep's rows are independent scenarios indexed by input row, not MC draws,
+# so the aggregate keeps row identity. Each row is first given the kind of the
+# host it is, then the rows aggregate at that kind:
 #
-#   numeric → NumericArrayBatch, one sweep level of (n,)
-#   Record → RecordBatch.stack (NumericRecordBatch when all leaves numeric)
-#   Distribution → DistributionArray
-#   a batch per row (each (m,)) → one batch, levels (sweep, …) over (n, m)
+#   numeric   → NumericArrayBatch          Record       → RecordBatch
+#   opaque    → OpaqueBatch                Distribution → DistributionArray
+#   callable  → FunctionBatch
 #
-# Opaque Python values (e.g. strings) that can't be stacked fall
-# through to a plain-list wrapping with a clear error if even that
-# fails.
-#
-# Caller attaches ``.with_provenance(...)`` externally via ``_coerce_output``.
+# A row that is itself a batch stacks into one batch, the sweep's levels in
+# front of the rows' own. Provenance is attached by ``_coerce_output``.
 # ---------------------------------------------------------------------------
 
 

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -203,6 +203,8 @@ class _MixtureSampling:
                 SAMPLE_LEVEL,
                 element_spec=stacked.element_spec,
                 axis_groups=(sample_shape,),
+                name=self.name,
+                name_is_auto=True,
             )
 
         try:
@@ -1116,6 +1118,8 @@ def _make_stack(
             shared = {
                 "element_spec": tpl,
                 "axis_groups": sweep_groups,
+                "name": name or field_name,
+                "name_is_auto": True,
             }
             try:
                 return NumericRecordBatch(columns, level_names, **shared)

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from .._weights import Weights
 from ..custom_types import Array
-from ._array_backend import _to_jax_array
+from ._array_backend import _event_shape_of, _is_numeric_leaf, _to_jax_array
 from ._distribution_base import Distribution
 from ._empirical import (
     EmpiricalDistribution,
@@ -699,6 +699,29 @@ def _agreeing_batch_rows(outs: list, *, field_name: str) -> Any:
     return first
 
 
+def _row_at_its_kind(row: Any, field_name: str) -> Any:
+    """One swept row as the tracked term of its own kind.
+
+    Only the two *structural* hosts are converted here. A numeric, opaque, or
+    callable row already reaches a branch below that batches it at its kind, and
+    converting it early would cost the vectorized path for no gain.
+
+    - a ``Mapping`` is a tree, so it becomes a ``Record`` and the rows stack into
+      a batch of records;
+    - a non-empty sequence is a multiplicity, so it becomes a batch of its own and
+      the rows stack with that level inside the sweep's.
+    """
+    from collections.abc import Mapping
+
+    from .record import Record
+
+    if isinstance(row, Mapping):
+        return Record(field_name, dict(row), name_is_auto=True)
+    if isinstance(row, (list, tuple)) and row:
+        return _make_stack(list(row), n=len(row), level_names=(field_name,), field_name=field_name)
+    return row
+
+
 def _make_stack(
     inner_outputs: Any,
     *,
@@ -840,6 +863,13 @@ def _make_stack(
                 )
                 for output in outs
             ]
+        else:
+            # Each row takes the kind of the host it is, before the branches
+            # below read what the rows are. A row is one call's return, and the
+            # boundary that names a *single* return's kind (V.0) is the same rule
+            # — reading a mapping row as an unstackable object, or a sequence row
+            # as event shape, states something the row never said.
+            outs = [_row_at_its_kind(output, field_name) for output in outs]
 
         # A batch per row stacks into one batch with the sweep in front of the
         # rows' own levels. Checked before the Record branch below, which would
@@ -969,6 +999,18 @@ def _make_stack(
                 axis_groups=sweep_groups,
                 name=name or field_name,
                 name_is_auto=name is None,
+            )
+
+        # Numeric rows that do not stack disagree on their shape, and an object
+        # column would record that disagreement as though it were the answer. The
+        # rows say what they are; the aggregate says so too.
+        if outs and all(_is_numeric_leaf(o) for o in outs):
+            shapes = sorted({tuple(_event_shape_of(o)) for o in outs})
+            raise ValueError(
+                f"{field_name}: the rows returned numeric values of differing shapes "
+                f"{shapes}, so they do not stack into one batch. Every row of a sweep "
+                f"contributes one element of one shape; pad the rows, or return a batch "
+                f"from each and let the levels record the difference"
             )
 
         # Rows that do not stack take the batch form of their own kind, which is

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -30,7 +30,7 @@ from ._function_batch import FunctionBatch
 from ._immutable import constructing, transient_memo
 from ._numeric_array_batch import NumericArrayBatch, _MappedBatchStore
 from ._numeric_record_batch import NumericRecordBatch
-from ._object_batch import _from_iterable, _is_object_array
+from ._object_batch import _from_iterable, _is_object_array, _ObjectBatch
 from ._opaque_batch import OpaqueBatch
 from ._record_batch import RecordBatch, _batch_class_for, _MappedBatchColumns
 from .event_template import (
@@ -677,13 +677,18 @@ def _agreeing_batch_rows(outs: list, *, field_name: str) -> Any:
     field the others have and misnaming their axes.
     """
     first = outs[0]
-    # The family, not the exact class: a RecordBatch and a NumericRecordBatch
-    # row hold the same thing, and only one of them says so in its name.
-    family = NumericArrayBatch if isinstance(first, NumericArrayBatch) else RecordBatch
+    # The family, not the exact class: a RecordBatch and a NumericRecordBatch row
+    # hold the same thing, and only one of them says so in its name. An
+    # OpaqueBatch and a FunctionBatch share their storage but not their element
+    # spec, so the spec comparison below is what separates them.
+    for candidate in (NumericArrayBatch, _ObjectBatch, RecordBatch):
+        if isinstance(first, candidate):
+            family = candidate
+            break
     if not all(isinstance(o, family) for o in outs):
         kinds = sorted({type(o).__name__ for o in outs})
         raise TypeError(
-            f"{field_name}: some rows returned a batch of records and some did not "
+            f"{field_name}: some rows returned a batch and some did not "
             f"({', '.join(kinds)}). A swept body returns one kind for every row, since "
             f"the aggregate has one schema; return a batch from every row or from none"
         )
@@ -723,7 +728,12 @@ def _row_at_its_kind(row: Any, field_name: str) -> Any:
 
     if isinstance(row, Mapping):
         return Record(field_name, dict(row), name_is_auto=True)
-    if isinstance(row, (list, tuple)) and row:
+    if isinstance(row, (list, tuple)):
+        if not row:
+            # A batch of nothing, exactly as ``_wrap_as_term`` reads an empty
+            # sequence returned on its own: no element to read a kind off, and the
+            # level still counts zero of them.
+            return OpaqueBatch([], field_name, name=field_name, name_is_auto=True)
         return _make_stack(list(row), n=len(row), level_names=(field_name,), field_name=field_name)
     return row
 
@@ -883,9 +893,20 @@ def _make_stack(
         # inner batch axis.
         # Both batch kinds a swept body can return; each keeps its own kind
         # through the sweep, as a scalar row does.
-        stackable = (RecordBatch, NumericArrayBatch)
+        stackable = (RecordBatch, NumericArrayBatch, _ObjectBatch)
         if outs and any(isinstance(o, stackable) for o in outs):
             first = _agreeing_batch_rows(outs, field_name=field_name)
+            if isinstance(first, _ObjectBatch):
+                # The elements are stored, not stacked, so the aggregate is one
+                # object array over the sweep's axes then the rows' own.
+                store = np.stack([o._store for o in outs], axis=0)
+                return type(first)(
+                    store.reshape(batch_shape + store.shape[1:]),
+                    (*level_names, *first.level_names),
+                    axis_groups=(*sweep_groups, *first.axis_groups),
+                    name=name or field_name,
+                    name_is_auto=True,
+                )
             if isinstance(first, NumericArrayBatch):
                 # One store rather than columns, so the rows stack directly —
                 # through the array backend, as the columns below do, since a

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -908,10 +908,11 @@ def _make_stack(
                     name_is_auto=True,
                 )
             if isinstance(first, NumericArrayBatch):
-                # One store rather than columns, so the rows stack directly —
-                # through the array backend, as the columns below do, since a
-                # row's store is in native form.
-                store = jnp.stack([_to_jax_array(o.values) for o in outs], axis=0)
+                # One store rather than columns, so the rows stack directly. Each
+                # row converts through ``as_jax``, not through the backend on its
+                # raw store: the conversion is the batch's own and is cached
+                # set-once there, so a row aggregated again is not converted again.
+                store = jnp.stack([o.as_jax() for o in outs], axis=0)
                 return NumericArrayBatch(
                     store.reshape(batch_shape + store.shape[1:]),
                     (*level_names, *first.level_names),

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -432,6 +432,7 @@ def _stack_declared_columns(
         element_spec=template,
         axis_groups=axis_groups,
         name=name,
+        name_is_auto=True,
     )
 
 
@@ -459,7 +460,14 @@ def _empty_declared_stack(
         else:
             columns[path] = np.empty(batch_shape, dtype=object)
     cls = _batch_class_for(template)
-    return cls(columns, level_names, element_spec=template, axis_groups=axis_groups, name=name)
+    return cls(
+        columns,
+        level_names,
+        element_spec=template,
+        axis_groups=axis_groups,
+        name=name,
+        name_is_auto=True,
+    )
 
 
 def _make_marginal(
@@ -815,7 +823,7 @@ def _make_stack(
             element_spec=inner_outputs.element_spec,
             axis_groups=(*sweep_groups, *inner_outputs.axis_groups),
             name=name or field_name,
-            name_is_auto=name is None,
+            name_is_auto=True,
         )
     if isinstance(inner_outputs, _MappedBatchColumns):
         return _batch_over_swept_columns(
@@ -891,7 +899,7 @@ def _make_stack(
                     element_spec=first.element_spec,
                     axis_groups=(*sweep_groups, *first.axis_groups),
                     name=name or field_name,
-                    name_is_auto=name is None,
+                    name_is_auto=True,
                 )
             # Columns are leaf-keyed, so a nested element needs no special
             # case — and they are read raw: a field that is not an array
@@ -935,8 +943,10 @@ def _make_stack(
             except (TypeError, ValueError):
                 flat = None
             if flat is not None:
-                if batch_shape == (n_total,):
-                    return flat
+                # No early return for the one-level case: the reshape below is
+                # an identity there, and ``stack`` named the batch after its own
+                # class, where every aggregation names it for the function that
+                # produced the rows.
                 n_cur = len(flat.batch_shape)
                 return NumericRecordBatch(
                     {
@@ -946,6 +956,8 @@ def _make_stack(
                     level_names,
                     element_spec=flat.element_spec,
                     axis_groups=sweep_groups,
+                    name=name or field_name,
+                    name_is_auto=True,
                 )
             # No declared template, so the element structure is inferred from the
             # rows. ``RecordBatch.stack`` is what infers it: columns are keyed by
@@ -967,6 +979,8 @@ def _make_stack(
                 level_names,
                 element_spec=flat.element_spec,
                 axis_groups=sweep_groups,
+                name=name or field_name,
+                name_is_auto=True,
             )
 
         # All Distributions → stacked DistributionArray, shaped to
@@ -998,7 +1012,7 @@ def _make_stack(
                 element_spec=NumericArraySpec(event_shape, dtype=stacked.dtype),
                 axis_groups=sweep_groups,
                 name=name or field_name,
-                name_is_auto=name is None,
+                name_is_auto=True,
             )
 
         # Numeric rows that do not stack disagree on their shape, and an object
@@ -1022,7 +1036,7 @@ def _make_stack(
             shared = {
                 "axis_groups": sweep_groups,
                 "name": name or field_name,
-                "name_is_auto": name is None,
+                "name_is_auto": True,
             }
             # ``outs`` first: every row of none is vacuously callable, and no row
             # is a reason to claim the function kind over the fallback.
@@ -1075,7 +1089,7 @@ def _make_stack(
             element_spec=NumericArraySpec(event_shape, dtype=inner_outputs.dtype),
             axis_groups=sweep_groups,
             name=name or field_name,
-            name_is_auto=name is None,
+            name_is_auto=True,
         )
 
     # vmap of a Record-returning function produces a Record with batched leaves

--- a/probpipe/core/_broadcast_distributions.py
+++ b/probpipe/core/_broadcast_distributions.py
@@ -28,7 +28,7 @@ from ._empirical import (
 )
 from ._function_batch import FunctionBatch
 from ._immutable import constructing, transient_memo
-from ._numeric_array_batch import NumericArrayBatch
+from ._numeric_array_batch import NumericArrayBatch, _MappedBatchStore
 from ._numeric_record_batch import NumericRecordBatch
 from ._object_batch import _from_iterable, _is_object_array
 from ._opaque_batch import OpaqueBatch
@@ -782,6 +782,18 @@ def _make_stack(
     # Before the generic pytree handling below, which would read the inner batch
     # axis as an event axis and drop the level names with it — the same reason
     # the batch-of-batches case precedes the Record case on the list path.
+    if isinstance(inner_outputs, _MappedBatchStore):
+        # One store rather than columns: the sweep's axes replace the leading one
+        # the transform produced, and the levels are the sweep's then the rows'.
+        store = inner_outputs.store
+        return NumericArrayBatch(
+            store.reshape(batch_shape + store.shape[1:]),
+            (*level_names, *inner_outputs.level_names),
+            element_spec=inner_outputs.element_spec,
+            axis_groups=(*sweep_groups, *inner_outputs.axis_groups),
+            name=name or field_name,
+            name_is_auto=name is None,
+        )
     if isinstance(inner_outputs, _MappedBatchColumns):
         return _batch_over_swept_columns(
             inner_outputs.columns,

--- a/probpipe/core/_empirical.py
+++ b/probpipe/core/_empirical.py
@@ -718,20 +718,11 @@ class RecordEmpiricalDistribution(
         for field_path in self._record_data:
             arr = jnp.asarray(self._record_data[field_path])
             fields[field_path] = arr[indices].reshape(*sample_shape, *arr.shape[1:])
-        # Return a ``NumericRecord`` rather than a ``NumericRecordBatch``
-        # for the batched case. ``NumericRecordBatch`` would carry a
-        # ``batch_shape`` that ``jax.vmap``'s pytree validation rejects
-        # when the empirical's ``_sample`` is wrapped inside a vmap'd
-        # callable (the array variant treats its leading axes as
-        # structural batch dims and refuses to be flattened/unflattened
-        # across that axis). Returning the looser ``NumericRecord``
-        # form is a deliberate deviation from the WF "uniform output
-        # wrap" contract; downstream consumers that need a batched
-        # container instead of per-field arrays don't currently exist
-        # — every callsite either iterates fields, indexes by name,
-        # or calls ``flatten_value`` (which handles both types).
-        # Single-field consumers still get the shape shim via the
-        # NumericRecord coercion path.
+        # The columns carry the draw axes, and the level naming them is the
+        # ``sample`` boundary's to mint: a law does not name what a caller's
+        # ``sample_shape`` ranges over. Building the batch here instead would put
+        # a named multiplicity inside a ``vmap``, whose pytree validation refuses
+        # the rank change it cannot name.
         return Record(self.name, fields, name_is_auto=True)
 
     # -- moments ------------------------------------------------------------

--- a/probpipe/core/_function_batch.py
+++ b/probpipe/core/_function_batch.py
@@ -31,8 +31,10 @@ class FunctionBatch(_ObjectBatch[Callable]):
         specifies a callable and neither of its templates.
     axis_groups : iterable of iterable of int, optional
         The axis sizes each level holds; defaults to one axis per level.
-    name : str, optional
-        The batch's name; defaults to ``"functionbatch"``, marked auto-derived.
+    name : str
+        The batch's name. Required, as it is for every batch: a batch is a value a
+        caller holds, and a name derived from its class says nothing about what it
+        holds.
     name_is_auto : bool, default False
         Whether *name* is auto-derived rather than user-given.
     provenance : Provenance, optional

--- a/probpipe/core/_function_batch.py
+++ b/probpipe/core/_function_batch.py
@@ -83,7 +83,7 @@ class FunctionBatch(_ObjectBatch[Callable]):
         *,
         element_spec: FunctionSpec | None = None,
         axis_groups: Iterable[Iterable[int]] | None = None,
-        name: str | None = None,
+        name: str,
         name_is_auto: bool = False,
         provenance: Provenance | None = None,
     ) -> None:

--- a/probpipe/core/_function_batch.py
+++ b/probpipe/core/_function_batch.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Iterable
 
 import numpy as np
 
+from ._kinds import register_kind
 from ._object_batch import _ObjectBatch
 from .event_template import FunctionSpec
 from .provenance import Provenance
@@ -109,3 +110,6 @@ class FunctionBatch(_ObjectBatch[Callable]):
         spec = self._spec.element_spec
         assert isinstance(spec, FunctionSpec)  # narrowed at construction
         return spec
+
+
+register_kind(FunctionSpec, batch_class=FunctionBatch)

--- a/probpipe/core/_function_contract.py
+++ b/probpipe/core/_function_contract.py
@@ -218,6 +218,36 @@ def _bind_function_inputs(
     )
 
 
+def _lifted_element_spec(value: Any, *, function_name: str, name: str) -> ValueSpec | EventTemplate:
+    """What one element of a lifted operand satisfies.
+
+    A :class:`~probpipe.core._batch.Batch` states this uniformly in
+    ``element_spec``, at every kind: a batch of records answers with a
+    ``RecordSpec``, one of arrays with a ``NumericArraySpec``, one of callables
+    with a ``FunctionSpec``. Reading the record-only ``event_template`` view
+    instead let only a batch of records be swept by a declared function, and made
+    a batch of records satisfy a declaration that named a bare array.
+
+    A distribution operand is not a batch, and is lifted by being sampled, so what
+    the body receives is one draw. Its schema is the operand's own event template,
+    passed as the template it is: a scalar law reports a single field named after
+    itself, which the unification pass reads against a declared leaf. Restating
+    that as a record declaration belongs with the ``Distribution``-side rework.
+    """
+    from ._batch import Batch
+
+    if isinstance(value, Batch):
+        return value.element_spec
+    template = getattr(value, "event_template", None)
+    if isinstance(template, EventTemplate):
+        return template
+    raise ValueError(
+        f"Function {function_name!r} input {name!r} states no element specification for "
+        f"lifting: a {type(value).__name__} reports neither an element_spec nor an "
+        f"event_template"
+    )
+
+
 def _bind_planned_function_inputs(
     *,
     function_name: str,
@@ -230,20 +260,9 @@ def _bind_planned_function_inputs(
         return None, {}
     schema_values = dict(values)
     for name in lifted_names:
-        value = values[name]
-        try:
-            lifted_template = value.event_template
-        except (AttributeError, TypeError) as error:
-            raise ValueError(
-                f"Function {function_name!r} input {name!r} does not expose an "
-                "authoritative event_template for lifting"
-            ) from error
-        if not isinstance(lifted_template, EventTemplate):
-            raise ValueError(
-                f"Function {function_name!r} input {name!r} does not expose an "
-                "authoritative event_template for lifting"
-            )
-        schema_values[name] = lifted_template
+        schema_values[name] = _lifted_element_spec(
+            values[name], function_name=function_name, name=name
+        )
     return _unify_event_template_with_value(
         input_template,
         schema_values,

--- a/probpipe/core/_kinds.py
+++ b/probpipe/core/_kinds.py
@@ -1,0 +1,85 @@
+"""The kind table: which tracked class and which batch form each value spec has.
+
+Every value spec has exactly one tracked class and one batch form (design II.2,
+III.1). That correspondence was open-coded at six sites, each knowing a
+different subset, so widening one of them left the others behind — a
+``NumericArrayBatch`` that the record layer could present but the workflow
+planner would not sweep.
+
+The table is declared once here and each kind registers itself at the bottom of
+its own module, next to the classes it names. Registration is import-order
+sensitive by construction, which is why ``probpipe/__init__.py`` imports the
+batch modules eagerly: a lookup before a kind's module has been imported would
+see a table that does not yet mention it.
+
+A spec with no registered batch form is not an oversight — a ``RecordSpec``
+belongs to :class:`~probpipe.RecordBatch`, whose choice between the plain and
+numeric class depends on the *template's* leaves rather than on the spec type
+alone, so the record layer keeps its own resolver.
+
+See design II.2, III.1.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "batch_class_for_spec",
+    "register_kind",
+    "term_class_for_spec",
+]
+
+#: spec type -> (tracked class, batch class). Either may be ``None`` where the
+#: kind has no class of that side.
+_KINDS: dict[type, tuple[type | None, type | None]] = {}
+
+
+def register_kind(
+    spec_type: type, *, term_class: type | None = None, batch_class: type | None = None
+) -> None:
+    """Declare the tracked class and batch form belonging to *spec_type*.
+
+    Called at the bottom of the module defining the classes, so the table is
+    populated by importing the kind rather than by a central list that a new
+    kind has to be added to.
+
+    Raises
+    ------
+    ValueError
+        If *spec_type* is already registered with a different pair. A kind has
+        one tracked class and one batch form; two registrations disagreeing is a
+        contradiction rather than an override.
+    """
+    existing = _KINDS.get(spec_type)
+    pair = (term_class, batch_class)
+    if existing is not None and existing != pair:
+        raise ValueError(
+            f"{spec_type.__name__} is already registered as {existing}, so registering "
+            f"{pair} would give one spec two kinds; a spec has one tracked class and one "
+            f"batch form"
+        )
+    _KINDS[spec_type] = pair
+
+
+def term_class_for_spec(spec: Any) -> type | None:
+    """The tracked class a value satisfying *spec* is returned as, if any."""
+    return _lookup(spec, 0)
+
+
+def batch_class_for_spec(spec: Any) -> type | None:
+    """The batch form a collection of values satisfying *spec* takes, if any."""
+    return _lookup(spec, 1)
+
+
+def _lookup(spec: Any, side: int) -> type | None:
+    """Resolve *spec*'s registered class, honouring subclass registrations.
+
+    The exact type first, then the MRO, so a spec subclass inherits its base's
+    kind unless it registers its own.
+    """
+    for candidate in type(spec).__mro__:
+        entry = _KINDS.get(candidate)
+        if entry is not None and entry[side] is not None:
+            return entry[side]
+    return None

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -20,6 +20,7 @@ from ._array_backend import (
     _to_numpy_array,
 )
 from ._batch import Batch, BatchSpec, _axis_groups_for
+from ._kinds import register_kind
 from ._numeric_array import NumericArray
 from .event_template import NumericArraySpec
 from .provenance import Provenance
@@ -290,3 +291,6 @@ def _numeric_array_batch_unflatten(aux, children):
 jax.tree_util.register_pytree_node(
     NumericArrayBatch, _numeric_array_batch_flatten, _numeric_array_batch_unflatten
 )
+
+# The numeric-array kind: its spec, its tracked class, and this batch form.
+register_kind(NumericArraySpec, term_class=NumericArray, batch_class=NumericArrayBatch)

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -86,7 +86,10 @@ class NumericArrayBatch(Batch[NumericArray]):
 
     _values: Any
 
-    __slots__ = ("_values",)
+    __slots__ = ("_jax_cache", "_values")
+
+    #: Derived from the store rather than transported, as for ``NumericArray``.
+    _transient_state = ("_jax_cache",)
 
     def __init__(
         self,
@@ -194,8 +197,23 @@ class NumericArrayBatch(Batch[NumericArray]):
         arr = np.asarray(arr, dtype=dtype) if dtype is not None else arr
         return arr.copy() if copy else arr
 
+    def as_jax(self) -> Any:
+        """The store as a ``jax.Array`` — the single conversion point.
+
+        A store already held as one passes through, tracers included; a native
+        container converts through its registered backend once and is memoised
+        for this instance, as a :class:`NumericArray`'s value is.
+        """
+        if isinstance(self._values, jax.Array):
+            return self._values
+        cached = getattr(self, "_jax_cache", None)
+        if cached is None:
+            cached = _to_jax_array(self._values)
+            object.__setattr__(self, "_jax_cache", cached)
+        return cached
+
     def __jax_array__(self) -> Any:
-        return _to_jax_array(self._values)
+        return self.as_jax()
 
     def __repr__(self) -> str:
         return (
@@ -245,8 +263,14 @@ class NumericArrayBatch(Batch[NumericArray]):
 
 
 def _numeric_array_batch_flatten(batch: NumericArrayBatch):
-    """Flatten for JAX traversal: the store, keyed by the aux spec."""
-    return [batch._values], (batch._spec, batch._name, batch._name_is_auto)
+    """Flatten for JAX traversal: the store, keyed by the aux spec.
+
+    The boundary presents a bare array, as a ``NumericArray``'s flatten does.
+    Handing the native container to JAX instead fails abstractification before
+    ``__jax_array__`` is ever consulted, so a pandas- or xarray-backed batch
+    could not enter a trace at all.
+    """
+    return [batch.as_jax()], (batch._spec, batch._name, batch._name_is_auto)
 
 
 def _numeric_array_batch_unflatten(aux, children):
@@ -272,6 +296,18 @@ def _numeric_array_batch_unflatten(aux, children):
         object.__setattr__(view, "_values", values)
         view._init_batch(spec, name=name, name_is_auto=name_is_auto)
         return view
+    # The element's own axes are not the transform's to change. A rank check
+    # alone would admit a store whose trailing axes no longer match what the
+    # element declares, and the batch would build with a spec that is a false
+    # statement about its own store — surfacing only at the first selection.
+    event_shape = tuple(element_spec.shape)
+    if event_rank and tuple(shape)[len(shape) - event_rank :] != event_shape:
+        raise ValueError(
+            f"a transform left this NumericArrayBatch over a store of {tuple(shape)}, whose "
+            f"trailing axes are not the event shape {event_shape} its elements declare. A "
+            f"transform maps the elements; changing what one *is* rebuilds the batch where "
+            f"the new element spec is known"
+        )
     surviving = tuple(shape)[: len(shape) - event_rank] if event_rank else tuple(shape)
     if surviving == tuple(spec.batch_shape):
         view = object.__new__(NumericArrayBatch)

--- a/probpipe/core/_numeric_array_batch.py
+++ b/probpipe/core/_numeric_array_batch.py
@@ -294,3 +294,79 @@ jax.tree_util.register_pytree_node(
 
 # The numeric-array kind: its spec, its tracked class, and this batch form.
 register_kind(NumericArraySpec, term_class=NumericArray, batch_class=NumericArrayBatch)
+
+
+class _MappedBatchStore:
+    """A single-store batch taken apart, to cross a mapping transform.
+
+    The counterpart of :class:`~probpipe.core._record_batch._MappedBatchColumns`
+    for a batch that holds one store rather than a column per field. The reason
+    is the same: unflattening refuses an added axis because it has no name to
+    give the level, which is right for a raw transform and wrong for an executor
+    that knows both. So the executor hands the transform this inert carrier —
+    its unflatten rebuilds it verbatim, checking nothing — and rebuilds the batch
+    on the far side, where the level name is in hand.
+
+    Private and short-lived: wrapped and unwrapped within one call.
+    """
+
+    __slots__ = ("axis_groups", "element_spec", "level_names", "name", "name_is_auto", "store")
+
+    def __init__(
+        self,
+        store: Any,
+        *,
+        element_spec: NumericArraySpec,
+        level_names: tuple[str, ...],
+        axis_groups: tuple[tuple[int, ...], ...],
+        name: str,
+        name_is_auto: bool,
+    ):
+        self.store = store
+        self.element_spec = element_spec
+        self.level_names = level_names
+        self.axis_groups = axis_groups
+        self.name = name
+        self.name_is_auto = name_is_auto
+
+    @classmethod
+    def of(cls, batch: NumericArrayBatch) -> _MappedBatchStore:
+        """Take *batch* apart, keeping what unflattening could not have inferred."""
+        return cls(
+            batch.values,
+            element_spec=batch.element_spec,
+            level_names=tuple(batch.level_names),
+            axis_groups=tuple(batch.axis_groups),
+            name=batch._name,
+            name_is_auto=batch._name_is_auto,
+        )
+
+
+def _mapped_batch_store_flatten(carried: _MappedBatchStore):
+    return [carried.store], (
+        carried.element_spec,
+        carried.level_names,
+        carried.axis_groups,
+        carried.name,
+        carried.name_is_auto,
+    )
+
+
+def _mapped_batch_store_unflatten(aux, children) -> _MappedBatchStore:
+    element_spec, level_names, axis_groups, name, name_is_auto = aux
+    (store,) = children
+    # No rank check, deliberately: the added axis is the point, and the caller
+    # that added it is the one that can name it.
+    return _MappedBatchStore(
+        store,
+        element_spec=element_spec,
+        level_names=level_names,
+        axis_groups=axis_groups,
+        name=name,
+        name_is_auto=name_is_auto,
+    )
+
+
+jax.tree_util.register_pytree_node(
+    _MappedBatchStore, _mapped_batch_store_flatten, _mapped_batch_store_unflatten
+)

--- a/probpipe/core/_numeric_record_batch.py
+++ b/probpipe/core/_numeric_record_batch.py
@@ -72,7 +72,7 @@ class NumericRecordBatch(RecordBatch):
         *,
         element_spec: RecordSpec | EventTemplate,
         axis_groups: Iterable[Iterable[int]] | None = None,
-        name: str | None = None,
+        name: str,
         name_is_auto: bool = False,
         provenance: Provenance | None = None,
     ) -> None:

--- a/probpipe/core/_object_batch.py
+++ b/probpipe/core/_object_batch.py
@@ -49,12 +49,13 @@ class _ObjectBatch[E](Batch[E]):
         elements are stored in. Defaults to one axis per level, which requires
         as many names as ``elements`` has axes; a level spanning several axes is
         stated explicitly.
-    name : str, optional
-        The batch's name. Defaults to the class name lowercased, marked
-        auto-derived.
+    name : str
+        The batch's name. Required, as it is for every batch: a batch is a value a
+        caller holds, and a name derived from its class says nothing about what it
+        holds.
     name_is_auto : bool, default False
-        Whether *name* is auto-derived rather than user-given. A batch left
-        unnamed is auto-named regardless.
+        Whether *name* is auto-derived rather than user-given, which is what an
+        operation naming its own result states.
     provenance : Provenance, optional
         How this batch was produced.
 
@@ -79,7 +80,7 @@ class _ObjectBatch[E](Batch[E]):
     suffixing. The caller that mints a level knows what it means.
 
     Construction admits no elements, as selection always did: ``batch[0:0]`` and
-    ``OpaqueBatch([], "draw")`` are both a batch of nothing. Zero is a count the
+    ``OpaqueBatch([], "draw", name="draws")`` are both a batch of nothing. Zero is a count the
     level can carry, and an object array of no elements still reports the shape
     ``(0,)`` to read it from. What is refused is a missing *axis*: a
     zero-dimensional store is one object, with no level to count along.

--- a/probpipe/core/_object_batch.py
+++ b/probpipe/core/_object_batch.py
@@ -99,7 +99,7 @@ class _ObjectBatch[E](Batch[E]):
         *,
         element_spec: ValueSpec,
         axis_groups: Iterable[Iterable[int]] | None = None,
-        name: str | None = None,
+        name: str,
         name_is_auto: bool = False,
         provenance: Provenance | None = None,
     ) -> None:
@@ -113,8 +113,8 @@ class _ObjectBatch[E](Batch[E]):
         )
         self._init_batch(
             BatchSpec(element_spec, groups, names),
-            name=name if name is not None else type(self).__name__.lower(),
-            name_is_auto=name is None or name_is_auto,
+            name=name,
+            name_is_auto=name_is_auto,
             provenance=provenance,
         )
 

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -10,8 +10,9 @@ from typing import Any
 
 import numpy as np
 
+from ._kinds import register_kind
 from ._object_batch import _ObjectBatch
-from ._opaque import OpaqueSpec
+from ._opaque import Opaque, OpaqueSpec
 from .provenance import Provenance
 
 __all__ = ["OpaqueBatch"]
@@ -111,3 +112,6 @@ class OpaqueBatch(_ObjectBatch[Any]):
         spec = self._spec.element_spec
         assert isinstance(spec, OpaqueSpec)  # narrowed at construction
         return spec
+
+
+register_kind(OpaqueSpec, term_class=Opaque, batch_class=OpaqueBatch)

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -86,7 +86,7 @@ class OpaqueBatch(_ObjectBatch[Any]):
         *,
         element_spec: OpaqueSpec | None = None,
         axis_groups: Iterable[Iterable[int]] | None = None,
-        name: str | None = None,
+        name: str,
         name_is_auto: bool = False,
         provenance: Provenance | None = None,
     ) -> None:

--- a/probpipe/core/_opaque_batch.py
+++ b/probpipe/core/_opaque_batch.py
@@ -31,8 +31,10 @@ class OpaqueBatch(_ObjectBatch[Any]):
         What every element satisfies. Defaults to ``OpaqueSpec()``.
     axis_groups : iterable of iterable of int, optional
         The axis sizes each level holds; defaults to one axis per level.
-    name : str, optional
-        The batch's name; defaults to ``"opaquebatch"``, marked auto-derived.
+    name : str
+        The batch's name. Required, as it is for every batch: a batch is a value a
+        caller holds, and a name derived from its class says nothing about what it
+        holds.
     name_is_auto : bool, default False
         Whether *name* is auto-derived rather than user-given.
     provenance : Provenance, optional

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -43,7 +43,6 @@ from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._function_batch import FunctionBatch
 from ._kinds import batch_class_for_spec
 from ._object_batch import _from_iterable, _frozen_object_column, _is_object_array
-from ._opaque import OpaqueSpec
 from ._opaque_batch import OpaqueBatch
 from .event_template import (
     EventTemplate,
@@ -242,15 +241,17 @@ class RecordBatch(Batch[Record]):
             if isinstance(spec, NumericArraySpec):
                 _check_array_column(column, spec, path=path, kind=kind)
                 continue
-            if not isinstance(spec, FunctionSpec | OpaqueSpec):
+            if batch_class_for_spec(spec) is None:
                 # A field kind with no batch form cannot be *read* back: reading
                 # one presents the column as the batch of its element kind, and
                 # there is none for this. Admitting it at construction would make
-                # a batch nobody can take a field from.
+                # a batch nobody can take a field from. The registry answers that,
+                # as it does at the reading end, so a newly registered kind is
+                # admitted here without this guard being widened to match.
                 raise TypeError(
                     f"{kind}: the field {path!r} is declared {type(spec).__name__}, which has no "
-                    f"batch form, so a batch cannot present its column; an array field, a "
-                    f"callable field, and an opaque field are the forms a column takes"
+                    f"batch form, so a batch cannot present its column; a kind registers its "
+                    f"batch form beside its classes (see core/_kinds.py)"
                 )
             if not _is_object_array(column):
                 raise TypeError(

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -88,12 +88,13 @@ class RecordBatch(Batch[Record]):
         The axis *sizes* each level holds, in order, tiling ``batch_shape``.
         Defaults to one axis per level, which requires as many names as there
         are batch axes.
-    name : str, optional
-        The batch's name. Defaults to the class name lowercased, marked
-        auto-derived.
+    name : str
+        The batch's name. Required, as it is for every batch: a batch is a value a
+        caller holds, and a name derived from its class says nothing about what it
+        holds.
     name_is_auto : bool, default False
-        Whether *name* is auto-derived rather than user-given. A batch left
-        unnamed is auto-named regardless.
+        Whether *name* is auto-derived rather than user-given, which is what an
+        operation naming its own result states.
     provenance : Provenance, optional
         How this batch was produced.
 

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -1426,6 +1426,23 @@ class _MappedBatchColumns:
             name_is_auto=batch._name_is_auto,
         )
 
+    @classmethod
+    def of_record(cls, record: Record) -> _MappedBatchColumns:
+        """One record as columns over no levels of its own.
+
+        A record row has a multiplicity of one, so the axis the map is about to
+        add is the only level the aggregate will have. Naming none here is what
+        says so.
+        """
+        return cls(
+            {path: record[path] for path in record.event_template},
+            element_spec=record.spec,
+            level_names=(),
+            axis_groups=(),
+            name=record._name,
+            name_is_auto=record._name_is_auto,
+        )
+
 
 def _mapped_batch_columns_flatten(carried: _MappedBatchColumns):
     return list(carried.columns.values()), (

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -41,6 +41,7 @@ import numpy as np
 from ._array_backend import _is_numeric_dtype, _to_jax_array
 from ._batch import Batch, BatchSpec, _axis_groups_for
 from ._function_batch import FunctionBatch
+from ._kinds import batch_class_for_spec
 from ._object_batch import _from_iterable, _frozen_object_column, _is_object_array
 from ._opaque import OpaqueSpec
 from ._opaque_batch import OpaqueBatch
@@ -381,19 +382,21 @@ class RecordBatch(Batch[Record]):
         spec = self.event_template[key]
         if isinstance(spec, NumericArraySpec):
             return column
-        name = f"{self.name}[{key!r}]"
-        column_spec = BatchSpec(spec, self.axis_groups, self.level_names)
-        if isinstance(spec, FunctionSpec):
-            return self._inherit_provenance(
-                FunctionBatch._over_store(column, spec=column_spec, name=name)
+        # Every other kind presents through its registered batch form, so a new
+        # kind is reachable here by registering itself rather than by being added
+        # to a switch this module would otherwise have to know about.
+        column_cls = batch_class_for_spec(spec)
+        if column_cls is None:
+            raise TypeError(
+                f"the field {key!r} is declared {type(spec).__name__}, which has no batch form; "
+                f"a kind registers its batch form beside its classes (see core/_kinds.py)"
             )
-        if isinstance(spec, OpaqueSpec):
-            return self._inherit_provenance(
-                OpaqueBatch._over_store(column, spec=column_spec, name=name)
+        return self._inherit_provenance(
+            column_cls._over_store(
+                column,
+                spec=BatchSpec(spec, self.axis_groups, self.level_names),
+                name=f"{self.name}[{key!r}]",
             )
-        raise TypeError(
-            f"the field {key!r} is declared {type(spec).__name__}, which has no batch form yet; "
-            f"an array field, a callable field, and an opaque field are the forms a column takes"
         )
 
     def _field_view(self, path: str, template: EventTemplate) -> Self:

--- a/probpipe/core/_record_batch.py
+++ b/probpipe/core/_record_batch.py
@@ -168,7 +168,7 @@ class RecordBatch(Batch[Record]):
         *,
         element_spec: RecordSpec | EventTemplate,
         axis_groups: Iterable[Iterable[int]] | None = None,
-        name: str | None = None,
+        name: str,
         name_is_auto: bool = False,
         provenance: Provenance | None = None,
     ) -> None:
@@ -189,7 +189,7 @@ class RecordBatch(Batch[Record]):
         object.__setattr__(self, "_columns", store)
         self._init_batch(
             BatchSpec(spec, groups, names),
-            name=name if name is not None else kind.lower(),
+            name=name,
             name_is_auto=name is None or name_is_auto,
             provenance=provenance,
         )
@@ -652,16 +652,19 @@ class RecordBatch(Batch[Record]):
         numeric is a ``NumericRecordBatch``, so an edit that removes the last
         non-numeric field promotes and one that introduces a non-numeric field
         demotes — which also makes a mixed ``merge`` give the same answer whichever
-        way round it is written. The **name** is preserved when the caller gave it
-        and left to the constructor to re-derive when it was auto, since the old one
-        described the pre-edit fields.
+        way round it is written. The **name** is carried over with the flag that
+        says where it came from. It used to be dropped when auto, for the
+        constructor to re-derive — but there is no class-name default to re-derive
+        from now, and an auto name is one something derived from real content
+        rather than a placeholder, so carrying it is better than having none.
         """
         return _batch_class_for(template)(
             dict(columns),
             self.level_names,
             element_spec=template,
             axis_groups=self.axis_groups,
-            name=None if self.name_is_auto else self.name,
+            name=self.name,
+            name_is_auto=self.name_is_auto,
         )
 
     # -- construction from elements -----------------------------------------
@@ -673,6 +676,7 @@ class RecordBatch(Batch[Record]):
         *,
         level_name: str,
         element_spec: RecordSpec | EventTemplate | None = None,
+        name: str | None = None,
     ) -> Self:
         """Stack records into a batch with one level of ``(len(records),)``.
 
@@ -687,6 +691,11 @@ class RecordBatch(Batch[Record]):
             What every element satisfies. Taken from the first record when
             omitted, which is exact whenever the records were built against a
             shared declaration.
+        name : str, optional
+            The batch's name. Taken from the first record when omitted and marked
+            auto — a batch of ``draw`` records is about ``draw``, so the name is
+            derived from what is being stacked rather than invented. A caller with
+            a better name passes one.
 
         Returns
         -------
@@ -734,7 +743,13 @@ class RecordBatch(Batch[Record]):
             key: _stack_column([record[key] for record in records], template[key], kind=kind)
             for key in fields
         }
-        return cls(columns, (level_name,), element_spec=spec)
+        return cls(
+            columns,
+            (level_name,),
+            element_spec=spec,
+            name=name if name is not None else records[0].name,
+            name_is_auto=name is None,
+        )
 
     # -- equality -----------------------------------------------------------
 

--- a/probpipe/core/_workflow_plan.py
+++ b/probpipe/core/_workflow_plan.py
@@ -17,7 +17,6 @@ from typing import Any, Literal, Union, get_args, get_origin
 from . import _workflow_call, _workflow_descendants, _workflow_distribution_normalization
 from ._batch import Batch
 from ._distribution_array import DistributionArray
-from ._record_batch import RecordBatch
 from .distribution import Distribution, EmpiricalDistribution
 
 BroadcastRegime = Literal["none", "distribution", "sweep", "nested"]
@@ -194,9 +193,13 @@ def build_broadcast_plan(
         value = _workflow_call.input_ref_value(values, ref)
         expected = _workflow_call.input_ref_hint(signature_info, ref)
 
-        is_batched_record = isinstance(value, RecordBatch)
+        # Any Batch is an operand: what makes a value sweepable is that it holds
+        # a multiplicity on named levels, which is the Batch contract rather than
+        # anything specific to records. A DistributionArray is a Distribution, not
+        # a Batch, so it stays a separate test.
+        is_batch = isinstance(value, Batch)
         is_dist_array = isinstance(value, DistributionArray)
-        if (is_batched_record or is_dist_array) and len(value.batch_shape) > 0:
+        if (is_batch or is_dist_array) and len(value.batch_shape) > 0:
             if _value_matches_hint(value, expected) or expected is Any:
                 continue
             array_args.append(ref)

--- a/probpipe/core/_workflow_result.py
+++ b/probpipe/core/_workflow_result.py
@@ -11,6 +11,7 @@ See design V.0.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any, Literal
 
@@ -73,8 +74,12 @@ def _wrap_as_term(
     # -- a raw host, wrapped into its own kind -----------------------------
     # The kind follows the host's *type*, empty or not: a mapping is a tree and a
     # sequence a multiplicity, and having no entries does not change which.
-    if isinstance(value, dict):
-        return Record(field_name, value, name_is_auto=True)
+    if isinstance(value, Mapping):
+        # Any mapping, not only ``dict``: the value layer reads a mapping as a
+        # tree, and an ``OrderedDict`` or a ``Mapping`` subclass is one. Falling
+        # through would reach ``Opaque``, which refuses mappings, so the return
+        # would raise rather than be wrapped.
+        return Record(field_name, dict(value), name_is_auto=True)
     if isinstance(value, (list, tuple)):
         if not value:
             # No element to read a kind off, and every element spec holds
@@ -83,14 +88,14 @@ def _wrap_as_term(
             from ._opaque_batch import OpaqueBatch
 
             return OpaqueBatch([], field_name, name=field_name, name_is_auto=True)
-        try:
-            # A returned sequence ranges over nothing the call named, so the
-            # level takes the function's own name.
-            return _make_stack(
-                list(value), n=len(value), level_names=(field_name,), field_name=field_name
-            )
-        except (TypeError, ValueError):
-            pass
+        # A returned sequence ranges over nothing the call named, so the level
+        # takes the function's own name. Errors are not caught here: the stack
+        # has a batch form for every element kind, so what reaches this and
+        # raises is the rows disagreeing — which is the caller's to see, not
+        # something to record as one opaque value.
+        return _make_stack(
+            list(value), n=len(value), level_names=(field_name,), field_name=field_name
+        )
     # ``_is_numeric_leaf`` excludes duck-typed objects (``MagicMock`` and the
     # like) whose attribute probing recurses inside ``jnp.asarray``.
     if _is_numeric_leaf(value):

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -33,6 +33,7 @@ from . import (
 from ._batch import Batch
 from ._broadcast_distributions import _make_stack
 from ._distribution_array import DistributionArray, _make_distribution_array
+from ._numeric_array_batch import NumericArrayBatch, _MappedBatchStore
 from ._record_batch import RecordBatch, _MappedBatchColumns
 from .config import WorkflowKind, prefect_config
 from .distribution import BroadcastDistribution, Distribution
@@ -332,6 +333,8 @@ def mapped_row_body(
         out = func(**_workflow_call.replace_input_refs(values, replacements))
         if isinstance(out, RecordBatch):
             return _MappedBatchColumns.of(out)
+        if isinstance(out, NumericArrayBatch):
+            return _MappedBatchStore.of(out)
         return out
 
     return one_row

--- a/probpipe/core/_workflow_sweep.py
+++ b/probpipe/core/_workflow_sweep.py
@@ -31,7 +31,7 @@ from . import (
     _workflow_result,
 )
 from ._batch import Batch
-from ._broadcast_distributions import _make_stack
+from ._broadcast_distributions import _make_stack, _row_at_its_kind
 from ._distribution_array import DistributionArray, _make_distribution_array
 from ._numeric_array_batch import NumericArrayBatch, _MappedBatchStore
 from ._record_batch import RecordBatch, _MappedBatchColumns
@@ -98,6 +98,7 @@ def execute_sweep(
             require_jax_traceable=require_jax_traceable,
             workflow_kind=workflow_kind,
             workflow_name=workflow_name,
+            output_is_declared=output_template is not None,
         )
         aggregate = _make_stack(
             per_row,
@@ -225,6 +226,7 @@ def execute_sweep_rows(
     require_jax_traceable: Callable[[dict[str, Any], list[_workflow_call.WorkflowInputRef]], None],
     workflow_kind: WorkflowKind = WorkflowKind.OFF,
     workflow_name: str = "workflow",
+    output_is_declared: bool = False,
 ) -> Any:
     """Execute pure sweep rows through JAX vmap or row-wise execution."""
     # Zero rows run nothing, so there is no body for a dispatch to trace and no
@@ -274,6 +276,7 @@ def execute_sweep_rows(
             n_total=plan.n_sweep,
             workflow_kind=workflow_kind,
             workflow_name=workflow_name,
+            output_is_declared=output_is_declared,
         )
 
     per_row_values = [
@@ -311,6 +314,8 @@ def mapped_row_body(
     func: Callable[..., Any],
     values: dict[str, Any],
     array_args: Sequence[_workflow_call.WorkflowInputRef],
+    field_name: str,
+    output_is_declared: bool = False,
 ) -> Callable[[Any], Any]:
     """The body ``jax.vmap`` runs for one sweep row, and the probe traces.
 
@@ -319,10 +324,15 @@ def mapped_row_body(
     functions cannot promise.
 
     A row's batched-record argument is rebuilt from raw leaf columns inside the
-    traced call, so nothing infers a batch axis on the way in. On the way out, a
-    returned :class:`Batch` is taken apart into :class:`_MappedBatchColumns`,
-    because the map is about to add an axis that the batch's own unflatten hook
-    could not name — the executor names it afterwards, from the sweep's levels.
+    traced call, so nothing infers a batch axis on the way in. On the way out the
+    row takes the kind of its own return, as a row-wise row does, and a record or
+    a batch is then taken apart into :class:`_MappedBatchColumns` or
+    :class:`_MappedBatchStore`: the map is about to add an axis that neither
+    class's unflatten hook could name, and the executor names it afterwards from
+    the sweep's levels.
+
+    *output_is_declared* says *func* already gave the row a declared template, in
+    which case that template is the row's kind and nothing here re-derives one.
     """
 
     def one_row(array_slice_leaves):
@@ -331,6 +341,12 @@ def mapped_row_body(
             for ref, leaves in zip(array_args, array_slice_leaves)
         }
         out = func(**_workflow_call.replace_input_refs(values, replacements))
+        if not output_is_declared:
+            out = _row_at_its_kind(out, field_name)
+            if isinstance(out, Record):
+                # As a batch row is carried, but with no level of its own: the
+                # axis the map adds is the only one the aggregate will have.
+                return _MappedBatchColumns.of_record(out)
         if isinstance(out, RecordBatch):
             return _MappedBatchColumns.of(out)
         if isinstance(out, NumericArrayBatch):
@@ -348,9 +364,16 @@ def execute_sweep_rows_jax(
     n_total: int,
     workflow_kind: WorkflowKind = WorkflowKind.OFF,
     workflow_name: str = "workflow",
+    output_is_declared: bool = False,
 ) -> Any:
     """Execute the limited single-batch sweep through ``jax.vmap``."""
-    single_call = mapped_row_body(func=func, values=values, array_args=array_args)
+    single_call = mapped_row_body(
+        func=func,
+        values=values,
+        array_args=array_args,
+        field_name=workflow_name,
+        output_is_declared=output_is_declared,
+    )
 
     vmap_input = []
     for ref in array_args:

--- a/probpipe/core/event_template.py
+++ b/probpipe/core/event_template.py
@@ -1499,6 +1499,11 @@ def _unify_template_node(
     path: str,
 ) -> EventTemplate:
     """Recursively unify one declared template node with actual structure."""
+    if isinstance(actual, RecordSpec):
+        # An authoritative record declaration states the same fields the template
+        # node does; reading them off it is what lets a declared record operand be
+        # unified from its spec rather than only from a live value.
+        actual = actual.event_template
     children = getattr(actual, "children", None)
 
     if isinstance(children, Mapping):

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -1048,7 +1048,11 @@ class Function(Node, TrackedTerm, Annotated):
                     # The executor's own body, not a copy maintained in the
                     # probe. ``dummy_kw`` already carries non-batched inputs.
                     _row_call = _workflow_sweep.mapped_row_body(
-                        func=func, values=dummy_kw, array_args=refs
+                        func=func,
+                        values=dummy_kw,
+                        array_args=refs,
+                        field_name=self._name,
+                        output_is_declared=self._output_template is not None,
                     )
 
                     probe_leaves = []

--- a/probpipe/core/node.py
+++ b/probpipe/core/node.py
@@ -40,6 +40,7 @@ from . import (
     _workflow_result,
     _workflow_sweep,
 )
+from ._batch import Batch
 from ._function_contract import (
     _bind_function_inputs,
     _bind_planned_function_inputs,
@@ -198,6 +199,18 @@ class Node(ABC):  # noqa: B024
     @property
     def inputs(self) -> Mapping[str, Any]:
         return self._inputs
+
+
+class _UnvectorizableBatchSignal(Exception):
+    """The probe met a batch whose rows the mapped body cannot be built from.
+
+    Raised so the reason survives to the caller: the generic tracing message
+    would say the function is not JAX-traceable, which is not what went wrong.
+    """
+
+    def __init__(self, kinds: list[str]) -> None:
+        super().__init__(", ".join(kinds))
+        self.kinds = kinds
 
 
 class Function(Node, TrackedTerm, Annotated):
@@ -991,6 +1004,7 @@ class Function(Node, TrackedTerm, Annotated):
             dummy_kw = dict(values)
             broadcast_refs = set(broadcast_args)
             batched_sources: dict[_workflow_call.WorkflowInputRef, Any] = {}
+            unvectorized_batches: dict[Any, Any] = {}
             drawn_refs: list[_workflow_call.WorkflowInputRef] = []
             for ref in _workflow_call.iter_input_refs(self._signature_info, values):
                 v = _workflow_call.input_ref_value(values, ref)
@@ -1001,6 +1015,15 @@ class Function(Node, TrackedTerm, Annotated):
                     if isinstance(v, RecordBatch):
                         batched_sources[ref] = v
                         dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, v[0])
+                    elif isinstance(v, Batch):
+                        # A batch that is not a batch of records is still a swept
+                        # source, not a draw. The probe's synthesis below builds a
+                        # leaf per field, which a single-store batch does not have,
+                        # so this route declines rather than mis-reading it as a
+                        # law: ``auto`` runs it sequentially and gets the right
+                        # answer, which an explicit ``jax`` should not silently
+                        # differ from.
+                        unvectorized_batches[ref] = v
                     else:
                         # Nothing to synthesize: the draw itself supplies the
                         # structure and dtype below, which is what lets a
@@ -1016,6 +1039,10 @@ class Function(Node, TrackedTerm, Annotated):
                         replacement = v
                     dummy_kw = _workflow_call.replace_input_ref(dummy_kw, ref, replacement)
             with _workflow_context._workflow_probe():
+                if unvectorized_batches:
+                    raise _UnvectorizableBatchSignal(
+                        sorted({type(b).__name__ for b in unvectorized_batches.values()})
+                    )
                 if batched_sources:
                     refs = list(batched_sources)
                     # The executor's own body, not a copy maintained in the
@@ -1143,6 +1170,12 @@ class Function(Node, TrackedTerm, Annotated):
         )
         if trace_error is None:
             return
+        if isinstance(trace_error, _UnvectorizableBatchSignal):
+            raise TypeError(
+                f"dispatch='jax' cannot vectorize over {', '.join(trace_error.kinds)}: the "
+                f"mapped row body is built from one leaf per field, which a single-store batch "
+                f"does not have. Use dispatch='auto' or 'sequential', which sweep it correctly."
+            ) from trace_error
         if isinstance(trace_error, _workflow_context._StochasticProbeSignal):
             raise TypeError(
                 "dispatch='jax' cannot execute a wrapped function that requests "

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -166,6 +166,44 @@ def _drawn_at_its_batch_form(
     )
 
 
+def _at_the_operands_levels(computed: Any, operand: Any) -> Any:
+    """Give *computed* the levels *operand* carried, when it is a batch.
+
+    An operation whose value parameter is ``Any``-hinted receives a batch whole
+    and evaluates it in one vectorized call rather than row by row. That is the
+    fused implementation design V.9 allows to register above the elementwise map
+    — but V.9 also says the batch axes are *preserved*, and a bare array does not
+    preserve them. So the levels the operand stated are restated on the result.
+
+    Only the axes the operand accounted for are levels; anything the operation
+    added beyond them belongs to the element, which is why the split is by the
+    operand's rank rather than by the result's.
+    """
+    from ._array_backend import _event_shape_of, _is_numeric_leaf, _numpy_dtype_of
+    from ._batch import Batch
+    from ._numeric_array_batch import NumericArrayBatch
+    from .event_template import NumericArraySpec
+
+    if not isinstance(operand, Batch) or not _is_numeric_leaf(computed):
+        return computed
+    batch_shape = tuple(operand.batch_shape)
+    shape = tuple(_event_shape_of(computed))
+    if shape[: len(batch_shape)] != batch_shape:
+        # The operation did not lay its result out over the operand's axes, so
+        # there is no correspondence to restate.
+        return computed
+    return NumericArrayBatch(
+        computed,
+        tuple(operand.level_names),
+        element_spec=NumericArraySpec(
+            shape=shape[len(batch_shape) :], dtype=_numpy_dtype_of(computed)
+        ),
+        axis_groups=tuple(operand.axis_groups),
+        name=operand.name,
+        name_is_auto=operand.name_is_auto,
+    )
+
+
 # -- keyword value form shared by the density ops ---------------------------
 #
 # Each density op accepts either a positional ``value`` or named field kwargs
@@ -222,7 +260,8 @@ def log_prob(dist: SupportsLogProb, value: Any = None, **field_kwargs: Any) -> A
     """
     if not isinstance(dist, SupportsLogProb):
         raise TypeError(f"{type(dist).__name__} does not support log_prob")
-    return dist._log_prob(_resolve_value("log_prob", dist, value, field_kwargs))
+    resolved = _resolve_value("log_prob", dist, value, field_kwargs)
+    return _at_the_operands_levels(dist._log_prob(resolved), resolved)
 
 
 @function

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -272,8 +272,8 @@ def prob(dist: SupportsLogProb, value: Any = None, **field_kwargs: Any) -> Array
     """
     if not isinstance(dist, SupportsLogProb):
         raise TypeError(f"{type(dist).__name__} does not support prob (missing _log_prob method)")
-    value = _resolve_value("prob", dist, value, field_kwargs)
-    return jnp.exp(dist._log_prob(value))
+    resolved = _resolve_value("prob", dist, value, field_kwargs)
+    return _at_the_operands_levels(jnp.exp(dist._log_prob(resolved)), resolved)
 
 
 @function
@@ -291,8 +291,8 @@ def unnormalized_log_prob(
             f"{type(dist).__name__} does not support unnormalized_log_prob "
             f"(missing _unnormalized_log_prob method)"
         )
-    value = _resolve_value("unnormalized_log_prob", dist, value, field_kwargs)
-    return dist._unnormalized_log_prob(value)
+    resolved = _resolve_value("unnormalized_log_prob", dist, value, field_kwargs)
+    return _at_the_operands_levels(dist._unnormalized_log_prob(resolved), resolved)
 
 
 @function
@@ -310,8 +310,8 @@ def unnormalized_prob(
             f"{type(dist).__name__} does not support unnormalized_prob "
             f"(missing _unnormalized_log_prob method)"
         )
-    value = _resolve_value("unnormalized_prob", dist, value, field_kwargs)
-    return jnp.exp(dist._unnormalized_log_prob(value))
+    resolved = _resolve_value("unnormalized_prob", dist, value, field_kwargs)
+    return _at_the_operands_levels(jnp.exp(dist._unnormalized_log_prob(resolved)), resolved)
 
 
 @function

--- a/probpipe/core/ops.py
+++ b/probpipe/core/ops.py
@@ -131,23 +131,76 @@ def _drawn_at_its_batch_form(
 ) -> Any:
     """Give a multi-draw result the batch form of the draw's kind.
 
-    A non-empty ``sample_shape`` puts those leading dimensions on one level
-    named for the operation that mints them, ``sample`` (design V.2, V.9). A record- or term-drawing law builds its own
-    batch, so a raw array is the case assembled here.
+    A non-empty ``sample_shape`` puts those leading dimensions on one level named
+    for the operation that mints them, ``sample`` (design V.2, V.9). The level is
+    minted here, at the boundary, for every kind of draw: a law that assembled the
+    draws itself — as a record of columns, or as an array of stored objects — did
+    not name what its leading axes range over, and reading them as event shape
+    says the draws were one wide value.
 
-    The event shape is read off the drawn array, which stays exact for a law
-    whose event shape is symbolic until a draw binds it. The batch takes the
-    law's own *name*, since the draws are that law's, and carries the law's
-    *name_is_auto* with it: the name is a caller's statement exactly when the
-    caller's name for the law was one.
+    The event shape is read off the draw, which stays exact for a law whose event
+    shape is symbolic until a draw binds it. The batch takes the law's own *name*,
+    since the draws are that law's, and carries the law's *name_is_auto* with it:
+    the name is a caller's statement exactly when the caller's name for the law
+    was one.
+
+    A law that built its own batch already named the level, and a term of some
+    other kind is left as it is.
     """
     from ._array_backend import _event_shape_of, _is_numeric_leaf, _numpy_dtype_of
-    from ._broadcast_distributions import SAMPLE_LEVEL
+    from ._batch import Batch
+    from ._broadcast_distributions import SAMPLE_LEVEL, _make_stack
     from ._numeric_array_batch import NumericArrayBatch
-    from .event_template import NumericArraySpec
+    from ._object_batch import _is_object_array
+    from ._record_batch import _batch_class_for
+    from .event_template import NumericArraySpec, _reshaped_template
+    from .record import Record
     from .tracked import TrackedTerm
 
-    if not sample_shape or isinstance(drawn, TrackedTerm) or not _is_numeric_leaf(drawn):
+    if not sample_shape or isinstance(drawn, Batch):
+        return drawn
+
+    n_draw_axes = len(sample_shape)
+    if isinstance(drawn, Record):
+        columns = {}
+        for path in drawn.event_template:
+            column = drawn[path]
+            if not _is_numeric_leaf(column):
+                return drawn
+            if tuple(_event_shape_of(column))[:n_draw_axes] != tuple(sample_shape):
+                # The draws are not where the contract puts them, so there is no
+                # split to make — the same conservatism the array case applies.
+                return drawn
+            columns[path] = column
+        # Only the draw axes move; the rest of each field's declaration rides
+        # through, which inferring an element template from the columns would lose.
+        element_spec = _reshaped_template(drawn.event_template, lambda shape: shape[n_draw_axes:])
+        return _batch_class_for(element_spec)(
+            columns,
+            SAMPLE_LEVEL,
+            element_spec=element_spec,
+            axis_groups=(tuple(sample_shape),),
+            name=name,
+            name_is_auto=name_is_auto,
+        )
+
+    if _is_object_array(drawn):
+        # Stored draws aggregate exactly as a sweep's rows do — each element at
+        # its own kind, under the one level the operation mints.
+        aggregate = _make_stack(
+            list(drawn.reshape(-1)),
+            batch_shape=tuple(sample_shape),
+            level_names=(SAMPLE_LEVEL,),
+            field_name=name,
+            name=name,
+        )
+        # An aggregation names its result for the function that produced the rows
+        # and marks that auto. Here the name is the law's, so whether it was a
+        # caller's statement is the law's answer, not this boundary's.
+        object.__setattr__(aggregate, "_name_is_auto", name_is_auto)
+        return aggregate
+
+    if isinstance(drawn, TrackedTerm) or not _is_numeric_leaf(drawn):
         return drawn
     shape = _event_shape_of(drawn)
     if shape[: len(sample_shape)] != tuple(sample_shape):

--- a/probpipe/core/protocols.py
+++ b/probpipe/core/protocols.py
@@ -121,15 +121,21 @@ class SupportsSampling(Protocol):
 
     Return-type convention
     ----------------------
-    The shape of the return value depends on whether the distribution
-    emits structured samples and whether the caller asks for a batch:
+    The return lays the draws out on leading axes, and what carries them depends
+    on whether the distribution emits structured samples:
 
-    =====================  =======================  =========================================
-    Distribution kind      ``sample_shape == ()``   ``sample_shape == (S1, S2, ...)``
-    =====================  =======================  =========================================
-    Numeric (raw array)    ``Array[*event_shape]``  ``Array[*sample_shape, *event_shape]``
-    ``RecordDistribution`` ``Record`` / ``NumericRecord``  ``NumericRecordBatch(batch_shape=sample_shape)``
-    =====================  =======================  =========================================
+    ======================  ==========================  ==============================
+    Distribution kind       ``sample_shape == ()``      ``sample_shape == (S1, ...)``
+    ======================  ==========================  ==============================
+    Numeric (raw array)     ``Array[*event_shape]``     ``Array[*sample_shape, ...]``
+    ``RecordDistribution``  ``Record``                  ``Record`` of stacked columns
+    ======================  ==========================  ==============================
+
+    An implementation is not asked to *name* what those axes range over: the
+    ``sample`` operation mints the level, since a law cannot know what a caller's
+    ``sample_shape`` means. So returning the columns is right here, and a batch
+    inside a ``vmap`` — whose pytree validation refuses a rank change it cannot
+    name — is avoided.
 
     To draw a single sample, call ``_sample(key, ())``. Implementations
     that find it clearer to factor out a single-draw helper should

--- a/tests/core/test_broadcast_distribution.py
+++ b/tests/core/test_broadcast_distribution.py
@@ -806,10 +806,16 @@ class TestRecordBatchMarginal:
         np.testing.assert_allclose(float(v["sum"]), 0.02, atol=0.02)
         np.testing.assert_allclose(float(v["diff"]), 0.02, atol=0.02)
 
-    def test_sample_returns_record(self, record_workflow, prior, key):
+    def test_sample_returns_a_batch_of_records_on_the_sample_level(
+        self, record_workflow, prior, key
+    ):
+        """The draws are a multiplicity, and the level says what they range over."""
         result = record_workflow(**prior.select("x", "y"))
+
         s = sample(result, key=key, sample_shape=(5,))
-        assert "sum" in s
+
+        assert (s.batch_shape, s.level_names) == ((5,), ("sample",))
+        assert list(s.event_template) == ["sum", "diff"]
         assert s["sum"].shape == (5,)
         assert s["diff"].shape == (5,)
 

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -2008,7 +2008,7 @@ class TestMultiplicityBindsFromAValue:
 
     @staticmethod
     def _batch(size=3, level="item"):
-        return OpaqueBatch([object() for _ in range(size)], level)
+        return OpaqueBatch([object() for _ in range(size)], level, name="batch")
 
     @staticmethod
     def _grid(shape, level_names="grid", axis_groups=None):
@@ -2016,7 +2016,9 @@ class TestMultiplicityBindsFromAValue:
         store = np.empty(shape, dtype=object)
         for index in np.ndindex(shape):
             store[index] = object()
-        return OpaqueBatch(store, level_names, axis_groups=axis_groups if axis_groups else [shape])
+        return OpaqueBatch(
+            store, level_names, axis_groups=axis_groups if axis_groups else [shape], name="batch"
+        )
 
     @staticmethod
     def _declared(axis="n", field=None):

--- a/tests/core/test_event_template.py
+++ b/tests/core/test_event_template.py
@@ -746,7 +746,7 @@ class TestValueSpecs:
 # ---------------------------------------------------------------------------
 
 
-class TestArraySpecIsValid:
+class TestNumericArraySpecIsValid:
     def test_shape_match(self):
         spec = NumericArraySpec((3,))
         assert spec.is_valid(jnp.ones(3))

--- a/tests/core/test_first_class_function.py
+++ b/tests/core/test_first_class_function.py
@@ -461,6 +461,71 @@ class TestApplyContract:
 
         assert result.num_atoms == 5
 
+    def test_every_batch_kind_lifts_against_its_element_spec(self):
+        """A batch states what one element satisfies in ``element_spec``, at every
+        kind, so a declared function reads every batch the same way."""
+        from probpipe import FunctionBatch, NumericArrayBatch, OpaqueBatch
+
+        cases = [
+            (
+                NumericArrayBatch(
+                    jnp.arange(3.0), "row", element_spec=NumericArraySpec(()), name="rows"
+                ),
+                EventTemplate(v=()),
+            ),
+            (OpaqueBatch([object(), object()], "row", name="rows"), EventTemplate(v=None)),
+            (
+                FunctionBatch([lambda z: z, lambda z: z], "row", name="rows"),
+                EventTemplate(v=FunctionSpec()),
+            ),
+            (
+                NumericRecordBatch(
+                    {"x": jnp.arange(3.0)}, "row", element_spec=EventTemplate(x=()), name="rows"
+                ),
+                EventTemplate(v=EventTemplate(x=())),
+            ),
+        ]
+        for operand, input_template in cases:
+            wrapped = Function(
+                func=lambda v: 1.0,
+                name="f",
+                input_template=input_template,
+                dispatch="sequential",
+            )
+
+            result = wrapped(v=operand)
+
+            assert isinstance(result, NumericArrayBatch), type(operand).__name__
+            assert result.level_names == ("row",), type(operand).__name__
+
+    def test_a_batch_of_records_does_not_satisfy_a_bare_array_declaration(self):
+        """Reading the record-only view made a one-field element pass as its field."""
+        rows = NumericRecordBatch(
+            {"x": jnp.arange(3.0)}, "row", element_spec=EventTemplate(x=()), name="rows"
+        )
+        wrapped = Function(
+            func=lambda v: 1.0,
+            name="f",
+            input_template=EventTemplate(v=()),
+            dispatch="sequential",
+        )
+
+        with pytest.raises(ValueError, match=r"RecordSpec.*does not conform"):
+            wrapped(v=rows)
+
+    def test_a_mismatched_element_kind_names_both_specs(self):
+        from probpipe import OpaqueBatch
+
+        wrapped = Function(
+            func=lambda v: 1.0,
+            name="f",
+            input_template=EventTemplate(v=()),
+            dispatch="sequential",
+        )
+
+        with pytest.raises(ValueError, match=r"OpaqueSpec.*does not conform.*NumericArraySpec"):
+            wrapped(v=OpaqueBatch([object()], "row", name="rows"))
+
     def test_authoritative_nested_mapping_must_match_exactly(self):
         template = EventTemplate(
             stats=EventTemplate(copy=("obs",), total=()),
@@ -686,8 +751,9 @@ class TestSymbolicCalls:
         with pytest.raises(
             ValueError,
             match=(
-                r"Function 'identity' input 'x' does not expose an authoritative "
-                r"event_template for lifting"
+                r"Function 'identity' input 'x' states no element specification for "
+                r"lifting: a DistributionArray reports neither an element_spec nor an "
+                r"event_template"
             ),
         ):
             wrapped(values)

--- a/tests/core/test_first_class_function.py
+++ b/tests/core/test_first_class_function.py
@@ -194,6 +194,7 @@ class TestApplyContract:
             level_names="draw",
             axis_groups=((2,),),
             element_spec=intrinsic,
+            name="batch",
         )
         wrapped = Function(func=lambda: returned, output_template=declared)
 
@@ -219,6 +220,7 @@ class TestApplyContract:
             level_names="draw",
             axis_groups=(batch_shape,),
             element_spec=template,
+            name="batch",
         )
         wrapped = Function(func=lambda: returned, output_template=template)
 
@@ -235,6 +237,7 @@ class TestApplyContract:
             level_names="draw",
             axis_groups=((2,),),
             element_spec=EventTemplate(y=(3,)),
+            name="batch",
         )
         wrapped = Function(func=lambda: returned, output_template=EventTemplate(y=()))
 
@@ -248,6 +251,7 @@ class TestApplyContract:
             level_names="draw",
             axis_groups=((2,),),
             element_spec=EventTemplate(y=()),
+            name="batch",
         )
 
         with pytest.raises(ValueError, match=r"output/y dtype float32 does not conform"):
@@ -259,6 +263,7 @@ class TestApplyContract:
             level_names="draw",
             axis_groups=((2,),),
             element_spec=EventTemplate(y=()),
+            name="batch",
         )
 
         with pytest.raises(ValueError, match=r"output at 'y'.*support positive"):
@@ -1454,6 +1459,7 @@ class TestDeclaredSupportOnABatchedOutput:
             {"a": jnp.ones(3), "b": jnp.ones(3) * 2},
             "draw",
             element_spec=EventTemplate(a=(), b=()),
+            name="batch",
         )
 
         result = Function(func=lambda: valid, output_template=template).apply()
@@ -1470,6 +1476,7 @@ class TestDeclaredSupportOnABatchedOutput:
             {"a": jnp.ones(3), "b": jnp.asarray([1.0, -2.0, 3.0])},
             "draw",
             element_spec=EventTemplate(a=(), b=()),
+            name="batch",
         )
 
         with pytest.raises(ValueError, match=r"output at 'b'.*support positive"):

--- a/tests/core/test_function_opaque_batch.py
+++ b/tests/core/test_function_opaque_batch.py
@@ -79,7 +79,7 @@ class TestConstruction:
     def test_axis_groups_may_put_several_axes_in_one_level(self):
         store = np.empty((2, 3), dtype=object)
         store[...] = "x"
-        batch = OpaqueBatch(store, "draw", axis_groups=[(2, 3)])
+        batch = OpaqueBatch(store, "draw", axis_groups=[(2, 3)], name="batch")
 
         assert batch.axis_groups == ((2, 3),)
         assert batch.level_names == ("draw",)
@@ -88,11 +88,10 @@ class TestConstruction:
     def test_a_single_string_names_a_single_level(self, labels):
         assert labels.level_names == ("site",)
 
-    def test_an_unnamed_batch_takes_an_auto_name(self):
-        batch = OpaqueBatch(["a"], "site")
-
-        assert batch.name == "opaquebatch"
-        assert batch.name_is_auto
+    def test_a_name_is_required(self):
+        """No class-name fallback, as `NumericArrayBatch` already required."""
+        with pytest.raises(TypeError, match="name"):
+            OpaqueBatch(["a"], "site")
 
     def test_a_given_name_is_not_auto(self, labels):
         assert labels.name == "s"
@@ -107,12 +106,12 @@ class TestConstruction:
 
     def test_a_provenance_is_carried_as_given(self):
         record = Provenance.create("sample", parents=[])
-        batch = OpaqueBatch(["a"], "site", provenance=record)
+        batch = OpaqueBatch(["a"], "site", provenance=record, name="batch")
 
         assert batch.provenance is record
 
     def test_a_generator_is_materialized_into_one_axis(self):
-        batch = OpaqueBatch((str(i) for i in range(3)), "site")
+        batch = OpaqueBatch((str(i) for i in range(3)), "site", name="batch")
 
         assert batch.batch_shape == (3,)
         assert [batch[i] for i in range(3)] == ["0", "1", "2"]
@@ -121,11 +120,11 @@ class TestConstruction:
 class TestConstructionRefusals:
     def test_a_non_callable_element_names_its_position(self):
         with pytest.raises(TypeError, match=r"element at 1 is a int"):
-            FunctionBatch([lambda x: x, 3], "variant")
+            FunctionBatch([lambda x: x, 3], "variant", name="batch")
 
     def test_a_mapping_is_not_an_opaque_element(self):
         with pytest.raises(TypeError, match="denotes a subtree"):
-            OpaqueBatch([{"a": 1}], "site")
+            OpaqueBatch([{"a": 1}], "site", name="batch")
 
     @pytest.mark.parametrize(
         ("cls", "good", "bad"),
@@ -139,7 +138,7 @@ class TestConstructionRefusals:
         store[1, 0] = bad
 
         with pytest.raises(TypeError, match=r"element at \(1, 0\)"):
-            cls(store, ["chain", "draw"])
+            cls(store, ["chain", "draw"], name="batch")
 
     def test_no_elements_is_a_batch_of_none(self):
         """A multiplicity of zero is a multiplicity; a *missing axis* is not.
@@ -148,22 +147,22 @@ class TestConstructionRefusals:
         refusal below is the real distinction: an object with no axis at all has
         no level to count along.
         """
-        batch = OpaqueBatch([], "site")
+        batch = OpaqueBatch([], "site", name="batch")
 
         assert (batch.batch_shape, batch.level_names) == ((0,), ("site",))
         assert len(batch) == 0
 
     def test_a_single_object_is_not_a_batch(self):
         with pytest.raises(ValueError, match="at least one batch axis"):
-            OpaqueBatch(np.array(None, dtype=object), "site")
+            OpaqueBatch(np.array(None, dtype=object), "site", name="batch")
 
     def test_a_numeric_array_is_not_object_storage(self):
         with pytest.raises(TypeError, match="dtype=object"):
-            OpaqueBatch(np.zeros(3), "site")
+            OpaqueBatch(np.zeros(3), "site", name="batch")
 
     def test_naming_fewer_levels_than_axes_is_refused(self):
         with pytest.raises(ValueError, match="2 axes need 2 level names"):
-            OpaqueBatch(np.empty((2, 2), dtype=object), "site")
+            OpaqueBatch(np.empty((2, 2), dtype=object), "site", name="batch")
 
     @pytest.mark.parametrize(
         ("cls", "spec", "match"),
@@ -174,7 +173,7 @@ class TestConstructionRefusals:
     )
     def test_the_element_spec_must_be_its_own_kind(self, cls, spec, match):
         with pytest.raises(TypeError, match=match):
-            cls([lambda: 1], "variant", element_spec=spec)
+            cls([lambda: 1], "variant", element_spec=spec, name="batch")
 
     @pytest.mark.parametrize(
         ("axis_groups", "why"),
@@ -192,7 +191,9 @@ class TestConstructionRefusals:
         store[...] = "x"
 
         with pytest.raises(ValueError, match="must tile the shape"):
-            OpaqueBatch(store, ["a", "b"][: len(axis_groups)], axis_groups=axis_groups)
+            OpaqueBatch(
+                store, ["a", "b"][: len(axis_groups)], axis_groups=axis_groups, name="batch"
+            )
 
     @pytest.mark.parametrize(
         ("elements", "match"),
@@ -208,11 +209,11 @@ class TestConstructionRefusals:
     def test_a_container_that_iterates_into_its_parts_is_refused(self, elements, match):
         """Each would give a batch of pieces of one object, not a batch of objects."""
         with pytest.raises(TypeError, match=match):
-            OpaqueBatch(elements, "site")
+            OpaqueBatch(elements, "site", name="batch")
 
     def test_something_not_iterable_at_all_is_refused(self):
         with pytest.raises(TypeError, match="iterable of elements"):
-            OpaqueBatch(3, "site")
+            OpaqueBatch(3, "site", name="batch")
 
 
 class TestSpec:
@@ -228,7 +229,7 @@ class TestSpec:
 
     def test_an_element_spec_may_be_given(self):
         declared = FunctionSpec(EventTemplate(x=()), EventTemplate(y=()))
-        batch = FunctionBatch([lambda x: x], "variant", element_spec=declared)
+        batch = FunctionBatch([lambda x: x], "variant", element_spec=declared, name="batch")
 
         assert batch.element_spec == declared
         assert batch.spec.element_spec == declared
@@ -243,10 +244,12 @@ class TestSpec:
         three = [lambda x: x, lambda x: 2 * x, lambda x: 3 * x]
 
         assert functions.spec.is_valid(functions)
-        assert not functions.spec.is_valid(FunctionBatch(three[:1], "variant"))
-        assert not functions.spec.is_valid(FunctionBatch(three, "flavor"))
+        assert not functions.spec.is_valid(FunctionBatch(three[:1], "variant", name="batch"))
+        assert not functions.spec.is_valid(FunctionBatch(three, "flavor", name="batch"))
         assert not functions.spec.is_valid(
-            FunctionBatch(three, "variant", element_spec=FunctionSpec(EventTemplate(x=())))
+            FunctionBatch(
+                three, "variant", element_spec=FunctionSpec(EventTemplate(x=())), name="batch"
+            )
         )
 
 
@@ -290,7 +293,7 @@ class TestElements:
 
     def test_elements_holding_arrays_are_not_unpacked(self):
         """`np.asarray` would stack these into one numeric array."""
-        batch = OpaqueBatch([jnp.zeros(3), jnp.ones(3)], "site")
+        batch = OpaqueBatch([jnp.zeros(3), jnp.ones(3)], "site", name="batch")
 
         assert batch.batch_shape == (2,)
         np.testing.assert_array_equal(np.asarray(batch[1]), np.ones(3))
@@ -305,13 +308,13 @@ class TestElements:
         store = np.empty(2, dtype=object)
         store[0], store[1] = jnp.zeros(3), jnp.ones(3)
 
-        batch = OpaqueBatch(store, "site")
+        batch = OpaqueBatch(store, "site", name="batch")
 
         assert batch.batch_shape == (2,)
         np.testing.assert_array_equal(np.asarray(batch[1]), np.ones(3))
 
     def test_elements_holding_sequences_are_not_unpacked(self):
-        batch = OpaqueBatch([[1, 2], [3, 4]], "site")
+        batch = OpaqueBatch([[1, 2], [3, 4]], "site", name="batch")
 
         assert batch.batch_shape == (2,)
         assert batch[0] == [1, 2]
@@ -374,7 +377,7 @@ class TestTheStorageContractIsSatisfiable:
         """Otherwise the caller could write past the per-element check."""
         store = np.empty(2, dtype=object)
         store[0], store[1] = "north", "south"
-        batch = OpaqueBatch(store, "site")
+        batch = OpaqueBatch(store, "site", name="batch")
 
         store[1] = {"a": 1}
 
@@ -470,7 +473,7 @@ class TestProvenance:
     def test_the_caller_can_still_set_its_own_provenance_afterwards(self, full_provenance_mode):
         """The write-once slot stays the caller's to spend."""
         element = Record("r", x=1.0)
-        batch = OpaqueBatch([element], "site")
+        batch = OpaqueBatch([element], "site", name="batch")
         batch[0]
 
         own = Provenance.create("fit", parents=[])

--- a/tests/core/test_iteration_protocol.py
+++ b/tests/core/test_iteration_protocol.py
@@ -187,6 +187,7 @@ def test_a_record_batch_iterates_leading_axis_views():
         level_names="draw",
         axis_groups=((5,),),
         element_spec=EventTemplate(a=(), b=()),
+        name="batch",
     )
     rows = list(iter(batch))
     assert len(rows) == 5
@@ -201,6 +202,7 @@ def test_a_numeric_record_batch_iterates_leading_axis_views():
         level_names="draw",
         axis_groups=((4,),),
         element_spec=NumericEventTemplate(a=(), b=()),
+        name="batch",
     )
     rows = list(iter(batch))
     assert len(rows) == 4

--- a/tests/core/test_kinds.py
+++ b/tests/core/test_kinds.py
@@ -1,0 +1,70 @@
+"""The kind table: one tracked class and one batch form per value spec.
+
+The correspondence was open-coded at six sites, each knowing a different
+subset, so widening one left the others behind. These tests pin the table
+itself and the property that made the duplication a bug: every registered kind
+answers both questions the same way wherever it is asked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from probpipe import (
+    FunctionBatch,
+    FunctionSpec,
+    NumericArray,
+    NumericArrayBatch,
+    NumericArraySpec,
+    Opaque,
+    OpaqueBatch,
+    OpaqueSpec,
+)
+from probpipe.core._kinds import batch_class_for_spec, register_kind, term_class_for_spec
+
+
+class TestEveryKindDeclaresItsClasses:
+    @pytest.mark.parametrize(
+        ("spec", "term", "batch"),
+        [
+            pytest.param(NumericArraySpec(shape=()), NumericArray, NumericArrayBatch, id="numeric"),
+            pytest.param(OpaqueSpec(), Opaque, OpaqueBatch, id="opaque"),
+            pytest.param(FunctionSpec(), None, FunctionBatch, id="function"),
+        ],
+    )
+    def test_a_spec_resolves_to_its_pair(self, spec, term, batch):
+        assert term_class_for_spec(spec) is term
+        assert batch_class_for_spec(spec) is batch
+
+    def test_a_kind_with_no_tracked_class_says_so(self):
+        """`FunctionSpec` has a batch form and no separate tracked class — a
+        callable is already a `Function`."""
+        assert term_class_for_spec(FunctionSpec()) is None
+
+
+class TestTheTableIsSingleValued:
+    def test_a_contradicting_registration_is_refused(self):
+        """One spec, one kind. A second registration is a contradiction, not an
+        override, so it raises rather than silently winning."""
+        with pytest.raises(ValueError, match="already registered"):
+            register_kind(OpaqueSpec, term_class=int, batch_class=int)
+
+    def test_re_registering_the_same_pair_is_harmless(self):
+        """Importing a module twice must not raise."""
+        register_kind(OpaqueSpec, term_class=Opaque, batch_class=OpaqueBatch)
+
+        assert batch_class_for_spec(OpaqueSpec()) is OpaqueBatch
+
+    def test_a_spec_subclass_inherits_its_bases_kind(self):
+        """Resolution walks the MRO, so a refinement need not re-register."""
+
+        class _NarrowerOpaque(OpaqueSpec):
+            pass
+
+        assert batch_class_for_spec(_NarrowerOpaque()) is OpaqueBatch
+
+    def test_an_unregistered_spec_resolves_to_nothing(self):
+        class _Unregistered:
+            pass
+
+        assert batch_class_for_spec(_Unregistered()) is None

--- a/tests/core/test_named_tree.py
+++ b/tests/core/test_named_tree.py
@@ -191,6 +191,7 @@ class TestWithPathNames:
             level_names="draw",
             axis_groups=((3,),),
             element_spec=EventTemplate(a=()),
+            name="batch",
         )
         renamed = ra.with_path_names(a="b")
         assert list(renamed.event_template) == ["b"]
@@ -385,6 +386,7 @@ class TestRecordAutoPromotion:
             level_names="draw",
             axis_groups=((3,),),
             element_spec=EventTemplate(a=()),
+            name="batch",
         )
         assert type(ra) is RecordBatch
         nrb = NumericRecordBatch(
@@ -392,6 +394,7 @@ class TestRecordAutoPromotion:
             level_names="draw",
             axis_groups=((3,),),
             element_spec=EventTemplate(a=()),
+            name="batch",
         )
         assert type(nrb) is NumericRecordBatch
 

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -33,7 +33,15 @@ from probpipe import (
     RecordBatch,
 )
 from probpipe.core.event_template import NumericEventTemplate
-from probpipe.core.ops import log_prob, mean, sample, variance
+from probpipe.core.ops import (
+    log_prob,
+    mean,
+    prob,
+    sample,
+    unnormalized_log_prob,
+    unnormalized_prob,
+    variance,
+)
 
 KEY = jax.random.PRNGKey(0)
 ELEMENT = NumericEventTemplate(a=())
@@ -274,37 +282,62 @@ class TestLevelsAreNamedForWhatMintsThem:
 
 
 class TestABatchOperandKeepsItsLevelsThroughAnOperation:
-    """Design V.9: `log_prob` maps elementwise "with the batch axes preserved".
+    """Design V.9: a density op maps elementwise "with the batch axes preserved".
 
     An operation whose value parameter is `Any`-hinted takes the batch whole and
     evaluates it in one vectorized call — the fused implementation V.9 allows.
     That is not licence to hand back a bare array: the axes the operand accounted
     for are levels, and a result that drops them says the draws were one value.
+
+    Every op that scores a value is covered, since which of them restates the
+    levels is not something a caller should have to know. `prob` and the two
+    unnormalized ops used to drop them, so the same draws scored as a batch under
+    one op and as one wide value under another.
     """
 
     LAW = Normal(0.0, 1.0, name="height")
 
-    def test_log_prob_of_a_batch_of_draws_keeps_the_sample_level(self):
+    @pytest.fixture(
+        params=[log_prob, prob, unnormalized_log_prob, unnormalized_prob], ids=lambda op: op.name
+    )
+    def density_op(self, request):
+        return request.param
+
+    def test_scoring_a_batch_of_draws_keeps_the_sample_level(self, density_op):
         drawn = sample(self.LAW, sample_shape=(3,), key=KEY)
 
-        scored = log_prob(self.LAW, drawn)
+        scored = density_op(self.LAW, drawn)
 
         assert (scored.batch_shape, scored.level_names) == ((3,), ("sample",))
 
-    def test_the_result_is_named_for_the_operand_it_scored(self):
+    def test_the_result_is_named_for_the_operand_it_scored(self, density_op):
         drawn = sample(self.LAW, sample_shape=(3,), key=KEY)
 
-        assert log_prob(self.LAW, drawn).name == drawn.name
+        assert density_op(self.LAW, drawn).name == drawn.name
 
-    def test_a_single_draw_is_still_a_single_value(self):
+    def test_several_levels_are_all_restated(self, density_op):
+        """The operand's own tiling, not one flat axis."""
+        drawn = NumericArrayBatch(
+            jnp.zeros((2, 3)),
+            ("chain", "draw"),
+            element_spec=NumericArraySpec(()),
+            axis_groups=((2,), (3,)),
+            name="draws",
+        )
+
+        scored = density_op(self.LAW, drawn)
+
+        assert (scored.batch_shape, scored.level_names) == ((2, 3), ("chain", "draw"))
+
+    def test_a_single_draw_is_still_a_single_value(self, density_op):
         """No operand levels to restate, so nothing is invented."""
-        scored = log_prob(self.LAW, sample(self.LAW, key=KEY))
+        scored = density_op(self.LAW, sample(self.LAW, key=KEY))
 
         assert not isinstance(scored, NumericArrayBatch)
 
-    def test_a_raw_array_operand_is_left_alone(self):
+    def test_a_raw_array_operand_is_left_alone(self, density_op):
         """A bare array states no levels, so the result carries none."""
-        scored = log_prob(self.LAW, jnp.zeros(3))
+        scored = density_op(self.LAW, jnp.zeros(3))
 
         assert not isinstance(scored, NumericArrayBatch)
 

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -280,6 +280,52 @@ class TestLevelsAreNamedForWhatMintsThem:
 
         assert result.level_names == ("myfunc",)
 
+    @pytest.mark.parametrize(
+        ("atoms", "expected"),
+        [
+            pytest.param(jnp.linspace(0.0, 1.0, 5), "NumericRecordBatch", id="numeric-atoms"),
+            pytest.param(
+                [Record("a", {"u": jnp.asarray(float(i))}) for i in range(4)],
+                "NumericRecordBatch",
+                id="record-atoms",
+            ),
+            pytest.param([object() for _ in range(3)], "OpaqueBatch", id="opaque-atoms"),
+        ],
+    )
+    def test_a_law_that_assembles_its_own_draws_still_gets_the_level(self, atoms, expected):
+        """The boundary mints the level for every kind of draw.
+
+        These laws lay the draws out themselves — as record columns, or as an array
+        of stored objects — and named nothing. The draws came back as one value:
+        a record whose fields had grown an axis, or a single opaque object holding
+        the whole array.
+        """
+        from probpipe import EmpiricalDistribution
+
+        drawn = sample(EmpiricalDistribution(atoms, name="atoms"), sample_shape=(3,), key=KEY)
+
+        assert type(drawn).__name__ == expected
+        assert (drawn.batch_shape, drawn.level_names) == ((3,), ("sample",))
+
+    def test_a_single_draw_from_such_a_law_is_not_a_batch(self):
+        """No sample_shape, no level to mint."""
+        from probpipe import EmpiricalDistribution
+
+        drawn = sample(EmpiricalDistribution(jnp.linspace(0.0, 1.0, 5), name="atoms"), key=KEY)
+
+        assert not isinstance(drawn, NumericRecordBatch)
+
+    def test_the_draws_keep_the_law_s_name_and_whether_it_was_given(self):
+        from probpipe import EmpiricalDistribution
+
+        drawn = sample(
+            EmpiricalDistribution([object() for _ in range(3)], name="atoms"),
+            sample_shape=(3,),
+            key=KEY,
+        )
+
+        assert (drawn.name, drawn.name_is_auto) == ("atoms", False)
+
 
 class TestABatchOperandKeepsItsLevelsThroughAnOperation:
     """Design V.9: a density op maps elementwise "with the batch axes preserved".

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -130,30 +130,24 @@ class TestWhichKindsRequireAName:
         )
 
     @pytest.mark.parametrize(
-        ("build", "expected"),
+        "build",
         [
             pytest.param(
-                lambda: RecordBatch(COLUMNS, "lvl", element_spec=ELEMENT),
-                "recordbatch",
-                id="RecordBatch",
+                lambda: RecordBatch(COLUMNS, "lvl", element_spec=ELEMENT), id="RecordBatch"
             ),
             pytest.param(
                 lambda: NumericRecordBatch(COLUMNS, "lvl", element_spec=ELEMENT),
-                "numericrecordbatch",
                 id="NumericRecordBatch",
             ),
-            pytest.param(lambda: OpaqueBatch([1, 2], "lvl"), "opaquebatch", id="OpaqueBatch"),
-            pytest.param(
-                lambda: FunctionBatch([lambda: 1], "lvl"), "functionbatch", id="FunctionBatch"
-            ),
+            pytest.param(lambda: OpaqueBatch([1, 2], "lvl"), id="OpaqueBatch"),
+            pytest.param(lambda: FunctionBatch([lambda: 1], "lvl"), id="FunctionBatch"),
         ],
     )
-    def test_the_other_batches_fall_back_to_their_class_name(self, build, expected):
-        """Recorded rather than endorsed: `NumericArrayBatch` requires a name, and
-        these do not. Aligning them is tracked separately."""
-        batch = build()
-
-        assert (batch.name, batch.name_is_auto) == (expected, True)
+    def test_every_batch_requires_a_name(self, build):
+        """No class-name fallback: a batch is what an operation hands back, and
+        naming it after its class names every batch in a pipeline alike."""
+        with pytest.raises(TypeError, match="name"):
+            build()
 
 
 class TestADerivedNameSaysSo:
@@ -381,3 +375,70 @@ class TestEveryAggregateIsNamedForItsFunction:
 
         assert (result.name, result.name_is_auto) == ("double", True)
         assert result.level_names == ("a", "b")
+
+
+class TestNoKindInventsAName:
+    """The rule the whole layer now shares: a name is given, or derived from
+    something that carries meaning. A class name carries none.
+
+    Every batch defaulted to its own lowercased class name, so a pipeline full
+    of them read `recordbatch`, `opaquebatch`, `numericrecordbatch` — names that
+    say what the object *is*, which its type already says, and nothing about
+    which one it is.
+    """
+
+    @pytest.mark.parametrize(
+        "build",
+        [
+            pytest.param(lambda: NumericArray(jnp.arange(3.0)), id="NumericArray"),
+            pytest.param(
+                lambda: RecordBatch(COLUMNS, "lvl", element_spec=ELEMENT), id="RecordBatch"
+            ),
+            pytest.param(
+                lambda: NumericRecordBatch(COLUMNS, "lvl", element_spec=ELEMENT),
+                id="NumericRecordBatch",
+            ),
+            pytest.param(
+                lambda: NumericArrayBatch(
+                    jnp.arange(4.0), "lvl", element_spec=NumericArraySpec(shape=())
+                ),
+                id="NumericArrayBatch",
+            ),
+            pytest.param(lambda: OpaqueBatch([1, 2], "lvl"), id="OpaqueBatch"),
+            pytest.param(lambda: FunctionBatch([lambda: 1], "lvl"), id="FunctionBatch"),
+        ],
+    )
+    def test_a_name_is_required(self, build):
+        with pytest.raises(TypeError, match="name"):
+            build()
+
+    def test_stack_derives_its_name_from_what_it_stacks(self):
+        """Derived from real content, so no call site has to invent one: a batch
+        of `draw` records is about `draw`."""
+        rows = [NumericRecord("draw", a=float(i)) for i in range(3)]
+
+        batch = NumericRecordBatch.stack(rows, level_name="row")
+
+        assert (batch.name, batch.name_is_auto) == ("draw", True)
+
+    def test_stack_takes_a_better_name_when_offered(self):
+        rows = [NumericRecord("draw", a=float(i)) for i in range(3)]
+
+        batch = NumericRecordBatch.stack(rows, level_name="row", name="posterior")
+
+        assert (batch.name, batch.name_is_auto) == ("posterior", False)
+
+    def test_a_structural_transform_carries_the_name_and_its_flag(self):
+        """There is no class-name default to re-derive from, and an auto name is
+        something derived rather than a placeholder."""
+        batch = NumericRecordBatch(
+            {"a": jnp.zeros(3), "b": jnp.zeros(3)},
+            "lvl",
+            element_spec=NumericEventTemplate(a=(), b=()),
+            name="derived",
+            name_is_auto=True,
+        )
+
+        edited = batch.without("b")
+
+        assert (edited.name, edited.name_is_auto) == ("derived", True)

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -313,3 +313,71 @@ class TestABatchOperandKeepsItsLevelsThroughAnOperation:
         scored = log_prob(self.LAW, jnp.zeros(3))
 
         assert not isinstance(scored, NumericArrayBatch)
+
+
+class TestEveryAggregateIsNamedForItsFunction:
+    """The naming table, widened across the axes that had diverged.
+
+    A sweep's aggregate is built by the boundary, not by a caller, so its name is
+    the producing function's and is marked auto. Three paths disagreed: the
+    undeclared record aggregate took `stack`'s class-name default, and the scalar,
+    opaque, and declared paths marked a derived name as user-given — which would
+    stop a later operation renaming it.
+    """
+
+    @staticmethod
+    def _rows(n: int = 3):
+        from probpipe.core.event_template import NumericEventTemplate
+
+        return NumericRecordBatch(
+            {"x": jnp.arange(float(n))},
+            "row",
+            element_spec=NumericEventTemplate(x=()),
+            name="rows",
+        )
+
+    def _swept(self, body, **controls):
+        return Function(func=body, name="double", dispatch="sequential", **controls)(v=self._rows())
+
+    @pytest.mark.parametrize(
+        ("label", "body"),
+        [
+            ("numeric", lambda v: jnp.asarray(v["x"]) * 2),
+            ("mapping", lambda v: {"y": jnp.asarray(v["x"])}),
+            ("opaque", lambda v: "tag"),
+            ("callable", lambda v: lambda: 1),
+            ("sequence", lambda v: [jnp.asarray(v["x"]), jnp.asarray(v["x"])]),
+        ],
+    )
+    def test_an_undeclared_aggregate_is_named_for_the_function(self, label, body):
+        result = self._swept(body)
+
+        assert (result.name, result.name_is_auto) == ("double", True)
+
+    def test_a_declared_aggregate_is_named_the_same_way(self):
+        from probpipe import EventTemplate
+
+        result = self._swept(
+            lambda v: {"y": jnp.asarray(v["x"])}, output_template=EventTemplate(y=())
+        )
+
+        assert (result.name, result.name_is_auto) == ("double", True)
+
+    def test_a_multi_axis_sweep_is_named_the_same_way(self):
+        """The re-cut to the sweep's own geometry is a separate construction, and
+        it had its own naming."""
+        from probpipe.core.event_template import NumericEventTemplate
+
+        grid = NumericRecordBatch(
+            {"x": jnp.arange(6.0).reshape(2, 3)},
+            ("a", "b"),
+            element_spec=NumericEventTemplate(x=()),
+            name="grid",
+        )
+
+        result = Function(
+            func=lambda v: {"y": jnp.asarray(v["x"])}, name="double", dispatch="sequential"
+        )(v=grid)
+
+        assert (result.name, result.name_is_auto) == ("double", True)
+        assert result.level_names == ("a", "b")

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -277,3 +277,39 @@ class TestLevelsAreNamedForWhatMintsThem:
         result = Function(func=lambda: [1.0, 2.0], name="myfunc")()
 
         assert result.level_names == ("myfunc",)
+
+
+class TestABatchOperandKeepsItsLevelsThroughAnOperation:
+    """Design V.9: `log_prob` maps elementwise "with the batch axes preserved".
+
+    An operation whose value parameter is `Any`-hinted takes the batch whole and
+    evaluates it in one vectorized call — the fused implementation V.9 allows.
+    That is not licence to hand back a bare array: the axes the operand accounted
+    for are levels, and a result that drops them says the draws were one value.
+    """
+
+    LAW = Normal(0.0, 1.0, name="height")
+
+    def test_log_prob_of_a_batch_of_draws_keeps_the_sample_level(self):
+        drawn = sample(self.LAW, sample_shape=(3,), key=KEY)
+
+        scored = log_prob(self.LAW, drawn)
+
+        assert (scored.batch_shape, scored.level_names) == ((3,), ("sample",))
+
+    def test_the_result_is_named_for_the_operand_it_scored(self):
+        drawn = sample(self.LAW, sample_shape=(3,), key=KEY)
+
+        assert log_prob(self.LAW, drawn).name == drawn.name
+
+    def test_a_single_draw_is_still_a_single_value(self):
+        """No operand levels to restate, so nothing is invented."""
+        scored = log_prob(self.LAW, sample(self.LAW, key=KEY))
+
+        assert not isinstance(scored, NumericArrayBatch)
+
+    def test_a_raw_array_operand_is_left_alone(self):
+        """A bare array states no levels, so the result carries none."""
+        scored = log_prob(self.LAW, jnp.zeros(3))
+
+        assert not isinstance(scored, NumericArrayBatch)

--- a/tests/core/test_numeric_array.py
+++ b/tests/core/test_numeric_array.py
@@ -700,3 +700,74 @@ class TestNumericArrayBatchArrayShim:
 
     def test_dtype_reports_the_store(self):
         assert _batch().dtype == jnp.float32
+
+
+class TestANativeBackedBatchCrossesJax:
+    """The compute boundary converts, as it does for a single value.
+
+    Flatten handed JAX the native container, which fails abstractification before
+    `__jax_array__` is ever consulted — so a pandas- or xarray-backed batch could
+    not enter a trace at all.
+    """
+
+    @staticmethod
+    def _pandas_backed():
+        pd = pytest.importorskip("pandas")
+        return NumericArrayBatch(
+            pd.Series([1.0, 2.0, 3.0]),
+            "row",
+            element_spec=NumericArraySpec(shape=()),
+            name="b",
+        )
+
+    def test_a_native_store_reaches_a_trace(self):
+        batch = self._pandas_backed()
+
+        out = jax.jit(lambda x: x)(batch)
+
+        assert isinstance(out, NumericArrayBatch)
+        assert out.level_names == ("row",)
+
+    def test_the_original_keeps_its_native_store(self):
+        """Converting at the boundary does not materialise the batch itself."""
+        pd = pytest.importorskip("pandas")
+        batch = self._pandas_backed()
+
+        jax.jit(lambda x: x)(batch)
+
+        assert isinstance(batch.values, pd.Series)
+
+    def test_conversion_happens_once_and_is_memoised(self):
+        batch = self._pandas_backed()
+
+        assert batch.as_jax() is batch.as_jax()
+
+
+class TestUnflattenChecksTheElementItRebuilds:
+    """A rank check alone admits a store the element spec is false about."""
+
+    @staticmethod
+    def _batch():
+        return NumericArrayBatch(
+            jnp.zeros((4, 3)), "row", element_spec=NumericArraySpec(shape=(3,)), name="b"
+        )
+
+    def test_a_changed_event_shape_is_refused(self):
+        """The element's own axes are not the transform's to change; the batch
+        would otherwise build and fail at the first selection instead."""
+        _, treedef = jax.tree_util.tree_flatten(self._batch())
+
+        with pytest.raises(ValueError, match="not the event shape"):
+            jax.tree_util.tree_unflatten(treedef, [jnp.zeros((4, 5))])
+
+    def test_an_unchanged_store_round_trips(self):
+        leaves, treedef = jax.tree_util.tree_flatten(self._batch())
+
+        rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+
+        assert (rebuilt.batch_shape, rebuilt.level_names) == ((4,), ("row",))
+
+    def test_removing_every_batch_axis_still_yields_the_element(self):
+        _, treedef = jax.tree_util.tree_flatten(self._batch())
+
+        assert isinstance(jax.tree_util.tree_unflatten(treedef, [jnp.zeros((3,))]), NumericArray)

--- a/tests/core/test_opaque.py
+++ b/tests/core/test_opaque.py
@@ -130,7 +130,7 @@ class TestOpaqueAndItsBatch:
         """Its elements are stored, so a batch hands back the caller's object."""
         payloads = [_Payload("a"), _Payload("b")]
 
-        batch = OpaqueBatch(payloads, "draw")
+        batch = OpaqueBatch(payloads, "draw", name="batch")
 
         assert batch[0] is payloads[0]
 
@@ -138,7 +138,7 @@ class TestOpaqueAndItsBatch:
         """An `Opaque` is itself a non-mapping value."""
         terms = [Opaque("first", _Payload("a")), Opaque("second", _Payload("b"))]
 
-        batch = OpaqueBatch(terms, "draw")
+        batch = OpaqueBatch(terms, "draw", name="batch")
 
         assert batch[1] is terms[1]
         assert batch[1].name == "second"

--- a/tests/core/test_record_batch.py
+++ b/tests/core/test_record_batch.py
@@ -60,6 +60,9 @@ def _object_column(values: list) -> np.ndarray:
 
 def nested_batch(n: int = 3, **kwargs) -> NumericRecordBatch:
     """A `NumericRecordBatch` of *n* elements over `NESTED`."""
+    if "name" not in kwargs:
+        kwargs["name"] = "batch"
+        kwargs.setdefault("name_is_auto", True)
     return NumericRecordBatch(
         {
             "outer/a": jnp.arange(float(n)),
@@ -91,6 +94,7 @@ class TestConstruction:
             {"outer": {"a": jnp.arange(3.0), "b": jnp.arange(3.0) * 2}, "m": jnp.zeros((3, 2))},
             "draw",
             element_spec=NESTED,
+            name="batch",
         )
         assert nested == by_path
 
@@ -105,6 +109,7 @@ class TestConstruction:
             {"x": jnp.zeros((4, 100, 2))},
             ("chain", "draw"),
             element_spec=EventTemplate(x=(2,)),
+            name="batch",
         )
         assert batch.batch_shape == (4, 100)
         assert batch.axis_groups == ((4,), (100,))
@@ -115,6 +120,7 @@ class TestConstruction:
             ("grid", "draw"),
             element_spec=EventTemplate(x=()),
             axis_groups=((2, 3), (5,)),
+            name="batch",
         )
         assert batch.axis_groups == ((2, 3), (5,))
         assert batch.batch_shape == (2, 3, 5)
@@ -124,11 +130,17 @@ class TestConstruction:
     def test_missing_and_unexpected_fields_are_named(self):
         with pytest.raises(ValueError, match=r"missing \['m'\]"):
             NumericRecordBatch(
-                {"outer/a": jnp.zeros(3), "outer/b": jnp.zeros(3)}, "draw", element_spec=NESTED
+                {"outer/a": jnp.zeros(3), "outer/b": jnp.zeros(3)},
+                "draw",
+                element_spec=NESTED,
+                name="batch",
             )
         with pytest.raises(ValueError, match=r"unexpected \['z'\]"):
             NumericRecordBatch(
-                {"x": jnp.zeros(3), "z": jnp.zeros(3)}, "draw", element_spec=EventTemplate(x=())
+                {"x": jnp.zeros(3), "z": jnp.zeros(3)},
+                "draw",
+                element_spec=EventTemplate(x=()),
+                name="batch",
             )
 
     def test_a_column_whose_trailing_axes_are_not_the_event_shape_is_named(self):
@@ -139,6 +151,7 @@ class TestConstruction:
                 {"outer/a": jnp.zeros(3), "outer/b": jnp.zeros(3), "m": jnp.zeros((3, 5))},
                 "draw",
                 element_spec=NESTED,
+                name="batch",
             )
 
     def test_fields_disagreeing_on_the_batch_axis_raise(self):
@@ -147,19 +160,24 @@ class TestConstruction:
                 {"x": jnp.zeros(3), "y": jnp.zeros(4)},
                 "draw",
                 element_spec=EventTemplate(x=(), y=()),
+                name="batch",
             )
 
     def test_a_batch_needs_at_least_one_axis(self):
         with pytest.raises(ValueError, match="at least one batch axis"):
-            NumericRecordBatch({"x": jnp.zeros(2)}, "draw", element_spec=EventTemplate(x=(2,)))
+            NumericRecordBatch(
+                {"x": jnp.zeros(2)}, "draw", element_spec=EventTemplate(x=(2,)), name="batch"
+            )
 
     def test_no_fields_raises(self):
         with pytest.raises(ValueError, match="at least one field"):
-            NumericRecordBatch({}, "draw", element_spec=EventTemplate(x=()))
+            NumericRecordBatch({}, "draw", element_spec=EventTemplate(x=()), name="batch")
 
     def test_a_non_mapping_fields_argument_raises(self):
         with pytest.raises(TypeError, match="fields must be a mapping"):
-            NumericRecordBatch([jnp.zeros(3)], "draw", element_spec=EventTemplate(x=()))
+            NumericRecordBatch(
+                [jnp.zeros(3)], "draw", element_spec=EventTemplate(x=()), name="batch"
+            )
 
     def test_axis_groups_must_tile_the_batch_shape(self):
         with pytest.raises(ValueError, match="must tile"):
@@ -168,15 +186,20 @@ class TestConstruction:
                 "draw",
                 element_spec=EventTemplate(x=()),
                 axis_groups=((3, 5),),
+                name="batch",
             )
 
     def test_a_missing_level_name_raises(self):
         with pytest.raises(ValueError, match="need 2 level names"):
-            NumericRecordBatch({"x": jnp.zeros((3, 4))}, "draw", element_spec=EventTemplate(x=()))
+            NumericRecordBatch(
+                {"x": jnp.zeros((3, 4))}, "draw", element_spec=EventTemplate(x=()), name="batch"
+            )
 
     def test_element_spec_must_be_a_record_declaration(self):
         with pytest.raises(TypeError, match="RecordSpec or an EventTemplate"):
-            NumericRecordBatch({"x": jnp.zeros(3)}, "draw", element_spec=NumericArraySpec(shape=()))
+            NumericRecordBatch(
+                {"x": jnp.zeros(3)}, "draw", element_spec=NumericArraySpec(shape=()), name="batch"
+            )
 
     def test_numeric_batch_refuses_a_non_numeric_element_spec(self):
         with pytest.raises(TypeError, match="carries a NumericEventTemplate"):
@@ -184,27 +207,35 @@ class TestConstruction:
                 {"x": jnp.zeros(3), "label": np.array(["a", "b", "c"], dtype=object)},
                 "draw",
                 element_spec=EventTemplate(x=(), label=None),
+                name="batch",
             )
 
     def test_numeric_batch_refuses_a_non_numeric_column(self):
         with pytest.raises(TypeError, match="its column is a numeric array"):
             NumericRecordBatch(
-                {"x": np.array(["a", "b", "c"])}, "draw", element_spec=EventTemplate(x=())
+                {"x": np.array(["a", "b", "c"])},
+                "draw",
+                element_spec=EventTemplate(x=()),
+                name="batch",
             )
 
     # -- the declaration, either form --------------------------------------
 
     def test_a_record_spec_declaration_is_accepted_and_stored(self):
         spec = RecordSpec(EventTemplate(x=(2,)))
-        batch = NumericRecordBatch({"x": jnp.zeros((3, 2))}, "draw", element_spec=spec)
+        batch = NumericRecordBatch(
+            {"x": jnp.zeros((3, 2))}, "draw", element_spec=spec, name="batch"
+        )
         assert batch.element_spec is spec
         assert batch.event_template is spec.event_template
 
     def test_the_two_declaration_forms_agree(self):
         template = EventTemplate(x=(2,))
         columns = {"x": jnp.zeros((3, 2))}
-        assert NumericRecordBatch(dict(columns), "draw", element_spec=template) == (
-            NumericRecordBatch(dict(columns), "draw", element_spec=RecordSpec(template))
+        assert NumericRecordBatch(dict(columns), "draw", element_spec=template, name="batch") == (
+            NumericRecordBatch(
+                dict(columns), "draw", element_spec=RecordSpec(template), name="batch"
+            )
         )
 
     def test_spec_accessors_are_views_on_one_object(self):
@@ -212,10 +243,17 @@ class TestConstruction:
         assert batch.element_spec is batch.spec.element_spec
         assert batch.event_template is batch.element_spec.event_template
 
-    def test_default_name_is_the_class_name_marked_auto(self):
-        batch = nested_batch()
-        assert batch.name == "numericrecordbatch"
-        assert batch.name_is_auto
+    def test_a_name_is_required(self):
+        """No class-name fallback: naming a batch after its class names every
+        batch in a pipeline alike."""
+        with pytest.raises(TypeError, match="name"):
+            NumericRecordBatch(
+                {"outer/a": jnp.zeros(3), "outer/b": jnp.zeros(3), "m": jnp.zeros((3, 2))},
+                "draw",
+                element_spec=NESTED,
+            )
+
+    def test_a_given_name_is_not_auto(self):
         assert not nested_batch(name="post").name_is_auto
 
 
@@ -273,7 +311,10 @@ class TestLeafKeyedFieldColumns:
         separator belongs to the prefix, or the two would collide."""
         template = EventTemplate({"out": (), "outer": EventTemplate(a=())})
         batch = NumericRecordBatch(
-            {"out": jnp.zeros(2), "outer/a": jnp.ones(2)}, "draw", element_spec=template
+            {"out": jnp.zeros(2), "outer/a": jnp.ones(2)},
+            "draw",
+            element_spec=template,
+            name="batch",
         )
         assert tuple(batch.event_template.keys()) == ("out", "outer/a")
         np.testing.assert_array_equal(np.asarray(batch["out"]), np.asarray([0.0, 0.0]))
@@ -284,7 +325,7 @@ class TestLeafKeyedFieldColumns:
     def test_sibling_subtrees_may_reuse_a_leaf_name(self):
         template = EventTemplate(a=EventTemplate(c=()), b=EventTemplate(c=()))
         batch = NumericRecordBatch(
-            {"a/c": jnp.zeros(2), "b/c": jnp.ones(2)}, "draw", element_spec=template
+            {"a/c": jnp.zeros(2), "b/c": jnp.ones(2)}, "draw", element_spec=template, name="batch"
         )
         np.testing.assert_array_equal(np.asarray(batch["a"]["c"]), np.asarray([0.0, 0.0]))
         np.testing.assert_array_equal(np.asarray(batch["b"]["c"]), np.asarray([1.0, 1.0]))
@@ -346,7 +387,10 @@ class TestColumnBatchForms:
         spec = EventTemplate({"d": DistributionSpec(law.event_template), "x": ()})
         with pytest.raises(TypeError, match="DistributionSpec, which has no batch form"):
             RecordBatch(
-                {"d": _object_column([law, law]), "x": jnp.zeros(2)}, "row", element_spec=spec
+                {"d": _object_column([law, law]), "x": jnp.zeros(2)},
+                "row",
+                element_spec=spec,
+                name="batch",
             )
 
     def test_a_column_batch_carries_a_derived_name(self):
@@ -370,6 +414,7 @@ class TestColumnBatchForms:
             {"f": _object_column([lambda x: x, lambda x: 2 * x])},
             "variant",
             element_spec=EventTemplate(f=FunctionSpec()),
+            name="batch",
         )
         first, second = batch["f"], batch["f"]
         assert first._store is batch._columns["f"]
@@ -386,6 +431,7 @@ class TestColumnBatchForms:
             {"f": np.array([], dtype=object)},
             "variant",
             element_spec=EventTemplate(f=FunctionSpec()),
+            name="batch",
         )
         assert batch.batch_shape == (0,)
         column = batch["f"]
@@ -404,6 +450,7 @@ class TestColumnEntryValidation:
                 {"o": _object_column(["fine", {"k": 1}, "fine"])},
                 "row",
                 element_spec=EventTemplate(o=None),
+                name="batch",
             )
 
     def test_a_callable_field_refuses_a_non_callable_entry(self):
@@ -412,6 +459,7 @@ class TestColumnEntryValidation:
                 {"f": _object_column(["not callable", lambda x: x])},
                 "row",
                 element_spec=EventTemplate({"f": FunctionSpec()}),
+                name="batch",
             )
 
     def test_an_array_column_carries_no_entries_to_walk(self):
@@ -429,6 +477,7 @@ class TestColumnSpecConformance:
                 {"x": jnp.zeros(3, dtype=jnp.float32)},
                 "draw",
                 element_spec=EventTemplate(x=NumericArraySpec(shape=(), dtype=jnp.int32)),
+                name="batch",
             )
 
     @pytest.mark.parametrize(
@@ -458,6 +507,7 @@ class TestColumnSpecConformance:
             {"x": column},
             "draw",
             element_spec=EventTemplate(x=NumericArraySpec(shape=(), dtype=declared)),
+            name="batch",
         )
 
     @pytest.mark.parametrize("spec", [FunctionSpec(), None], ids=["function", "opaque"])
@@ -466,7 +516,9 @@ class TestColumnSpecConformance:
         elements rather than the values themselves, and the column could not be
         presented as the batch form its spec calls for."""
         with pytest.raises(TypeError, match="no stacked form"):
-            RecordBatch({"f": jnp.zeros(3)}, "draw", element_spec=EventTemplate({"f": spec}))
+            RecordBatch(
+                {"f": jnp.zeros(3)}, "draw", element_spec=EventTemplate({"f": spec}), name="batch"
+            )
 
     def test_an_element_of_a_validated_batch_conforms_to_its_own_spec(self):
         batch = nested_batch()
@@ -482,11 +534,15 @@ class TestConstructionRefusals:
             {"x": jnp.zeros((2, 2)), "o": ["a", "b"]},
         ):
             with pytest.raises(TypeError, match="reports no shape"):
-                RecordBatch(columns, "row", element_spec=EventTemplate(o=None, x=(2,)))
+                RecordBatch(
+                    columns, "row", element_spec=EventTemplate(o=None, x=(2,)), name="batch"
+                )
 
     def test_a_column_too_short_for_its_event_shape_is_refused(self):
         with pytest.raises(ValueError, match="too short to carry"):
-            NumericRecordBatch({"x": jnp.zeros(3)}, "draw", element_spec=EventTemplate(x=(2, 2)))
+            NumericRecordBatch(
+                {"x": jnp.zeros(3)}, "draw", element_spec=EventTemplate(x=(2, 2)), name="batch"
+            )
 
 
 class TestProvenance:
@@ -522,7 +578,10 @@ class TestPlainRecordBatch:
 
     def test_it_has_no_flat_layout(self):
         batch = RecordBatch(
-            {"site": _object_column(["north"])}, "row", element_spec=EventTemplate(site=None)
+            {"site": _object_column(["north"])},
+            "row",
+            element_spec=EventTemplate(site=None),
+            name="batch",
         )
         assert not hasattr(batch, "to_vector")
 
@@ -531,6 +590,7 @@ class TestPlainRecordBatch:
             {"site": _object_column(["north", "south"])},
             "row",
             element_spec=EventTemplate(site=None),
+            name="batch",
         )
         assert pickle.loads(pickle.dumps(batch)) == batch
         leaves, treedef = jax.tree_util.tree_flatten(batch)
@@ -597,7 +657,9 @@ class TestStructuralTransforms:
 
     def test_merge_unions_the_fields(self):
         batch = nested_batch()
-        other = NumericRecordBatch({"z": jnp.ones(3)}, "draw", element_spec=EventTemplate(z=()))
+        other = NumericRecordBatch(
+            {"z": jnp.ones(3)}, "draw", element_spec=EventTemplate(z=()), name="batch"
+        )
         merged = batch.merge(other)
         assert tuple(merged.event_template.keys()) == ("outer/a", "outer/b", "m", "z")
         np.testing.assert_array_equal(np.asarray(merged["z"]), np.asarray(jnp.ones(3)))
@@ -605,7 +667,9 @@ class TestStructuralTransforms:
     def test_merge_pairs_elements_so_the_axes_must_agree(self):
         with pytest.raises(ValueError, match="span the same axes under the same names"):
             nested_batch(3).merge(
-                NumericRecordBatch({"z": jnp.ones(4)}, "draw", element_spec=EventTemplate(z=()))
+                NumericRecordBatch(
+                    {"z": jnp.ones(4)}, "draw", element_spec=EventTemplate(z=()), name="batch"
+                )
             )
 
     def test_merge_refuses_overlapping_fields(self):
@@ -632,9 +696,14 @@ class TestStructuralTransforms:
     def test_a_transform_re_derives_the_class_from_its_result(self):
         """The class follows the edited fields, not the object's history — which is
         also what makes a mixed ``merge`` give the same answer either way round."""
-        numeric = NumericRecordBatch({"x": jnp.zeros(3)}, "draw", element_spec=EventTemplate(x=()))
+        numeric = NumericRecordBatch(
+            {"x": jnp.zeros(3)}, "draw", element_spec=EventTemplate(x=()), name="batch"
+        )
         plain = RecordBatch(
-            {"s": _object_column(list("abc"))}, "draw", element_spec=EventTemplate(s=None)
+            {"s": _object_column(list("abc"))},
+            "draw",
+            element_spec=EventTemplate(s=None),
+            name="batch",
         )
         assert type(numeric.replace({"x": _object_column(list("abc"))})) is RecordBatch
         assert type(plain.replace({"s": jnp.ones(3)})) is NumericRecordBatch
@@ -645,6 +714,7 @@ class TestStructuralTransforms:
             {"f": _object_column([lambda x: x] * 2)},
             "draw",
             element_spec=EventTemplate({"f": FunctionSpec()}),
+            name="batch",
         )
         # A column of callables stays a function field rather than going opaque.
         edited = plain.replace({"f": _object_column([lambda x: 2 * x] * 2)})
@@ -654,7 +724,10 @@ class TestStructuralTransforms:
         """A unicode array's entries are numpy scalars, not the values the field
         holds, and it is not numeric either — so it is named rather than guessed at."""
         plain = RecordBatch(
-            {"s": _object_column(list("ab"))}, "draw", element_spec=EventTemplate(s=None)
+            {"s": _object_column(list("ab"))},
+            "draw",
+            element_spec=EventTemplate(s=None),
+            name="batch",
         )
         with pytest.raises(TypeError, match="no stacked form"):
             plain.replace({"s": np.array(["x", "y"])})
@@ -664,6 +737,7 @@ class TestStructuralTransforms:
             {"f": _object_column([lambda x: x] * 2), "x": jnp.zeros(2)},
             "draw",
             element_spec=EventTemplate({"f": FunctionSpec(), "x": ()}),
+            name="batch",
         )
         # ``batch["f"]`` is a FunctionBatch; putting one back must work.
         assert isinstance(plain.replace({"f": plain["f"]}), RecordBatch)
@@ -699,7 +773,10 @@ class TestCollectionNotTree:
 
     def test_len_is_the_leading_axis_of_a_multi_level_batch(self):
         batch = NumericRecordBatch(
-            {"x": jnp.zeros((4, 100))}, ("chain", "draw"), element_spec=EventTemplate(x=())
+            {"x": jnp.zeros((4, 100))},
+            ("chain", "draw"),
+            element_spec=EventTemplate(x=()),
+            name="batch",
         )
         assert len(batch) == 4
 
@@ -819,12 +896,15 @@ class TestLevels:
             {"site": _object_column(["a", "b", "c", "d"])},
             "row",
             element_spec=EventTemplate(site=None),
+            name="batch",
         )
         assert np.shares_memory(batch[1:3]._columns["site"], batch._columns["site"])
 
     def test_an_object_column_cannot_be_written_through(self):
         column = _object_column(["a", "b"])
-        batch = RecordBatch({"site": column}, "row", element_spec=EventTemplate(site=None))
+        batch = RecordBatch(
+            {"site": column}, "row", element_spec=EventTemplate(site=None), name="batch"
+        )
         with pytest.raises(ValueError, match="read-only"):
             batch._columns["site"][0] = "MUTATED"
         # Nor can the caller's own handle reach in after construction.
@@ -903,7 +983,10 @@ class TestSingleFieldCoercion:
     @staticmethod
     def one_field():
         return NumericRecordBatch(
-            {"x": jnp.arange(6.0).reshape(3, 2)}, "draw", element_spec=EventTemplate(x=(2,))
+            {"x": jnp.arange(6.0).reshape(3, 2)},
+            "draw",
+            element_spec=EventTemplate(x=(2,)),
+            name="batch",
         )
 
     def test_array_conversions_forward_to_the_sole_field(self):
@@ -966,6 +1049,7 @@ class TestFlatLayout:
             {"x": jnp.arange(24.0).reshape(2, 3, 4)},
             ("chain", "draw"),
             element_spec=EventTemplate(x=(4,)),
+            name="batch",
         )
         vec = batch.to_vector()
         assert vec.shape == (2, 3, 4)
@@ -1000,6 +1084,7 @@ class TestFlatLayout:
             {"i": jnp.arange(3, dtype=jnp.int32), "f": jnp.ones(3, dtype=jnp.float32)},
             "draw",
             element_spec=template,
+            name="batch",
         )
         assert batch.to_vector().dtype == jnp.float32  # the promotion
         rebuilt = NumericRecordBatch.from_vector(
@@ -1191,15 +1276,19 @@ class TestEqualityAndCopying:
         them.
         """
         spec = EventTemplate(x=())
-        zeros = NumericRecordBatch({"x": jnp.zeros(3)}, "draw", element_spec=spec)
-        ones = NumericRecordBatch({"x": jnp.ones(3)}, "draw", element_spec=spec)
+        zeros = NumericRecordBatch({"x": jnp.zeros(3)}, "draw", element_spec=spec, name="batch")
+        ones = NumericRecordBatch({"x": jnp.ones(3)}, "draw", element_spec=spec, name="batch")
         assert zeros.spec == ones.spec
         assert zeros != ones
 
     def test_a_single_differing_entry_compares_unequal(self):
         spec = EventTemplate(x=())
-        left = NumericRecordBatch({"x": jnp.asarray([1.0, 2.0, 3.0])}, "draw", element_spec=spec)
-        right = NumericRecordBatch({"x": jnp.asarray([1.0, 2.0, 4.0])}, "draw", element_spec=spec)
+        left = NumericRecordBatch(
+            {"x": jnp.asarray([1.0, 2.0, 3.0])}, "draw", element_spec=spec, name="batch"
+        )
+        right = NumericRecordBatch(
+            {"x": jnp.asarray([1.0, 2.0, 4.0])}, "draw", element_spec=spec, name="batch"
+        )
         assert left != right
 
     def test_an_object_column_compares_by_value(self):
@@ -1207,9 +1296,11 @@ class TestEqualityAndCopying:
         ``jnp.array_equal`` cannot walk it."""
         spec = EventTemplate(site=None)
         labels = ["north", "south"]
-        left = RecordBatch({"site": _object_column(labels)}, "row", element_spec=spec)
-        same = RecordBatch({"site": _object_column(labels)}, "row", element_spec=spec)
-        other = RecordBatch({"site": _object_column(["north", "east"])}, "row", element_spec=spec)
+        left = RecordBatch({"site": _object_column(labels)}, "row", element_spec=spec, name="batch")
+        same = RecordBatch({"site": _object_column(labels)}, "row", element_spec=spec, name="batch")
+        other = RecordBatch(
+            {"site": _object_column(["north", "east"])}, "row", element_spec=spec, name="batch"
+        )
         assert left == same
         assert left != other
 
@@ -1218,13 +1309,22 @@ class TestEqualityAndCopying:
         vectorized comparison cannot answer; they are compared entry by entry."""
         spec = EventTemplate(cov=None)
         left = RecordBatch(
-            {"cov": _object_column([np.zeros(2), np.zeros(3)])}, "row", element_spec=spec
+            {"cov": _object_column([np.zeros(2), np.zeros(3)])},
+            "row",
+            element_spec=spec,
+            name="batch",
         )
         same = RecordBatch(
-            {"cov": _object_column([np.zeros(2), np.zeros(3)])}, "row", element_spec=spec
+            {"cov": _object_column([np.zeros(2), np.zeros(3)])},
+            "row",
+            element_spec=spec,
+            name="batch",
         )
         other = RecordBatch(
-            {"cov": _object_column([np.zeros(2), np.ones(3)])}, "row", element_spec=spec
+            {"cov": _object_column([np.zeros(2), np.ones(3)])},
+            "row",
+            element_spec=spec,
+            name="batch",
         )
         assert left == same
         assert left != other
@@ -1241,7 +1341,10 @@ class TestEqualityAndCopying:
 
     def test_reflexive_with_nan(self):
         batch = NumericRecordBatch(
-            {"x": jnp.asarray([jnp.nan, 1.0])}, "draw", element_spec=EventTemplate(x=())
+            {"x": jnp.asarray([jnp.nan, 1.0])},
+            "draw",
+            element_spec=EventTemplate(x=()),
+            name="batch",
         )
         assert batch == batch
 
@@ -1300,7 +1403,9 @@ class TestPyTree:
         )
 
     def test_a_different_spec_gives_a_different_treedef(self):
-        other = NumericRecordBatch({"x": jnp.zeros(3)}, "draw", element_spec=EventTemplate(x=()))
+        other = NumericRecordBatch(
+            {"x": jnp.zeros(3)}, "draw", element_spec=EventTemplate(x=()), name="batch"
+        )
         assert jax.tree_util.tree_structure(nested_batch()) != jax.tree_util.tree_structure(other)
 
     def test_tree_map_preserves_the_batch(self):
@@ -1351,7 +1456,10 @@ class TestPyTree:
         ``in_axes`` as much as for a named one.
         """
         batch = NumericRecordBatch(
-            {"x": jnp.zeros((2, 3, 4))}, ("chain", "draw"), element_spec=EventTemplate(x=(4,))
+            {"x": jnp.zeros((2, 3, 4))},
+            ("chain", "draw"),
+            element_spec=EventTemplate(x=(4,)),
+            name="batch",
         )
         with pytest.raises(ValueError, match="keeps every batch axis or removes all of them"):
             jax.vmap(lambda inner: inner["x"].sum(), in_axes=in_axes)(batch)
@@ -1365,6 +1473,7 @@ class TestPyTree:
             ("grid", "draw"),
             element_spec=EventTemplate(x=()),
             axis_groups=((2, 3), (5,)),
+            name="batch",
         )
         with pytest.raises(ValueError, match="keeps every batch axis or removes all of them"):
             jax.vmap(lambda inner: inner["x"].sum(), in_axes=1)(batch)
@@ -1408,6 +1517,7 @@ class TestPyTreeRebuildContract:
 
     @staticmethod
     def _batch(shape, levels, **kwargs):
+        kwargs.setdefault("name", "batch")
         return NumericRecordBatch(
             {"x": jnp.zeros(shape)}, levels, element_spec=EventTemplate(x=()), **kwargs
         )
@@ -1495,6 +1605,7 @@ class TestPyTreeRebuildContract:
             {"x": jnp.zeros(3, dtype=jnp.int32)},
             "draw",
             element_spec=EventTemplate(x=NumericArraySpec(shape=(), dtype=jnp.int32)),
+            name="batch",
         )
         with pytest.raises(TypeError, match="does not admit"):
             jax.tree.map(lambda column: column.astype(jnp.float32), batch)
@@ -1505,7 +1616,9 @@ class TestPyTreeRebuildContract:
         while the batch still declares ``FunctionSpec``. The element's kind is
         the element type's, not the transform's."""
         column = _object_column([lambda x: x, lambda x: 2 * x])
-        batch = RecordBatch({"f": column}, "row", element_spec=EventTemplate(f=FunctionSpec()))
+        batch = RecordBatch(
+            {"f": column}, "row", element_spec=EventTemplate(f=FunctionSpec()), name="batch"
+        )
         with pytest.raises(TypeError, match="does not admit"):
             jax.tree.map(lambda _: np.array([1, 2], dtype=object), batch)
 
@@ -1515,7 +1628,10 @@ class TestPyTreeRebuildContract:
 
         column = _object_column(["north", "south"])
         batch = RecordBatch(
-            {"site": column}, "row", element_spec=EventTemplate(site=OpaqueSpec(meta="units"))
+            {"site": column},
+            "row",
+            element_spec=EventTemplate(site=OpaqueSpec(meta="units")),
+            name="batch",
         )
         replacement = np.empty(2, dtype=object)
         replacement[0], replacement[1] = {"a": 1}, {"b": 2}
@@ -1528,7 +1644,9 @@ class TestPyTreeRebuildContract:
         """A non-array field's column holds one entry per element; a dense array
         would make its *entries* array elements rather than the values."""
         column = _object_column([lambda x: x, lambda x: 2 * x])
-        batch = RecordBatch({"f": column}, "row", element_spec=EventTemplate(f=FunctionSpec()))
+        batch = RecordBatch(
+            {"f": column}, "row", element_spec=EventTemplate(f=FunctionSpec()), name="batch"
+        )
         with pytest.raises(TypeError, match="object array"):
             jax.tree.map(lambda _: jnp.zeros(2), batch)
 
@@ -1536,14 +1654,17 @@ class TestPyTreeRebuildContract:
         """The batch axes are the transform's; the element's own are the element
         type's."""
         batch = NumericRecordBatch(
-            {"x": jnp.zeros((3, 4))}, "draw", element_spec=EventTemplate(x=(4,))
+            {"x": jnp.zeros((3, 4))}, "draw", element_spec=EventTemplate(x=(4,)), name="batch"
         )
         with pytest.raises(ValueError, match="never the element's own"):
             jax.tree.map(lambda column: column[:, :2], batch)
 
     def test_columns_disagreeing_on_the_batch_axes_are_refused(self):
         batch = NumericRecordBatch(
-            {"x": jnp.zeros(4), "y": jnp.zeros(4)}, "draw", element_spec=EventTemplate(x=(), y=())
+            {"x": jnp.zeros(4), "y": jnp.zeros(4)},
+            "draw",
+            element_spec=EventTemplate(x=(), y=()),
+            name="batch",
         )
         leaves, treedef = jax.tree_util.tree_flatten(batch)
         with pytest.raises(ValueError, match="disagreeing batch axes"):
@@ -1583,7 +1704,7 @@ class TestRankZeroReconstruction:
         handing it straight to the record would declare the field's kind over a
         zero-dimensional ndarray — a value its own spec refuses."""
         column = _object_column([value])
-        batch = RecordBatch({"f": column}, "row", element_spec=EventTemplate(f=spec))
+        batch = RecordBatch({"f": column}, "row", element_spec=EventTemplate(f=spec), name="batch")
         element = jax.tree.map(lambda c: c.reshape(()), batch)
         assert isinstance(element, Record)
         assert spec.is_valid(element["f"])

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -1103,3 +1103,37 @@ class TestEveryBatchIsAnOperand:
 
         assert (out.batch_shape, out.level_names) == ((2,), ("row",))
         np.testing.assert_allclose(out.values, [1.0, 2.0])
+
+
+class TestSweepingASingleStoreBatchAgreesAcrossDispatch:
+    """A row that returns a single-store batch keeps its levels, as a record row does."""
+
+    @staticmethod
+    def _rows(n: int = 3):
+        return NumericArrayBatch(
+            jnp.arange(float(n)), "row", element_spec=NumericArraySpec(shape=()), name="rows"
+        )
+
+    @staticmethod
+    def _inner(v):
+        return NumericArrayBatch(
+            jnp.stack([jnp.asarray(v), jnp.asarray(v)]),
+            "inner",
+            element_spec=NumericArraySpec(shape=()),
+            name="i",
+        )
+
+    @pytest.mark.parametrize("dispatch", ["auto", "sequential"])
+    def test_the_rows_own_level_survives(self, dispatch):
+        out = Function(func=self._inner, name="f", dispatch=dispatch)(v=self._rows())
+
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "inner"))
+
+    def test_explicit_jax_says_what_it_cannot_do(self):
+        """The probe builds one leaf per field, which a single-store batch lacks.
+
+        Declining beats mis-reading it as a law: `auto` sweeps it correctly, and
+        an explicit `jax` should not silently differ from that.
+        """
+        with pytest.raises(TypeError, match="cannot vectorize over NumericArrayBatch"):
+            Function(func=self._inner, name="f", dispatch="jax")(v=self._rows())

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -22,7 +22,9 @@ import pytest
 from probpipe import (
     EventTemplate,
     Function,
+    FunctionBatch,
     Normal,
+    NumericArray,
     NumericArrayBatch,
     NumericArraySpec,
     NumericRecord,
@@ -1048,3 +1050,56 @@ class TestDeclaredOpaqueOutputAcrossDispatches:
         assert column.shape == (2,)
         assert [int(v) for v in result[0]["y"]] == [1, 2]
         assert [int(v) for v in result[1]["y"]] == [2, 3]
+
+
+class TestEveryBatchIsAnOperand:
+    """A batch is swept because it holds a multiplicity, not because it holds records.
+
+    The planner recognised only `RecordBatch` and `DistributionArray`, so the
+    other batch kinds were handed to a body whole. A body written for one element
+    then saw the whole collection, and the levels collapsed into the value's
+    shape on the way out.
+    """
+
+    @staticmethod
+    def _numeric(n: int = 3):
+        return NumericArrayBatch(
+            jnp.arange(float(n)), "row", element_spec=NumericArraySpec(shape=()), name="rows"
+        )
+
+    def test_a_numeric_array_batch_reaches_the_body_as_an_element(self):
+        seen: list = []
+
+        Function(func=lambda v: (seen.append(v), 0.0)[1], name="f", dispatch="sequential")(
+            v=self._numeric()
+        )
+
+        assert seen
+        assert all(isinstance(row, NumericArray) for row in seen)
+        assert not any(isinstance(row, NumericArrayBatch) for row in seen)
+
+    def test_sweeping_a_numeric_array_batch_keeps_its_level(self):
+        out = Function(func=lambda v: jnp.asarray(v) * 2.0, name="double", dispatch="sequential")(
+            v=self._numeric()
+        )
+
+        assert (out.batch_shape, out.level_names) == ((3,), ("row",))
+
+    def test_an_opaque_batch_hands_the_body_its_stored_element(self):
+        """`OpaqueBatch` stores rather than materializes, so the body sees the
+        caller's own object."""
+        seen: list = []
+
+        Function(func=lambda v: (seen.append(v), 0.0)[1], name="f", dispatch="sequential")(
+            v=OpaqueBatch(["a", "b"], "row", name="rows")
+        )
+
+        assert seen == ["a", "b"]
+
+    def test_a_function_batch_is_swept_too(self):
+        out = Function(func=lambda f: float(f()), name="call", dispatch="sequential")(
+            f=FunctionBatch([lambda: 1.0, lambda: 2.0], "row", name="rows")
+        )
+
+        assert (out.batch_shape, out.level_names) == ((2,), ("row",))
+        np.testing.assert_allclose(out.values, [1.0, 2.0])

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -147,6 +147,7 @@ class TestFieldExtraction:
             "draw",
             element_spec=NumericEventTemplate(a=(), b=()),
             axis_groups=((4,),),
+            name="batch",
         )
 
         assert np.allclose(joint["a"]._extract(batch), batch["a"])
@@ -211,6 +212,7 @@ class TestDesignCoercion:
                 "draw",
                 element_spec=NumericEventTemplate(y=()),
                 axis_groups=((4,),),
+                name="batch",
             )
         )
 
@@ -240,6 +242,7 @@ class TestBroadcastComponents:
             "draw",
             element_spec=NumericEventTemplate(a=()),
             axis_groups=((5, 2),),
+            name="batch",
         )
 
         taken = _take_rows(batch, jnp.array([1, 3]))
@@ -316,6 +319,7 @@ class TestSiblingViewsZipThroughACall:
             {"x": jnp.arange(3.0), "y": jnp.arange(3.0) * 10},
             "draw",
             element_spec=EventTemplate(x=(), y=()),
+            name="batch",
         )
         views = batch.select_all()
 
@@ -343,6 +347,7 @@ class TestOpaqueColumnsAreRearrangedRaw:
             },
             "draw",
             element_spec=EventTemplate(tag=None, x=()),
+            name="batch",
         )
 
     def test_presented_and_raw_columns_differ_for_an_opaque_field(self):
@@ -380,6 +385,7 @@ class TestRetypingADeclaredOutputKeepsColumnsWithTheirKeys:
             {"a": jnp.arange(3.0), "b": jnp.arange(3.0) * 10},
             "draw",
             element_spec=EventTemplate(a=(), b=()),
+            name="batch",
         )
 
         retyped = _copy_result_term(batch, output_template=EventTemplate(b=(), a=()))
@@ -401,6 +407,7 @@ class TestATransformCannotAddAnUnnamedLevel:
                 "inner",
                 element_spec=EventTemplate(s=()),
                 axis_groups=((2,),),
+                name="batch",
             )
 
         with pytest.raises(ValueError, match="An added axis belongs to no level"):
@@ -415,12 +422,15 @@ class TestATransformCannotAddAnUnnamedLevel:
             ("outer", "inner"),
             element_spec=EventTemplate(s=()),
             axis_groups=((3,), (2,)),
+            name="batch",
         )
 
         with pytest.raises(ValueError, match="keeps every batch axis or removes all of them"):
             jax.vmap(lambda b: jnp.zeros(()))(batch)
 
-        single = NumericRecordBatch({"s": jnp.zeros(3)}, "outer", element_spec=EventTemplate(s=()))
+        single = NumericRecordBatch(
+            {"s": jnp.zeros(3)}, "outer", element_spec=EventTemplate(s=()), name="batch"
+        )
         seen: list[Any] = []
         jax.vmap(lambda b: seen.append(type(b).__name__) or jnp.zeros(()))(single)
         assert seen == ["NumericRecord"]
@@ -432,7 +442,11 @@ class TestBatchFingerprinting:
     @staticmethod
     def _one(level: str = "draw", groups=((3,),)):
         return NumericRecordBatch(
-            {"x": jnp.arange(3.0)}, (level,), element_spec=EventTemplate(x=()), axis_groups=groups
+            {"x": jnp.arange(3.0)},
+            (level,),
+            element_spec=EventTemplate(x=()),
+            axis_groups=groups,
+            name="batch",
         )
 
     def test_a_multi_field_batch_fingerprints(self):
@@ -442,6 +456,7 @@ class TestBatchFingerprinting:
             {"a": jnp.arange(3.0), "b": jnp.arange(3.0)},
             "draw",
             element_spec=EventTemplate(a=(), b=()),
+            name="batch",
         )
 
         assert isinstance(fingerprint(batch), str)
@@ -464,6 +479,7 @@ class TestBatchFingerprinting:
                 {"a": jnp.arange(3.0), "b": jnp.arange(3.0) * 10},
                 "draw",
                 element_spec=EventTemplate(a=(), b=()),
+                name="batch",
             )
 
         assert fingerprint(build()) == fingerprint(build())
@@ -475,11 +491,13 @@ class TestBatchFingerprinting:
             {"a": jnp.arange(3.0), "b": jnp.arange(3.0) * 10},
             "draw",
             element_spec=EventTemplate(a=(), b=()),
+            name="batch",
         )
         ba = NumericRecordBatch(
             {"a": jnp.arange(3.0) * 10, "b": jnp.arange(3.0)},
             "draw",
             element_spec=EventTemplate(a=(), b=()),
+            name="batch",
         )
 
         assert fingerprint(ab) != fingerprint(ba)
@@ -492,12 +510,14 @@ class TestBatchFingerprinting:
             ("a", "b"),
             element_spec=EventTemplate(x=()),
             axis_groups=((2,), (3,)),
+            name="batch",
         )
         joined = NumericRecordBatch(
             {"x": jnp.zeros((2, 3))},
             "a",
             element_spec=EventTemplate(x=()),
             axis_groups=((2, 3),),
+            name="batch",
         )
 
         assert fingerprint(split) != fingerprint(joined)
@@ -513,6 +533,7 @@ class TestMultiLevelSweeps:
             ("chain", "draw"),
             element_spec=EventTemplate(x=()),
             axis_groups=((2,), (3,)),
+            name="batch",
         )
 
         @function
@@ -528,8 +549,12 @@ class TestMultiLevelSweeps:
         """The aggregate mints one level per swept group, then the rows' own
         levels: collapsing the sweep into one group would leave more names than
         levels and refuse."""
-        a = NumericRecordBatch({"a": jnp.arange(2.0)}, "outer", element_spec=EventTemplate(a=()))
-        b = NumericRecordBatch({"b": jnp.arange(3.0)}, "inner", element_spec=EventTemplate(b=()))
+        a = NumericRecordBatch(
+            {"a": jnp.arange(2.0)}, "outer", element_spec=EventTemplate(a=()), name="batch"
+        )
+        b = NumericRecordBatch(
+            {"b": jnp.arange(3.0)}, "inner", element_spec=EventTemplate(b=()), name="batch"
+        )
 
         @function
         def rows(a, b):
@@ -538,6 +563,7 @@ class TestMultiLevelSweeps:
                 "rows",
                 element_spec=EventTemplate(s=()),
                 axis_groups=((2,),),
+                name="batch",
             )
 
         out = rows(a=a, b=b)
@@ -555,7 +581,7 @@ class TestAutoDispatchFallsBackForABatchReturningBody:
         resolves to sequential instead of failing mid-call. Dispatch paths
         agree on results by contract, so the fallback changes speed alone."""
         source = NumericRecordBatch(
-            {"x": jnp.arange(3.0)}, "draw", element_spec=EventTemplate(x=())
+            {"x": jnp.arange(3.0)}, "draw", element_spec=EventTemplate(x=()), name="batch"
         )
 
         def body(v):
@@ -564,6 +590,7 @@ class TestAutoDispatchFallsBackForABatchReturningBody:
                 "inner",
                 element_spec=EventTemplate(s=()),
                 axis_groups=((2,),),
+                name="batch",
             )
 
         out = Function(func=body)(v=source)
@@ -579,7 +606,7 @@ class TestAutoDispatchFallsBackForABatchReturningBody:
 
     def test_a_numeric_body_is_unaffected(self):
         source = NumericRecordBatch(
-            {"x": jnp.arange(3.0)}, "draw", element_spec=EventTemplate(x=())
+            {"x": jnp.arange(3.0)}, "draw", element_spec=EventTemplate(x=()), name="batch"
         )
 
         @function
@@ -602,6 +629,7 @@ class TestSameRankTransformsCannotLieEither:
             {"x": jnp.arange(2.0), "y": jnp.arange(2.0) * 10},
             "draw",
             element_spec=EventTemplate(x=(), y=()),
+            name="batch",
         )
 
         with pytest.raises(ValueError, match="keeps every batch axis or removes all of them"):
@@ -619,6 +647,7 @@ class TestSameRankTransformsCannotLieEither:
             {"x": jnp.arange(2.0), "y": jnp.arange(2.0)},
             "draw",
             element_spec=EventTemplate(x=(), y=()),
+            name="batch",
         )
         _, treedef = jtu.tree_flatten(batch)
 
@@ -641,6 +670,7 @@ class TestOpaqueBatchesStack:
                 },
                 "inner",
                 element_spec=EventTemplate(tag=None, x=()),
+                name="batch",
             )
             for i in range(3)
         ]
@@ -664,6 +694,7 @@ class TestObjectValuedMarginals:
             {"tag": np.array(["a", "b", "c"], dtype=object), "x": jnp.arange(3.0)},
             "draw",
             element_spec=EventTemplate(tag=None, x=()),
+            name="batch",
         )
 
         marginal = _make_marginal(batch)
@@ -676,7 +707,7 @@ class TestObjectValuedMarginals:
 class TestAnEmptySweepAnswersToItsTemplate:
     def test_zero_rows_still_build_the_declared_fields(self):
         source = NumericRecordBatch(
-            {"x": jnp.zeros((0,))}, "design", element_spec=EventTemplate(x=())
+            {"x": jnp.zeros((0,))}, "design", element_spec=EventTemplate(x=()), name="batch"
         )
 
         @function(output_template=EventTemplate(y=()))
@@ -697,7 +728,7 @@ class TestATransformCannotResizeTheElement:
     @staticmethod
     def _vector_batch():
         return NumericRecordBatch(
-            {"x": jnp.zeros((3, 2))}, "draw", element_spec=EventTemplate(x=(2,))
+            {"x": jnp.zeros((3, 2))}, "draw", element_spec=EventTemplate(x=(2,)), name="batch"
         )
 
     def test_slicing_an_event_axis_is_refused(self):
@@ -752,6 +783,7 @@ class TestZeroWidthEventsUnderExplicitJax:
             {"x": jnp.zeros((3, 0)), "row": jnp.arange(3.0)},
             "draw",
             element_spec=EventTemplate(x=(0,), row=()),
+            name="batch",
         )
 
         out = Function(
@@ -779,6 +811,7 @@ class TestShapeCannotRecoverAxisProvenance:
             ("chain", "draw"),
             element_spec=EventTemplate(x=()),
             axis_groups=((chain,), (draw,)),
+            name="batch",
         )
 
     @pytest.mark.parametrize(("chain", "draw"), [(2, 2), (2, 3)], ids=["equal", "distinct"])
@@ -800,6 +833,7 @@ class TestATransformCannotRetypeTheElement:
             {"x": jnp.zeros(3, dtype=jnp.float32)},
             "draw",
             element_spec=EventTemplate(x=NumericArraySpec((), dtype=jnp.float32)),
+            name="batch",
         )
 
         with pytest.raises(TypeError, match="does not admit"):
@@ -812,6 +846,7 @@ class TestATransformCannotRetypeTheElement:
             {"x": jnp.zeros(3, dtype=jnp.float16)},
             "draw",
             element_spec=EventTemplate(x=NumericArraySpec((), dtype=jnp.float32)),
+            name="batch",
         )
 
         widened = jax.tree.map(lambda leaf: leaf.astype(jnp.float32), batch)
@@ -829,6 +864,7 @@ class TestZeroRowsAgreeAcrossDispatch:
             ("a", "b"),
             element_spec=EventTemplate(x=()),
             axis_groups=((2,), (0,)),
+            name="batch",
         )
 
         def body(v):
@@ -858,6 +894,7 @@ class TestFunctionValuedColumnsStack:
                 {"f": np.array([(lambda i=i, j=j: i * 10 + j) for j in range(2)], dtype=object)},
                 "inner",
                 element_spec=EventTemplate(f=FunctionSpec()),
+                name="batch",
             )
             for i in range(3)
         ]
@@ -881,6 +918,7 @@ class TestAnEmpiricalTakesABatch:
             {"X": jnp.arange(4.0), "y": jnp.arange(4.0) * 10},
             "obs",
             element_spec=EventTemplate(X=(), y=()),
+            name="batch",
         )
 
         empirical = EmpiricalDistribution(data)
@@ -902,12 +940,16 @@ class TestBatchValuedRowAggregation:
             {"x": jnp.arange(float(n))},
             "row",
             element_spec=EventTemplate(x=NumericArraySpec(shape=())),
+            name="batch",
         )
 
     @staticmethod
     def _inner(n: int, level: str = "inner"):
         return NumericRecordBatch(
-            {"y": jnp.zeros(n)}, level, element_spec=EventTemplate(y=NumericArraySpec(shape=()))
+            {"y": jnp.zeros(n)},
+            level,
+            element_spec=EventTemplate(y=NumericArraySpec(shape=())),
+            name="batch",
         )
 
     def test_mixing_batch_and_non_batch_rows_is_refused(self):
@@ -939,6 +981,7 @@ class TestBatchValuedRowAggregation:
                 {"z": jnp.zeros(2)},
                 "inner",
                 element_spec=EventTemplate(z=NumericArraySpec(shape=())),
+                name="batch",
             )
 
         with pytest.raises(ValueError, match="returned batches that disagree"):

--- a/tests/core/test_record_batch_interop.py
+++ b/tests/core/test_record_batch_interop.py
@@ -956,7 +956,7 @@ class TestBatchValuedRowAggregation:
         def body(x):
             return self._inner(2) if float(x["x"]) < 1.5 else Record("r", y=0.0)
 
-        with pytest.raises(TypeError, match="some rows returned a batch of records"):
+        with pytest.raises(TypeError, match="some rows returned a batch and some did not"):
             Function(func=body, dispatch="sequential")(x=self._rows())
 
     @pytest.mark.parametrize(

--- a/tests/core/test_record_serialization.py
+++ b/tests/core/test_record_serialization.py
@@ -159,6 +159,7 @@ def test_record_batch_pickle_roundtrip():
         level_names="draw",
         axis_groups=((2,),),
         element_spec=template,
+        name="batch",
     )
     ra2 = roundtrip(ra)
     assert ra2.batch_shape == (2,)
@@ -173,6 +174,7 @@ def test_record_batch_template_preserved():
         level_names="draw",
         axis_groups=((1,),),
         element_spec=template,
+        name="batch",
     )
     ra2 = roundtrip(ra)
     assert ra2.event_template == template
@@ -190,6 +192,7 @@ def test_numeric_record_batch_pickle_roundtrip():
         level_names="draw",
         axis_groups=((3,),),
         element_spec=template,
+        name="batch",
     )
     nra2 = roundtrip(nrb)
     assert type(nra2) is NumericRecordBatch
@@ -204,6 +207,7 @@ def test_numeric_record_batch_cloudpickle_roundtrip():
         level_names="draw",
         axis_groups=((2,),),
         element_spec=template,
+        name="batch",
     )
     nra2 = cloudpickle_roundtrip(nrb)
     assert type(nra2) is NumericRecordBatch

--- a/tests/core/test_tracked.py
+++ b/tests/core/test_tracked.py
@@ -56,6 +56,7 @@ class TestMixinMembership:
             level_names="draw",
             axis_groups=((3,),),
             element_spec=EventTemplate(a=()),
+            name="batch",
         )
         assert isinstance(ra, TrackedTerm)
 
@@ -122,12 +123,15 @@ class TestNameIsAuto:
         assert r.name == "sample"
         assert r.name_is_auto is True
 
-    def test_unnamed_record_batch_is_auto(self):
+    def test_a_derived_batch_name_is_auto(self):
+        """A caller that derives a name says so; there is no unnamed batch."""
         ra = RecordBatch(
             {"a": jnp.zeros((3,))},
             level_names="draw",
             axis_groups=((3,),),
             element_spec=EventTemplate(a=()),
+            name="derived",
+            name_is_auto=True,
         )
         assert ra.name_is_auto is True
         named = RecordBatch(
@@ -298,6 +302,8 @@ class TestWithNameOnBatchTypes:
             level_names="draw",
             axis_groups=((3,),),
             element_spec=EventTemplate(a=()),
+            name="derived",
+            name_is_auto=True,
         )
         ra2 = ra.with_name("mine")
         assert ra2 is not ra

--- a/tests/core/test_workflow_plan.py
+++ b/tests/core/test_workflow_plan.py
@@ -625,6 +625,7 @@ def _batch(level: str = "draw", n: int = 3, **fields) -> Any:
         dict(fields),
         (level,),
         element_spec=EventTemplate({name: value.shape[1:] for name, value in fields.items()}),
+        name="batch",
     )
 
 
@@ -700,6 +701,7 @@ class TestPartialLevelOverlap:
             ("chain", "draw"),
             element_spec=EventTemplate(x=()),
             axis_groups=((2,), (3,)),
+            name="batch",
         )
         one = _batch("draw", 3)
 
@@ -741,12 +743,14 @@ class TestPartialLevelOverlap:
             ("a", "b"),
             element_spec=EventTemplate(x=()),
             axis_groups=((2,), (3, 4)),
+            name="batch",
         )
         gb = NumericRecordBatch(
             {"y": jnp.zeros((2, 3, 4))},
             ("a", "b"),
             element_spec=EventTemplate(y=()),
             axis_groups=((2, 3), (4,)),
+            name="batch",
         )
 
         with pytest.raises(ValueError, match="same levels but are batched differently"):

--- a/tests/core/test_workflow_sweep.py
+++ b/tests/core/test_workflow_sweep.py
@@ -371,6 +371,7 @@ class TestASweptBodyThatReturnsABatch:
             "cell",
             element_spec=EventTemplate(x=()),
             axis_groups=((2, 3),),
+            name="batch",
         )
 
         mapped = Function(func=self._body, name="swept")(grid)

--- a/tests/core/test_wrap_at_the_declared_kind.py
+++ b/tests/core/test_wrap_at_the_declared_kind.py
@@ -308,10 +308,15 @@ class TestEachSweptRowTakesItsOwnKind:
     """A row is one call's return, so the rule that names a single return's kind
     is the rule that names a row's.
 
-    Rows reached the aggregation raw, so the branches there read them as whatever
-    they happened to stack as: a mapping row was an unstackable object, and a
-    sequence row's multiplicity became event shape.
+    Every case runs under both dispatches. Which executor a sweep picks is a
+    performance decision, so a row's kind cannot depend on it: the mapped path
+    reads its rows through the same rule the row-wise path does, and the two
+    agree here rather than in prose.
     """
+
+    @pytest.fixture(params=["auto", "sequential"])
+    def dispatch(self, request):
+        return request.param
 
     @staticmethod
     def _rows(n: int = 3):
@@ -325,32 +330,60 @@ class TestEachSweptRowTakesItsOwnKind:
             name="rows",
         )
 
-    def _swept(self, body):
-        return Function(func=body, name="f", dispatch="sequential")(v=self._rows())
+    def _swept(self, body, dispatch):
+        return Function(func=body, name="f", dispatch=dispatch)(v=self._rows())
 
-    def test_a_mapping_row_gives_a_batch_of_records(self):
-        out = self._swept(lambda v: {"y": jnp.asarray(v["x"]) * 2})
+    def test_a_mapping_row_gives_a_batch_of_records(self, dispatch):
+        out = self._swept(lambda v: {"y": jnp.asarray(v["x"]) * 2}, dispatch)
 
         assert list(out.event_template) == ["y"]
         assert (out.batch_shape, out.level_names) == ((3,), ("row",))
+        np.testing.assert_array_equal(np.asarray(out["y"]), np.arange(3.0) * 2)
 
-    def test_any_mapping_counts_not_only_dict(self):
+    def test_a_nested_mapping_row_keeps_its_subtree(self, dispatch):
+        out = self._swept(
+            lambda v: {"lo": jnp.asarray(v["x"]) - 1, "grp": {"hi": jnp.asarray(v["x"]) + 1}},
+            dispatch,
+        )
+
+        assert list(out.event_template) == ["lo", "grp/hi"]
+        np.testing.assert_array_equal(np.asarray(out["grp/hi"]), np.arange(3.0) + 1)
+
+    def test_any_mapping_counts_not_only_dict(self, dispatch):
         from collections import OrderedDict
 
-        out = self._swept(lambda v: OrderedDict(y=jnp.asarray(v["x"])))
+        out = self._swept(lambda v: OrderedDict(y=jnp.asarray(v["x"])), dispatch)
 
         assert list(out.event_template) == ["y"]
 
-    def test_a_sequence_row_keeps_its_own_level(self):
+    def test_a_sequence_row_keeps_its_own_level(self, dispatch):
         """The row's multiplicity is a level, not part of the element's shape."""
-        out = self._swept(lambda v: [jnp.asarray(v["x"]), jnp.asarray(v["x"])])
+        out = self._swept(lambda v: [jnp.asarray(v["x"]), jnp.asarray(v["x"])], dispatch)
 
         assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "f"))
 
-    def test_rows_of_differing_numeric_shape_are_refused(self):
+    def test_a_batch_row_keeps_the_level_it_named(self, dispatch):
+        """A row that names its own level keeps that name inside the sweep's."""
+        from probpipe import NumericRecordBatch
+        from probpipe.core.event_template import NumericEventTemplate
+
+        def body(v):
+            x = jnp.asarray(v["x"])
+            return NumericRecordBatch(
+                {"y": jnp.stack([x, x * 2])},
+                "part",
+                element_spec=NumericEventTemplate(y=()),
+                name="parts",
+            )
+
+        out = self._swept(body, dispatch)
+
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "part"))
+
+    def test_rows_of_differing_numeric_shape_are_refused(self, dispatch):
         """An object column would record the disagreement as if it were the answer."""
         with pytest.raises(ValueError, match="differing shapes"):
-            self._swept(lambda v: jnp.ones(int(jnp.asarray(v["x"])) + 1))
+            self._swept(lambda v: jnp.ones(int(jnp.asarray(v["x"])) + 1), dispatch)
 
     def test_a_disagreement_inside_a_returned_sequence_is_not_swallowed(self):
         """The stack has a batch form for every element kind, so what raises here
@@ -363,7 +396,8 @@ class TestASweptEmptyMappingHitsTheSameWall:
     """Per-row wrapping makes a `{}` row a `Record`, so the sweep reaches the
     field guard and says what the direct routes say."""
 
-    def test_a_swept_body_returning_an_empty_mapping_is_refused(self):
+    @pytest.mark.parametrize("dispatch", ["auto", "sequential"])
+    def test_a_swept_body_returning_an_empty_mapping_is_refused(self, dispatch):
         from probpipe import NumericRecordBatch
         from probpipe.core.event_template import NumericEventTemplate
 
@@ -375,4 +409,4 @@ class TestASweptEmptyMappingHitsTheSameWall:
         )
 
         with pytest.raises(ValueError, match="at least one field"):
-            Function(func=lambda v: {}, name="f", dispatch="sequential")(v=rows)
+            Function(func=lambda v: {}, name="f", dispatch=dispatch)(v=rows)

--- a/tests/core/test_wrap_at_the_declared_kind.py
+++ b/tests/core/test_wrap_at_the_declared_kind.py
@@ -302,3 +302,77 @@ class TestAnEmptyRecordHasNoBatch:
 
         with pytest.raises(ValueError, match="at least one field"):
             RecordBatch({}, "x", element_spec=EventTemplate())
+
+
+class TestEachSweptRowTakesItsOwnKind:
+    """A row is one call's return, so the rule that names a single return's kind
+    is the rule that names a row's.
+
+    Rows reached the aggregation raw, so the branches there read them as whatever
+    they happened to stack as: a mapping row was an unstackable object, and a
+    sequence row's multiplicity became event shape.
+    """
+
+    @staticmethod
+    def _rows(n: int = 3):
+        from probpipe import NumericRecordBatch
+        from probpipe.core.event_template import NumericEventTemplate
+
+        return NumericRecordBatch(
+            {"x": jnp.arange(float(n))},
+            "row",
+            element_spec=NumericEventTemplate(x=()),
+            name="rows",
+        )
+
+    def _swept(self, body):
+        return Function(func=body, name="f", dispatch="sequential")(v=self._rows())
+
+    def test_a_mapping_row_gives_a_batch_of_records(self):
+        out = self._swept(lambda v: {"y": jnp.asarray(v["x"]) * 2})
+
+        assert list(out.event_template) == ["y"]
+        assert (out.batch_shape, out.level_names) == ((3,), ("row",))
+
+    def test_any_mapping_counts_not_only_dict(self):
+        from collections import OrderedDict
+
+        out = self._swept(lambda v: OrderedDict(y=jnp.asarray(v["x"])))
+
+        assert list(out.event_template) == ["y"]
+
+    def test_a_sequence_row_keeps_its_own_level(self):
+        """The row's multiplicity is a level, not part of the element's shape."""
+        out = self._swept(lambda v: [jnp.asarray(v["x"]), jnp.asarray(v["x"])])
+
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "f"))
+
+    def test_rows_of_differing_numeric_shape_are_refused(self):
+        """An object column would record the disagreement as if it were the answer."""
+        with pytest.raises(ValueError, match="differing shapes"):
+            self._swept(lambda v: jnp.ones(int(jnp.asarray(v["x"])) + 1))
+
+    def test_a_disagreement_inside_a_returned_sequence_is_not_swallowed(self):
+        """The stack has a batch form for every element kind, so what raises here
+        is the rows disagreeing — which the caller should see."""
+        with pytest.raises(ValueError, match="differing shapes"):
+            Function(func=lambda: [jnp.ones(1), jnp.ones(2)], name="g")()
+
+
+class TestASweptEmptyMappingHitsTheSameWall:
+    """Per-row wrapping makes a `{}` row a `Record`, so the sweep reaches the
+    field guard and says what the direct routes say."""
+
+    def test_a_swept_body_returning_an_empty_mapping_is_refused(self):
+        from probpipe import NumericRecordBatch
+        from probpipe.core.event_template import NumericEventTemplate
+
+        rows = NumericRecordBatch(
+            {"x": jnp.arange(3.0)},
+            "row",
+            element_spec=NumericEventTemplate(x=()),
+            name="rows",
+        )
+
+        with pytest.raises(ValueError, match="at least one field"):
+            Function(func=lambda v: {}, name="f", dispatch="sequential")(v=rows)

--- a/tests/core/test_wrap_at_the_declared_kind.py
+++ b/tests/core/test_wrap_at_the_declared_kind.py
@@ -362,6 +362,38 @@ class TestEachSweptRowTakesItsOwnKind:
 
         assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "f"))
 
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            (lambda v: [object(), object()], "OpaqueBatch"),
+            (lambda v: [lambda z: z, lambda z: z], "FunctionBatch"),
+        ],
+        ids=["opaque", "callable"],
+    )
+    def test_a_row_of_unstackable_elements_keeps_its_level_too(self, dispatch, body, expected):
+        """The level does not depend on what the elements are.
+
+        These rows were stored whole: the row's own batch became one opaque
+        element of the aggregate, so its multiplicity vanished and a batch of
+        callables came back as opaque.
+        """
+        out = self._swept(body, dispatch)
+
+        assert type(out).__name__ == expected
+        assert (out.batch_shape, out.level_names) == ((3, 2), ("row", "f"))
+
+    def test_an_empty_sequence_row_counts_zero_on_its_level(self, dispatch):
+        """A batch of nothing is still a batch, as it is for a single return."""
+        out = self._swept(lambda v: [], dispatch)
+
+        assert (out.batch_shape, out.level_names) == ((3, 0), ("row", "f"))
+
+    def test_two_nested_anonymous_levels_are_refused(self, dispatch):
+        """Both would take the function's name, and a clash is not resolved by
+        suffixing it."""
+        with pytest.raises(ValueError, match="level names must be unique"):
+            self._swept(lambda v: [[jnp.asarray(v["x"])], [jnp.asarray(v["x"])]], dispatch)
+
     def test_a_batch_row_keeps_the_level_it_named(self, dispatch):
         """A row that names its own level keeps that name inside the sweep's."""
         from probpipe import NumericRecordBatch

--- a/tests/core/test_wrap_at_the_declared_kind.py
+++ b/tests/core/test_wrap_at_the_declared_kind.py
@@ -301,7 +301,7 @@ class TestAnEmptyRecordHasNoBatch:
         from probpipe import EventTemplate, RecordBatch
 
         with pytest.raises(ValueError, match="at least one field"):
-            RecordBatch({}, "x", element_spec=EventTemplate())
+            RecordBatch({}, "x", element_spec=EventTemplate(), name="batch")
 
 
 class TestEachSweptRowTakesItsOwnKind:

--- a/tests/distributions/test_kde.py
+++ b/tests/distributions/test_kde.py
@@ -158,6 +158,7 @@ class TestLogProbDualInput:
             {"intercept": jnp.array([0.5, 0.6, 0.7]), "slope": jnp.array([-0.3, -0.4, -0.5])},
             "draw",
             element_spec=NumericEventTemplate(intercept=(), slope=()),
+            name="batch",
         )
         lp = kde._log_prob(nrb)
         assert lp.shape == (3,)

--- a/tests/inference/test_minibatch.py
+++ b/tests/inference/test_minibatch.py
@@ -242,6 +242,7 @@ class TestInnerDraw:
             level_names="draw",
             axis_groups=((n,),),
             element_spec=NumericEventTemplate(X=(X.shape[1],), y=()),
+            name="batch",
         )
 
         m_rec = MinibatchedDistribution(prior, likelihood, record_data, batch_size=20)
@@ -487,6 +488,7 @@ def test_a_multi_axis_batch_is_refused_at_construction(prior, likelihood):
         {"x": jnp.ones((4, 3))},
         ("n", "k"),
         element_spec=EventTemplate(x=NumericArraySpec(shape=())),
+        name="batch",
     )
     with pytest.raises(ValueError, match="rows are one axis"):
         MinibatchedDistribution(prior, likelihood, grid, batch_size=2)


### PR DESCRIPTION
Stacked on #439. Part of #398. Closes the gaps a second external review of the stack found, plus the ones measuring them turned up.

Every fix here is the same shape: an answer that depended on something it should not have — which executor ran the call, which operation was named, which kind the value happened to be. Each is now stated once and read the same way everywhere.

## What changed

**One answer per computation, whichever executor runs it.** The row-wise sweep gave each row the kind of its own return; the mapped path did not, so a body returning a mapping raised `_make_stack cannot aggregate output of type dict` under `dispatch="auto"` and returned a `NumericRecordBatch` under `"sequential"`. A sequence row raised a bogus count error. The mapped path now applies the same per-row rule and carries a record row across the map the way it already carried a batch one. A declared `output_template` still wins, as it does row-wise. The tests for this are a parametrised dispatch matrix rather than a second test, since agreement is the property being asserted.

**Every batch is read the way the `Batch` contract states it.** Lifting a function's declaration against a batched operand read `event_template` — the convenience view only a batch of records has — so a `NumericArrayBatch`, `OpaqueBatch`, or `FunctionBatch` operand could not be swept by a declared function at all, however its declaration was written. It reads `element_spec` now, which the ABC states at every kind; the unification pass already had the spec-against-spec path this needs.

That view was also unsound. It unwrapped a single-field element to that field, so `EventTemplate(v=())` — a declaration naming a bare array — accepted an operand whose elements are records. Reading the element spec refuses it and names both specs.

A distribution operand is deliberately left alone: it is lifted by being sampled, and a scalar law reports its event as one field named after itself. Restating that belongs with the `Distribution`-side work.

**Every density op keeps its operand's levels.** `log_prob` restated them; `prob`, `unnormalized_log_prob`, and `unnormalized_prob` returned a bare array, so the axes survived only as event shape. The same draws scored as a batch over `("chain", "draw")` under one op and as one value of shape `(2, 3)` under another. All four share the helper the `log_prob` work introduced for exactly this.

**A row of unstackable elements keeps its level.** The row-stacking path knew two of the four batch forms, so a row returning a sequence of opaque objects or callables had its own batch stored whole as one element: the row's multiplicity vanished, and a row of callables came back as an `OpaqueBatch`. Object batches now get the stacking path their storage calls for. An empty-sequence row is a batch of nothing on its own level, matching how a single return already reads one — which settles the last dispatch disagreement. Two nested anonymous levels stay refused: both would take the function's name, and a clash is not resolved by suffixing it.

**`sample` mints its level for every kind of draw.** *Breaking.* The boundary assumed a law that assembles its own draws also names what they range over. An empirical does not: `sample_shape=(3,)` came back as one `NumericRecord` whose fields had grown an axis, or — for record and opaque atoms — as a single `Opaque` holding the whole object array. All three now give the batch form of the draw's kind over a `sample` level, matching what a plain law already gave.

The empirical's own comment called returning a record "a deliberate deviation from the uniform output wrap contract", because a batch inside a `vmap` is refused. That reason holds for `_sample` and is now stated as such: the level is minted at the boundary, outside the trace, so the deviation is gone without putting a named multiplicity where `vmap` would reject it.

**The kind table answers where it already can.** `RecordBatch` construction listed the admissible field kinds inline while the reading end asked the registry — the split the registry was introduced to close.

## Breaking changes

- `sample(law, sample_shape=...)` on an empirical returns a batch. Code that read `drawn["field"]` now reads a column of a batch rather than a field of a record, and `"field" in drawn` becomes `"field" in drawn.event_template`. A single draw is unchanged.
- A batch of one-field records no longer satisfies a declaration naming a bare array.
- A row of callables aggregates to a `FunctionBatch`, not an `OpaqueBatch`.

## Documentation

Updated alongside the code rather than separately. Requiring a name on every batch had left three notebooks constructing one without a name — they would have raised when CI executed them — four docstrings offering "defaults to the class name lowercased", and the empty-batch example written as a call that no longer constructs. The `_sample` protocol table promised a `NumericRecordBatch` for a batched structured draw, which no implementation returns and none should; it now says the columns come back, and why.

## Verification

- 5720 passing, 52 skipped; `ruff format` and `ruff check` clean; `mkdocs build --strict` clean.
- `docs/user_guide/02_records.ipynb` and `docs/user_guide/12_diagnostics_workflow.ipynb` execute clean under `nbconvert`. `docs/tutorials/getting_started.ipynb` gets past its batch-construction cell and stops later on a locally missing `pymc`, which the tutorial CI leg installs.

## Not addressed

`quantile(dist, q)` drops the levels of a batched `q` for the same reason the density ops did, but its result is a per-field record rather than an array, so restating them needs the record-valued form of the helper. Left out rather than half-done.
